### PR TITLE
fix(helpers): should be able to highlight first row (0)

### DIFF
--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -49,6 +49,7 @@ const dataviewStub = {
   deleteItem: jest.fn(),
   deleteItems: jest.fn(),
   getIdxById: jest.fn(),
+  getItemMetadata: jest.fn(),
   getItem: jest.fn(),
   getRowById: jest.fn(),
   insertItem: jest.fn(),
@@ -1506,6 +1507,28 @@ describe('Grid Service', () => {
 
       expect(extensionSpy).toHaveBeenCalled();
       expect(gridStateSpy).toHaveBeenCalledWith(mockColumns);
+    });
+  });
+
+  describe('highlightRow method', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should be able to highlight first row at zero index', () => {
+      const mockRowMetadata = (rowNumber) => ({ cssClasses: `row-${rowNumber}` });
+      const mockItem = { id: 0, firstName: 'John', lastName: 'Doe' };
+      jest.spyOn(service, 'getItemRowMetadataToHighlight').mockReturnValue(mockRowMetadata);
+      jest.spyOn(dataviewStub, 'getItem').mockReturnValue(mockItem);
+      jest.spyOn(dataviewStub, 'getIdxById').mockReturnValue(0);
+      const updateSpy = jest.spyOn(dataviewStub, 'updateItem');
+      const renderSpy = jest.spyOn(service, 'renderGrid');
+
+      service.highlightRow(0, 10, 15);
+      jest.runAllTimers(); // fast-forward timer
+
+      expect(updateSpy).toHaveBeenCalledWith(0, mockItem)
+      expect(renderSpy).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -312,7 +312,7 @@ export class GridService {
     const item = this._dataView.getItem(rowNumber);
     const idPropName = this._gridOptions.datasetIdPropertyName || 'id';
 
-    if (item && item[idPropName]) {
+    if (item?.[idPropName] !== undefined) {
       item.rowClass = 'highlight';
       this._dataView.updateItem(item[idPropName], item);
       this.renderGrid();
@@ -327,7 +327,7 @@ export class GridService {
 
       // delete the row's CSS highlight classes once the delay is passed
       setTimeout(() => {
-        if (item && item[idPropName]) {
+        if (item?.[idPropName] !== undefined) {
           delete item.rowClass;
           if (this._dataView.getIdxById(item[idPropName]) !== undefined) {
             this._dataView.updateItem(item[idPropName], item);
@@ -416,7 +416,7 @@ export class GridService {
 
     // row number in the grid, by default it will be on first row (top is the default)
     let rowNumber: number | undefined = 0;
-    const itemId = item && item[idPropName] || '';
+    const itemId = item?.[idPropName] ?? '';
 
     // do we want the item to be sorted in the grid, when set to False it will insert on first row (defaults to false)
     if (options.resortGrid) {
@@ -552,7 +552,7 @@ export class GridService {
 
     const itemIds: string[] = [];
     items.forEach((item: T) => {
-      if (item && item[idPropName] !== undefined) {
+      if (item?.[idPropName] !== undefined) {
         itemIds.push(item[idPropName]);
       }
     });


### PR DESCRIPTION
- calling `highlightRow(0)` was not highlighting the row when it should
- fixes Aurelia-Slickgrid [issue #527](https://github.com/ghiscoding/aurelia-slickgrid/issues/527)