### PR TITLE
feat(examples): add mass update feat to Example 11

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example11-modal.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example11-modal.html
@@ -1,0 +1,18 @@
+<div class="modal">
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Mass Update</p>
+      <button class="delete" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <h4 class="subtitle">Enter new value on the field(s) you wish to be mass updated.</h4>
+      <br />
+      <div class="modal-grid"></div>
+    </section>
+    <footer class="modal-card-foot" style="justify-content: flex-end;">
+      <button class="button close is-small">Cancel</button>
+      <button class="button is-success" onclick.delegate="saveMassUpdate()">Save changes</button>
+    </footer>
+  </div>
+</div>

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example11-modal.scss
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example11-modal.scss
@@ -1,6 +1,5 @@
-$control-height: 2.4em;
-$subtitle-color: hsl(0, 0%, 29%);
+$subtitle-color: #3EC46D;
+$modal-content-width: 1200px;
 
 @import '@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-salesforce.scss';
 @import 'bulma/bulma';
-

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example11-modal.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example11-modal.ts
@@ -1,0 +1,153 @@
+import {
+  Column,
+  Formatter,
+  Formatters,
+  GridOption,
+  emptyElement,
+} from '@slickgrid-universal/common';
+import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+
+import { ExampleGridOptions } from './example-grid-options';
+import '../salesforce-styles.scss';
+import './example11-modal.scss';
+
+export class Example11Modal {
+  columnDefinitions: Column[];
+  gridOptions: GridOption;
+  sgb: SlickVanillaGridBundle;
+  gridContainerElm: HTMLDivElement;
+  remoteCallbackFn: any;
+  selectedIds: string[] = [];
+
+  attached() {
+    this.openBulmaModal(this.handleOnModalClose.bind(this));
+    this.initializeGrid();
+  }
+
+  bind(bindings: any) {
+    if (bindings) {
+      if (bindings.columnDefinitions) {
+        this.columnDefinitions = bindings.columnDefinitions;
+        this.gridContainerElm = document.querySelector<HTMLDivElement>(`.modal-grid`);
+        const dataset = [this.createEmptyItem(bindings.columnDefinitions)];
+        this.sgb = new Slicker.GridBundle(this.gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, dataset);
+        this.gridContainerElm.addEventListener('onvalidationerror', this.handleValidationError.bind(this));
+      }
+      this.remoteCallbackFn = bindings.remoteCallback;
+      this.selectedIds = bindings.selectedIds || [];
+    }
+  }
+
+  dispose() {
+    this.sgb?.dispose();
+  }
+
+  initializeGrid() {
+    this.gridOptions = {
+      autoEdit: true,
+      autoCommitEdit: true,
+      editable: true,
+      enableCellNavigation: true,
+      enableGridMenu: false,
+      gridHeight: 200,
+      gridWidth: 1160,
+      rowHeight: 33,
+    };
+  }
+
+  createEmptyItem(columnDefinitions: Column[]) {
+    const emptyObj: any = { id: 0 };
+    columnDefinitions.forEach(column => {
+      emptyObj[column.id] = undefined;
+    });
+
+    return emptyObj;
+  }
+
+  handleValidationError(event) {
+    console.log('handleValidationError', event.detail);
+    const args = event.detail && event.detail.args;
+    if (args.validationResults) {
+      alert(args.validationResults.msg);
+    }
+    return false;
+  }
+
+  handleOnModalClose() {
+    this.sgb?.dispose();
+    this.gridContainerElm = emptyElement(this.gridContainerElm);
+    this.closeBulmaModal();
+  }
+
+  /**
+   * Instead of manually adding a Custom Formatter on every column definition that is editable, let's do it in an automated way
+   * We'll loop through all column definitions and add a Formatter (blue background) when necessary
+   * Note however that if there's already a Formatter on that column definition, we need to turn it into a Formatters.multiple
+   */
+  autoAddCustomEditorFormatter(columnDefinitions: Column[], customFormatter: Formatter) {
+    if (Array.isArray(columnDefinitions)) {
+      for (const columnDef of columnDefinitions) {
+        if (columnDef.editor) {
+          if (columnDef.formatter && columnDef.formatter !== Formatters.multiple) {
+            const prevFormatter = columnDef.formatter;
+            columnDef.formatter = Formatters.multiple;
+            columnDef.params = { ...columnDef.params, formatters: [prevFormatter, customFormatter] };
+          } else if (columnDef.formatter && columnDef.formatter === Formatters.multiple) {
+            if (!columnDef.params) {
+              columnDef.params = {};
+            }
+            columnDef.params.formatters = [...columnDef.params.formatters, customFormatter];
+          } else {
+            columnDef.formatter = customFormatter;
+          }
+        }
+      }
+    }
+  }
+
+  saveMassUpdate() {
+    this.handleOnModalClose();
+    const editedItem = this.sgb.dataView.getItemByIdx(0);
+
+    if (typeof this.remoteCallbackFn === 'function') {
+      // before calling the remote callback, let's remove the unnecessary "id" and any undefined properties
+      for (const key in editedItem) {
+        if (editedItem[key] === undefined || key === 'id') {
+          delete editedItem[key];
+        }
+      }
+
+      // finally execute the remote callback
+      this.remoteCallbackFn(editedItem, this.selectedIds);
+    }
+  }
+
+  private openBulmaModal(callback?: () => void) {
+    const modalElm = document.querySelector<HTMLDivElement>('.modal');
+    modalElm.classList.add('is-active');
+
+    this.bindCloseBulmaModal(callback);
+  }
+
+  private bindCloseBulmaModal(callback?: () => void) {
+    const modalCloseBtnElms = document.querySelectorAll<HTMLButtonElement>('.close, .delete, .modal-close');
+
+    window.addEventListener('click', (event: any) => {
+      if (event.target.className === 'modal-background') {
+        this.closeBulmaModal(callback);
+      }
+    });
+
+    if (modalCloseBtnElms) {
+      modalCloseBtnElms.forEach(closeElm => closeElm.addEventListener('click', () => this.closeBulmaModal(callback)));
+    }
+  }
+
+  private closeBulmaModal(callback?: () => void) {
+    const modalElm = document.querySelector<HTMLDivElement>('.modal');
+    modalElm.classList.remove('is-active');
+    if (typeof callback === 'function') {
+      callback();
+    }
+  }
+}

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example11.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example11.html
@@ -28,6 +28,9 @@
   </div>
 </section>
 
