### PR TITLE
WIP - feat(tree): improve Tree Data speed considerably, fixes #307

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.html
@@ -15,28 +15,39 @@
 </h6>
 <div class="columns">
   <div class="column is-narrow">
-    <button onclick.delegate="addNewRow()" class="button is-small is-info">
-      <span class="icon mdi mdi-plus"></span>
-      <span>Add New Item (in 1st group)</span>
-    </button>
-    <button onclick.delegate="collapseAll()" data-test="collapse-all" class="button is-small">
-      <span class="icon mdi mdi-arrow-collapse"></span>
-      <span>Collapse All</span>
-    </button>
-    <button onclick.delegate="expandAll()" data-test="expand-all" class="button is-small">
-      <span class="icon mdi mdi-arrow-expand"></span>
-      <span>Expand All</span>
-    </button>
-    <button onclick.delegate="logFlatStructure()" class="button is-small">
-      <span>Log Flat Structure</span>
-    </button>
-    <button onclick.delegate="logHierarchicalStructure()" class="button is-small">
-      <span>Log Hierarchical Structure</span>
-    </button>
-    <button onclick.delegate="dynamicallyChangeFilter()" class="button is-small">
-      <span class="icon mdi mdi-filter-outline"></span>
-      <span>Dynamically Change Filter (% complete &lt; 40)</span>
-    </button>
+    <div class="row" style="margin-bottom: 4px;">
+      <button class="button is-small" data-test="add-500-rows-btn" onclick.delegate="loadData(500)">
+        500 rows
+      </button>
+      <button class="button is-small" data-test="add-50k-rows-btn" onclick.delegate="loadData(50000)">
+        50k rows
+      </button>
+      <button onclick.delegate="dynamicallyChangeFilter()" class="button is-small">
+        <span class="icon mdi mdi-filter-outline"></span>
+        <span>Dynamically Change Filter (% complete &lt; 40)</span>
+      </button>
+    </div>
+
+    <div class="row" style="margin-bottom: 4px;">
+      <button onclick.delegate="addNewRow()" class="button is-small is-info">
+        <span class="icon mdi mdi-plus"></span>
+        <span>Add New Item (in 1st group)</span>
+      </button>
+      <button onclick.delegate="collapseAll()" data-test="collapse-all" class="button is-small">
+        <span class="icon mdi mdi-arrow-collapse"></span>
+        <span>Collapse All</span>
+      </button>
+      <button onclick.delegate="expandAll()" data-test="expand-all" class="button is-small">
+        <span class="icon mdi mdi-arrow-expand"></span>
+        <span>Expand All</span>
+      </button>
+      <button onclick.delegate="logFlatStructure()" class="button is-small">
+        <span>Log Flat Structure</span>
+      </button>
+      <button onclick.delegate="logHierarchicalStructure()" class="button is-small">
+        <span>Log Hierarchical Structure</span>
+      </button>
+    </div>
   </div>
 </div>
 

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example05.ts
@@ -11,7 +11,7 @@ import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bu
 import { ExampleGridOptions } from './example-grid-options';
 import './example05.scss';
 
