### PR TITLE
fix(tree): few issues found with Tree Data, fixes #307

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.html
@@ -28,10 +28,10 @@
       <span>Expand All</span>
     </button>
     <button onclick.delegate="logFlatStructure()" class="button is-small">
-      <span>Log Flag Structure</span>
+      <span>Log Flat Structure</span>
     </button>
-    <button onclick.delegate="logExpandedStructure()" class="button is-small">
-      <span>Log Expanded Structure</span>
+    <button onclick.delegate="logHierarchicalStructure()" class="button is-small">
+      <span>Log Hierarchical Structure</span>
     </button>
   </div>
 </div>

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.html
@@ -33,6 +33,10 @@
     <button onclick.delegate="logHierarchicalStructure()" class="button is-small">
       <span>Log Hierarchical Structure</span>
     </button>
+    <button onclick.delegate="dynamicallyChangeFilter()" class="button is-small">
+      <span class="icon mdi mdi-filter-outline"></span>
+      <span>Dynamically Change Filter (% complete &lt; 40)</span>
+    </button>
   </div>
 </div>
 

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -38,15 +38,17 @@ export class Example5 {
     this.columnDefinitions = [
       {
         id: 'title', name: 'Title', field: 'title', width: 220, cssClass: 'cell-title',
-        filterable: true, sortable: true,
+        filterable: true, sortable: true, exportWithFormatter: false,
         queryFieldSorter: 'id', type: FieldType.string,
-        formatter: Formatters.tree,
+        formatter: Formatters.tree, exportCustomFormatter: Formatters.treeExport
+
       },
       { id: 'duration', name: 'Duration', field: 'duration', minWidth: 90, filterable: true },
       {
-        id: 'percentComplete', name: '% Complete', field: 'percentComplete', minWidth: 120, maxWidth: 200,
+        id: 'percentComplete', name: '% Complete', field: 'percentComplete',
+        minWidth: 120, maxWidth: 200, exportWithFormatter: false,
         sortable: true, filterable: true, filter: { model: Filters.compoundSlider, operator: '>=' },
-        formatter: Formatters.percentCompleteBarWithText, type: FieldType.number,
+        formatter: Formatters.percentCompleteBar, type: FieldType.number,
       },
       {
         id: 'start', name: 'Start', field: 'start', minWidth: 60,
@@ -62,7 +64,8 @@ export class Example5 {
       },
       {
         id: 'effortDriven', name: 'Effort Driven', width: 80, minWidth: 20, maxWidth: 80, cssClass: 'cell-effort-driven', field: 'effortDriven',
-        formatter: Formatters.checkmarkMaterial, cannotTriggerInsert: true,
+        exportWithFormatter: false,
+        formatter: Formatters.checkmark, cannotTriggerInsert: true,
         filterable: true,
         filter: {
           collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }],
@@ -78,10 +81,8 @@ export class Example5 {
       enableAutoSizeColumns: true,
       enableAutoResize: true,
       enableExcelExport: true,
-      excelExportOptions: {
-        exportWithFormatter: true,
-        sanitizeDataExport: true
-      },
+      exportOptions: { exportWithFormatter: true },
+      excelExportOptions: { exportWithFormatter: true },
       registerExternalResources: [new ExcelExportService()],
       enableFiltering: true,
       showCustomFooter: true, // display some metrics in the bottom custom footer

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -122,28 +122,23 @@ export class Example5 {
     const childItemFound = this.sgb.dataset.find((item) => item[treeLevelPropName] === newTreeLevel);
     const parentItemFound = this.sgb.dataView.getItemByIdx(childItemFound[parentPropName]);
 
-    const newItem = {
-      id: newId,
-      indent: newTreeLevel,
-      parentId: parentItemFound.id,
-      title: `Task ${newId}`,
-      duration: '1 day',
-      percentComplete: 99,
-      start: new Date(),
-      finish: new Date(),
-      effortDriven: false
-    };
-    this.sgb.dataView.addItem(newItem);
+    if (childItemFound && parentItemFound) {
+      const newItem = {
+        id: newId,
+        indent: newTreeLevel,
+        parentId: parentItemFound.id,
+        title: `Task ${newId}`,
+        duration: '1 day',
+        percentComplete: 99,
+        start: new Date(),
+        finish: new Date(),
+        effortDriven: false
+      };
 
-    // force a refresh of the data by getting the updated list from the DataView & override our local copy as well
-    this.dataset = this.sgb.dataView.getItems();
-    this.sgb.dataset = this.dataset;
-
-    // scroll to the new row
-    setTimeout(() => {
-      const rowIndex = this.sgb.dataView.getIdxById(newItem.id);
-      this.sgb.slickGrid.scrollRowIntoView(rowIndex, false);
-    }, 10);
+      // use the Grid Service to insert the item,
+      // it will also internally take care of updating & resorting the hierarchical dataset
+      this.sgb.gridService.addItem(newItem);
+    }
   }
 
   collapseAll() {

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -149,12 +149,16 @@ export class Example5 {
     this.sgb.treeDataService.toggleTreeDataCollapse(false);
   }
 
+  dynamicallyChangeFilter() {
+    this.sgb.filterService.updateFilters([{ columnId: 'percentComplete', operator: '<', searchTerms: [40] }]);
+  }
+
   logHierarchicalStructure() {
-    console.log('hierarchical array', this.sgb.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
+    console.log('hierarchical array', this.sgb.treeDataService.datasetHierarchical);
   }
 
   logFlatStructure() {
-    console.log('flat array', this.sgb.treeDataService.dataset /* , JSON.stringify(outputFlatArray, null, 2) */);
+    console.log('flat array', this.sgb.treeDataService.dataset);
   }
 
   mockDataset() {

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -92,6 +92,7 @@ export class Example5 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
+        // levelPropName: 'treeLevel',
         parentPropName: 'parentId',
 
         // you can optionally sort by a different column and/or sort direction

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -92,7 +92,7 @@ export class Example5 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        levelPropName: 'indent', // this is optional, except that in our case we just need to define it because we are adding new item in the demo
+        // levelPropName: 'indent', // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         parentPropName: 'parentId',
 
         // you can optionally sort by a different column and/or sort direction
@@ -109,15 +109,14 @@ export class Example5 {
   }
 
   /**
-   * A simple method to add a new item inside the first group that we find.
+   * A simple method to add a new item inside the first group that we find (it's random and is only for demo purposes).
    * After adding the item, it will sort by parent/child recursively
    */
   addNewRow() {
     const newId = this.sgb.dataset.length;
     const parentPropName = 'parentId';
-    const treeLevelPropName = 'indent';
+    const treeLevelPropName = '__treeLevel'; // if undefined in your options, the default prop name is "__treeLevel"
     const newTreeLevel = 1;
-
     // find first parent object and add the new item as a child
     const childItemFound = this.sgb.dataset.find((item) => item[treeLevelPropName] === newTreeLevel);
     const parentItemFound = this.sgb.dataView.getItemByIdx(childItemFound[parentPropName]);
@@ -125,7 +124,6 @@ export class Example5 {
     if (childItemFound && parentItemFound) {
       const newItem = {
         id: newId,
-        indent: newTreeLevel,
         parentId: parentItemFound.id,
         title: `Task ${newId}`,
         duration: '1 day',

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -92,7 +92,7 @@ export class Example5 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        // levelPropName: 'treeLevel',
+        levelPropName: 'indent', // this is optional, except that in our case we just need to define it because we are adding new item in the demo
         parentPropName: 'parentId',
 
         // you can optionally sort by a different column and/or sort direction
@@ -113,13 +113,13 @@ export class Example5 {
    * After adding the item, it will sort by parent/child recursively
    */
   addNewRow() {
-    const newId = this.dataset.length;
+    const newId = this.sgb.dataset.length;
     const parentPropName = 'parentId';
     const treeLevelPropName = 'indent';
     const newTreeLevel = 1;
 
     // find first parent object and add the new item as a child
-    const childItemFound = this.dataset.find((item) => item[treeLevelPropName] === newTreeLevel);
+    const childItemFound = this.sgb.dataset.find((item) => item[treeLevelPropName] === newTreeLevel);
     const parentItemFound = this.sgb.dataView.getItemByIdx(childItemFound[parentPropName]);
 
     const newItem = {
@@ -128,25 +128,22 @@ export class Example5 {
       parentId: parentItemFound.id,
       title: `Task ${newId}`,
       duration: '1 day',
-      percentComplete: 0,
+      percentComplete: 99,
       start: new Date(),
       finish: new Date(),
       effortDriven: false
     };
     this.sgb.dataView.addItem(newItem);
+
+    // force a refresh of the data by getting the updated list from the DataView & override our local copy as well
     this.dataset = this.sgb.dataView.getItems();
     this.sgb.dataset = this.dataset;
 
-    // force a resort
-    const titleColumn = this.columnDefinitions.find((col) => col.id === 'title');
-    this.sgb.sortService.onLocalSortChanged(this.sgb.slickGrid, [{ columnId: 'title', sortCol: titleColumn, sortAsc: true }]);
-
-    // update dataset and re-render (invalidate) the grid
-    this.sgb.slickGrid.invalidate();
-
     // scroll to the new row
-    const rowIndex = this.sgb.dataView.getIdxById(newItem.id);
-    this.sgb.slickGrid.scrollRowIntoView(rowIndex, false);
+    setTimeout(() => {
+      const rowIndex = this.sgb.dataView.getIdxById(newItem.id);
+      this.sgb.slickGrid.scrollRowIntoView(rowIndex, false);
+    }, 10);
   }
 
   collapseAll() {

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -92,8 +92,13 @@ export class Example5 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        levelPropName: 'indent',
-        parentPropName: 'parentId'
+        parentPropName: 'parentId',
+
+        // you can optionally sort by a different column and/or sort direction
+        initialSort: {
+          columnId: 'title',
+          direction: 'ASC'
+        }
       },
       multiColumnSort: false, // multi-column sorting is not supported with Tree Data, so you need to disable it
       presets: {
@@ -151,8 +156,8 @@ export class Example5 {
     this.sgb.treeDataService.toggleTreeDataCollapse(false);
   }
 
-  logExpandedStructure() {
-    console.log('exploded array', this.sgb.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
+  logHierarchicalStructure() {
+    console.log('hierarchical array', this.sgb.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
   }
 
   logFlatStructure() {
@@ -188,9 +193,9 @@ export class Example5 {
       }
 
       d['id'] = i;
-      d['indent'] = indent;
       d['parentId'] = parentId;
-      d['title'] = 'Task ' + i;
+      // d['title'] = `Task ${i}    -   [P]: ${parentId}`;
+      d['title'] = `Task ${i}`;
       d['duration'] = '5 days';
       d['percentComplete'] = Math.round(Math.random() * 100);
       d['start'] = new Date(randomYear, randomMonth, randomDay);

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example06.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example06.html
@@ -27,10 +27,10 @@
       <span>Expand All</span>
     </button>
     <button onclick.delegate="logFlatStructure()" class="button is-small">
-      <span>Log Flag Structure</span>
+      <span>Log Flat Structure</span>
     </button>
-    <button onclick.delegate="logExpandedStructure()" class="button is-small">
-      <span>Log Expanded Structure</span>
+    <button onclick.delegate="logHierarchicalStructure()" class="button is-small">
+      <span>Log Hierarchical Structure</span>
     </button>
   </div>
   <div class="column is-6">

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example06.ts
@@ -172,8 +172,8 @@ export class Example6 {
     this.sgb.treeDataService.toggleTreeDataCollapse(false);
   }
 
-  logExpandedStructure() {
-    console.log('exploded array', this.sgb.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
+  logHierarchicalStructure() {
+    console.log('hierarchical array', this.sgb.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
   }
 
   logFlatStructure() {

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example06.ts
@@ -173,11 +173,11 @@ export class Example6 {
   }
 
   logHierarchicalStructure() {
-    console.log('hierarchical array', this.sgb.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
+    console.log('hierarchical array', this.sgb.treeDataService.datasetHierarchical);
   }
 
   logFlatStructure() {
-    console.log('flat array', this.sgb.treeDataService.dataset /* , JSON.stringify(outputFlatArray, null, 2) */);
+    console.log('flat array', this.sgb.treeDataService.dataset);
   }
 
   mockDataset() {

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example06.ts
@@ -78,7 +78,8 @@ export class Example6 {
         //   columnId: 'file',
         //   direction: 'DESC'
         // }
-      }
+      },
+      showCustomFooter: true,
     };
   }
 
@@ -142,7 +143,7 @@ export class Example6 {
    * After adding the item, it will sort by parent/child recursively
    */
   addNewFile() {
-    const newId = this.sgb.dataView.getLength() + 100;
+    const newId = this.sgb.dataView.getItemCount() + 100;
 
     // find first parent object and add the new item as a child
     const popItem = findItemInHierarchicalStructure(this.datasetHierarchical, x => x.file === 'pop', 'files');
@@ -158,9 +159,11 @@ export class Example6 {
       // overwrite hierarchical dataset which will also trigger a grid sort and rendering
       this.sgb.datasetHierarchical = this.datasetHierarchical;
 
-      // scroll into the position where the item was added
-      const rowIndex = this.sgb.dataView.getRowById(popItem.id);
-      this.sgb.slickGrid.scrollRowIntoView(rowIndex + 3);
+      // scroll into the position where the item was added with a delay since it needs to recreate the tree grid
+      setTimeout(() => {
+        const rowIndex = this.sgb.dataView.getRowById(popItem.id);
+        this.sgb.slickGrid.scrollRowIntoView(rowIndex + 3);
+      }, 0);
     }
   }
 

--- a/packages/common/src/formatters/__tests__/treeExportFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeExportFormatter.spec.ts
@@ -1,0 +1,132 @@
+import { Column, SlickDataView, GridOption, SlickGrid } from '../../interfaces/index';
+import { treeExportFormatter } from '../treeExportFormatter';
+
+const dataViewStub = {
+  getIdxById: jest.fn(),
+  getItemByIdx: jest.fn(),
+  getIdPropertyName: jest.fn(),
+} as unknown as SlickDataView;
+
+const gridStub = {
+  getData: jest.fn(),
+  getOptions: jest.fn(),
+} as unknown as SlickGrid;
+
+describe('Tree Export Formatter', () => {
+  let dataset: any[];
+  let mockGridOptions: GridOption;
+
+  beforeEach(() => {
+    dataset = [
+      { id: 0, firstName: 'John', lastName: 'Smith', fullName: 'John Smith', email: 'john.smith@movie.com', address: { zip: 123456 }, parentId: null, indent: 0 },
+      { id: 1, firstName: 'Jane', lastName: 'Doe', fullName: 'Jane Doe', email: 'jane.doe@movie.com', address: { zip: 222222 }, parentId: 0, indent: 1 },
+      { id: 2, firstName: 'Bob', lastName: 'Cane', fullName: 'Bob Cane', email: 'bob.cane@movie.com', address: { zip: 333333 }, parentId: 1, indent: 2, __collapsed: true },
+      { id: 3, firstName: 'Barbara', lastName: 'Cane', fullName: 'Barbara Cane', email: 'barbara.cane@movie.com', address: { zip: 444444 }, parentId: null, indent: 0, __collapsed: true },
+      { id: 4, firstName: 'Anonymous', lastName: 'Doe', fullName: 'Anonymous < Doe', email: 'anonymous.doe@anom.com', address: { zip: 556666 }, parentId: null, indent: 0, __collapsed: true },
+    ];
+    mockGridOptions = {
+      treeDataOptions: { levelPropName: 'indent' }
+    } as GridOption;
+    jest.spyOn(gridStub, 'getOptions').mockReturnValue(mockGridOptions);
+  });
+
+  it('should throw an error when oarams are mmissing', () => {
+    expect(() => treeExportFormatter(1, 1, 'blah', {} as Column, {}, gridStub))
+      .toThrowError('You must provide valid "treeDataOptions" in your Grid Options and it seems that there are no tree level found in this row');
+  });
+
+  it('should return empty string when DataView is not correctly formed', () => {
+    const output = treeExportFormatter(1, 1, '', {} as Column, dataset[1], gridStub);
+    expect(output).toBe('');
+  });
+
+  it('should return empty string when value is null', () => {
+    const output = treeExportFormatter(1, 1, null, {} as Column, dataset[1], gridStub);
+    expect(output).toBe('');
+  });
+
+  it('should return empty string when value is undefined', () => {
+    const output = treeExportFormatter(1, 1, undefined, {} as Column, dataset[1], gridStub);
+    expect(output).toBe('');
+  });
+
+  it('should return empty string when item is undefined', () => {
+    const output = treeExportFormatter(1, 1, 'blah', {} as Column, undefined, gridStub);
+    expect(output).toBe('');
+  });
+
+  it('should return a span without any icon and ', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[0]);
+
+    const output = treeExportFormatter(1, 1, dataset[0]['firstName'], {} as Column, dataset[0], gridStub);
+    expect(output).toBe(`John`);
+  });
+
+  it('should return a span without any icon and 15px indentation of a tree level 1', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[1]);
+
+    const output = treeExportFormatter(1, 1, dataset[1]['firstName'], {} as Column, dataset[1], gridStub);
+    expect(output).toBe(`.     Jane`);
+  });
+
+  it('should return a span without any icon and 30px indentation of a tree level 2', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[1]);
+
+    const output = treeExportFormatter(1, 1, dataset[2]['firstName'], {} as Column, dataset[2], gridStub);
+    expect(output).toBe(`.         Bob`);
+  });
+
+  it('should return a span with expanded icon and 15px indentation of a tree level 1 when current item is greater than next item', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[2]);
+
+    const output = treeExportFormatter(1, 1, dataset[1]['firstName'], {} as Column, dataset[1], gridStub);
+    expect(output).toBe(`⮟      Jane`);
+  });
+
+  it('should return a span with collapsed icon and 0px indentation of a tree level 0 when current item is lower than next item', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[1]);
+
+    const output = treeExportFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub);
+    expect(output).toBe(`⮞  Barbara`);
+  });
+
+  it('should execute "queryFieldNameGetterFn" callback to get field name to use when it is defined', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[1]);
+
+    const mockColumn = { id: 'firstName', field: 'firstName', queryFieldNameGetterFn: (dataContext) => 'fullName' } as Column;
+    const output = treeExportFormatter(1, 1, null, mockColumn as Column, dataset[3], gridStub);
+    expect(output).toBe(`⮞  Barbara Cane`);
+  });
+
+  it('should execute "queryFieldNameGetterFn" callback to get field name and also apply html encoding when output value includes a character that should be encoded', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(2);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[2]);
+
+    const mockColumn = { id: 'firstName', field: 'firstName', queryFieldNameGetterFn: (dataContext) => 'fullName' } as Column;
+    const output = treeExportFormatter(1, 1, null, mockColumn as Column, dataset[4], gridStub);
+    expect(output).toBe(`⮞  Anonymous < Doe`);
+  });
+
+  it('should execute "queryFieldNameGetterFn" callback to get field name, which has (.) dot notation reprensenting complex object', () => {
+    jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+    jest.spyOn(dataViewStub, 'getIdxById').mockReturnValue(1);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValue(dataset[1]);
+
+    const mockColumn = { id: 'zip', field: 'zip', queryFieldNameGetterFn: (dataContext) => 'address.zip' } as Column;
+    const output = treeExportFormatter(1, 1, null, mockColumn as Column, dataset[3], gridStub);
+    expect(output).toBe(`⮞  444444`);
+  });
+});

--- a/packages/common/src/formatters/formatters.index.ts
+++ b/packages/common/src/formatters/formatters.index.ts
@@ -32,6 +32,7 @@ import { percentCompleteFormatter } from './percentCompleteFormatter';
 import { percentSymbolFormatter } from './percentSymbolFormatter';
 import { progressBarFormatter } from './progressBarFormatter';
 import { translateFormatter } from './translateFormatter';
+import { treeExportFormatter } from './treeExportFormatter';
 import { treeFormatter } from './treeFormatter';
 import { translateBooleanFormatter } from './translateBooleanFormatter';
 import { uppercaseFormatter } from './uppercaseFormatter';
@@ -236,6 +237,9 @@ export const Formatters = {
 
   /** Formatter that must be use with a Tree Data column */
   tree: treeFormatter,
+
+  /** Formatter that must be use with a Tree Data column for Exporting the data */
+  treeExport: treeExportFormatter,
 
   /** Takes a value and displays it all uppercase */
   uppercase: uppercaseFormatter,

--- a/packages/common/src/formatters/index.ts
+++ b/packages/common/src/formatters/index.ts
@@ -32,6 +32,7 @@ export * from './percentSymbolFormatter';
 export * from './progressBarFormatter';
 export * from './translateFormatter';
 export * from './translateBooleanFormatter';
+export * from './treeExportFormatter';
 export * from './treeFormatter';
 export * from './uppercaseFormatter';
 export * from './yesNoFormatter';

--- a/packages/common/src/formatters/treeExportFormatter.ts
+++ b/packages/common/src/formatters/treeExportFormatter.ts
@@ -1,0 +1,48 @@
+import { SlickDataView, Formatter } from './../interfaces/index';
+import { addWhiteSpaces, getDescendantProperty } from '../services/utilities';
+
+/** Formatter that must be use with a Tree Data column */
+export const treeExportFormatter: Formatter = (_row, _cell, value, columnDef, dataContext, grid) => {
+  const dataView = grid?.getData<SlickDataView>();
+  const gridOptions = grid?.getOptions();
+  const treeDataOptions = gridOptions?.treeDataOptions;
+  const treeLevelPropName = treeDataOptions?.levelPropName ?? '__treeLevel';
+  const indentMarginLeft = treeDataOptions?.exportIndentMarginLeft ?? 4;
+  const groupCollapsedSymbol = gridOptions?.excelExportOptions?.groupCollapsedSymbol ?? '⮞';
+  const groupExpandedSymbol = gridOptions?.excelExportOptions?.groupExpandedSymbol ?? '⮟';
+  let outputValue = value;
+
+  if (typeof columnDef.queryFieldNameGetterFn === 'function') {
+    const fieldName = columnDef.queryFieldNameGetterFn(dataContext);
+    if (fieldName?.indexOf('.') >= 0) {
+      outputValue = getDescendantProperty(dataContext, fieldName);
+    } else {
+      outputValue = dataContext.hasOwnProperty(fieldName) ? dataContext[fieldName] : value;
+    }
+  }
+  if (outputValue === null || outputValue === undefined || dataContext === undefined) {
+    return '';
+  }
+
+  if (!dataContext.hasOwnProperty(treeLevelPropName)) {
+    throw new Error('You must provide valid "treeDataOptions" in your Grid Options and it seems that there are no tree level found in this row');
+  }
+
+  if (dataView?.getItemByIdx) {
+    const identifierPropName = dataView.getIdPropertyName() || 'id';
+    const treeLevel = dataContext[treeLevelPropName] || 0;
+    const spacer = addWhiteSpaces(indentMarginLeft * treeLevel);
+    const idx = dataView.getIdxById(dataContext[identifierPropName]);
+    const nextItemRow = dataView.getItemByIdx((idx || 0) + 1);
+
+    if (nextItemRow?.[treeLevelPropName] > treeLevel) {
+      if (dataContext.__collapsed) {
+        return `${groupCollapsedSymbol} ${spacer} ${outputValue}`;
+      } else {
+        return `${groupExpandedSymbol} ${spacer} ${outputValue}`;
+      }
+    }
+    return treeLevel === 0 ? outputValue : `.${spacer} ${outputValue}`;
+  }
+  return '';
+};

--- a/packages/common/src/formatters/treeFormatter.ts
+++ b/packages/common/src/formatters/treeFormatter.ts
@@ -26,16 +26,17 @@ export const treeFormatter: Formatter = (_row, _cell, value, columnDef, dataCont
     throw new Error('You must provide valid "treeDataOptions" in your Grid Options and it seems that there are no tree level found in this row');
   }
 
-  if (dataView && dataView.getIdxById && dataView.getItemByIdx) {
+  if (dataView?.getItemByIdx) {
     if (typeof outputValue === 'string') {
       outputValue = htmlEncode(outputValue);
     }
     const identifierPropName = dataView.getIdPropertyName() || 'id';
-    const spacer = `<span style="display:inline-block; width:${indentMarginLeft * dataContext[treeLevelPropName]}px;"></span>`;
+    const treeLevel = dataContext[treeLevelPropName] || 0;
+    const spacer = `<span style="display:inline-block; width:${indentMarginLeft * treeLevel}px;"></span>`;
     const idx = dataView.getIdxById(dataContext[identifierPropName]);
     const nextItemRow = dataView.getItemByIdx((idx || 0) + 1);
 
-    if (nextItemRow && nextItemRow[treeLevelPropName] > dataContext[treeLevelPropName]) {
+    if (nextItemRow?.[treeLevelPropName] > treeLevel) {
       if (dataContext.__collapsed) {
         return `${spacer}<span class="slick-group-toggle collapsed"></span>&nbsp;${outputValue}`;
       } else {

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -1,5 +1,5 @@
 import { DelimiterType, EventNamingStyle, FileType, GridAutosizeColsMode, OperatorType } from './enums/index';
-import { Column, GridOption } from './interfaces/index';
+import { Column, GridOption, TreeDataOption } from './interfaces/index';
 import { Filters } from './filters';
 
 /** Global Grid Options Defaults */
@@ -137,8 +137,8 @@ export const GlobalGridOptions: GridOption = {
     filename: 'export',
     format: FileType.xlsx,
     groupingColumnHeaderTitle: 'Group By',
-    groupCollapsedSymbol: '\u25B9',
-    groupExpandedSymbol: '\u25BF',
+    groupCollapsedSymbol: '⮞',
+    groupExpandedSymbol: '⮟',
     groupingAggregatorRowText: '',
     sanitizeDataExport: false,
   },
@@ -228,6 +228,10 @@ export const GlobalGridOptions: GridOption = {
   resizeFormatterPaddingWidthInPx: 0,
   resizeDefaultRatioForStringType: 0.88,
   resizeMaxItemToInspectCellContentWidth: 1000,
+  treeDataOptions: {
+    exportIndentMarginLeft: 4,
+    exportIndentationLeadingChar: '.',
+  } as unknown as TreeDataOption
 };
 
 /**

--- a/packages/common/src/interfaces/excelExportOption.interface.ts
+++ b/packages/common/src/interfaces/excelExportOption.interface.ts
@@ -27,10 +27,10 @@ export interface ExcelExportOption {
   /** The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator */
   groupingAggregatorRowText?: string;
 
-  /** Symbol use to show that the group title is collapsed (you can use unicode like '\u25B9' or '\u25B7') */
+  /** Symbol use to show that the group title is collapsed (you can use unicode like '⮞' or '\u25B7') */
   groupCollapsedSymbol?: string;
 
-  /** Symbol use to show that the group title is expanded (you can use unicode like '\u25BF' or '\u25BD') */
+  /** Symbol use to show that the group title is expanded (you can use unicode like '⮟' or '\u25BD') */
   groupExpandedSymbol?: string;
 
   /** Defaults to false, which leads to Sanitizing all data (striping out any HTML tags) when being evaluated on export. */

--- a/packages/common/src/interfaces/filterCallback.interface.ts
+++ b/packages/common/src/interfaces/filterCallback.interface.ts
@@ -15,6 +15,12 @@ export interface FilterCallbackArg {
   searchTerms?: SearchTerm[] | undefined | null;
 
   /**
+   * Defaults to undefined, do we want to force the onSearchChange event to trigger?
+   * This is used at least with `updateFilters()` from the Filter Service.
+   */
+  forceOnSearchChangeEvent?: boolean;
+
+  /**
    * Defaults to true, should we trigger a query?
    * Change to false when calling a clearFilters to avoid multiple backend queries.
    */

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -40,4 +40,16 @@ export interface TreeDataOption {
    * For example if tree depth level is 2, the calculation will be (2 * 15 = 30), so the column will be displayed 30px from the left
    */
   indentMarginLeft?: number;
+
+  /**
+   * Defaults to 4, indentation spaces to add from the left (calculated by the tree level multiplied by this number).
+   * For example if tree depth level is 2, the calculation will be (2 * 15 = 30), so the column will be displayed 30px from the left
+   */
+  exportIndentMarginLeft?: number;
+
+  /**
+   * Defaults to dot (.), we added this because Excel seems to trim spaces leading character
+   * and if we add a regular character like a dot then it keeps all tree level indentation spaces
+   */
+  exportIndentationLeadingChar?: string;
 }

--- a/packages/common/src/services/__tests__/excelExport.service.spec.ts
+++ b/packages/common/src/services/__tests__/excelExport.service.spec.ts
@@ -1,10 +1,10 @@
 import { SlickGrid } from '../../interfaces/slickGrid.interface';
+import { ContainerService } from '../container.service';
 import { ExcelExportService } from '../excelExport.service';
-import { SharedService } from '../shared.service';
 
 describe('ExcelExport Service', () => {
   it('should display a not implemented when calling "init" method', () => {
-    expect(() => ExcelExportService.prototype.init({} as unknown as SlickGrid, {} as unknown as SharedService)).toThrow('ExcelExportService the "init" method must be implemented');
+    expect(() => ExcelExportService.prototype.init({} as unknown as SlickGrid, {} as unknown as ContainerService)).toThrow('ExcelExportService the "init" method must be implemented');
   });
 
   it('should display a not implemented when calling "exportToExcel" method', () => {

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -1075,6 +1075,7 @@ describe('FilterService', () => {
 
     beforeEach(() => {
       gridOptionMock.enableFiltering = true;
+      gridOptionMock.enableTreeData = false;
       gridOptionMock.backendServiceApi = undefined;
       mockColumn1 = { id: 'firstName', name: 'firstName', field: 'firstName', filterable: true, filter: { model: Filters.inputText } };
       mockColumn2 = { id: 'isActive', name: 'isActive', field: 'isActive', type: FieldType.boolean, filterable: true, filter: { model: Filters.select, collection: [{ value: true, label: 'True' }, { value: false, label: 'False' }], } };
@@ -1193,6 +1194,66 @@ describe('FilterService', () => {
       });
       expect(clearSpy).toHaveBeenCalledWith(false);
     });
+
+    it('should expect filters to be set in ColumnFilters and also expect onSearchChange to be called when last argument is set to True', () => {
+      const clearSpy = jest.spyOn(service, 'clearFilters');
+      const emitSpy = jest.spyOn(service, 'emitFilterChanged');
+      const spySearchChange = jest.spyOn(service.onSearchChange as any, 'notify');
+
+      gridOptionMock.enableTreeData = true;
+      service.init(gridStub);
+      service.bindLocalOnFilter(gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs1 as any, new Slick.EventData(), gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs2 as any, new Slick.EventData(), gridStub);
+      service.updateFilters(mockNewFilters.slice(0, 1), true, false, true);
+
+      expect(emitSpy).toHaveBeenCalledWith('local');
+      expect(clearSpy).toHaveBeenCalledWith(false);
+      expect(service.getColumnFilters()).toEqual({
+        firstName: { columnId: 'firstName', columnDef: mockColumn1, searchTerms: ['Jane'], operator: 'StartsWith', parsedSearchTerms: ['Jane'], type: FieldType.string },
+      });
+      expect(spySearchChange).toHaveBeenCalledWith({
+        clearFilterTriggered: undefined,
+        shouldTriggerQuery: true,
+        columnId: 'firstName',
+        columnDef: mockColumn1,
+        columnFilters: { firstName: { columnDef: mockColumn1, columnId: 'firstName', operator: 'StartsWith', searchTerms: ['Jane'], parsedSearchTerms: ['Jane'], type: FieldType.string } },
+        operator: 'StartsWith',
+        searchTerms: ['Jane'],
+        parsedSearchTerms: ['Jane'],
+        grid: gridStub
+      }, undefined);
+    });
+
+    it('should expect filters to be set in ColumnFilters and also expect onSearchChange to be called when "enableTreeData" is set', () => {
+      const clearSpy = jest.spyOn(service, 'clearFilters');
+      const emitSpy = jest.spyOn(service, 'emitFilterChanged');
+      const spySearchChange = jest.spyOn(service.onSearchChange as any, 'notify');
+
+      gridOptionMock.enableTreeData = true;
+      service.init(gridStub);
+      service.bindLocalOnFilter(gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs1 as any, new Slick.EventData(), gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs2 as any, new Slick.EventData(), gridStub);
+      service.updateFilters(mockNewFilters.slice(0, 1));
+
+      expect(emitSpy).toHaveBeenCalledWith('local');
+      expect(clearSpy).toHaveBeenCalledWith(false);
+      expect(service.getColumnFilters()).toEqual({
+        firstName: { columnId: 'firstName', columnDef: mockColumn1, searchTerms: ['Jane'], operator: 'StartsWith', parsedSearchTerms: ['Jane'], type: FieldType.string },
+      });
+      expect(spySearchChange).toHaveBeenCalledWith({
+        clearFilterTriggered: undefined,
+        shouldTriggerQuery: true,
+        columnId: 'firstName',
+        columnDef: mockColumn1,
+        columnFilters: { firstName: { columnDef: mockColumn1, columnId: 'firstName', operator: 'StartsWith', searchTerms: ['Jane'], parsedSearchTerms: ['Jane'], type: FieldType.string } },
+        operator: 'StartsWith',
+        searchTerms: ['Jane'],
+        parsedSearchTerms: ['Jane'],
+        grid: gridStub
+      }, undefined);
+    });
   });
 
   describe('updateSingleFilter method', () => {
@@ -1203,6 +1264,7 @@ describe('FilterService', () => {
 
     beforeEach(() => {
       gridOptionMock.enableFiltering = true;
+      gridOptionMock.enableTreeData = false;
       gridOptionMock.backendServiceApi = undefined;
       mockColumn1 = { id: 'firstName', name: 'firstName', field: 'firstName', };
       mockColumn2 = { id: 'isActive', name: 'isActive', field: 'isActive', type: FieldType.boolean, };

--- a/packages/common/src/services/__tests__/sort.service.spec.ts
+++ b/packages/common/src/services/__tests__/sort.service.spec.ts
@@ -989,6 +989,7 @@ describe('SortService', () => {
         { columnId: 'file', sortAsc: false, sortCol: { id: 'file', field: 'file', width: 75 } }
       ];
 
+      sharedService.hierarchicalDataset = [];
       service.bindLocalOnSort(gridStub);
       gridStub.onSort.notify({ multiColumnSort: true, sortCols: mockSortedCols, grid: gridStub }, new Slick.EventData(), gridStub);
 
@@ -1009,11 +1010,13 @@ describe('SortService', () => {
       const spyCurrentSort = jest.spyOn(service, 'getCurrentLocalSorters');
       const spyOnLocalSort = jest.spyOn(service, 'onLocalSortChanged');
       const spyUpdateSorting = jest.spyOn(service, 'updateSorting');
+
       const mockSortedCols: ColumnSort[] = [
         { columnId: 'lastName', sortAsc: true, sortCol: { id: 'lastName', field: 'lastName', width: 100 } },
         { columnId: 'file', sortAsc: false, sortCol: { id: 'file', field: 'file', width: 75 } }
       ];
 
+      sharedService.hierarchicalDataset = [];
       service.bindLocalOnSort(gridStub);
       gridStub.onSort.notify({ multiColumnSort: true, sortCols: mockSortedCols, grid: gridStub }, new Slick.EventData(), gridStub);
 

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -226,7 +226,7 @@ describe('TreeData Service', () => {
       });
     });
 
-    describe('initializeHierarchicalDataset method', () => {
+    describe('convertToHierarchicalDatasetAndSort method', () => {
       let mockColumns: Column[];
       let mockFlatDataset;
 
@@ -248,7 +248,7 @@ describe('TreeData Service', () => {
         jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
 
         service.init(gridStub);
-        const result = service.initializeHierarchicalDataset(mockFlatDataset, [mockColumn]);
+        const result = service.convertToHierarchicalDatasetAndSort(mockFlatDataset, [mockColumn]);
 
         expect(setSortSpy).toHaveBeenCalledWith([{
           columnId: 'file',
@@ -273,7 +273,7 @@ describe('TreeData Service', () => {
         jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
 
         service.init(gridStub);
-        const result = service.initializeHierarchicalDataset(mockFlatDataset, [mockColumn]);
+        const result = service.convertToHierarchicalDatasetAndSort(mockFlatDataset, [mockColumn]);
 
         expect(setSortSpy).toHaveBeenCalledWith([{
           columnId: 'size',

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -3,12 +3,11 @@ import { Column, SlickDataView, GridOption, SlickEventHandler, SlickGrid, SlickN
 import { SharedService } from '../shared.service';
 import { SortService } from '../sort.service';
 import { TreeDataService } from '../treeData.service';
-import * as utilities from '../utilities';
 
-const mockConvertParentChildArray = jest.fn();
 declare const Slick: SlickNamespace;
 
 const gridOptionsMock = {
+  multiColumnSort: false,
   enableTreeData: true,
   treeDataOptions: {
     columnId: 'file'
@@ -56,12 +55,23 @@ describe('TreeData Service', () => {
   });
 
   afterEach(() => {
+    gridOptionsMock.multiColumnSort = false;
     jest.clearAllMocks();
     service.dispose();
   });
 
   it('should create the service', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should throw an error when used with multi-column sorting', (done) => {
+    try {
+      gridOptionsMock.multiColumnSort = true;
+      service.init(gridStub);
+    } catch (e) {
+      expect(e.toString()).toContain('[Slickgrid-Universal] Tree Data does not currently support multi-column sorting');
+      done();
+    }
   });
 
   it('should dispose of the event handler', () => {

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -1,4 +1,3 @@
-
 import { Column, SlickDataView, GridOption, SlickEventHandler, SlickGrid, SlickNamespace } from '../../interfaces/index';
 import { SharedService } from '../shared.service';
 import { SortService } from '../sort.service';
@@ -49,13 +48,13 @@ describe('TreeData Service', () => {
   const sharedService = new SharedService();
 
   beforeEach(() => {
+    gridOptionsMock.multiColumnSort = false;
     service = new TreeDataService(sharedService, sortServiceStub);
     slickgridEventHandler = service.eventHandler;
     jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
   });
 
   afterEach(() => {
-    gridOptionsMock.multiColumnSort = false;
     jest.clearAllMocks();
     service.dispose();
   });

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -789,8 +789,8 @@ export class FilterService {
           this.updateColumnFilters(newFilter.searchTerms, uiFilter.columnDef, newOperator);
           uiFilter.setValues(newFilter.searchTerms || [], newOperator);
 
-          if (triggerOnSearchChangeEvent) {
-            this.callbackSearchEvent(undefined, { columnDef: uiFilter.columnDef, operator: newOperator, searchTerms: newFilter.searchTerms, shouldTriggerQuery: true });
+          if (triggerOnSearchChangeEvent || this._gridOptions?.enableTreeData) {
+            this.callbackSearchEvent(undefined, { columnDef: uiFilter.columnDef, operator: newOperator, searchTerms: newFilter.searchTerms, shouldTriggerQuery: true, forceOnSearchChangeEvent: true });
           }
         }
       });
@@ -818,13 +818,16 @@ export class FilterService {
   }
 
   /**
+   * **NOTE**: This should only ever be used when having a global external search and hidding the grid inline filters (with `enableFiltering: true` and `showHeaderRow: false`).
+   * For inline filters, please use `updateFilters()` instead.
+   *
    * Update a Single Filter dynamically just by providing (columnId, operator and searchTerms)
    * You can also choose emit (default) a Filter Changed event that will be picked by the Grid State Service.
-   *
    * Also for backend service only, you can choose to trigger a backend query (default) or not if you wish to do it later,
    * this could be useful when using updateFilters & updateSorting and you wish to only send the backend query once.
    * @param filters array
    * @param triggerEvent defaults to True, do we want to emit a filter changed event?
+   * @param triggerBackendQuery defaults to True, which will query the backend.
    */
   updateSingleFilter(filter: CurrentFilter, emitChangedEvent = true, triggerBackendQuery = true) {
     const columnDef = this.sharedService.allColumns.find(col => col.id === filter.columnId);
@@ -858,6 +861,10 @@ export class FilterService {
           columnFilters: this._columnFilters,
           grid: this._grid
         });
+
+        // when using Tree Data, we also need to refresh the filters because of the tree structure with recursion
+        this.refreshTreeDataFilters();
+
         this._dataView.refresh();
       }
 
@@ -974,7 +981,7 @@ export class FilterService {
       // trigger an event only if Filters changed or if ENTER key was pressed
       const eventKey = (event as KeyboardEvent)?.key;
       const eventKeyCode = (event as KeyboardEvent)?.keyCode;
-      if (this._onSearchChange && (eventKey === 'Enter' || eventKeyCode === KeyCode.ENTER || !dequal(oldColumnFilters, this._columnFilters))) {
+      if (this._onSearchChange && (args.forceOnSearchChangeEvent || eventKey === 'Enter' || eventKeyCode === KeyCode.ENTER || !dequal(oldColumnFilters, this._columnFilters))) {
         this._onSearchChange.notify({
           clearFilterTriggered: args.clearFilterTriggered,
           shouldTriggerQuery: args.shouldTriggerQuery,

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -241,7 +241,7 @@ export class FilterService {
     }
 
     let emitter: EmitterType = EmitterType.local;
-    const isBackendApi = this._gridOptions && this._gridOptions.backendServiceApi || false;
+    const isBackendApi = this._gridOptions?.backendServiceApi ?? false;
 
     // when using a backend service, we need to manually trigger a filter change but only if the filter was previously filled
     if (isBackendApi) {

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -480,7 +480,7 @@ export class GridService {
 
       // insert position top/bottom, defaults to top
       // when position is top we'll call insert at index 0, else call addItem which just push to the DataView array
-      if (insertPosition === 'bottom') {
+      if (insertPosition === 'bottom' || this._gridOptions?.enableTreeData) {
         this._dataView.addItems(items);
       } else {
         this._dataView.insertItems(0, items); // insert at index 0 to the start of the dataset
@@ -488,11 +488,6 @@ export class GridService {
 
       // end the bulk transaction since we're all done
       this._dataView.endUpdate();
-
-      // if we add/remove item(s) from the dataset, we need to also refresh our tree data filters
-      if (this._gridOptions?.enableTreeData) {
-        this.invalidateHierarchicalDataset();
-      }
     }
 
     if (this._gridOptions?.enableTreeData) {
@@ -882,7 +877,7 @@ export class GridService {
   invalidateHierarchicalDataset() {
     // if we add/remove item(s) from the dataset, we need to also refresh our tree data filters
     if (this._gridOptions?.enableTreeData && this.treeDataService) {
-      const sortedDatasetResult = this.treeDataService.convertToHierarchicalDatasetAndSort(this._dataView.getItems(), this.sharedService.allColumns);
+      const sortedDatasetResult = this.treeDataService.convertToHierarchicalDatasetAndSort(this._dataView.getItems(), this.sharedService.allColumns, this._gridOptions);
       this.sharedService.hierarchicalDataset = sortedDatasetResult.hierarchical;
       this.filterService.refreshTreeDataFilters();
       this._dataView.setItems(sortedDatasetResult.flat);

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -323,16 +323,16 @@ export class SortService {
   /** Process the initial sort, typically it will sort ascending by the column that has the Tree Data unless user specifies a different initialSort */
   processTreeDataInitialSort() {
     // when a Tree Data view is defined, we must sort the data so that the UI works correctly
-    if (this._gridOptions && this._gridOptions.enableTreeData && this._gridOptions.treeDataOptions) {
+    if (this._gridOptions?.enableTreeData && this._gridOptions.treeDataOptions) {
       // first presort it once by tree level
       const treeDataOptions = this._gridOptions.treeDataOptions;
-      const columnWithTreeData = this._columnDefinitions.find((col: Column) => col && col.id === treeDataOptions.columnId);
+      const columnWithTreeData = this._columnDefinitions.find((col: Column) => col.id === treeDataOptions.columnId);
       if (columnWithTreeData) {
         let sortDirection = SortDirection.ASC;
         let sortTreeLevelColumn: ColumnSort = { columnId: treeDataOptions.columnId, sortCol: columnWithTreeData, sortAsc: true };
 
         // user could provide a custom sort field id, if so get that column and sort by it
-        if (treeDataOptions && treeDataOptions.initialSort && treeDataOptions.initialSort.columnId) {
+        if (treeDataOptions?.initialSort?.columnId) {
           const initialSortColumnId = treeDataOptions.initialSort.columnId;
           const initialSortColumn = this._columnDefinitions.find((col: Column) => col.id === initialSortColumnId);
           sortDirection = (treeDataOptions.initialSort.direction || SortDirection.ASC).toUpperCase() as SortDirection;
@@ -340,7 +340,7 @@ export class SortService {
         }
 
         // when we have a valid column with Tree Data, we can sort by that column
-        if (sortTreeLevelColumn && sortTreeLevelColumn.columnId) {
+        if (sortTreeLevelColumn?.columnId && this.sharedService?.hierarchicalDataset) {
           this.updateSorting([{ columnId: sortTreeLevelColumn.columnId || '', direction: sortDirection }]);
         }
       }
@@ -383,12 +383,8 @@ export class SortService {
 
       if (isTreeDataEnabled && this.sharedService && Array.isArray(this.sharedService.hierarchicalDataset)) {
         const hierarchicalDataset = this.sharedService.hierarchicalDataset;
-        this.sortTreeData(hierarchicalDataset, sortColumns);
-        const dataViewIdIdentifier = this._gridOptions?.datasetIdPropertyName ?? 'id';
-        const treeDataOpt: TreeDataOption = this._gridOptions?.treeDataOptions ?? { columnId: '' };
-        const treeDataOptions = { ...treeDataOpt, identifierPropName: treeDataOpt.identifierPropName ?? dataViewIdIdentifier };
-        const sortedFlatArray = convertHierarchicalViewToParentChildArray(hierarchicalDataset, treeDataOptions);
-        dataView.setItems(sortedFlatArray, this._gridOptions?.datasetIdPropertyName ?? 'id');
+        const datasetSortResult = this.sortHierarchicalDataset(hierarchicalDataset, sortColumns);
+        this._dataView.setItems(datasetSortResult.flat, this._gridOptions?.datasetIdPropertyName ?? 'id');
       } else {
         dataView.sort(this.sortComparers.bind(this, sortColumns));
       }
@@ -404,6 +400,17 @@ export class SortService {
         }));
       }
     }
+  }
+
+  /** Takes a hierarchical dataset and sort it recursively,  */
+  sortHierarchicalDataset(hierarchicalDataset: any[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>): { hierarchical: any[]; flat: any[]; } {
+    this.sortTreeData(hierarchicalDataset, sortColumns);
+    const dataViewIdIdentifier = this._gridOptions?.datasetIdPropertyName ?? 'id';
+    const treeDataOpt: TreeDataOption = this._gridOptions?.treeDataOptions ?? { columnId: '' };
+    const treeDataOptions = { ...treeDataOpt, identifierPropName: treeDataOpt.identifierPropName ?? dataViewIdIdentifier };
+    const sortedFlatArray = convertHierarchicalViewToParentChildArray(hierarchicalDataset, treeDataOptions);
+
+    return { hierarchical: hierarchicalDataset, flat: sortedFlatArray };
   }
 
   /** Call a local grid sort by its default sort field id (user can customize default field by configuring "defaultColumnSortFieldId" in the grid options, defaults to "id") */
@@ -510,11 +517,11 @@ export class SortService {
     }
 
     if (Array.isArray(sorters)) {
-      const backendApi = this._gridOptions && this._gridOptions.backendServiceApi;
+      const backendApi = this._gridOptions?.backendServiceApi;
 
       if (backendApi) {
-        const backendApiService = backendApi && backendApi.service;
-        if (backendApiService && backendApiService.updateSorters) {
+        const backendApiService = backendApi?.service;
+        if (backendApiService?.updateSorters) {
           backendApiService.updateSorters(undefined, sorters);
           if (triggerBackendQuery) {
             this.backendUtilities?.refreshBackendDataset(this._gridOptions);

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -88,7 +88,7 @@ export class SortService {
   bindLocalOnSort(grid: SlickGrid) {
     this._isBackendGrid = false;
     this._grid = grid;
-    this._dataView = grid?.getData && grid.getData() as SlickDataView;
+    this._dataView = grid.getData() as SlickDataView;
 
     this.processTreeDataInitialSort();
 

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -58,7 +58,7 @@ export class TreeDataService {
   }
 
   /** Takes a flat dataset, converts it into a hierarchical dataset, sort it by recursion and finally return back the final and sorted flat array */
-  initializeHierarchicalDataset(flatDataset: any[], columnDefinitions: Column[]) {
+  convertToHierarchicalDatasetAndSort(flatDataset: any[], columnDefinitions: Column[]): { hierarchical: any[]; flat: any[]; } {
     // 1- convert the flat array into a hierarchical array
     const datasetHierarchical = this.convertFlatDatasetConvertToHierarhicalView(flatDataset);
 

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -46,12 +46,19 @@ export class TreeDataService {
   init(grid: SlickGrid) {
     this._grid = grid;
 
-    if (this.gridOptions?.enableTreeData && this.gridOptions?.multiColumnSort) {
-      throw new Error('[Slickgrid-Universal] Tree Data does not currently support multi-column sorting, you can disable it via "multiColumnSort: false" grid option and/or help in providing support for this feature.');
-    }
+    // there's a few limitations with Tree Data, we'll just throw error when that happens
+    if (this.gridOptions?.enableTreeData) {
+      if (this.gridOptions?.multiColumnSort) {
+        throw new Error('[Slickgrid-Universal] It looks like you are trying to use Tree Data with multi-column sorting, unfortunately it is not supported because of its complexity, you can disable it via "multiColumnSort: false" grid option and/or help in providing support for this feature.');
+      }
 
-    if (this.gridOptions?.enableTreeData && (this.gridOptions?.backendServiceApi || this.gridOptions?.enablePagination)) {
-      throw new Error('[Slickgrid-Universal] Tree Data does not support backend services (like OData, GraphQL) and/or Pagination, it can only be used with a regular grid without Pagination.');
+      if (this.gridOptions?.backendServiceApi || this.gridOptions?.enablePagination) {
+        throw new Error('[Slickgrid-Universal] It looks like you are trying to use Tree Data with Pagination and/or a Backend Service (OData, GraphQL) but unfortunately that is simply not supported because of its complexity.');
+      }
+
+      if (!this.gridOptions.treeDataOptions || !this.gridOptions.treeDataOptions.columnId) {
+        throw new Error('[Slickgrid-Universal] When enabling tree data, you must also provide the "treeDataOption" property in your Grid Options with "childrenPropName" or "parentPropName" (depending if your array is hierarchical or flat) for the Tree Data to work properly.');
+      }
     }
 
     // subscribe to the SlickGrid event and call the backend execution
@@ -61,31 +68,37 @@ export class TreeDataService {
     }
   }
 
+  getInitialSort(columnDefinitions: Column[], gridOptions: GridOption): ColumnSort {
+    const treeDataOptions = gridOptions?.treeDataOptions;
+    const initialColumnSorting = treeDataOptions?.initialSort ?? { columnId: treeDataOptions?.columnId ?? '', direction: 'ASC' };
+    const initialSortColumn = columnDefinitions.find(col => col.id === initialColumnSorting.columnId);
+
+    return {
+      columnId: initialColumnSorting.columnId,
+      sortAsc: initialColumnSorting?.direction?.toUpperCase() !== 'DESC',
+      sortCol: initialSortColumn as Column,
+    };
+  }
+
   /** Takes a flat dataset, converts it into a hierarchical dataset, sort it by recursion and finally return back the final and sorted flat array */
-  convertToHierarchicalDatasetAndSort(flatDataset: any[], columnDefinitions: Column[]): { hierarchical: any[]; flat: any[]; } {
+  convertToHierarchicalDatasetAndSort(flatDataset: any[], columnDefinitions: Column[], gridOptions: GridOption): { hierarchical: any[]; flat: any[]; } {
     // 1- convert the flat array into a hierarchical array
-    const datasetHierarchical = this.convertFlatDatasetConvertToHierarhicalView(flatDataset);
+    const datasetHierarchical = this.convertFlatDatasetConvertToHierarhicalView(flatDataset, gridOptions);
 
     // 2- sort the hierarchical array recursively by an optional "initialSort" OR if nothing is provided we'll sort by the column defined as the Tree column
     // also note that multi-column is not currently supported with Tree Data
-    const treeDataOptions = this.gridOptions?.treeDataOptions;
-    const initialColumnSort = treeDataOptions?.initialSort ?? { columnId: treeDataOptions?.columnId ?? '', direction: 'ASC' };
-    const columnSort: ColumnSort = {
-      columnId: initialColumnSort.columnId,
-      sortAsc: initialColumnSort?.direction?.toUpperCase() !== 'DESC',
-      sortCol: columnDefinitions[this._grid.getColumnIndex(initialColumnSort.columnId || '')],
-    };
+    const columnSort = this.getInitialSort(columnDefinitions, gridOptions);
     const datasetSortResult = this.sortService.sortHierarchicalDataset(datasetHierarchical, [columnSort]);
 
     // and finally add the sorting icon (this has to be done manually in SlickGrid) to the column we used for the sorting
-    this._grid.setSortColumns([columnSort]);
+    this._grid?.setSortColumns([columnSort]);
 
     return datasetSortResult;
   }
 
-  convertFlatDatasetConvertToHierarhicalView(flatDataset: any[]): any[] {
-    const dataViewIdIdentifier = this.gridOptions?.datasetIdPropertyName ?? 'id';
-    const treeDataOpt: TreeDataOption = this.gridOptions?.treeDataOptions ?? { columnId: 'id' };
+  convertFlatDatasetConvertToHierarhicalView(flatDataset: any[], gridOptions: GridOption): any[] {
+    const dataViewIdIdentifier = gridOptions?.datasetIdPropertyName ?? 'id';
+    const treeDataOpt: TreeDataOption = gridOptions?.treeDataOptions ?? { columnId: 'id' };
     const treeDataOptions = { ...treeDataOpt, identifierPropName: treeDataOpt.identifierPropName ?? dataViewIdIdentifier };
     return convertParentChildArrayToHierarchicalView(flatDataset, treeDataOptions);
   }
@@ -110,6 +123,11 @@ export class TreeDataService {
         }
       }
     }
+  }
+
+  sortHierarchicalDataset(hierarchicalDataset: any[]): { hierarchical: any[]; flat: any[]; } {
+    const columnSort = this.getInitialSort(this.sharedService.allColumns, this.gridOptions);
+    return this.sortService.sortHierarchicalDataset(hierarchicalDataset, [columnSort]);
   }
 
   toggleTreeDataCollapse(collapsing: boolean) {

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -46,6 +46,10 @@ export class TreeDataService {
   init(grid: SlickGrid) {
     this._grid = grid;
 
+    if (this.gridOptions?.multiColumnSort && this.gridOptions?.enableTreeData) {
+      throw new Error('[Slickgrid-Universal] Tree Data does not currently support multi-column sorting, you can disable it via "multiColumnSort: false" grid option and/or help in providing support for this feature.');
+    }
+
     // subscribe to the SlickGrid event and call the backend execution
     const onClickHandler = grid.onClick;
     if (onClickHandler) {

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -46,8 +46,12 @@ export class TreeDataService {
   init(grid: SlickGrid) {
     this._grid = grid;
 
-    if (this.gridOptions?.multiColumnSort && this.gridOptions?.enableTreeData) {
+    if (this.gridOptions?.enableTreeData && this.gridOptions?.multiColumnSort) {
       throw new Error('[Slickgrid-Universal] Tree Data does not currently support multi-column sorting, you can disable it via "multiColumnSort: false" grid option and/or help in providing support for this feature.');
+    }
+
+    if (this.gridOptions?.enableTreeData && (this.gridOptions?.backendServiceApi || this.gridOptions?.enablePagination)) {
+      throw new Error('[Slickgrid-Universal] Tree Data does not support backend services (like OData, GraphQL) and/or Pagination, it can only be used with a regular grid without Pagination.');
     }
 
     // subscribe to the SlickGrid event and call the backend execution

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -77,12 +77,12 @@ export function castObservableToPromise<T>(rxjs: RxJsFacade, input: Promise<T> |
  * @param options you can provide the following options:: "parentPropName" (defaults to "parent"), "childrenPropName" (defaults to "children") and "identifierPropName" (defaults to "id")
  * @return roots - hierarchical data view array
  */
-export function convertParentChildArrayToHierarchicalView<T = any>(flatArray: T[], options?: { parentPropName?: string; childrenPropName?: string; identifierPropName?: string; }): T[] {
+export function convertParentChildArrayToHierarchicalView<T = any>(flatArray: T[], options?: { parentPropName?: string; childrenPropName?: string; identifierPropName?: string; levelPropName?: string; }): T[] {
   const childrenPropName = options?.childrenPropName ?? 'children';
   const parentPropName = options?.parentPropName ?? '__parentId';
   const identifierPropName = options?.identifierPropName ?? 'id';
   const hasChildrenFlagPropName = '__hasChildren';
-  const treeLevelPropName = '__treeLevel';
+  const treeLevelPropName = options?.levelPropName ?? '__treeLevel';
   const inputArray: T[] = deepCopy(flatArray || []);
 
   const roots: T[] = []; // things without parent
@@ -137,11 +137,11 @@ export function convertHierarchicalViewToParentChildArray<T = any>(hierarchicalA
  * @param treeLevel - tree level number
  * @param parentId - parent ID
  */
-export function convertHierarchicalViewToParentChildArrayByReference<T = any>(hierarchicalArray: T[], outputArrayRef: T[], options?: { childrenPropName?: string; parentPropName?: string; hasChildrenFlagPropName?: string; treeLevelPropName?: string; identifierPropName?: string; }, treeLevel = 0, parentId?: string) {
+export function convertHierarchicalViewToParentChildArrayByReference<T = any>(hierarchicalArray: T[], outputArrayRef: T[], options?: { childrenPropName?: string; parentPropName?: string; hasChildrenFlagPropName?: string; levelPropName?: string; identifierPropName?: string; }, treeLevel = 0, parentId?: string) {
   const childrenPropName = options?.childrenPropName ?? 'children';
   const identifierPropName = options?.identifierPropName ?? 'id';
   const hasChildrenFlagPropName = options?.hasChildrenFlagPropName ?? '__hasChildren';
-  const treeLevelPropName = options?.treeLevelPropName ?? '__treeLevel';
+  const treeLevelPropName = options?.levelPropName ?? '__treeLevel';
   const parentPropName = options?.parentPropName ?? '__parentId';
 
   if (Array.isArray(hierarchicalArray)) {

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -83,23 +83,23 @@ export function convertParentChildArrayToHierarchicalView<T = any>(flatArray: T[
   const identifierPropName = options?.identifierPropName ?? 'id';
   const hasChildrenFlagPropName = '__hasChildren';
   const treeLevelPropName = '__treeLevel';
-  const inputArray: T[] = $.extend(true, [], flatArray);
+  const inputArray: T[] = deepCopy(flatArray || []);
 
   const roots: T[] = []; // things without parent
 
   // make them accessible by guid on this map
-  const all = {};
+  const all: any = {};
 
-  inputArray.forEach((item) => (all as any)[(item as any)[identifierPropName]] = item);
+  inputArray.forEach((item: any) => all[item[identifierPropName]] = item);
 
   // connect childrens to its parent, and split roots apart
   Object.keys(all).forEach((id) => {
-    const item = (all as any)[id];
-    if (item[parentPropName] === null || !item.hasOwnProperty(parentPropName)) {
+    const item = all[id];
+    if (!(parentPropName in item) || item[parentPropName] === null || item[parentPropName] === undefined || item[parentPropName] === '') {
       delete item[parentPropName];
       roots.push(item);
     } else if (item[parentPropName] in all) {
-      const p = (all as any)[item[parentPropName]];
+      const p = all[item[parentPropName]];
       if (!(childrenPropName in p)) {
         p[childrenPropName] = [];
       }

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -150,7 +150,7 @@ export function convertHierarchicalViewToParentChildArrayByReference<T = any>(hi
         const itemExist = outputArrayRef.some((itm: T) => (itm as any)[identifierPropName] === (item as any)[identifierPropName]);
         if (!itemExist) {
           (item as any)[treeLevelPropName] = treeLevel; // save tree level ref
-          (item as any)[parentPropName] = parentId || null;
+          (item as any)[parentPropName] = parentId ?? null;
           outputArrayRef.push(item);
         }
         if (Array.isArray((item as any)[childrenPropName])) {

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -724,7 +724,7 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Position', },
               { metadata: { style: 1, }, value: 'Order', },
             ],
-            ['▿ Order: 20 (2 items)'],
+            ['⮟ Order: 20 (2 items)'],
             ['', '1E06', 'John', 'Z', 'SALES_REP', '10'],
             ['', '2B02', 'Jane', 'DOE', 'FINANCE_MANAGER', '10'],
             ['', '', '', '', '', 'Custom: 20'],
@@ -818,7 +818,7 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Position', },
               { metadata: { style: 1, }, value: 'Order', },
             ],
-            ['▿ Order: 20 (2 items)'],
+            ['⮟ Order: 20 (2 items)'],
             ['', '1E06', 'John', 'Z', 'Sales Rep.', '10'],
             ['', '2B02', 'Jane', 'DOE', 'Finance Manager', '10'],
             ['', '', '', '', '', '20'],
@@ -941,12 +941,12 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Position', },
               { metadata: { style: 1, }, value: 'Order', },
             ],
-            ['▿ Order: 20 (2 items)'],
-            ['▿      Last Name: Z (1 items)'], // expanded
+            ['⮟ Order: 20 (2 items)'],
+            ['⮟      Last Name: Z (1 items)'], // expanded
             ['', '1E06', 'John', 'Z', 'Sales Rep.', '10'],
-            ['▿      Last Name: Doe (1 items)'], // expanded
+            ['⮟      Last Name: Doe (1 items)'], // expanded
             ['', '2B02', 'Jane', 'DOE', 'Finance Manager', '10'],
-            ['▹      Last Name: null (0 items)'], // collapsed
+            ['⮞      Last Name: null (0 items)'], // collapsed
             ['', '', '', '', '', '20'],
             ['', '', '', '', '', '10'],
           ]
@@ -1365,8 +1365,8 @@ describe('ExcelExportService', () => {
 
     describe('grid with colspan', () => {
       let mockCollection;
-      let oddMetatadata = { columns: { lastName: { colspan: 2 } } } as ItemMetadata;
-      let evenMetatadata = { columns: { 0: { colspan: '*' } } } as ItemMetadata;
+      const oddMetatadata = { columns: { lastName: { colspan: 2 } } } as ItemMetadata;
+      const evenMetatadata = { columns: { 0: { colspan: '*' } } } as ItemMetadata;
 
       beforeEach(() => {
         mockGridOptions.enableTranslate = true;

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -595,8 +595,8 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
     const groupName = sanitizeHtmlToText(itemObj.title);
 
     if (this._excelExportOptions && this._excelExportOptions.addGroupIndentation) {
-      const collapsedSymbol = this._excelExportOptions && this._excelExportOptions.groupCollapsedSymbol || '\u25B9';
-      const expandedSymbol = this._excelExportOptions && this._excelExportOptions.groupExpandedSymbol || '\u25BF';
+      const collapsedSymbol = this._excelExportOptions && this._excelExportOptions.groupCollapsedSymbol || '⮞';
+      const expandedSymbol = this._excelExportOptions && this._excelExportOptions.groupExpandedSymbol || '⮟';
       const chevron = itemObj.collapsed ? collapsedSymbol : expandedSymbol;
       return chevron + ' ' + addWhiteSpaces(5 * itemObj.level) + groupName;
     }

--- a/packages/excel-export/src/interfaces/excelExportOption.interface.ts
+++ b/packages/excel-export/src/interfaces/excelExportOption.interface.ts
@@ -27,10 +27,10 @@ export interface ExcelExportOption {
   /** The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator */
   groupingAggregatorRowText?: string;
 
-  /** Symbol use to show that the group title is collapsed (you can use unicode like '\u25B9' or '\u25B7') */
+  /** Symbol use to show that the group title is collapsed (you can use unicode like '⮞' or '\u25B7') */
   groupCollapsedSymbol?: string;
 
-  /** Symbol use to show that the group title is expanded (you can use unicode like '\u25BF' or '\u25BD') */
+  /** Symbol use to show that the group title is expanded (you can use unicode like '⮟' or '\u25BD') */
   groupExpandedSymbol?: string;
 
   /** Defaults to false, which leads to Sanitizing all data (striping out any HTML tags) when being evaluated on export. */

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -121,6 +121,7 @@ const filterServiceStub = {
   bindLocalOnSort: jest.fn(),
   bindBackendOnSort: jest.fn(),
   populateColumnFilterSearchTermPresets: jest.fn(),
+  refreshTreeDataFilters: jest.fn(),
   getColumnFilters: jest.fn(),
 } as unknown as FilterService;
 
@@ -2050,12 +2051,14 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockHierarchical = [{ id: 0, file: 'documents', files: [{ id: 1, file: 'vacation.txt' }] }];
         const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
         jest.spyOn(treeDataServiceStub, 'initializeHierarchicalDataset').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        const refreshTreeSpy = jest.spyOn(filterServiceStub, 'refreshTreeDataFilters');
 
         component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file', parentPropName: 'parentId', childrenPropName: 'files' } } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockFlatDataset;
 
         expect(hierarchicalSpy).toHaveBeenCalledWith(mockHierarchical);
+        expect(refreshTreeSpy).not.toHaveBeenCalled();
       });
 
       it('should change hierarchical dataset and expect processTreeDataInitialSort being called with other methods', () => {
@@ -2073,6 +2076,22 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(clearFilterSpy).toHaveBeenCalled();
         expect(processSpy).toHaveBeenCalled();
         expect(setItemsSpy).toHaveBeenCalledWith([], 'id');
+      });
+
+      it('should expect "refreshTreeDataFilters" method to be called when our flat dataset was already set and it just got changed a 2nd time', () => {
+        const mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', parentId: 0 }];
+        const mockHierarchical = [{ id: 0, file: 'documents', files: [{ id: 1, file: 'vacation.txt' }] }];
+        const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
+        jest.spyOn(treeDataServiceStub, 'initializeHierarchicalDataset').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        const refreshTreeSpy = jest.spyOn(filterServiceStub, 'refreshTreeDataFilters');
+
+        component.dataset = [{ id: 0, file: 'documents' }];
+        component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file', parentPropName: 'parentId', childrenPropName: 'files' } } as unknown as GridOption;
+        component.initialization(divContainer, slickEventHandler);
+        component.dataset = mockFlatDataset;
+
+        expect(hierarchicalSpy).toHaveBeenCalledWith(mockHierarchical);
+        expect(refreshTreeSpy).toHaveBeenCalled();
       });
     });
   });

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -180,7 +180,7 @@ const sortServiceStub = {
 const treeDataServiceStub = {
   init: jest.fn(),
   convertFlatDatasetConvertToHierarhicalView: jest.fn(),
-  initializeHierarchicalDataset: jest.fn(),
+  convertToHierarchicalDatasetAndSort: jest.fn(),
   dispose: jest.fn(),
   handleOnCellClick: jest.fn(),
   toggleTreeDataCollapse: jest.fn(),
@@ -2050,7 +2050,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', parentId: 0 }];
         const mockHierarchical = [{ id: 0, file: 'documents', files: [{ id: 1, file: 'vacation.txt' }] }];
         const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
-        jest.spyOn(treeDataServiceStub, 'initializeHierarchicalDataset').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
         const refreshTreeSpy = jest.spyOn(filterServiceStub, 'refreshTreeDataFilters');
 
         component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file', parentPropName: 'parentId', childrenPropName: 'files' } } as unknown as GridOption;
@@ -2082,7 +2082,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', parentId: 0 }];
         const mockHierarchical = [{ id: 0, file: 'documents', files: [{ id: 1, file: 'vacation.txt' }] }];
         const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
-        jest.spyOn(treeDataServiceStub, 'initializeHierarchicalDataset').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
         const refreshTreeSpy = jest.spyOn(filterServiceStub, 'refreshTreeDataFilters');
 
         component.dataset = [{ id: 0, file: 'documents' }];

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -174,7 +174,7 @@ export class SlickVanillaGridBundle {
 
     // when Tree Data is enabled and we don't yet have the hierarchical dataset filled, we can force a convert & sort of the array
     if (this._gridOptions.enableTreeData && Array.isArray(newDataset) && (newDataset.length > 0 || newDataset.length !== prevDatasetLn)) {
-      const sortedDatasetResult = this.treeDataService.initializeHierarchicalDataset(data, this._columnDefinitions);
+      const sortedDatasetResult = this.treeDataService.convertToHierarchicalDatasetAndSort(data, this._columnDefinitions);
       this.sharedService.hierarchicalDataset = sortedDatasetResult.hierarchical;
       data = sortedDatasetResult.flat;
 
@@ -386,7 +386,7 @@ export class SlickVanillaGridBundle {
     );
 
     this.gridStateService = services?.gridStateService ?? new GridStateService(this.extensionService, this.filterService, this._eventPubSubService, this.sharedService, this.sortService);
-    this.gridService = services?.gridService ?? new GridService(this.gridStateService, this.filterService, this._eventPubSubService, this.paginationService, this.sharedService, this.sortService);
+    this.gridService = services?.gridService ?? new GridService(this.gridStateService, this.filterService, this._eventPubSubService, this.paginationService, this.sharedService, this.sortService, this.treeDataService);
     this.groupingService = services?.groupingAndColspanService ?? new GroupingAndColspanService(this.extensionUtility, this.extensionService, this._eventPubSubService);
 
     if (hierarchicalDataset) {


### PR DESCRIPTION
1. initial sort not always working
2. tree level property should not be required while providing a `parentId` relation
3. tree data was loading and rendering the grid more than once (at least 1x time before the sort and another time after the tree was built) while it should only be rendered once

- fixes #307

#### TODOs
- [x] should work with all 3 things mentioned
- [x] add missing unit tests
- [x] need to investigate, it seems to remove the tree level property when original dataset doesn't have the property (e,g, `indent`)
- [x] do more tests in our SF implementation
- [x] add throw error to not use multi-column sorting with Tree Data
- [x] should also work when adding new item dynamically as shown in the demo 
  - there was an issue in the demo because the demo also has a filter preset
- [x] use `gridService.addItem(x)` (and `addItems()`) and make sure that it refreshes & resort the hierarchical dataset by itself (user shouldn't have to do anything except calling this service addItem)
- [x] it should also work with `updateFilters` and `updateSingleFilter`
- [x] add throw error when using backend service api with Tree Data since it isn't supported
- [x] export to file/excel should also export the tree and its indentation