### PR TITLE
fix(plugins): add missing Row Detail filtering code

### DIFF
--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -22,7 +22,7 @@ import {
   HeaderMenu,
   Locale,
   Pagination,
-  // RowDetailView,
+  RowDetailView,
   RowMoveManager,
   RowSelectionModelOption,
   TextExportOption,
@@ -435,7 +435,7 @@ export interface GridOption {
   registerExternalResources?: ExternalResource[];
 
   /** Row Detail View Plugin options & events (columnId, cssClass, toolTip, width) */
-  // rowDetailView?: RowDetailView;
+  rowDetailView?: RowDetailView;
 
   /** Grid row height in pixels (only type the number). Row of cell values. */
   rowHeight?: number;

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -12,6 +12,7 @@ import {
   GridMenuItem,
   GridOption,
   MenuCommandItem,
+  RowDetailView,
   SlickDataView,
   SlickEventHandler,
   SlickGrid,
@@ -754,34 +755,34 @@ describe('FilterService', () => {
       expect(output).toBe(true);
     });
 
-    // it('should return True when using row detail and the item is found in its parent', () => {
-    //   gridOptionMock.enableRowDetailView = true;
-    //   const mockColumn1 = { id: 'zip', field: 'zip', filterable: true, queryFieldFilter: 'address.zip' } as Column;
-    //   const mockItem2 = { __isPadding: true, __parent: mockItem1 };
-    //   jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
-    //   jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(0);
+    it('should return True when using row detail and the item is found in its parent', () => {
+      gridOptionMock.enableRowDetailView = true;
+      const mockColumn1 = { id: 'zip', field: 'zip', filterable: true, queryFieldFilter: 'address.zip' } as Column;
+      const mockItem2 = { __isPadding: true, __parent: mockItem1 };
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+      jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(0);
 
-    //   service.init(gridStub);
-    //   const columnFilters = { zip: { columnDef: mockColumn1, columnId: 'zip', operator: 'EQ', searchTerms: [123456] } };
-    //   const output = service.customLocalFilter(mockItem2, { dataView: dataViewStub, grid: gridStub, columnFilters });
+      service.init(gridStub);
+      const columnFilters = { zip: { columnDef: mockColumn1, columnId: 'zip', operator: 'EQ', searchTerms: [123456] } };
+      const output = service.customLocalFilter(mockItem2, { dataView: dataViewStub, grid: gridStub, columnFilters });
 
-    //   expect(output).toBe(true);
-    // });
+      expect(output).toBe(true);
+    });
 
-    // it('should return True when using row detail custom "keyPrefix" and the item is found in its parent', () => {
-    //   gridOptionMock.rowDetailView = { keyPrefix: 'prefix_' } as RowDetail;
-    //   gridOptionMock.enableRowDetailView = true;
-    //   const mockColumn1 = { id: 'zip', field: 'zip', filterable: true, queryFieldFilter: 'address.zip' } as Column;
-    //   const mockItem2 = { prefix_isPadding: true, prefix_parent: mockItem1 };
-    //   jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
-    //   jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(0);
+    it('should return True when using row detail custom "keyPrefix" and the item is found in its parent', () => {
+      gridOptionMock.rowDetailView = { keyPrefix: 'prefix_' } as RowDetailView;
+      gridOptionMock.enableRowDetailView = true;
+      const mockColumn1 = { id: 'zip', field: 'zip', filterable: true, queryFieldFilter: 'address.zip' } as Column;
+      const mockItem2 = { prefix_isPadding: true, prefix_parent: mockItem1 };
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+      jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(0);
 
-    //   service.init(gridStub);
-    //   const columnFilters = { zip: { columnDef: mockColumn1, columnId: 'zip', operator: 'EQ', searchTerms: [123456] } };
-    //   const output = service.customLocalFilter(mockItem2, { dataView: dataViewStub, grid: gridStub, columnFilters });
+      service.init(gridStub);
+      const columnFilters = { zip: { columnDef: mockColumn1, columnId: 'zip', operator: 'EQ', searchTerms: [123456] } };
+      const output = service.customLocalFilter(mockItem2, { dataView: dataViewStub, grid: gridStub, columnFilters });
 
-    //   expect(output).toBe(true);
-    // });
+      expect(output).toBe(true);
+    });
 
     it('should execute "queryFieldNameGetterFn()" callback and return True when input value matches the full name', () => {
       const mockColumn1 = { id: 'name', field: 'name', filterable: true, queryFieldNameGetterFn: () => 'fullName' } as Column;

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -350,12 +350,12 @@ export class FilterService {
     }
 
     // Row Detail View plugin, if the row is padding we just get the value we're filtering on from it's parent
-    // if (this._gridOptions.enableRowDetailView) {
-    //   const metadataPrefix = this._gridOptions.rowDetailView && this._gridOptions.rowDetailView.keyPrefix || '__';
-    //   if (item[`${metadataPrefix}isPadding`] && item[`${metadataPrefix}parent`]) {
-    //     item = item[`${metadataPrefix}parent`];
-    //   }
-    // }
+    if (this._gridOptions.enableRowDetailView) {
+      const metadataPrefix = this._gridOptions.rowDetailView && this._gridOptions.rowDetailView.keyPrefix || '__';
+      if (item[`${metadataPrefix}isPadding`] && item[`${metadataPrefix}parent`]) {
+        item = item[`${metadataPrefix}parent`];
+      }
+    }
 
     const dataKey = columnDef.dataKey;
     let queryFieldName = columnDef.filter?.queryField || columnDef.queryFieldFilter || columnDef.queryField || columnDef.field || '';


### PR DESCRIPTION
- get the item data context from its parrent object when using row detail