### PR TITLE
feat(addon): provide grid menu labels for all built-in commands

### DIFF
--- a/packages/common/src/extensions/__tests__/extensionUtility.spec.ts
+++ b/packages/common/src/extensions/__tests__/extensionUtility.spec.ts
@@ -168,7 +168,7 @@ describe('extensionUtility', () => {
 
       it('should not change "frozenColumn" when showing a column that was not found in the visibleColumns columns array', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
-        const visibleColumns = [{ id: 'field1' }, { field: 'field2' }] as Column[];
+        const visibleColumns = [{ id: 'field1' }, { field: 'field2' }] as unknown as Column[];
         const setOptionSpy = jest.spyOn(SharedService.prototype.slickGrid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(0, allColumns, visibleColumns);
@@ -204,6 +204,13 @@ describe('extensionUtility', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         const output = utility.translateWhenEnabledAndServiceExist('COMMANDS', 'NOT_EXIST');
         expect(output).toBe('NOT_EXIST');
+      });
+
+      it('should return the same text when provided as the 3rd argument', () => {
+        const gridOptionsMock = { enableTranslate: false, enableGridMenu: true, gridMenu: { hideForceFitButton: false, hideSyncResizeButton: true, columnTitle: 'Columns' } } as GridOption;
+        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
+        const output = utility.translateWhenEnabledAndServiceExist('COMMANDS', 'NOT_EXIST', 'last argument wins');
+        expect(output).toBe('last argument wins');
       });
     });
   });

