### PR TITLE
fix(filters): rollback a change made in PR #288 causing preset issues

### DIFF
--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -864,7 +864,7 @@ export class FilterService {
       let searchTerms: SearchTerm[] | undefined;
       let operator: OperatorString | OperatorType | undefined;
       const newFilter: Filter | undefined = this.filterFactory.createFilter(columnDef.filter);
-      operator = columnDef?.filter?.operator ?? newFilter?.operator;
+      operator = (columnDef && columnDef.filter && columnDef.filter.operator) || (newFilter && newFilter.operator);
 
       if (this._columnFilters[columnDef.id]) {
         searchTerms = this._columnFilters[columnDef.id].searchTerms || undefined;


### PR DESCRIPTION
- rolling back this change (in previous PR #288) since Aurelia-Slickgrid filter presets on Client Example was no longer working as expected