+<div class="modal-container">
+</div>
+
 <br>
 
 <div class="grid11">

--- a/examples/webpack-demo-vanilla-bundle/src/examples/utilities.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/utilities.ts
@@ -1,0 +1,23 @@
+import { Renderer } from '../renderer';
+
+export function loadComponent<T = any>(containerElement: HTMLDivElement, componentModuleId: string, bindings?: any): T {
+  if (containerElement) {
+    const renderer = new Renderer(containerElement);
+    const viewModel = renderer.loadViewModel(require(`${componentModuleId}.ts`));
+    if (viewModel && viewModel.dispose) {
+      window.onunload = viewModel.dispose; // dispose when leaving SPA
+    }
+
+    renderer.loadView(require(`${componentModuleId}.html`));
+    if (viewModel && viewModel.attached && renderer.className) {
+      const viewModelObj = {};
+      viewModelObj[renderer.className] = viewModel;
+      viewModel.attached();
+      if (viewModel && viewModel.bind) {
+        viewModel.bind(bindings);
+      }
+    }
+    return viewModel;
+  }
+  return null;
+}

--- a/examples/webpack-demo-vanilla-bundle/src/renderer.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/renderer.ts
@@ -12,7 +12,7 @@ export class Renderer {
   private _viewModel: any;
   private _observers: BindingService[] = [];
 
-  constructor(private viewTemplate: HTMLDivElement) {
+  constructor(private viewTemplate: HTMLElement) {
     this.viewTemplate.innerHTML = `Loading`;
   }
 

--- a/packages/common/src/aggregators/__tests__/countAggregator.spec.ts
+++ b/packages/common/src/aggregators/__tests__/countAggregator.spec.ts
@@ -1,0 +1,52 @@
+import { CountAggregator } from '../countAggregator';
+
+describe('CountAggregator', () => {
+  let aggregator: CountAggregator;
+  let dataset = [];
+
+  beforeEach(() => {
+    dataset = [
+      { id: 0, title: 'Product 0', price: 58.5, productGroup: 'Sub-Cat1' },
+      { id: 1, title: 'Product 1', price: 14, productGroup: 'Sub-Cat1' },
+      { id: 2, title: 'Product 2', price: 2, productGroup: 'Sub-Cat2' },
+      { id: 3, title: 'Product 3', price: 87, productGroup: 'Sub-Cat1' },
+      { id: 4, title: 'Product 4', price: null, productGroup: 'Sub-Cat2' },
+    ];
+  });
+
+  it('should return a length of 1 when the dataset found 1 item', () => {
+    // arrange
+    const fieldName = 'title';
+    const groupTotals = {
+      group: {
+        rows: dataset.filter((item) => item.title === 'Product 1')
+      }
+    };
+    aggregator = new CountAggregator(fieldName);
+    aggregator.init();
+
+    // act
+    aggregator.storeResult(groupTotals);
+
+    // assert
+    expect(groupTotals['count'][fieldName]).toBe(1);
+  });
+
+  it('should return a count of the full dataset length when the group has all the same data', () => {
+    const fieldName = 'productGroup';
+    const groupTotals = {
+      count: {},
+      group: {
+        rows: dataset
+      }
+    };
+    aggregator = new CountAggregator(fieldName);
+    aggregator.init();
+
+    aggregator.storeResult(groupTotals);
+
+    expect(aggregator.field).toBe(fieldName);
+    expect(aggregator.type).toBe('count');
+    expect(groupTotals.count[fieldName]).toBe(5);
+  });
+});

--- a/packages/common/src/aggregators/avgAggregator.ts
+++ b/packages/common/src/aggregators/avgAggregator.ts
@@ -1,7 +1,7 @@
 import { Aggregator } from './../interfaces/aggregator.interface';
 
 export class AvgAggregator implements Aggregator {
-  private _nonNullCount: number = 0;
+  private _nonNullCount = 0;
   private _sum: number;
   private _field: number | string;
   private _type = 'avg';
@@ -32,11 +32,11 @@ export class AvgAggregator implements Aggregator {
   }
 
   storeResult(groupTotals: any) {
-    if (!groupTotals || groupTotals.avg === undefined) {
-      groupTotals.avg = {};
+    if (!groupTotals || groupTotals[this._type] === undefined) {
+      groupTotals[this._type] = {};
     }
     if (this._nonNullCount !== 0) {
-      groupTotals.avg[this._field] = this._sum / this._nonNullCount;
+      groupTotals[this._type][this._field] = this._sum / this._nonNullCount;
     }
   }
 }

--- a/packages/common/src/aggregators/cloneAggregator.ts
+++ b/packages/common/src/aggregators/cloneAggregator.ts
@@ -29,9 +29,9 @@ export class CloneAggregator implements Aggregator {
   }
 
   storeResult(groupTotals: any) {
-    if (!groupTotals || groupTotals.clone === undefined) {
-      groupTotals.clone = {};
+    if (!groupTotals || groupTotals[this._type] === undefined) {
+      groupTotals[this._type] = {};
     }
-    groupTotals.clone[this._field] = this._data;
+    groupTotals[this._type][this._field] = this._data;
   }
 }

--- a/packages/common/src/aggregators/countAggregator.ts
+++ b/packages/common/src/aggregators/countAggregator.ts
@@ -1,9 +1,8 @@
 import { Aggregator } from './../interfaces/aggregator.interface';
 
-export class MaxAggregator implements Aggregator {
-  private _max: number | null;
+export class CountAggregator implements Aggregator {
   private _field: number | string;
-  private _type = 'max';
+  private _type = 'count';
 
   constructor(field: number | string) {
     this._field = field;
@@ -18,22 +17,12 @@ export class MaxAggregator implements Aggregator {
   }
 
   init(): void {
-    this._max = null;
-  }
-
-  accumulate(item: any) {
-    const val = (item && item.hasOwnProperty(this._field)) ? item[this._field] : null;
-    if (val !== null && val !== '' && !isNaN(val)) {
-      if (this._max === null || val > this._max) {
-        this._max = parseFloat(val);
-      }
-    }
   }
 
   storeResult(groupTotals: any) {
     if (!groupTotals || groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }
-    groupTotals[this._type][this._field] = this._max;
+    groupTotals[this._type][this._field] = groupTotals.group.rows.length;
   }
 }

--- a/packages/common/src/aggregators/distinctAggregator.ts
+++ b/packages/common/src/aggregators/distinctAggregator.ts
@@ -29,9 +29,9 @@ export class DistinctAggregator implements Aggregator {
   }
 
   storeResult(groupTotals: any) {
-    if (!groupTotals || groupTotals.avg === undefined) {
-      groupTotals.distinct = {};
+    if (!groupTotals || groupTotals[this._type] === undefined) {
+      groupTotals[this._type] = {};
     }
-    groupTotals.distinct[this._field] = this._distinctValues;
+    groupTotals[this._type][this._field] = this._distinctValues;
   }
 }

--- a/packages/common/src/aggregators/index.ts
+++ b/packages/common/src/aggregators/index.ts
@@ -1,5 +1,6 @@
 import { AvgAggregator } from './avgAggregator';
 import { CloneAggregator } from './cloneAggregator';
+import { CountAggregator } from './countAggregator';
 import { DistinctAggregator } from './distinctAggregator';
 import { MinAggregator } from './minAggregator';
 import { MaxAggregator } from './maxAggregator';
@@ -12,6 +13,9 @@ export const Aggregators = {
 
   /** Clone Aggregator will simply clone (copy) over the last defined value of a given group */
   Clone: CloneAggregator,
+
+  /** Count Aggregator will count the number of rows in the group */
+  Count: CountAggregator,
 
   /** Distinct Aggregator will return an array of distinct values found inside the given group */
   Distinct: DistinctAggregator,

--- a/packages/common/src/aggregators/minAggregator.ts
+++ b/packages/common/src/aggregators/minAggregator.ts
@@ -31,9 +31,9 @@ export class MinAggregator implements Aggregator {
   }
 
   storeResult(groupTotals: any) {
-    if (!groupTotals || groupTotals.min === undefined) {
-      groupTotals.min = {};
+    if (!groupTotals || groupTotals[this._type] === undefined) {
+      groupTotals[this._type] = {};
     }
-    groupTotals.min[this._field] = this._min;
+    groupTotals[this._type][this._field] = this._min;
   }
 }

--- a/packages/common/src/aggregators/sumAggregator.ts
+++ b/packages/common/src/aggregators/sumAggregator.ts
@@ -1,7 +1,7 @@
 import { Aggregator } from './../interfaces/aggregator.interface';
 
 export class SumAggregator implements Aggregator {
-  private _sum: number = 0;
+  private _sum = 0;
   private _field: number | string;
   private _type = 'sum';
 
@@ -29,9 +29,9 @@ export class SumAggregator implements Aggregator {
   }
 
   storeResult(groupTotals: any) {
-    if (!groupTotals || groupTotals.sum === undefined) {
-      groupTotals.sum = {};
+    if (!groupTotals || groupTotals[this._type] === undefined) {
+      groupTotals[this._type] = {};
     }
-    groupTotals.sum[this._field] = this._sum;
+    groupTotals[this._type][this._field] = this._sum;
   }
 }

--- a/packages/common/src/extensions/__tests__/contextMenuExtension.spec.ts
+++ b/packages/common/src/extensions/__tests__/contextMenuExtension.spec.ts
@@ -492,6 +492,7 @@ describe('contextMenuExtension', () => {
     describe('adding Context Menu Command Items', () => {
       const commandItemsMock = [{
         iconCssClass: 'fa fa-question-circle',
+        title: 'Help',
         titleKey: 'HELP',
         disabled: false,
         command: 'help',
@@ -516,7 +517,6 @@ describe('contextMenuExtension', () => {
 
         jest.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(dataViewStub);
         jest.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
-        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
         jest.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock);
         jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
@@ -527,7 +527,30 @@ describe('contextMenuExtension', () => {
         extension.dispose();
       });
 
-      it('should have user Context Menu Command items', () => {
+      it('should have user Context Menu Command items when "enableTranslate" is disabled', () => {
+        const copyGridOptionsMock = {
+          ...gridOptionsMock, enableTranslate: false, enableExport: true,
+          contextMenu: {
+            commandItems: commandItemsMock,
+            hideCopyCellValueCommand: true,
+            hideExportCsvCommand: false,
+            hideExportExcelCommand: true,
+            hideExportTextDelimitedCommand: true,
+            hideClearAllGrouping: true,
+            hideCollapseAllGroups: true,
+            hideExpandAllGroups: true,
+          }
+        } as GridOption;
+        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        extension.register();
+        expect(SharedService.prototype.gridOptions.contextMenu.commandItems).toEqual([
+          { action: expect.anything(), command: 'export-csv', disabled: false, iconCssClass: 'fa fa-download', positionOrder: 51, title: 'Export in CSV format' },
+          // { action: expect.anything(), command: 'export-excel', disabled: false, iconCssClass: 'fa fa-file-excel-o text-success', positionOrder: 54, title: 'Exporter vers Excel' },
+          { command: 'help', disabled: false, iconCssClass: 'fa fa-question-circle', positionOrder: 99, title: 'Help', titleKey: 'HELP' },
+        ]);
+      });
+
+      it('should have user Context Menu Command items when "enableTranslate" is active', () => {
         extension.register();
         expect(SharedService.prototype.gridOptions.contextMenu.commandItems).toEqual([
           { action: expect.anything(), command: 'export-csv', disabled: false, iconCssClass: 'fa fa-download', positionOrder: 51, title: 'Exporter en format CSV' },

--- a/packages/common/src/extensions/contextMenuExtension.ts
+++ b/packages/common/src/extensions/contextMenuExtension.ts
@@ -70,8 +70,11 @@ export class ContextMenuExtension implements Extension {
       this.extensionUtility.loadExtensionDynamically(ExtensionName.contextMenu);
       this.sharedService.gridOptions.contextMenu = { ...contextMenu };
 
+      // merge the original commands with the built-in internal commands
+      const originalCommandItems = this._userOriginalContextMenu && Array.isArray(this._userOriginalContextMenu.commandItems) ? this._userOriginalContextMenu.commandItems : [];
+      contextMenu.commandItems = [...originalCommandItems, ...this.addMenuCustomCommands(originalCommandItems)];
+
       // sort all menu items by their position order when defined
-      contextMenu.commandItems = this.addMenuCustomCommands([]);
       this.extensionUtility.sortItems(contextMenu.commandItems || [], 'positionOrder');
       this.extensionUtility.sortItems(contextMenu.optionItems || [], 'positionOrder');
 

--- a/packages/common/src/extensions/contextMenuExtension.ts
+++ b/packages/common/src/extensions/contextMenuExtension.ts
@@ -68,11 +68,11 @@ export class ContextMenuExtension implements Extension {
 
       // dynamically import the SlickGrid plugin (addon) with RequireJS
       this.extensionUtility.loadExtensionDynamically(ExtensionName.contextMenu);
-      this.sharedService.gridOptions.contextMenu = { ...contextMenu };
 
       // merge the original commands with the built-in internal commands
       const originalCommandItems = this._userOriginalContextMenu && Array.isArray(this._userOriginalContextMenu.commandItems) ? this._userOriginalContextMenu.commandItems : [];
       contextMenu.commandItems = [...originalCommandItems, ...this.addMenuCustomCommands(originalCommandItems)];
+      this.sharedService.gridOptions.contextMenu = { ...contextMenu };
 
       // sort all menu items by their position order when defined
       this.extensionUtility.sortItems(contextMenu.commandItems || [], 'positionOrder');

--- a/packages/common/src/interfaces/aggregator.interface.ts
+++ b/packages/common/src/interfaces/aggregator.interface.ts
@@ -9,7 +9,7 @@ export interface Aggregator {
   init: () => void;
 
   /** Mathod to accumulate the result with different logic depending on each aggregator type */
-  accumulate: (item: any) => void;
+  accumulate?: (item: any) => void;
 
   /** Method to store the result into the given group total argument provided */
   storeResult?: (groupTotals: any | undefined) => void;

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -9,6 +9,7 @@ import {
   decimalFormatted,
   debounce,
   deepCopy,
+  emptyElement,
   findItemInHierarchicalStructure,
   findOrDefault,
   formatNumber,
@@ -391,6 +392,18 @@ describe('Service/Utilies', () => {
       expect(arr1[1].address.zip).toBe(222222);
       expect(arr2[0].address.zip).toBe(888888);
       expect(arr2[1].address.zip).toBe(999999);
+    });
+  });
+
+  describe('emptyElement method', () => {
+    const div = document.createElement('div');
+    div.innerHTML = `<ul><li>Item 1</li><li>Item 2</li></ul>`;
+    document.body.appendChild(div);
+
+    it('should empty the DOM element', () => {
+      expect(div.outerHTML).toBe('<div><ul><li>Item 1</li><li>Item 2</li></ul></div>');
+      emptyElement(div);
+      expect(div.outerHTML).toBe('<div></div>');
     });
   });
 

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -152,10 +152,10 @@ export function debounce<F extends ((...args: any[]) => any | void)>(func: F, wa
 /**
  * Create an immutable clone of an array or object
  * (c) 2019 Chris Ferdinandi, MIT License, https://gomakethings.com
- * @param  {Array|Object} obj The array or object to copy
+ * @param  {Array|Object} objectOrArray The array or object to copy
  * @return {Array|Object}     The clone of the array or object
  */
-export function deepCopy(obj: any) {
+export function deepCopy(objectOrArray: any) {
   /**
    * Create an immutable copy of an object
    * @return {Object}
@@ -166,9 +166,9 @@ export function deepCopy(obj: any) {
 
     // Loop through each item in the original
     // Recursively copy it's value and add to the clone
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        clone[key] = deepCopy(obj[key]);
+    for (const key in objectOrArray) {
+      if (Object.prototype.hasOwnProperty.call(objectOrArray, key)) {
+        clone[key] = deepCopy(objectOrArray[key]);
       }
     }
     return clone;
@@ -179,12 +179,12 @@ export function deepCopy(obj: any) {
    * @return {Array}
    */
   const cloneArr = () => {
-    return obj.map((item: any) => deepCopy(item));
+    return objectOrArray.map((item: any) => deepCopy(item));
   };
 
   // -- init --//
   // Get object type
-  const type = Object.prototype.toString.call(obj).slice(8, -1).toLowerCase();
+  const type = Object.prototype.toString.call(objectOrArray).slice(8, -1).toLowerCase();
 
   // If an object
   if (type === 'object') {
@@ -195,7 +195,18 @@ export function deepCopy(obj: any) {
     return cloneArr();
   }
   // Otherwise, return it as-is
-  return obj;
+  return objectOrArray;
+}
+
+/** Empty a DOM element by removing all of its DOM element children leaving with an empty element (basically an empty shell) */
+export function emptyElement(element?: HTMLElement) {
+  if (element?.firstChild) {
+    while (element.firstChild) {
+      if (element.lastChild) {
+        element.removeChild(element.lastChild);
+      }
+    }
+  }
 }
 
 /**

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -198,8 +198,11 @@ export function deepCopy(objectOrArray: any) {
   return objectOrArray;
 }
 
-/** Empty a DOM element by removing all of its DOM element children leaving with an empty element (basically an empty shell) */
-export function emptyElement(element?: HTMLElement) {
+/**
+ * Empty a DOM element by removing all of its DOM element children leaving with an empty element (basically an empty shell)
+ * @return {object} element - updated element
+ */
+export function emptyElement<T extends HTMLElement = HTMLElement>(element?: T): T | undefined {
   if (element?.firstChild) {
     while (element.firstChild) {
       if (element.lastChild) {
@@ -207,6 +210,7 @@ export function emptyElement(element?: HTMLElement) {
       }
     }
   }
+  return element;
 }
 
 /**

--- a/packages/common/src/styles/material-svg-icons.scss
+++ b/packages/common/src/styles/material-svg-icons.scss
@@ -39,6 +39,7 @@ $icon-color-mdi-playlist-remove: $icon-color !default;
 $icon-color-mdi-plus: $icon-color !default;
 $icon-color-mdi-redo: $icon-color !default;
 $icon-color-mdi-refresh: $icon-color !default;
+$icon-color-mdi-shape-square-plus: $icon-color !default;
 $icon-color-mdi-sort-ascending: $icon-color !default;
 $icon-color-mdi-sort-descending: $icon-color !default;
 $icon-color-mdi-swap-horizontal: $icon-color !default;
@@ -89,6 +90,7 @@ $icon-width-mdi-playlist-remove: $icon-width !default;
 $icon-width-mdi-plus: $icon-width !default;
 $icon-width-mdi-redo: $icon-width !default;
 $icon-width-mdi-refresh: $icon-width !default;
+$icon-width-mdi-shape-square-plus: $icon-width !default;
 $icon-width-mdi-sort-ascending: $icon-width !default;
 $icon-width-mdi-sort-descending: $icon-width !default;
 $icon-width-mdi-swap-horizontal: $icon-width !default;
@@ -305,6 +307,11 @@ $icon-width-mdi-undo: $icon-width !default;
     width: $icon-width-mdi-refresh;
     display: inline-block;
     content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{encodecolor($icon-color-mdi-refresh)}" viewBox="0 0 24 24"><path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"></path></svg>');
+  }
+  &.mdi-shape-square-plus:before {
+    width: $icon-width-mdi-shape-square-plus;
+    display: inline-block;
+    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{encodecolor($icon-color-mdi-shape-square-plus)}" viewBox="0 0 24 24"><path d="M19,5H22V7H19V10H17V7H14V5H17V2H19V5M17,19V13H19V21H3V5H11V7H5V19H17Z"></path></svg>');
   }
   &.mdi-sort-ascending:before {
     width: $icon-width-mdi-sort-ascending;

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid-constructor.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid-constructor.spec.ts
@@ -256,14 +256,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   let translateService: TranslateServiceStub;
   const http = new HttpStub();
 
-  const template = `
-  <div class="demo-container">
-    <div class="grid1 grid-pane">
-      <div class="slickgrid-container slickgrid_12345">
-        <div class="slick-pane slick-pane-header slick-pane-left" style="width: 100%;"></div>
-      </div>
-    </div>
-  </div>`;
+  const template = `<div class="demo-container"><div class="grid1"></div></div>`;
 
   beforeEach(() => {
     divContainer = document.createElement('div');

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -235,7 +235,12 @@ export class SlickVanillaGridBundle {
   }
 
   constructor(gridParentContainerElm: HTMLElement, columnDefs?: Column[], options?: GridOption, dataset?: any[], hierarchicalDataset?: any[]) {
-    // make sure that the grid container has the "slickgrid-container" css class exist since we use it for slickgrid styling
+    // make sure that the grid container doesn't already have the "slickgrid-container" css class
+    // if it does then we won't create yet another grid, just stop there
+    if (gridParentContainerElm.querySelectorAll('.slickgrid-container').length !== 0) {
+      return;
+    }
+
     gridParentContainerElm.classList.add('grid-pane');
     this._gridParentContainerElm = gridParentContainerElm as HTMLDivElement;
     this._gridContainerElm = document.createElement('div') as HTMLDivElement;

--- a/packages/vanilla-bundle/src/services/resizer.service.ts
+++ b/packages/vanilla-bundle/src/services/resizer.service.ts
@@ -170,7 +170,6 @@ export class ResizerService {
 
         // user could choose to manually stop the looped of auto resize fix
         if (this._isStopResizeIntervalRequested) {
-          // clearInterval(this._intervalId); // stop the interval if we don't need resize or if we passed let say 70min
           isResizeRequired = false;
         }
 

--- a/packages/vanilla-bundle/src/services/resizer.service.ts
+++ b/packages/vanilla-bundle/src/services/resizer.service.ts
@@ -15,8 +15,8 @@ import {
 declare const Slick: SlickNamespace;
 const DATAGRID_FOOTER_HEIGHT = 25;
 const DATAGRID_PAGINATION_HEIGHT = 35;
-const INTERVAL_MAX_RETRIES = 70;
-const INTERVAL_RETRY_DELAY = 250;
+const DEFAULT_INTERVAL_MAX_RETRIES = 70;
+const DEFAULT_INTERVAL_RETRY_DELAY = 250;
 
 export class ResizerService {
   private _grid: SlickGrid;
@@ -24,6 +24,8 @@ export class ResizerService {
   private _eventHandler: SlickEventHandler;
   private _intervalId: NodeJS.Timeout;
   private _intervalExecutionCounter = 0;
+  private _intervalRetryDelay = DEFAULT_INTERVAL_RETRY_DELAY;
+  private _isStopResizeIntervalRequested = false;
 
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
@@ -37,6 +39,13 @@ export class ResizerService {
   /** Getter for the grid uid */
   get gridUid(): string {
     return this._grid?.getUID() ?? '';
+  }
+
+  get intervalRetryDelay(): number {
+    return this._intervalRetryDelay;
+  }
+  set intervalRetryDelay(delay: number) {
+    this._intervalRetryDelay = delay;
   }
 
   constructor(private eventPubSubService: PubSubService) {
@@ -73,7 +82,7 @@ export class ResizerService {
     if (this.gridOptions.enableAutoResize && this._addon?.resizeGrid() instanceof Promise) {
       this._addon.resizeGrid()
         .then(() => this.resizeGridWhenStylingIsBrokenUntilCorrected())
-        .catch((error: any) => console.log('Error:', error));
+        .catch((rejection: any) => console.log('Error:', rejection));
     }
 
     // Events
@@ -107,6 +116,10 @@ export class ResizerService {
    */
   pauseResizer(isResizePaused: boolean) {
     this._addon.pauseResizer(isResizePaused);
+  }
+
+  requestStopOfAutoFixResizeGrid(isStopRequired = true) {
+    this._isStopResizeIntervalRequested = isStopRequired;
   }
 
   /**
@@ -153,14 +166,20 @@ export class ResizerService {
 
         // if header row is Y coordinate 0 (happens when user is not in current Tab) or when header titles are lower than the viewport of dataset (this can happen when user change Tab and DOM is not shown)
         // for these cases we'll resize until it's no longer true or until we reach a max time limit (70min)
-        const isResizeRequired = (headerPos?.top === 0 || (headerOffsetTop - viewportOffsetTop) > 40) ? true : false;
+        let isResizeRequired = (headerPos?.top === 0 || (headerOffsetTop - viewportOffsetTop) > 40) ? true : false;
+
+        // user could choose to manually stop the looped of auto resize fix
+        if (this._isStopResizeIntervalRequested) {
+          // clearInterval(this._intervalId); // stop the interval if we don't need resize or if we passed let say 70min
+          isResizeRequired = false;
+        }
 
         if (isResizeRequired && this._addon?.resizeGrid) {
           this._addon.resizeGrid();
-        } else if ((!isResizeRequired && !this.gridOptions.useSalesforceDefaultGridOptions) || (this._intervalExecutionCounter++ > (4 * 60 * INTERVAL_MAX_RETRIES))) { // interval is 250ms, so 4x is 1sec, so (4 * 60 * intervalMaxTimeInMin) shoud be 70min
+        } else if ((!isResizeRequired && !this.gridOptions.useSalesforceDefaultGridOptions) || (this._intervalExecutionCounter++ > (4 * 60 * DEFAULT_INTERVAL_MAX_RETRIES))) { // interval is 250ms, so 4x is 1sec, so (4 * 60 * intervalMaxTimeInMin) shoud be 70min
           clearInterval(this._intervalId); // stop the interval if we don't need resize or if we passed let say 70min
         }
-      }, INTERVAL_RETRY_DELAY);
+      }, this.intervalRetryDelay);
     }
   }
 }


### PR DESCRIPTION
- add a Mass Update (modal window) functionality via the Grid Menu and/or Context Menu. The Mass Update can be done for the entire dataset (when no rows are selected) or a set of selected rows 