--- a/packages/common/src/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/packages/common/src/extensions/__tests__/gridMenuExtension.spec.ts
@@ -98,6 +98,17 @@ describe('gridMenuExtension', () => {
       postProcess: jest.fn(),
     },
     gridMenu: {
+      commandLabels: {
+        clearAllFiltersCommandKey: 'CLEAR_ALL_FILTERS',
+        clearAllSortingCommandKey: 'CLEAR_ALL_SORTING',
+        clearFrozenColumnsCommandKey: 'CLEAR_PINNING',
+        exportCsvCommandKey: 'EXPORT_TO_CSV',
+        exportExcelCommandKey: 'EXPORT_TO_EXCEL',
+        exportTextDelimitedCommandKey: 'EXPORT_TO_TAB_DELIMITED',
+        refreshDatasetCommandKey: 'REFRESH_DATASET',
+        toggleFilterCommandKey: 'TOGGLE_FILTER_ROW',
+        togglePreHeaderCommandKey: 'TOGGLE_PRE_HEADER_ROW',
+      },
       customItems: [],
       hideClearAllFiltersCommand: false,
       hideClearFrozenColumnsCommand: true,
@@ -382,7 +393,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should expect menu related to "Unfreeze Columns/Rows"', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, gridMenu: { hideClearFrozenColumnsCommand: false, } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: false, } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -404,7 +415,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have only 1 menu "clear-filter" when all other menus are defined as hidden & when "enableFilering" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideToggleFilterCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideToggleFilterCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -414,7 +425,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have only 1 menu "toggle-filter" when all other menus are defined as hidden & when "enableFilering" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -424,7 +435,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have only 1 menu "refresh-dataset" when all other menus are defined as hidden & when "enableFilering" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideToggleFilterCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideToggleFilterCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -444,7 +455,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "toggle-preheader" menu command when "showPreHeaderPanel" and "hideTogglePreHeaderCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideTogglePreHeaderCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideTogglePreHeaderCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect(SharedService.prototype.gridOptions.gridMenu!.customItems).toEqual([]);
@@ -461,14 +472,14 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "clear-sorting" menu command when "enableSorting" and "hideClearAllSortingCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllSortingCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideClearAllSortingCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect(SharedService.prototype.gridOptions.gridMenu!.customItems).toEqual([]);
       });
 
       it('should have the "export-csv" menu command when "enableTextExport" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -478,14 +489,14 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "export-csv" menu command when "enableTextExport" and "hideExportCsvCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect(SharedService.prototype.gridOptions.gridMenu!.customItems).toEqual([]);
       });
 
       it('should have the "export-excel" menu command when "enableTextExport" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableExcelExport: true, enableTextExport: false, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: false } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExcelExport: true, enableTextExport: false, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: false } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -495,7 +506,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have the "export-text-delimited" menu command when "enableTextExport" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -505,7 +516,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "export-text-delimited" menu command when "enableTextExport" and "hideExportCsvCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableTextExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu.commandLabels, hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect(SharedService.prototype.gridOptions.gridMenu!.customItems).toEqual([]);
@@ -526,6 +537,7 @@ describe('gridMenuExtension', () => {
           ...gridOptionsMock,
           enableTextExport: true,
           gridMenu: {
+            commandLabels: gridOptionsMock.gridMenu.commandLabels,
             customItems: customItemsMock,
             hideClearFrozenColumnsCommand: true,
             hideExportCsvCommand: false,

--- a/packages/common/src/extensions/extensionUtility.ts
+++ b/packages/common/src/extensions/extensionUtility.ts
@@ -20,11 +20,11 @@ export class ExtensionUtility {
     }
 
     let output = '';
-    const picker = this.sharedService.gridOptions && this.sharedService.gridOptions[pickerName] || {};
-    const enableTranslate = this.sharedService.gridOptions && this.sharedService.gridOptions.enableTranslate || false;
+    const picker = this.sharedService.gridOptions?.[pickerName] ?? {};
+    const enableTranslate = this.sharedService.gridOptions?.enableTranslate ?? false;
 
     // get locales provided by user in forRoot or else use default English locales via the Constants
-    const locales = this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.locales || Constants.locales;
+    const locales = this.sharedService.gridOptions?.locales ?? Constants.locales;
 
     const title = (picker as any)?.[propName];
     const titleKey = (picker as any)?.[`${propName}Key`];
@@ -95,8 +95,8 @@ export class ExtensionUtility {
 
   /**
    * Sort items (by pointers) in an array by a property name
-   * @params items array
-   * @param property name to sort with
+   * @param {Array<Object>} items array
+   * @param {String} property name to sort with
    */
   sortItems(items: any[], propertyName: string) {
     // sort the custom items by their position in the list
@@ -123,19 +123,22 @@ export class ExtensionUtility {
 
   /**
    * When "enabledTranslate" is set to True, we will try to translate if the Translate Service exist or use the Locales when not
-   * @param translationKey
-   * @param localeKey
+   * @param {String} translationKey
+   * @param {String} localeKey
+   * @param {String} textToUse - optionally provide a static text to use (that will completely override the other arguments of the method)
    */
-  translateWhenEnabledAndServiceExist(translationKey: string, localeKey: string): string {
+  translateWhenEnabledAndServiceExist(translationKey: string, localeKey: string, textToUse?: string): string {
     let text = '';
-    const gridOptions = this.sharedService && this.sharedService.gridOptions;
+    const gridOptions = this.sharedService?.gridOptions;
 
     // get locales provided by user in main file or else use default English locales via the Constants
-    const locales = gridOptions && gridOptions.locales || Constants.locales;
+    const locales = gridOptions?.locales ?? Constants.locales;
 
-    if (gridOptions.enableTranslate && this.translaterService && this.translaterService.getCurrentLanguage && this.translaterService.translate) {
+    if (textToUse) {
+      text = textToUse;
+    } else if (gridOptions.enableTranslate && this.translaterService?.translate) {
       text = this.translaterService.translate(translationKey || ' ');
-    } else if (locales && locales.hasOwnProperty(localeKey)) {
+    } else if (localeKey in locales) {
       text = locales[localeKey as keyof Locale] as string;
     } else {
       text = localeKey;

--- a/packages/common/src/extensions/gridMenuExtension.ts
+++ b/packages/common/src/extensions/gridMenuExtension.ts
@@ -50,10 +50,10 @@ export class GridMenuExtension implements Extension {
   dispose() {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
-    if (this._addon && this._addon.destroy) {
+    if (this._addon?.destroy) {
       this._addon.destroy();
     }
-    if (this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu && this.sharedService.gridOptions.gridMenu.customItems) {
+    if (this.sharedService.gridOptions?.gridMenu?.customItems) {
       this.sharedService.gridOptions.gridMenu = this._userOriginalGridMenu;
     }
     this.extensionUtility.nullifyFunctionNameStartingWithOn(this._gridMenuOptions);
@@ -68,11 +68,11 @@ export class GridMenuExtension implements Extension {
 
   /** Register the 3rd party addon (plugin) */
   register(): SlickGridMenu | null {
-    if (this.sharedService.gridOptions && this.sharedService.gridOptions.enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
+    if (this.sharedService.gridOptions?.enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
 
-    if (this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu) {
+    if (this.sharedService?.gridOptions?.gridMenu) {
       // keep original user grid menu, useful when switching locale to translate
       this._userOriginalGridMenu = { ...this.sharedService.gridOptions.gridMenu };
 
@@ -204,7 +204,7 @@ export class GridMenuExtension implements Extension {
   translateGridMenu() {
     // update the properties by pointers, that is the only way to get Grid Menu Control to see the new values
     // we also need to call the control init so that it takes the new Grid object with latest values
-    if (this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu) {
+    if (this.sharedService?.gridOptions?.gridMenu) {
       this.sharedService.gridOptions.gridMenu.customItems = [];
       this.emptyGridMenuTitles();
 
@@ -223,7 +223,7 @@ export class GridMenuExtension implements Extension {
       this.extensionUtility.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
 
       // update the Titles of each sections (command, customTitle, ...)
-      if (this._addon && this._addon.updateAllTitles) {
+      if (this._addon?.updateAllTitles) {
         this._addon.updateAllTitles(this.sharedService.gridOptions.gridMenu);
       }
     }
@@ -239,6 +239,7 @@ export class GridMenuExtension implements Extension {
     const gridMenuCustomItems: Array<GridMenuItem | 'divider'> = [];
     const gridOptions = this.sharedService.gridOptions;
     const translationPrefix = getTranslationPrefix(gridOptions);
+    const commandLabels = this._gridMenuOptions?.commandLabels;
 
     // show grid menu: Unfreeze Columns/Rows
     if (this.sharedService.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideClearFrozenColumnsCommand) {
@@ -247,7 +248,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconClearFrozenColumnsCommand || 'fa fa-times',
-            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}CLEAR_PINNING`, 'TEXT_CLEAR_PINNING'),
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.clearFrozenColumnsCommandKey}`, 'TEXT_CLEAR_PINNING', commandLabels?.clearFrozenColumnsCommand),
             disabled: false,
             command: commandName,
             positionOrder: 52
@@ -264,7 +265,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconClearAllFiltersCommand || 'fa fa-filter text-danger',
-              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}CLEAR_ALL_FILTERS`, 'TEXT_CLEAR_ALL_FILTERS'),
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.clearAllFiltersCommandKey}`, 'TEXT_CLEAR_ALL_FILTERS', commandLabels?.clearAllFiltersCommand),
               disabled: false,
               command: commandName,
               positionOrder: 50
@@ -280,7 +281,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconToggleFilterCommand || 'fa fa-random',
-              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}TOGGLE_FILTER_ROW`, 'TEXT_TOGGLE_FILTER_ROW'),
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.toggleFilterCommandKey}`, 'TEXT_TOGGLE_FILTER_ROW', commandLabels?.toggleFilterCommand),
               disabled: false,
               command: commandName,
               positionOrder: 53
@@ -296,7 +297,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconRefreshDatasetCommand || 'fa fa-refresh',
-              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}REFRESH_DATASET`, 'TEXT_REFRESH_DATASET'),
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.refreshDatasetCommandKey}`, 'TEXT_REFRESH_DATASET', commandLabels?.refreshDatasetCommand),
               disabled: false,
               command: commandName,
               positionOrder: 57
@@ -314,7 +315,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconTogglePreHeaderCommand || 'fa fa-random',
-              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}TOGGLE_PRE_HEADER_ROW`, 'TEXT_TOGGLE_PRE_HEADER_ROW'),
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.togglePreHeaderCommandKey}`, 'TEXT_TOGGLE_PRE_HEADER_ROW', commandLabels?.togglePreHeaderCommand),
               disabled: false,
               command: commandName,
               positionOrder: 53
@@ -332,7 +333,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconClearAllSortingCommand || 'fa fa-unsorted text-danger',
-              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}CLEAR_ALL_SORTING`, 'TEXT_CLEAR_ALL_SORTING'),
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.clearAllSortingCommandKey}`, 'TEXT_CLEAR_ALL_SORTING', commandLabels?.clearAllSortingCommand),
               disabled: false,
               command: commandName,
               positionOrder: 51
@@ -349,7 +350,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconExportCsvCommand || 'fa fa-download',
-            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}EXPORT_TO_CSV`, 'TEXT_EXPORT_TO_CSV'),
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.exportCsvCommandKey}`, 'TEXT_EXPORT_TO_CSV', commandLabels?.exportCsvCommand),
             disabled: false,
             command: commandName,
             positionOrder: 54
@@ -365,7 +366,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconExportExcelCommand || 'fa fa-file-excel-o text-success',
-            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}EXPORT_TO_EXCEL`, 'TEXT_EXPORT_TO_EXCEL'),
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.exportExcelCommandKey}`, 'TEXT_EXPORT_TO_EXCEL', commandLabels?.exportExcelCommand),
             disabled: false,
             command: commandName,
             positionOrder: 55
@@ -381,7 +382,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconExportTextDelimitedCommand || 'fa fa-download',
-            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}EXPORT_TO_TAB_DELIMITED`, 'TEXT_EXPORT_TO_TAB_DELIMITED'),
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.exportTextDelimitedCommandKey}`, 'TEXT_EXPORT_TO_TAB_DELIMITED', commandLabels?.exportTextDelimitedCommand),
             disabled: false,
             command: commandName,
             positionOrder: 56
@@ -496,7 +497,7 @@ export class GridMenuExtension implements Extension {
   }
 
   private emptyGridMenuTitles() {
-    if (this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu) {
+    if (this.sharedService?.gridOptions?.gridMenu) {
       this.sharedService.gridOptions.gridMenu.customTitle = '';
       this.sharedService.gridOptions.gridMenu.columnTitle = '';
       this.sharedService.gridOptions.gridMenu.forceFitTitle = '';

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -157,6 +157,17 @@ export const GlobalGridOptions: GridOption = {
   forceFitColumns: false,
   frozenHeaderWidthCalcDifferential: 1,
   gridMenu: {
+    commandLabels: {
+      clearAllFiltersCommandKey: 'CLEAR_ALL_FILTERS',
+      clearAllSortingCommandKey: 'CLEAR_ALL_SORTING',
+      clearFrozenColumnsCommandKey: 'CLEAR_PINNING',
+      exportCsvCommandKey: 'EXPORT_TO_CSV',
+      exportExcelCommandKey: 'EXPORT_TO_EXCEL',
+      exportTextDelimitedCommandKey: 'EXPORT_TO_TAB_DELIMITED',
+      refreshDatasetCommandKey: 'REFRESH_DATASET',
+      toggleFilterCommandKey: 'TOGGLE_FILTER_ROW',
+      togglePreHeaderCommandKey: 'TOGGLE_PRE_HEADER_ROW',
+    },
     hideClearAllFiltersCommand: false,
     hideClearAllSortingCommand: false,
     hideClearFrozenColumnsCommand: true, // opt-in command

--- a/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
@@ -42,6 +42,7 @@ export interface CompositeEditorOpenDetailOption {
   /** Defaults to (dataset length + 1), what is the default insert Id to use when creating a new item? */
   insertNewId?: number;
 
+  /** All the text labels that can be customized */
   labels?: CompositeEditorLabel;
 
   /**

--- a/packages/common/src/interfaces/gridMenuLabel.interface.ts
+++ b/packages/common/src/interfaces/gridMenuLabel.interface.ts
@@ -1,0 +1,55 @@
+export interface GridMenuLabel {
+  /** Defaults to "Clear all Filters" */
+  clearAllFiltersCommand?: string;
+
+  /** Defaults to "CLEAR_ALL_FILTERS" translation key */
+  clearAllFiltersCommandKey?: string;
+
+  /** Defaults to "Clear all Sorting" */
+  clearAllSortingCommand?: string;
+
+  /** Defaults to "CLEAR_ALL_SORTING" translation key */
+  clearAllSortingCommandKey?: string;
+
+  /** Defaults to "Unfreeze Columns/Rows" */
+  clearFrozenColumnsCommand?: string;
+
+  /** Defaults to "CLEAR_PINNING" translation key */
+  clearFrozenColumnsCommandKey?: string;
+
+  /** Defaults to "Export to CSV" */
+  exportCsvCommand?: string;
+
+  /** Defaults to "EXPORT_TO_CSV" translation key */
+  exportCsvCommandKey?: string;
+
+  /** Defaults to "Export to Excel" */
+  exportExcelCommand?: string;
+
+  /** Defaults to "EXPORT_TO_EXCEL" translation key */
+  exportExcelCommandKey?: string;
+
+  /** Defaults to "Export to Text Delimited" */
+  exportTextDelimitedCommand?: string;
+
+  /** Defaults to "EXPORT_TO_TAB_DELIMITED" translation key */
+  exportTextDelimitedCommandKey?: string;
+
+  /** Defaults to "Refresh Dataset" */
+  refreshDatasetCommand?: string;
+
+  /** Defaults to "REFRESH_DATASET" translation key */
+  refreshDatasetCommandKey?: string;
+
+  /** Defaults to "Toggle Filter Row" */
+  toggleFilterCommand?: string;
+
+  /** Defaults to "TOGGLE_FILTER_ROW" translation key */
+  toggleFilterCommandKey?: string;
+
+  /** Defaults to "Toggle Pre-Header Row" */
+  togglePreHeaderCommand?: string;
+
+  /** Defaults to "TOGGLE_PRE_HEADER_ROW" translation key */
+  togglePreHeaderCommandKey?: string;
+}

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -1,9 +1,12 @@
-import { Column } from './column.interface';
-import { GridMenuItem } from './gridMenuItem.interface';
-import { GridOption } from './gridOption.interface';
-import { MenuCallbackArgs } from './menuCallbackArgs.interface';
+import { Column, GridMenuItem, GridMenuLabel, GridOption, MenuCallbackArgs, } from './index';
 
 export interface GridMenuOption {
+  /**
+   * All the commands text labels
+   * NOTE: some of the text have other properties outside of this option (like 'customTitle', 'forceFitTitle', ...) and that is because they were created prior to this refactoring of labels
+   */
+  commandLabels?: GridMenuLabel;
+
   /** Defaults to 0 (auto), minimum width of grid menu content (command, column list) */
   contentMinWidth?: number;
 

--- a/packages/common/src/interfaces/index.ts
+++ b/packages/common/src/interfaces/index.ts
@@ -72,6 +72,7 @@ export * from './formatterOption.interface';
 export * from './formatterResultObject.interface';
 export * from './gridMenu.interface';
 export * from './gridMenuItem.interface';
+export * from './gridMenuLabel.interface';
 export * from './gridMenuOption.interface';
 export * from './gridOption.interface';
 export * from './gridServiceDeleteOption.interface';

--- a/packages/vanilla-bundle/src/salesforce-global-grid-options.ts
+++ b/packages/vanilla-bundle/src/salesforce-global-grid-options.ts
@@ -32,10 +32,17 @@ export const SalesforceGlobalGridOptions = {
     thousandSeparator: ','
   },
   frozenHeaderWidthCalcDifferential: 2,
+  columnPicker: {
+    hideForceFitButton: true,
+  },
   gridMenu: {
+    commandLabels: {
+      clearFrozenColumnsCommand: 'Unfreeze Columns',
+    },
     hideTogglePreHeaderCommand: true,
     hideRefreshDatasetCommand: true,
     hideClearFrozenColumnsCommand: false,
+    hideForceFitButton: true,
   },
   headerMenu: {
     hideFreezeColumnsCommand: false,


### PR DESCRIPTION
- prior to the change, we couldn't change the label, we would only be able to change the translation key but we couldn't change the text when we're not using translations. This PR provides both way of customizing these labels, via its label and/or with a label translation key