### PR TITLE
fix(tsc): running dev watch was overriding commonjs folder

### DIFF
--- a/packages/excel-export/tsconfig.json
+++ b/packages/excel-export/tsconfig.json
@@ -2,14 +2,12 @@
   "extends": "../tsconfig-build.json",
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "src",
-    "declarationDir": "dist/commonjs",
-    "outDir": "dist/commonjs",
+    "declarationDir": "dist/esm",
+    "outDir": "dist/esm",
     "target": "es2020",
     "module": "esnext",
     "sourceMap": true,
-    "allowSyntheticDefaultImports": true,
     "noImplicitReturns": true,
     "lib": [
       "es2020",
@@ -17,6 +15,7 @@
     ],
     "types": [
       "moment",
+      "jquery",
       "node"
     ],
     "typeRoots": [

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -3,8 +3,8 @@
   "compileOnSave": false,
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "dist/commonjs",
-    "outDir": "dist/commonjs",
+    "declarationDir": "dist/esm",
+    "outDir": "dist/esm",
     "target": "es2020",
     "module": "esnext",
     "sourceMap": true,

--- a/packages/odata/tsconfig.json
+++ b/packages/odata/tsconfig.json
@@ -3,8 +3,8 @@
   "compileOnSave": false,
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "dist/commonjs",
-    "outDir": "dist/commonjs",
+    "declarationDir": "dist/esm",
+    "outDir": "dist/esm",
     "target": "es2020",
     "module": "esnext",
     "sourceMap": true,

--- a/packages/text-export/tsconfig.json
+++ b/packages/text-export/tsconfig.json
@@ -3,8 +3,8 @@
   "compileOnSave": false,
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "dist/commonjs",
-    "outDir": "dist/commonjs",
+    "declarationDir": "dist/esm",
+    "outDir": "dist/esm",
     "target": "es2020",
     "module": "esnext",
     "sourceMap": true,


### PR DESCRIPTION
- the build folder was incorrectly set in a few packages which was overriding the commonjs folder when running dev watch and also breaking Jest when run in parallel which requires commonjs when testing