### PR TITLE
fix(core): change moment/lodash imports so it works with ES6 module

### DIFF
--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -3,7 +3,7 @@ import * as moment_ from 'moment-mini';
 import { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
 import { FlatpickrFn } from 'flatpickr/dist/types/instance';
 const flatpickr: FlatpickrFn = _flatpickr as any; // patch for rollup
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import { Constants } from './../constants';
 import { FieldType } from '../enums/index';

--- a/packages/common/src/filter-conditions/executeMappedCondition.ts
+++ b/packages/common/src/filter-conditions/executeMappedCondition.ts
@@ -10,7 +10,7 @@ import { mapMomentDateFormatWithFieldType } from './../services/utilities';
 import { testFilterCondition } from './filterUtilities';
 import * as moment_ from 'moment-mini';
 
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 export const executeMappedCondition: FilterCondition = (options: FilterConditionOption) => {
   // when using a multi-select ('IN' operator) we will not use the field type but instead go directly with a collection search

--- a/packages/common/src/filters/dateRangeFilter.ts
+++ b/packages/common/src/filters/dateRangeFilter.ts
@@ -1,6 +1,6 @@
 import * as flatpickr from 'flatpickr';
 import * as moment_ from 'moment-mini';
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import {
   FieldType,

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -2,7 +2,7 @@ import { FieldType } from '../enums/fieldType.enum';
 import { Column, Formatter, GridOption, SlickGrid } from '../interfaces/index';
 import { mapMomentDateFormatWithFieldType } from '../services/utilities';
 import * as moment_ from 'moment-mini';
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 /**
  * Find the option value from the following (in order of execution)

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -1,5 +1,5 @@
 import * as isequal_ from 'lodash.isequal';
-const isequal = isequal_; // patch to fix rollup to work
+const isequal = isequal_['default'] || isequal_; // patch to fix rollup to work
 
 import { FilterConditions } from './../filter-conditions/index';
 import { FilterFactory } from './../filters/filterFactory';

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -1,5 +1,5 @@
 import * as isequal_ from 'lodash.isequal';
-const isequal = isequal_; // patch to fix rollup to work
+const isequal = isequal_['default'] || isequal_; // patch to fix rollup to work
 
 import {
   ExtensionName,

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -1,5 +1,5 @@
 import * as isequal_ from 'lodash.isequal';
-const isequal = isequal_; // patch to fix rollup to work
+const isequal = isequal_['default'] || isequal_; // patch to fix rollup to work
 
 import {
   BackendServiceApi,

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -1,7 +1,7 @@
 import * as DOMPurify_ from 'dompurify';
 import * as moment_ from 'moment-mini';
 const DOMPurify = DOMPurify_; // patch to fix rollup to work
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import { FieldType, OperatorString, OperatorType } from '../enums/index';
 import { GridOption } from '../interfaces/index';

--- a/packages/common/src/sortComparers/dateUtilities.ts
+++ b/packages/common/src/sortComparers/dateUtilities.ts
@@ -2,7 +2,7 @@ import { mapMomentDateFormatWithFieldType } from '../services/utilities';
 import { FieldType } from '../enums/fieldType.enum';
 import { Column, GridOption, SortComparer } from '../interfaces/index';
 import * as moment_ from 'moment-mini';
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 export function compareDates(value1: any, value2: any, sortDirection: number, sortColumn: Column, gridOptions: GridOption, format: string | moment_.MomentBuiltinFormat, strict?: boolean) {
   let diff = 0;

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -1,6 +1,6 @@
 import * as ExcelBuilder from 'excel-builder-webpacker';
 import * as moment_ from 'moment-mini';
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import {
   // utility functions

--- a/packages/vanilla-bundle/src/components/slick-footer.component.ts
+++ b/packages/vanilla-bundle/src/components/slick-footer.component.ts
@@ -1,5 +1,5 @@
 import * as moment_ from 'moment-mini';
-const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+const moment = moment_['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import {
   Constants,


### PR DESCRIPTION
- ES6 wants us to use `import moment` but in TypeScript it asks for `import * as moment`, if we do `const moment = moment_['default'] || moment_;` we will get either/or, whichever works first and that works on both side of the fence