### PR TITLE
feat(core): refactor code using the container service everywhere

### DIFF
--- a/packages/common/src/services/__tests__/shared.service.spec.ts
+++ b/packages/common/src/services/__tests__/shared.service.spec.ts
@@ -268,11 +268,6 @@ describe('Shared Service', () => {
     expect(service.hideHeaderRowAfterPageLoad).toEqual(true);
   });
 
-  it('should call "internalPubSubService" GETTER and SETTER expect same value to be returned', () => {
-    service.internalPubSubService = pubSubServiceStub;
-    expect(service.internalPubSubService).toEqual(pubSubServiceStub);
-  });
-
   it('should call "externalRegisteredResources" GETTER and return all columns', () => {
     // @ts-ignore:2511
     const mockRegisteredResources = [new ExcelExportService()];

--- a/packages/common/src/services/excelExport.service.ts
+++ b/packages/common/src/services/excelExport.service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ExcelExportOption, SlickGrid } from '../interfaces/index';
-import { SharedService } from '../services/shared.service';
+import { ContainerService } from '../services/container.service';
 
 export abstract class ExcelExportService {
   /** ExcelExportService class name which is use to find service instance in the external registered services */
@@ -9,8 +9,9 @@ export abstract class ExcelExportService {
   /**
    * Initialize the Export Service
    * @param _grid
+   * @param _containerService
    */
-  init(_grid: SlickGrid, _sharedService: SharedService): void {
+  init(_grid: SlickGrid, _containerService: ContainerService): void {
     throw new Error('ExcelExportService the "init" method must be implemented');
   }
 

--- a/packages/common/src/services/shared.service.ts
+++ b/packages/common/src/services/shared.service.ts
@@ -1,5 +1,4 @@
 import { Column, CurrentPagination, SlickDataView, GridOption, SlickGrid, SlickGroupItemMetadataProvider } from '../interfaces/index';
-import { PubSubService } from '..';
 
 export class SharedService {
   private _allColumns: Column[];
@@ -11,7 +10,6 @@ export class SharedService {
   private _visibleColumns: Column[];
   private _hideHeaderRowAfterPageLoad = false;
   private _hierarchicalDataset: any[] | undefined;
-  private _internalPubSubService: PubSubService;
   private _externalRegisteredResources: any[];
   private _frozenVisibleColumnId: string | number;
 
@@ -95,15 +93,6 @@ export class SharedService {
   /** Setter for knowing if user want to hide header row after 1st page load */
   set hideHeaderRowAfterPageLoad(hideHeaderRowAfterPageLoad: boolean) {
     this._hideHeaderRowAfterPageLoad = hideHeaderRowAfterPageLoad;
-  }
-
-  /** Getter to know if user want to hide header row after 1st page load */
-  get internalPubSubService(): PubSubService {
-    return this._internalPubSubService;
-  }
-  /** Setter for knowing if user want to hide header row after 1st page load */
-  set internalPubSubService(internalPubSubService: PubSubService) {
-    this._internalPubSubService = internalPubSubService;
   }
 
   /** Getter to know if user want to hide header row after 1st page load */

--- a/packages/common/src/services/textExport.service.ts
+++ b/packages/common/src/services/textExport.service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { TextExportOption, SlickGrid } from '../interfaces/index';
-import { SharedService } from './shared.service';
+import { ContainerService } from '../services/container.service';
 
 export abstract class TextExportService {
   /** ExcelExportService class name which is use to find service instance in the external registered services */
@@ -9,8 +9,9 @@ export abstract class TextExportService {
   /**
    * Initialize the Export Service
    * @param _grid
+   * @param _containerService
    */
-  init(_grid: SlickGrid, _sharedService: SharedService): void {
+  init(_grid: SlickGrid, _containerService: ContainerService): void {
     throw new Error('ExportService the "init" method must be implemented');
   }
 

--- a/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
@@ -6,7 +6,6 @@ import {
   GridOption,
   GridService,
   GridStateService,
-  SharedService,
   SlickDataView,
   SlickGrid,
   SlickNamespace,
@@ -123,7 +122,6 @@ function createNewColumDefinitions(count) {
 describe('CompositeEditorService', () => {
   let container: ContainerServiceStub;
   let component: SlickCompositeEditorComponent;
-  let sharedService: SharedService;
   let div: HTMLDivElement;
   let translateService: TranslateServiceStub;
   const columnsMock: Column[] = [
@@ -134,7 +132,6 @@ describe('CompositeEditorService', () => {
 
   beforeEach(() => {
     container = new ContainerServiceStub();
-    sharedService = new SharedService();
     container.registerInstance('GridService', gridServiceStub);
     container.registerInstance('GridStateService', gridStateServiceStub);
     div = document.createElement('div');
@@ -164,6 +161,17 @@ describe('CompositeEditorService', () => {
       gridOptionsMock.enableCellNavigation = true;
     });
 
+    it('should throw an error when trying to call "init()" method without finding GridService and/or GridStateService from the ContainerService', (done) => {
+      try {
+        container.registerInstance('GridService', null);
+        component = new SlickCompositeEditorComponent();
+        component.init(gridStub, container);
+      } catch (e) {
+        expect(e.toString()).toContain('[Slickgrid-Universal] it seems that the GridService and/or GridStateService are not being loaded properly, make sure the Container Service is properly implemented.');
+        done();
+      }
+    });
+
     it('should throw an error when "enableTranslateLabel" is set without a valid Translater Service', (done) => {
       try {
         const newGridOptions = { ...gridOptionsMock, enableTranslate: true };
@@ -171,7 +179,7 @@ describe('CompositeEditorService', () => {
 
         translateService = undefined as any;
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
       } catch (e) {
         expect(e.toString()).toContain(`[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.`);
         done();
@@ -185,7 +193,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
 
       const mockOnError = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', modalType: 'create', onError: mockOnError } as CompositeEditorOpenDetailOption;
@@ -202,7 +210,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(null);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
 
       const mockOnError = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', modalType: 'edit', onError: mockOnError } as CompositeEditorOpenDetailOption;
@@ -220,7 +228,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getOptions').mockReturnValue(newGridOptions);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
 
       const mockOnError = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', onError: mockOnError } as CompositeEditorOpenDetailOption;
@@ -239,7 +247,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getOptions').mockReturnValue(newGridOptions);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
 
       const mockModalOptions = { headerTitle: 'Details' } as CompositeEditorOpenDetailOption;
 
@@ -254,7 +262,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getActiveCell').mockReturnValue(null as any);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       const mockOnError = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', onError: mockOnError } as CompositeEditorOpenDetailOption;
       const spyOnError = jest.spyOn(mockModalOptions, 'onError');
@@ -271,7 +279,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getOptions').mockReturnValue(newGridOptions);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       const mockOnError = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', onError: mockOnError } as CompositeEditorOpenDetailOption;
       const spyOnError = jest.spyOn(mockModalOptions, 'onError');
@@ -292,7 +300,7 @@ describe('CompositeEditorService', () => {
       ]);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       const mockOnError = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', onError: mockOnError } as CompositeEditorOpenDetailOption;
       const spyOnError = jest.spyOn(mockModalOptions, 'onError');
@@ -309,7 +317,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit').mockReturnValue(false);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -324,7 +332,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -361,7 +369,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -391,7 +399,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', viewColumnLayout: 'auto' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -421,7 +429,7 @@ describe('CompositeEditorService', () => {
       const setActiveSpy = jest.spyOn(gridStub, 'setActiveCell');
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
@@ -437,7 +445,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
@@ -456,7 +464,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', backdrop: null });
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
@@ -479,7 +487,7 @@ describe('CompositeEditorService', () => {
       const mockModalOptions = { headerTitle: 'Details', modalType: 'edit', onClose: mockOnClose } as CompositeEditorOpenDetailOption;
       const spyOnClose = jest.spyOn(mockModalOptions, 'onClose').mockReturnValue(Promise.resolve(true));
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
       component.editors = { field1: { setValue: jest.fn(), isValueChanged: () => true } as unknown as Editor }; // return True for value changed
       gridStub.onCompositeEditorChange.notify({ row: 0, cell: 0, column: columnsMock[0], item: mockProduct, formValues: { field1: 'test' }, editors: {}, grid: gridStub });
@@ -521,7 +529,7 @@ describe('CompositeEditorService', () => {
       const mockModalOptions = { headerTitle: 'Details', modalType: 'edit', onClose: mockOnClose } as CompositeEditorOpenDetailOption;
       const spyOnClose = jest.spyOn(mockModalOptions, 'onClose').mockReturnValue(Promise.resolve(false));
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
       gridStub.onCompositeEditorChange.notify({ row: 0, cell: 0, column: columnsMock[0], item: mockProduct, formValues: { fieldX: 'test' }, editors: {}, grid: gridStub });
 
@@ -558,7 +566,7 @@ describe('CompositeEditorService', () => {
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Editing ({{id}}) - {{product.name}}' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -580,7 +588,7 @@ describe('CompositeEditorService', () => {
       const cancelSpy = jest.spyOn(gridStub.getEditController(), 'cancelCurrentEdit');
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -602,7 +610,7 @@ describe('CompositeEditorService', () => {
       const validateSpy = jest.spyOn(currentEditorMock, 'validate');
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -623,7 +631,7 @@ describe('CompositeEditorService', () => {
       const cancelSpy = jest.spyOn(gridStub.getEditController(), 'cancelCurrentEdit');
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -643,7 +651,7 @@ describe('CompositeEditorService', () => {
       const closeSpy = jest.spyOn(gridStub.getEditController(), 'cancelCurrentEdit');
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Some Details', showCloseButtonOutside: true });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -663,7 +671,7 @@ describe('CompositeEditorService', () => {
       const saveSpy = jest.spyOn(gridStub.getEditController(), 'commitCurrentEdit');
 
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -689,7 +697,7 @@ describe('CompositeEditorService', () => {
 
       const mockModalOptions = { headerTitle: 'Details', modalType: 'create' } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
       component.editors = { field1: { setValue: jest.fn(), isValueChanged: () => true } as unknown as Editor }; // return True for value changed
 
@@ -727,7 +735,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -758,7 +766,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -792,7 +800,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.editors = { field3: mockEditor };
         component.openDetails({ headerTitle: 'Details' });
 
@@ -811,7 +819,7 @@ describe('CompositeEditorService', () => {
         const disableSpy = jest.spyOn(mockEditor, 'disable');
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -844,7 +852,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -874,7 +882,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.editors = { field3: mockEditor };
         component.openDetails({ headerTitle: 'Details' });
 
@@ -893,7 +901,7 @@ describe('CompositeEditorService', () => {
         const disableSpy = jest.spyOn(mockEditor, 'disable');
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -932,7 +940,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(gridStub, 'getSelectedRows').mockReturnValue([]);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
 
         const mockOnError = jest.fn();
         const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-selection', onError: mockOnError } as CompositeEditorOpenDetailOption;
@@ -950,7 +958,7 @@ describe('CompositeEditorService', () => {
         const mockOnError = jest.fn();
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-selection', onError: mockOnError } as CompositeEditorOpenDetailOption;
         const spyOnError = jest.spyOn(mockModalOptions, 'onError');
 
@@ -963,7 +971,7 @@ describe('CompositeEditorService', () => {
 
       it('should expect to have a header title & modal type representing "mass-update" when using "auto-mass" type and there are not row selected', () => {
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: '', modalType: 'auto-mass', headerTitleMassUpdate: 'Mass Update', headerTitleMassSelection: 'Mass Selection' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -981,7 +989,7 @@ describe('CompositeEditorService', () => {
         jest.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct]);
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: '', modalType: 'auto-mass', headerTitleMassUpdate: 'Mass Update', headerTitleMassSelection: 'Mass Selection' });
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1001,7 +1009,7 @@ describe('CompositeEditorService', () => {
         const setActiveSpy = jest.spyOn(gridStub, 'setActiveCell');
 
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails({ headerTitle: '', modalType: 'auto-mass', headerTitleMassUpdate: 'Mass Update', headerTitleMassSelection: 'Mass Selection' });
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
@@ -1027,7 +1035,7 @@ describe('CompositeEditorService', () => {
         const mockOnError = jest.fn();
         const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-selection', onError: mockOnError } as CompositeEditorOpenDetailOption;
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails(mockModalOptions);
         const spyOnError = jest.spyOn(mockModalOptions, 'onError');
 
@@ -1078,7 +1086,7 @@ describe('CompositeEditorService', () => {
 
         const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-selection' } as CompositeEditorOpenDetailOption;
         component = new SlickCompositeEditorComponent();
-        component.init(gridStub, sharedService, container);
+        component.init(gridStub, container);
         component.openDetails(mockModalOptions);
 
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1143,7 +1151,7 @@ describe('CompositeEditorService', () => {
       const mockOnClose = jest.fn();
       const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-update', onClose: mockOnClose } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1194,7 +1202,7 @@ describe('CompositeEditorService', () => {
       mockOnSave.mockResolvedValue(Promise.resolve(true));
       const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-update', onSave: mockOnSave } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1243,7 +1251,7 @@ describe('CompositeEditorService', () => {
       mockOnSave.mockResolvedValue(Promise.reject(new Error('some error')));
       const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-update', onSave: mockOnSave } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1282,7 +1290,6 @@ describe('CompositeEditorService', () => {
   describe('with Translate Service', () => {
     beforeEach(() => {
       container = new ContainerServiceStub();
-      sharedService = new SharedService();
       translateService = new TranslateServiceStub();
       translateService.use('fr');
       container.registerInstance('GridService', gridServiceStub);
@@ -1307,7 +1314,7 @@ describe('CompositeEditorService', () => {
 
       const mockModalOptions = { headerTitle: 'Details', modalType: 'create' } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1346,7 +1353,7 @@ describe('CompositeEditorService', () => {
 
       const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-selection' } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
@@ -1392,7 +1399,7 @@ describe('CompositeEditorService', () => {
 
       const mockModalOptions = { headerTitle: 'Details', modalType: 'mass-update' } as CompositeEditorOpenDetailOption;
       component = new SlickCompositeEditorComponent();
-      component.init(gridStub, sharedService, container);
+      component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -25,7 +25,6 @@ import {
   SlickNamespace,
   SlickDataView,
   TranslaterService,
-  SharedService,
 } from '@slickgrid-universal/common';
 
 // using external non-typed js libraries
@@ -82,11 +81,15 @@ export class SlickCompositeEditorComponent {
     this._bindEventService = new BindingEventService();
   }
 
-  init(grid: SlickGrid, _sharedService: SharedService, containerService: ContainerService) {
+  init(grid: SlickGrid, containerService: ContainerService) {
     this.grid = grid;
     this.gridService = containerService.get<GridService>('GridService');
     this.gridStateService = containerService.get<GridStateService>('GridStateService');
     this.translaterService = containerService.get<TranslaterService>('TranslaterService');
+
+    if (!this.gridService || !this.gridStateService) {
+      throw new Error('[Slickgrid-Universal] it seems that the GridService and/or GridStateService are not being loaded properly, make sure the Container Service is properly implemented.');
+    }
 
     if (this.gridOptions.enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -16,6 +16,7 @@ import {
   SortComparers,
   PubSubService,
 } from '@slickgrid-universal/common';
+import { ContainerServiceStub } from '../../../test/containerServiceStub';
 import { TranslateServiceStub } from '../../../test/translateServiceStub';
 import { ExcelExportService } from './excelExport.service';
 
@@ -72,8 +73,8 @@ const gridStub = {
 } as unknown as SlickGrid;
 
 describe('ExcelExportService', () => {
+  let container: ContainerServiceStub;
   let service: ExcelExportService;
-  let sharedService: SharedService;
   let translateService: TranslateServiceStub;
   let mockColumns: Column[];
   let mockExcelBlob: Blob;
@@ -81,10 +82,10 @@ describe('ExcelExportService', () => {
 
   describe('with Translater Service', () => {
     beforeEach(() => {
-      sharedService = new SharedService();
       translateService = new TranslateServiceStub();
+      container = new ContainerServiceStub();
+      container.registerInstance('PubSubService', pubSubServiceStub);
       mockGridOptions.translater = translateService;
-      sharedService.internalPubSubService = pubSubServiceStub;
 
       (navigator as any).__defineGetter__('appName', () => 'Netscape');
       navigator.msSaveOrOpenBlob = undefined as any;
@@ -115,7 +116,7 @@ describe('ExcelExportService', () => {
 
       const optionExpectation = { filename: 'export.xlsx', format: FileType.xlsx };
 
-      service.init(gridStub, sharedService);
+      service.init(gridStub, container);
       const result = await service.exportToExcel(mockExportExcelOptions);
 
       expect(result).toBeTruthy();
@@ -141,17 +142,17 @@ describe('ExcelExportService', () => {
 
       it('should throw an error when trying call exportToExcel" without a grid and/or dataview object initialized', async () => {
         try {
-          service.init(null as any, sharedService);
+          service.init(null as any, container);
           await service.exportToExcel(mockExportExcelOptions);
         } catch (e) {
-          expect(e.toString()).toContain('[Slickgrid-Universal] it seems that the SlickGrid & DataView objects are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
+          expect(e.toString()).toContain('[Slickgrid-Universal] it seems that the SlickGrid & DataView objects and/or PubSubService are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
         }
       });
 
       it('should trigger an event before exporting the file', async () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         const result = await service.exportToExcel(mockExportExcelOptions);
 
         expect(result).toBeTruthy();
@@ -161,7 +162,7 @@ describe('ExcelExportService', () => {
       it('should trigger an event after exporting the file', async () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         const result = await service.exportToExcel(mockExportExcelOptions);
 
         expect(result).toBeTruthy();
@@ -174,7 +175,7 @@ describe('ExcelExportService', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyUrlCreate = jest.spyOn(URL, 'createObjectURL');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         const result = await service.exportToExcel(mockExportExcelOptions);
 
         expect(result).toBeTruthy();
@@ -189,7 +190,7 @@ describe('ExcelExportService', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyMsSave = jest.spyOn(navigator, 'msSaveOrOpenBlob');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         const result = await service.exportToExcel(mockExportExcelOptions);
 
         expect(result).toBeTruthy();
@@ -211,7 +212,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: FileType.xlsx };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -240,7 +241,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -269,7 +270,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -298,7 +299,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -327,7 +328,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -356,7 +357,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -386,7 +387,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -416,7 +417,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -466,7 +467,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -522,7 +523,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: FileType.xlsx };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -569,7 +570,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -616,7 +617,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -707,7 +708,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -801,7 +802,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -924,7 +925,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -961,7 +962,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -994,7 +995,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '2012-02-28 15:07:59';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTime);
 
@@ -1005,7 +1006,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '2012-02-28 15:07:59';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeIso);
 
@@ -1016,7 +1017,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '2012-02-28 15:07';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeShortIso);
 
@@ -1027,7 +1028,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '2012-02-28 03:07:59 pm';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeIsoAmPm);
 
@@ -1038,7 +1039,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '2012-02-28 03:07:59 PM';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeIsoAM_PM);
 
@@ -1049,7 +1050,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/02/2012';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateEuro);
 
@@ -1060,7 +1061,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/2/12';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateEuroShort);
 
@@ -1071,7 +1072,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/02/2012 15:07:59';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeEuro);
 
@@ -1082,7 +1083,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/02/2012 15:07';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeShortEuro);
 
@@ -1093,7 +1094,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/02/2012 03:07:59 pm';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeEuroAmPm);
 
@@ -1104,7 +1105,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/02/2012 03:07:59 PM';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeEuroAM_PM);
 
@@ -1115,7 +1116,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/2/12 15:7:59';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeEuroShort);
 
@@ -1126,7 +1127,7 @@ describe('ExcelExportService', () => {
         const input = '2012-02-28 15:07:59';
         const expectedDate = '28/2/12 3:7:59 pm';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeEuroShortAmPm);
 
@@ -1137,7 +1138,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '02/28/2012';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateUs);
 
@@ -1148,7 +1149,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '2/28/12';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateUsShort);
 
@@ -1159,7 +1160,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '02/28/2012 15:07:59';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeUs);
 
@@ -1170,7 +1171,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '02/28/2012 15:07';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeShortUs);
 
@@ -1181,7 +1182,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '02/28/2012 03:07:59 pm';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeUsAmPm);
 
@@ -1192,7 +1193,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '02/28/2012 03:07:59 PM';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeUsAM_PM);
 
@@ -1203,7 +1204,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '2/28/12 15:7:59';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeUsShort);
 
@@ -1214,7 +1215,7 @@ describe('ExcelExportService', () => {
         const input = new Date('2012-02-28 15:07:59');
         const expectedDate = '2/28/12 3:7:59 pm';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateTimeUsShortAmPm);
 
@@ -1225,7 +1226,7 @@ describe('ExcelExportService', () => {
         const input = moment('2013-05-23T17:55:00.325').utcOffset(420); // timezone that is +7 UTC hours
         const expectedDate = '2013-05-24T04:55:00.325+07:00';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.dateUtc);
 
@@ -1236,7 +1237,7 @@ describe('ExcelExportService', () => {
         const input = new Date(Date.UTC(2012, 1, 28, 23, 1, 52, 103));
         const expectedDate = '2012-02-28';
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
         const output = service.useCellFormatByFieldType(input, FieldType.date);
 
@@ -1274,7 +1275,7 @@ describe('ExcelExportService', () => {
 
         const optionExpectation = { filename: 'export.xlsx', format: FileType.xlsx };
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         await service.exportToExcel(mockExportExcelOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -1333,7 +1334,7 @@ describe('ExcelExportService', () => {
 
           const optionExpectation = { filename: 'export.xlsx', format: FileType.xlsx };
 
-          service.init(gridStub, sharedService);
+          service.init(gridStub, container);
           await service.exportToExcel(mockExportExcelOptions);
 
           expect(pubSubSpy).toHaveBeenCalledWith(`onAfterExportToExcel`, optionExpectation);
@@ -1372,7 +1373,7 @@ describe('ExcelExportService', () => {
       const gridOptionsMock = { enableTranslate: true, enableGridMenu: true, translater: undefined as any, gridMenu: { hideForceFitButton: false, hideSyncResizeButton: true, columnTitleKey: 'TITLE' } } as GridOption;
       jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
 
-      expect(() => service.init(gridStub, sharedService)).toThrowError('[Slickgrid-Universal] requires a Translate Service to be passed in the "translater" Grid Options when "enableTranslate" is enabled.');
+      expect(() => service.init(gridStub, container)).toThrowError('[Slickgrid-Universal] requires a Translate Service to be passed in the "translater" Grid Options when "enableTranslate" is enabled.');
     });
   });
 });

--- a/packages/text-export/src/textExport.service.spec.ts
+++ b/packages/text-export/src/textExport.service.spec.ts
@@ -16,6 +16,7 @@ import {
   SortDirectionNumber,
   TextExportOption,
 } from '@slickgrid-universal/common';
+import { ContainerServiceStub } from '../../../test/containerServiceStub';
 import { TranslateServiceStub } from '../../../test/translateServiceStub';
 
 function removeMultipleSpaces(textS) {
@@ -66,8 +67,8 @@ const gridStub = {
 } as unknown as SlickGrid;
 
 describe('ExportService', () => {
+  let container: ContainerServiceStub;
   let service: TextExportService;
-  let sharedService: SharedService;
   let translateService: TranslateServiceStub;
   let mockColumns: Column[];
   let mockExportCsvOptions: TextExportOption;
@@ -77,10 +78,10 @@ describe('ExportService', () => {
 
   describe('with Translater Service', () => {
     beforeEach(() => {
-      sharedService = new SharedService();
       translateService = new TranslateServiceStub();
+      container = new ContainerServiceStub();
+      container.registerInstance('PubSubService', pubSubServiceStub);
       mockGridOptions.translater = translateService;
-      sharedService.internalPubSubService = pubSubServiceStub;
 
       (navigator as any).__defineGetter__('appName', () => 'Netscape');
       navigator.msSaveOrOpenBlob = undefined as any;
@@ -120,7 +121,7 @@ describe('ExportService', () => {
       const optionExpectation = { filename: 'export.csv', format: 'csv', mimeType: 'text/plain', useUtf8WithBom: false };
       const contentExpectation = '';
 
-      service.init(gridStub, sharedService);
+      service.init(gridStub, container);
       service.exportToFile(mockExportCsvOptions);
 
       setTimeout(() => {
@@ -147,10 +148,10 @@ describe('ExportService', () => {
 
       it('should throw an error when trying call exportToFile" without a grid and/or dataview object initialized', (done) => {
         try {
-          service.init(null as any, sharedService);
+          service.init(null as any, container);
           service.exportToFile(mockExportTxtOptions);
         } catch (e) {
-          expect(e.toString()).toContain('[Slickgrid-Universal] it seems that the SlickGrid & DataView objects are not initialized did you forget to enable the grid option flag "enableTextExport"?');
+          expect(e.toString()).toContain('[Slickgrid-Universal] it seems that the SlickGrid & DataView objects and/or PubSubService are not initialized did you forget to enable the grid option flag "enableTextExport"?');
           done();
         }
       });
@@ -158,7 +159,7 @@ describe('ExportService', () => {
       it('should trigger an event before exporting the file', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         expect(pubSubSpy).toHaveBeenCalledWith(`onBeforeExportToTextFile`, true);
@@ -167,7 +168,7 @@ describe('ExportService', () => {
       it('should trigger an event after exporting the file', (done) => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         setTimeout(() => {
@@ -181,7 +182,7 @@ describe('ExportService', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyUrlCreate = jest.spyOn(URL, 'createObjectURL');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -196,7 +197,7 @@ describe('ExportService', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyMsSave = jest.spyOn(navigator, 'msSaveOrOpenBlob');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -210,7 +211,7 @@ describe('ExportService', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyUrlCreate = jest.spyOn(URL, 'createObjectURL');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         setTimeout(() => {
@@ -225,7 +226,7 @@ describe('ExportService', () => {
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyMsSave = jest.spyOn(navigator, 'msSaveOrOpenBlob');
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         setTimeout(() => {
@@ -256,7 +257,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="1E06","John","Z","SALES_REP","<b>10</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -281,7 +282,7 @@ describe('ExportService', () => {
           `"User Id";;"FirstName";;"LastName";;"Position";;"Order"
               ="1E06";;"John";;"Z";;"SALES_REP";;"<b>10</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -306,7 +307,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="1E06","John","Z","SALES_REP","<b>10</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -330,7 +331,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="2B02","Jane","DOE","FINANCE_MANAGER","<b>1</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -354,7 +355,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="3C2","Ava Luna","","HUMAN_RESOURCES","<b>3</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -378,7 +379,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="","Ava","LUNA","HUMAN_RESOURCES","<b>3</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -402,7 +403,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="3C2","Ava","LUNA","HUMAN_RESOURCES",""`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -426,7 +427,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="","","CASH","SALES_REP","<b>3</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -451,7 +452,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="2B02","Jane","DOE","FINANCE_MANAGER","1"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -477,7 +478,7 @@ describe('ExportService', () => {
           `"User Id","FirstName","LastName","Position","Order"
           ="2B02","Jane","DOE","FINANCE_MANAGER","<b>1</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -516,7 +517,7 @@ describe('ExportService', () => {
           `"First Name","Last Name","Position"
               "John","Z","SALES_REP"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -565,7 +566,7 @@ describe('ExportService', () => {
           `"User Id","First Name","Last Name","Position","Order"
           ="1E06","John","Z","Sales Rep.","<b>10</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -653,7 +654,7 @@ describe('ExportService', () => {
              "",="2B02","Jane","DOE","FINANCE_MANAGER","10"
              "","","","","","20"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -677,7 +678,7 @@ describe('ExportService', () => {
              ;=2B02;Jane;DOE;FINANCE_MANAGER;10
              ;;;;;20`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         setTimeout(() => {
@@ -765,7 +766,7 @@ describe('ExportService', () => {
              "",="2B02","Jane","DOE","Finance Manager","10"
              "","","","","","20"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -789,7 +790,7 @@ describe('ExportService', () => {
              ;=2B02;Jane;DOE;Finance Manager;10
              ;;;;;20`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         setTimeout(() => {
@@ -901,7 +902,7 @@ describe('ExportService', () => {
              "","","","","","20"
              "","","","","","10"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -928,7 +929,7 @@ describe('ExportService', () => {
              ;;;;;20
              ;;;;;10`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportTxtOptions);
 
         setTimeout(() => {
@@ -974,7 +975,7 @@ describe('ExportService', () => {
           "FirstName","LastName","User Id","Position","Order"
           "John","Z",="1E06","SALES_REP","<b>10</b>"`;
 
-        service.init(gridStub, sharedService);
+        service.init(gridStub, container);
         service.exportToFile(mockExportCsvOptions);
 
         setTimeout(() => {
@@ -1022,7 +1023,7 @@ describe('ExportService', () => {
             "First Name","Last Name","User Id","Position","Order"
             "John","Z",="1E06","Sales Rep.","<b>10</b>"`;
 
-          service.init(gridStub, sharedService);
+          service.init(gridStub, container);
           service.exportToFile(mockExportCsvOptions);
 
           setTimeout(() => {
@@ -1046,7 +1047,7 @@ describe('ExportService', () => {
       const gridOptionsMock = { enableTranslate: true, enableGridMenu: true, translater: undefined as any, gridMenu: { hideForceFitButton: false, hideSyncResizeButton: true, columnTitleKey: 'TITLE' } } as GridOption;
       jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
 
-      expect(() => service.init(gridStub, sharedService)).toThrowError('[Slickgrid-Universal] requires a Translate Service to be passed in the "translater" Grid Options when "enableTranslate" is enabled.');
+      expect(() => service.init(gridStub, container)).toThrowError('[Slickgrid-Universal] requires a Translate Service to be passed in the "translater" Grid Options when "enableTranslate" is enabled.');
     });
   });
 });

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -845,7 +845,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
 
         // @ts-ignore
-        expect(spy).toHaveBeenCalledWith(mockGrid, sharedService, container);
+        expect(spy).toHaveBeenCalledWith(mockGrid, container);
       });
 
       it('should not initialize groupingAndColspanService when "createPreHeaderPanel" grid option is enabled and "enableDraggableGrouping" is also enabled', () => {

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -363,6 +363,7 @@ export class SlickVanillaGridBundle {
     const eventHandler = new Slick.EventHandler();
 
     // register all service instances in the container
+    this.universalContainerService.registerInstance('PubSubService', this._eventPubSubService); // external resources require this one registration (ExcelExport, TextExport)
     this.universalContainerService.registerInstance('EventPubSubService', this._eventPubSubService);
     this.universalContainerService.registerInstance('ExtensionUtility', this.extensionUtility);
     this.universalContainerService.registerInstance('FilterService', this.filterService);
@@ -473,7 +474,6 @@ export class SlickVanillaGridBundle {
     this.backendServiceApi = this._gridOptions?.backendServiceApi;
     this._isLocalGrid = !this.backendServiceApi; // considered a local grid if it doesn't have a backend service set
     this._eventPubSubService.eventNamingStyle = this._gridOptions?.eventNamingStyle ?? EventNamingStyle.camelCase;
-    this.sharedService.internalPubSubService = this._eventPubSubService;
     this._paginationOptions = this.gridOptions?.pagination;
 
     this.createBackendApiInternalPostProcessCallback(this._gridOptions);
@@ -645,7 +645,7 @@ export class SlickVanillaGridBundle {
     if (Array.isArray(this._registeredResources)) {
       for (const service of this._registeredResources) {
         if (typeof service.init === 'function') {
-          service.init(this.slickGrid, this.sharedService, this.universalContainerService);
+          service.init(this.slickGrid, this.universalContainerService);
           if (service instanceof SlickCompositeEditorComponent) {
             this.slickCompositeEditor = service;
           }

--- a/packages/vanilla-bundle/src/services/__tests__/textExport.service.spec.ts
+++ b/packages/vanilla-bundle/src/services/__tests__/textExport.service.spec.ts
@@ -1,4 +1,5 @@
 import { GridOption, SharedService, SlickGrid, SlickDataView, PubSubService } from '@slickgrid-universal/common';
+import { ContainerServiceStub } from '../../../../../test/containerServiceStub';
 import { TextExportService } from '../textExport.service';
 
 const mockGridOptions = { enableTranslate: false } as GridOption;
@@ -30,18 +31,18 @@ const pubSubServiceStub = {
 
 describe('TextExport Service', () => {
   let service: TextExportService;
-  let sharedService: SharedService;
+  let container: ContainerServiceStub;
 
   beforeEach(() => {
-    sharedService = new SharedService();
-    sharedService.internalPubSubService = pubSubServiceStub;
+    container = new ContainerServiceStub();
+    container.registerInstance('PubSubService', pubSubServiceStub);
     service = new TextExportService();
   });
 
   it('should initialize the service', () => {
     const spy = jest.spyOn(service, 'exportToFile');
 
-    service.init(gridStub, sharedService);
+    service.init(gridStub, container);
     service.exportToFile({ exportWithFormatter: true, sanitizeDataExport: true });
 
     expect(service).toBeTruthy();

--- a/packages/vanilla-bundle/src/services/textExport.service.ts
+++ b/packages/vanilla-bundle/src/services/textExport.service.ts
@@ -1,4 +1,4 @@
-import { SharedService, SlickGrid, TextExportOption } from '@slickgrid-universal/common';
+import { ContainerService, SlickGrid, TextExportOption } from '@slickgrid-universal/common';
 import { TextExportService as UniversalExportService } from '@slickgrid-universal/text-export';
 
 export class TextExportService extends UniversalExportService {
@@ -6,8 +6,8 @@ export class TextExportService extends UniversalExportService {
     super();
   }
 
-  init(grid: SlickGrid, sharedService: SharedService): void {
-    super.init(grid, sharedService);
+  init(grid: SlickGrid, containerService: ContainerService): void {
+    super.init(grid, containerService);
   }
 
   exportToFile(options: TextExportOption): Promise<boolean> {

--- a/test/containerServiceStub.ts
+++ b/test/containerServiceStub.ts
@@ -16,9 +16,11 @@ export class ContainerServiceStub implements ContainerService {
   }
 
   registerInstance(key: string, instance: any) {
-    const dependency = this.dependencies.find(dep => dep.key === key);
-    if (!dependency) {
+    const dependencyIndex = this.dependencies.findIndex(dep => dep.key === key);
+    if (dependencyIndex === -1) {
       this.dependencies.push({ key, instance });
+    } else {
+      this.dependencies[dependencyIndex].instance = instance;
     }
   }
 }


### PR DESCRIPTION
- also removed the `internalPubSubService` since it's no longer necessary because we can now get it from the container instead