-const NB_ITEMS = 200;
+const NB_ITEMS = 500;
 
 export class Example5 {
   columnDefinitions: Column[];
@@ -26,8 +26,8 @@ export class Example5 {
     const gridContainerElm = document.querySelector<HTMLDivElement>('.grid5');
 
     this.sgb = new Slicker.GridBundle(gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions });
-    this.dataset = this.mockDataset();
-    this.sgb.dataset = this.dataset;
+    this.dataset = this.loadData(NB_ITEMS);
+    // this.sgb.dataset = this.dataset;
   }
 
   dispose() {
@@ -93,10 +93,12 @@ export class Example5 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        // levelPropName: 'indent', // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         parentPropName: 'parentId',
+        // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
+        // levelPropName: 'indent',
 
         // you can optionally sort by a different column and/or sort direction
+        // this is the recommend approach, unless you are 100% that your original array is already sorted (in most cases it's not)
         initialSort: {
           columnId: 'title',
           direction: 'ASC'
@@ -160,17 +162,17 @@ export class Example5 {
     console.log('flat array', this.sgb.treeDataService.dataset);
   }
 
-  mockDataset() {
+  loadData(rowCount: number) {
     let indent = 0;
     const parents = [];
     const data = [];
 
     // prepare the data
-    for (let i = 0; i < NB_ITEMS; i++) {
+    for (let i = 0; i < rowCount; i++) {
       const randomYear = 2000 + Math.floor(Math.random() * 10);
       const randomMonth = Math.floor(Math.random() * 11);
       const randomDay = Math.floor((Math.random() * 29));
-      const d = (data[i] = {});
+      const item = (data[i] = {});
       let parentId;
 
       // for implementing filtering/sorting, don't go over indent of 2
@@ -188,15 +190,19 @@ export class Example5 {
         parentId = null;
       }
 
-      d['id'] = i;
-      d['parentId'] = parentId;
-      // d['title'] = `Task ${i}    -   [P]: ${parentId}`;
-      d['title'] = `Task ${i}`;
-      d['duration'] = '5 days';
-      d['percentComplete'] = Math.round(Math.random() * 100);
-      d['start'] = new Date(randomYear, randomMonth, randomDay);
-      d['finish'] = new Date(randomYear, (randomMonth + 1), randomDay);
-      d['effortDriven'] = (i % 5 === 0);
+      item['id'] = i;
+      // item['__treeLevel'] = indent;
+      item['parentId'] = parentId;
+      // item['title'] = `Task ${i}`;
+      item['title'] = `<span style="font-weight:500">Task ${i}</span>  <span style="font-size:11px; margin-left: 15px;">(parentId: ${parentId})</span>`;
+      item['duration'] = '5 days';
+      item['percentComplete'] = Math.round(Math.random() * 100);
+      item['start'] = new Date(randomYear, randomMonth, randomDay);
+      item['finish'] = new Date(randomYear, (randomMonth + 1), randomDay);
+      item['effortDriven'] = (i % 5 === 0);
+    }
+    if (this.sgb) {
+      this.sgb.dataset = data;
     }
     return data;
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -70,7 +70,8 @@
     "jquery-ui-dist": "^1.12.1",
     "moment-mini": "^2.24.0",
     "multiple-select-modified": "^1.3.11",
-    "slickgrid": "^2.4.34"
+    "slickgrid": "^2.4.34",
+    "un-flatten-tree": "^2.0.12"
   },
   "devDependencies": {
     "@types/dompurify": "^2.2.2",

--- a/packages/common/src/formatters/__tests__/treeExportFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeExportFormatter.spec.ts
@@ -32,7 +32,7 @@ describe('Tree Export Formatter', () => {
 
   it('should throw an error when oarams are mmissing', () => {
     expect(() => treeExportFormatter(1, 1, 'blah', {} as Column, {}, gridStub))
-      .toThrowError('You must provide valid "treeDataOptions" in your Grid Options and it seems that there are no tree level found in this row');
+      .toThrowError('[Slickgrid-Universal] You must provide valid "treeDataOptions" in your Grid Options, however it seems that we could not find any tree level info on the current item datacontext row.');
   });
 
   it('should return empty string when DataView is not correctly formed', () => {

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -32,7 +32,7 @@ describe('Tree Formatter', () => {
 
   it('should throw an error when oarams are mmissing', () => {
     expect(() => treeFormatter(1, 1, 'blah', {} as Column, {}, gridStub))
-      .toThrowError('You must provide valid "treeDataOptions" in your Grid Options and it seems that there are no tree level found in this row');
+      .toThrowError('[Slickgrid-Universal] You must provide valid "treeDataOptions" in your Grid Options, however it seems that we could not find any tree level info on the current item datacontext row.');
   });
 
   it('should return empty string when DataView is not correctly formed', () => {

--- a/packages/common/src/formatters/treeExportFormatter.ts
+++ b/packages/common/src/formatters/treeExportFormatter.ts
@@ -25,7 +25,7 @@ export const treeExportFormatter: Formatter = (_row, _cell, value, columnDef, da
   }
 
   if (!dataContext.hasOwnProperty(treeLevelPropName)) {
-    throw new Error('You must provide valid "treeDataOptions" in your Grid Options and it seems that there are no tree level found in this row');
+    throw new Error('[Slickgrid-Universal] You must provide valid "treeDataOptions" in your Grid Options, however it seems that we could not find any tree level info on the current item datacontext row.');
   }
 
   if (dataView?.getItemByIdx) {

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -32,9 +32,6 @@ export interface TreeDataOption {
   /** Defaults to "__treeLevel", object property name used to designate the Tree Level depth number */
   levelPropName?: string;
 
-  /** Defaults to "__hasChildren", object property name used to designate if the item has Children flag */
-  hasChildrenFlagPropName?: string;
-
   /**
    * Defaults to 15px, margin to add from the left (calculated by the tree level multiplied by this number).
    * For example if tree depth level is 2, the calculation will be (2 * 15 = 30), so the column will be displayed 30px from the left

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -86,7 +86,7 @@ const paginationServiceStub = {
 } as unknown as PaginationService;
 
 const treeDataServiceStub = {
-  convertFlatDatasetConvertToHierarhicalView: jest.fn(),
+  convertFlatToHierarchicalDataset: jest.fn(),
   init: jest.fn(),
   convertToHierarchicalDatasetAndSort: jest.fn(),
   dispose: jest.fn(),
@@ -811,7 +811,7 @@ describe('Grid Service', () => {
 
       jest.spyOn(dataviewStub, 'getItems').mockReturnValue(mockFlatDataset);
       jest.spyOn(dataviewStub, 'getRowById').mockReturnValue(0);
-      jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+      jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
       jest.spyOn(gridStub, 'getOptions').mockReturnValue({ enableAutoResize: true, enableRowSelection: true, enableTreeData: true } as GridOption);
       jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(mockColumns);
       const setItemSpy = jest.spyOn(dataviewStub, 'setItems');
@@ -836,7 +836,7 @@ describe('Grid Service', () => {
 
       jest.spyOn(dataviewStub, 'getItems').mockReturnValue(mockFlatDataset);
       jest.spyOn(dataviewStub, 'getRowById').mockReturnValue(0);
-      jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+      jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
       jest.spyOn(gridStub, 'getOptions').mockReturnValue({ enableAutoResize: true, enableRowSelection: true, enableTreeData: true } as GridOption);
       jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(mockColumns);
       const setItemSpy = jest.spyOn(dataviewStub, 'setItems');

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -87,6 +87,16 @@ describe('TreeData Service', () => {
     }
   });
 
+  it('should throw an error when used without filter grid option', (done) => {
+    try {
+      gridOptionsMock.multiColumnSort = true;
+      service.init(gridStub);
+    } catch (e) {
+      expect(e.toString()).toContain('[Slickgrid-Universal] It looks like you are trying to use Tree Data without using the filtering option');
+      done();
+    }
+  });
+
   it('should throw an error when enableTreeData is enabled with Pagination since that is not supported', (done) => {
     try {
       gridOptionsMock.enablePagination = true;
@@ -293,7 +303,7 @@ describe('TreeData Service', () => {
         }];
         const setSortSpy = jest.spyOn(gridStub, 'setSortColumns');
         jest.spyOn(gridStub, 'getColumnIndex').mockReturnValue(0);
-        jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+        jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
 
         service.init(gridStub);
         const result = service.convertToHierarchicalDatasetAndSort(mockFlatDataset, mockColumns, gridOptionsMock);
@@ -303,7 +313,7 @@ describe('TreeData Service', () => {
           sortAsc: true,
           sortCol: mockColumns[0]
         }]);
-        expect(result).toEqual({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+        expect(result).toEqual({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
       });
 
       it('should sort by the Tree column by the "initialSort" provided', () => {
@@ -318,7 +328,7 @@ describe('TreeData Service', () => {
         }];
         const setSortSpy = jest.spyOn(gridStub, 'setSortColumns');
         jest.spyOn(gridStub, 'getColumnIndex').mockReturnValue(0);
-        jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+        jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
 
         service.init(gridStub);
         const result = service.convertToHierarchicalDatasetAndSort(mockFlatDataset, mockColumns, gridOptionsMock);
@@ -328,7 +338,7 @@ describe('TreeData Service', () => {
           sortAsc: false,
           sortCol: mockColumns[1]
         }]);
-        expect(result).toEqual({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+        expect(result).toEqual({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
       });
     });
 

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -2,7 +2,7 @@ import 'jest-extended';
 import { of } from 'rxjs';
 
 import { FieldType, OperatorType } from '../../enums/index';
-import { GridOption, Subscription } from '../../interfaces/index';
+import { EventSubscription, GridOption } from '../../interfaces/index';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub';
 import {
   addToArrayWhenNotExists,
@@ -85,6 +85,10 @@ describe('Service/Utilies', () => {
 
     it('should return the a simple string with x spaces only where x is the number of spaces provided as argument', () => {
       expect(addWhiteSpaces(5)).toBe('     ');
+    });
+
+    it('should return the a simple html string with x &nbsp; separator where x is the number of spaces provided as argument', () => {
+      expect(addWhiteSpaces(2)).toBe('&nbsp;&nbsp;');
     });
   });
 
@@ -1488,7 +1492,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should be able to unsubscribe all Observables', () => {
-      const subscriptions: Subscription[] = [];
+      const subscriptions: EventSubscription[] = [];
       const observable1 = of([1, 2]);
       const observable2 = of([1, 2]);
       subscriptions.push(observable1.subscribe(), observable2.subscribe());

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -691,11 +691,12 @@ export class FilterService {
   /**
    * when we have a Filter Presets on a Tree Data View grid, we need to call the pre-filtering of tree data
    * we need to do this because Tree Data is the only type of grid that requires a pre-filter (preFilterTreeData) to be executed before the final filtering
-   * @param filters
+   * @param {Array<Object>} [items] - optional flat array of parent/child items to use while redoing the full sort & refresh
    */
-  refreshTreeDataFilters() {
+  refreshTreeDataFilters(items?: any[]) {
+    const inputItems = items ?? this._dataView.getItems();
     if (this._dataView && this._gridOptions?.enableTreeData) {
-      this._tmpPreFilteredData = this.preFilterTreeData(this._dataView.getItems(), this._columnFilters);
+      this._tmpPreFilteredData = this.preFilterTreeData(inputItems, this._columnFilters);
       this._dataView.refresh(); // and finally this refresh() is what triggers a DataView filtering check
     }
   }

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -870,16 +870,18 @@ export class GridService {
   }
 
   /**
-   * When dealing with hierarchical dataset, we can invalidate all the rows and force a resort & re-render of the hierarchical dataset.
+   * When dealing with hierarchical (tree) dataset, we can invalidate all the rows and force a full resort & re-render of the hierarchical tree dataset.
    * This method will automatically be called anytime user called `addItem()` or `addItems()`.
    * However please note that it won't be called when `updateItem`, if the data that gets updated does change the tree data column then you should call this method.
+   * @param {Array<Object>} [items] - optional flat array of parent/child items to use while redoing the full sort & refresh
    */
-  invalidateHierarchicalDataset() {
+  invalidateHierarchicalDataset(items?: any[]) {
     // if we add/remove item(s) from the dataset, we need to also refresh our tree data filters
     if (this._gridOptions?.enableTreeData && this.treeDataService) {
-      const sortedDatasetResult = this.treeDataService.convertToHierarchicalDatasetAndSort(this._dataView.getItems(), this.sharedService.allColumns, this._gridOptions);
+      const inputItems = items ?? this._dataView.getItems();
+      const sortedDatasetResult = this.treeDataService.convertToHierarchicalDatasetAndSort(inputItems, this.sharedService.allColumns, this._gridOptions);
       this.sharedService.hierarchicalDataset = sortedDatasetResult.hierarchical;
-      this.filterService.refreshTreeDataFilters();
+      this.filterService.refreshTreeDataFilters(items);
       this._dataView.setItems(sortedDatasetResult.flat);
     }
   }

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -375,7 +375,7 @@ export class SortService {
   onLocalSortChanged(grid: SlickGrid, sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>, forceReSort = false, emitSortChanged = false) {
     const isTreeDataEnabled = this._gridOptions?.enableTreeData ?? false;
     const dataView = grid?.getData && grid.getData() as SlickDataView;
-
+    console.time('sort changed');
     if (grid && dataView) {
       if (forceReSort && !isTreeDataEnabled) {
         dataView.reSort();
@@ -390,7 +390,7 @@ export class SortService {
       }
 
       grid.invalidate();
-
+      console.timeEnd('sort changed');
       if (emitSortChanged) {
         this.emitSortChanged(EmitterType.local, sortColumns.map(col => {
           return {
@@ -403,12 +403,18 @@ export class SortService {
   }
 
   /** Takes a hierarchical dataset and sort it recursively,  */
-  sortHierarchicalDataset(hierarchicalDataset: any[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>): { hierarchical: any[]; flat: any[]; } {
+  sortHierarchicalDataset<T>(hierarchicalDataset: T[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>) {
+    console.time('sort tree array');
     this.sortTreeData(hierarchicalDataset, sortColumns);
+    console.timeEnd('sort tree array');
+
     const dataViewIdIdentifier = this._gridOptions?.datasetIdPropertyName ?? 'id';
     const treeDataOpt: TreeDataOption = this._gridOptions?.treeDataOptions ?? { columnId: '' };
     const treeDataOptions = { ...treeDataOpt, identifierPropName: treeDataOpt.identifierPropName ?? dataViewIdIdentifier };
+
+    console.time('reconvert to flat parent/child');
     const sortedFlatArray = convertHierarchicalViewToParentChildArray(hierarchicalDataset, treeDataOptions);
+    console.timeEnd('reconvert to flat parent/child');
 
     return { hierarchical: hierarchicalDataset, flat: sortedFlatArray };
   }

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -52,6 +52,10 @@ export class TreeDataService {
         throw new Error('[Slickgrid-Universal] It looks like you are trying to use Tree Data with multi-column sorting, unfortunately it is not supported because of its complexity, you can disable it via "multiColumnSort: false" grid option and/or help in providing support for this feature.');
       }
 
+      if (!this.gridOptions?.enableFiltering) {
+        throw new Error('[Slickgrid-Universal] It looks like you are trying to use Tree Data without using the filtering option, unfortunately that is not possible with Tree Data since it relies heavily on the filters to expand/collapse the tree. You need to enable it via "enableFiltering: true"');
+      }
+
       if (this.gridOptions?.backendServiceApi || this.gridOptions?.enablePagination) {
         throw new Error('[Slickgrid-Universal] It looks like you are trying to use Tree Data with Pagination and/or a Backend Service (OData, GraphQL) but unfortunately that is simply not supported because of its complexity.');
       }
@@ -80,10 +84,15 @@ export class TreeDataService {
     };
   }
 
-  /** Takes a flat dataset, converts it into a hierarchical dataset, sort it by recursion and finally return back the final and sorted flat array */
-  convertToHierarchicalDatasetAndSort(flatDataset: any[], columnDefinitions: Column[], gridOptions: GridOption): { hierarchical: any[]; flat: any[]; } {
+  /**
+   * Takes a flat dataset, converts it into a hierarchical dataset, sort it by recursion and finally return back the final and sorted flat array
+   * @param {Array<Object>} flatDataset - parent/child flat dataset
+   * @param {Object} gridOptions - grid options
+   * @returns {Array<Object>} - tree dataset
+   */
+  convertToHierarchicalDatasetAndSort<P, T extends P & { [childrenPropName: string]: T[] }>(flatDataset: P[], columnDefinitions: Column[], gridOptions: GridOption) {
     // 1- convert the flat array into a hierarchical array
-    const datasetHierarchical = this.convertFlatDatasetConvertToHierarhicalView(flatDataset, gridOptions);
+    const datasetHierarchical = this.convertFlatToHierarchicalDataset(flatDataset, gridOptions);
 
     // 2- sort the hierarchical array recursively by an optional "initialSort" OR if nothing is provided we'll sort by the column defined as the Tree column
     // also note that multi-column is not currently supported with Tree Data
@@ -96,7 +105,13 @@ export class TreeDataService {
     return datasetSortResult;
   }
 
-  convertFlatDatasetConvertToHierarhicalView(flatDataset: any[], gridOptions: GridOption): any[] {
+  /**
+   * Takes a flat dataset, converts it into a hierarchical dataset
+   * @param {Array<Object>} flatDataset - parent/child flat dataset
+   * @param {Object} gridOptions - grid options
+   * @returns {Array<Object>} - tree dataset
+   */
+  convertFlatToHierarchicalDataset<P, T extends P & { [childrenPropName: string]: P[] }>(flatDataset: P[], gridOptions: GridOption): T[] {
     const dataViewIdIdentifier = gridOptions?.datasetIdPropertyName ?? 'id';
     const treeDataOpt: TreeDataOption = gridOptions?.treeDataOptions ?? { columnId: 'id' };
     const treeDataOptions = { ...treeDataOpt, identifierPropName: treeDataOpt.identifierPropName ?? dataViewIdIdentifier };
@@ -125,9 +140,15 @@ export class TreeDataService {
     }
   }
 
-  sortHierarchicalDataset(hierarchicalDataset: any[]): { hierarchical: any[]; flat: any[]; } {
-    const columnSort = this.getInitialSort(this.sharedService.allColumns, this.gridOptions);
-    return this.sortService.sortHierarchicalDataset(hierarchicalDataset, [columnSort]);
+  /**
+   * Takes a hierarchical (tree) input array and sort it (if an `initialSort` exist, it will use that to sort)
+   * @param {Array<Object>} hierarchicalDataset - inpu
+   * @returns {Object} sort result object that includes both the flat & tree data arrays
+   */
+  sortHierarchicalDataset<T>(hierarchicalDataset: T[], inputColumnSorts?: ColumnSort | ColumnSort[]) {
+    const columnSorts = inputColumnSorts ?? this.getInitialSort(this.sharedService.allColumns, this.gridOptions);
+    const finalColumnSorts = Array.isArray(columnSorts) ? columnSorts : [columnSorts];
+    return this.sortService.sortHierarchicalDataset(hierarchicalDataset, finalColumnSorts);
   }
 
   toggleTreeDataCollapse(collapsing: boolean) {

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -179,7 +179,7 @@ const sortServiceStub = {
 
 const treeDataServiceStub = {
   init: jest.fn(),
-  convertFlatDatasetConvertToHierarhicalView: jest.fn(),
+  convertFlatToHierarchicalDataset: jest.fn(),
   convertToHierarchicalDatasetAndSort: jest.fn(),
   dispose: jest.fn(),
   handleOnCellClick: jest.fn(),
@@ -2033,7 +2033,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', parentId: 0 }];
         const mockHierarchical = [{ id: 0, file: 'documents', files: [{ id: 1, file: 'vacation.txt' }] }];
         const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
-        jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ hierarchical: mockHierarchical as any[], flat: mockFlatDataset as any[] });
         const refreshTreeSpy = jest.spyOn(filterServiceStub, 'refreshTreeDataFilters');
 
         component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file', parentPropName: 'parentId', childrenPropName: 'files' } } as unknown as GridOption;
@@ -2068,7 +2068,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const clearFilterSpy = jest.spyOn(filterServiceStub, 'clearFilters');
         const setItemsSpy = jest.spyOn(mockDataView, 'setItems');
         const processSpy = jest.spyOn(sortServiceStub, 'processTreeDataInitialSort');
-        const sortHierarchicalSpy = jest.spyOn(treeDataServiceStub, 'sortHierarchicalDataset').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        const sortHierarchicalSpy = jest.spyOn(treeDataServiceStub, 'sortHierarchicalDataset').mockReturnValue({ hierarchical: mockHierarchical as any[], flat: mockFlatDataset as any[] });
 
         component.dispose();
         component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file' } } as unknown as GridOption;
@@ -2086,7 +2086,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', parentId: 0 }];
         const mockHierarchical = [{ id: 0, file: 'documents', files: [{ id: 1, file: 'vacation.txt' }] }];
         const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
-        jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ hierarchical: mockHierarchical, flat: mockFlatDataset });
+        jest.spyOn(treeDataServiceStub, 'convertToHierarchicalDatasetAndSort').mockReturnValue({ hierarchical: mockHierarchical as any[], flat: mockFlatDataset as any[] });
         const refreshTreeSpy = jest.spyOn(filterServiceStub, 'refreshTreeDataFilters');
 
         component.dataset = [{ id: 0, file: 'documents' }];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11520,6 +11520,11 @@ umask@^1.1.0:
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
+un-flatten-tree@^2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/un-flatten-tree/-/un-flatten-tree-2.0.12.tgz#8d92ec454a1b7e1aead948ed029907e1cb9a9ed8"
+  integrity sha1-jZLsRUobfhrq2UjtApkH4cuantg=
+
 unbox-primitive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.0.tgz#eeacbc4affa28e9b3d36b5eaeccc50b3251b1d3f"


### PR DESCRIPTION
- fixes #307 

#### TODOs
- [x] refactor flat to tree structure and vice versa to optimize speed
   - so far it seems to be 50x faster 😮 (previous code to convert from tree to flat was extremely slow, deep copy and item search were the main culprit)
- [x] add ways to change dataset dynamically in the demo (2 buttons to change from 500 to 50k rows)
- [ ] update all unit tests