### PR TITLE
chore(build): use dequal/lite ref issue #297

### DIFF
--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -1,4 +1,4 @@
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 
 import { Constants } from '../constants';
 import { FieldType } from './../enums/index';

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -1,4 +1,4 @@
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 
 import { FilterConditions, getParsedSearchTermsByFieldType } from './../filter-conditions/index';
 import { FilterFactory } from './../filters/filterFactory';

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -1,4 +1,4 @@
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 
 import {
   ExtensionName,

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -1,4 +1,4 @@
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 
 import {
   BackendServiceApi,


### PR DESCRIPTION
- dequal/lite is a bit smaller and since we don't need to compare against Set/Map/Symbol, we can use, it even seems to be a bit faster
- this might help in supporting legacy browser like IE11
- ref issue #297