### PR TITLE
fix(demo): we should be able to move row(s) and keep selections

### DIFF
--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -257,8 +257,8 @@ export class GridStateService {
    * @return current pagination state
    */
   getCurrentPagination(): CurrentPagination | null {
-    if (this._gridOptions.enablePagination) {
-      if (this._gridOptions?.backendServiceApi) {
+    if (this._gridOptions?.enablePagination) {
+      if (this._gridOptions.backendServiceApi) {
         const backendService = this._gridOptions.backendServiceApi.service;
         if (backendService?.getCurrentPagination) {
           return backendService.getCurrentPagination();

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -155,7 +155,7 @@ export class GridStateService {
     }
 
     if (this.hasRowSelectionEnabled()) {
-      const currentRowSelection = this.getCurrentRowSelections(args && args.requestRefreshRowFilteredRow);
+      const currentRowSelection = this.getCurrentRowSelections(args?.requestRefreshRowFilteredRow);
       if (currentRowSelection) {
         gridState.rowSelection = currentRowSelection;
       }
@@ -181,7 +181,7 @@ export class GridStateService {
 
     if (gridColumns && Array.isArray(gridColumns)) {
       gridColumns.forEach((column: Column) => {
-        if (column && column.id) {
+        if (column?.id) {
           currentColumns.push({
             columnId: column.id as string,
             cssClass: column.cssClass || '',
@@ -207,7 +207,7 @@ export class GridStateService {
     if (currentColumns && Array.isArray(currentColumns)) {
       currentColumns.forEach((currentColumn: CurrentColumn) => {
         const gridColumn: Column | undefined = gridColumns.find((c: Column) => c.id === currentColumn.columnId);
-        if (gridColumn && gridColumn.id) {
+        if (gridColumn?.id) {
           columns.push({
             ...gridColumn,
             cssClass: currentColumn.cssClass,
@@ -243,10 +243,10 @@ export class GridStateService {
   getCurrentFilters(): CurrentFilter[] | null {
     if (this._gridOptions && this._gridOptions.backendServiceApi) {
       const backendService = this._gridOptions.backendServiceApi.service;
-      if (backendService && backendService.getCurrentFilters) {
+      if (backendService?.getCurrentFilters) {
         return backendService.getCurrentFilters() as CurrentFilter[];
       }
-    } else if (this.filterService && this.filterService.getCurrentLocalFilters) {
+    } else if (this.filterService?.getCurrentLocalFilters) {
       return this.filterService.getCurrentLocalFilters();
     }
     return null;
@@ -258,9 +258,9 @@ export class GridStateService {
    */
   getCurrentPagination(): CurrentPagination | null {
     if (this._gridOptions.enablePagination) {
-      if (this._gridOptions && this._gridOptions.backendServiceApi) {
+      if (this._gridOptions?.backendServiceApi) {
         const backendService = this._gridOptions.backendServiceApi.service;
-        if (backendService && backendService.getCurrentPagination) {
+        if (backendService?.getCurrentPagination) {
           return backendService.getCurrentPagination();
         }
       } else {
@@ -298,12 +298,12 @@ export class GridStateService {
    * @return current sorters
    */
   getCurrentSorters(): CurrentSorter[] | null {
-    if (this._gridOptions && this._gridOptions.backendServiceApi) {
+    if (this._gridOptions?.backendServiceApi) {
       const backendService = this._gridOptions.backendServiceApi.service;
-      if (backendService && backendService.getCurrentSorters) {
+      if (backendService?.getCurrentSorters) {
         return backendService.getCurrentSorters() as CurrentSorter[];
       }
-    } else if (this.sortService && this.sortService.getCurrentLocalSorters) {
+    } else if (this.sortService?.getCurrentLocalSorters) {
       return this.sortService.getCurrentLocalSorters();
     }
     return null;
@@ -312,7 +312,7 @@ export class GridStateService {
   /** Check whether the row selection needs to be preserved */
   needToPreserveRowSelection(): boolean {
     let preservedRowSelection = false;
-    if (this._gridOptions && this._gridOptions.dataView && this._gridOptions.dataView.hasOwnProperty('syncGridSelection')) {
+    if (this._gridOptions?.dataView && this._gridOptions.dataView.hasOwnProperty('syncGridSelection')) {
       const syncGridSelection = this._gridOptions.dataView.syncGridSelection;
       if (typeof syncGridSelection === 'boolean') {
         preservedRowSelection = this._gridOptions.dataView.syncGridSelection as boolean;
@@ -353,8 +353,8 @@ export class GridStateService {
   resetRowSelectionWhenRequired() {
     if (!this.needToPreserveRowSelection() && (this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector)) {
       // this also requires the Row Selection Model to be registered as well
-      const rowSelectionExtension = this.extensionService && this.extensionService.getExtensionByName && this.extensionService.getExtensionByName(ExtensionName.rowSelection);
-      if (rowSelectionExtension && rowSelectionExtension.instance) {
+      const rowSelectionExtension = this.extensionService?.getExtensionByName?.(ExtensionName.rowSelection);
+      if (rowSelectionExtension?.instance) {
         this._grid.setSelectedRows([]);
       }
     }
@@ -433,12 +433,12 @@ export class GridStateService {
    * @param event name
    */
   private bindExtensionAddonEventToGridStateChange(extensionName: ExtensionName, eventName: string) {
-    const extension = this.extensionService && this.extensionService.getExtensionByName && this.extensionService.getExtensionByName(extensionName);
-    const slickEvent = extension && extension.instance && extension.instance[eventName];
+    const extension = this.extensionService?.getExtensionByName?.(extensionName);
+    const slickEvent = extension?.instance?.[eventName];
 
     if (slickEvent && typeof slickEvent.subscribe === 'function') {
       (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof slickEvent>>).subscribe(slickEvent, (_e, args) => {
-        const columns: Column[] = args && args.columns;
+        const columns: Column[] = args?.columns;
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       });
@@ -547,7 +547,7 @@ export class GridStateService {
           // this could happen if the previous step was a page change
           const shouldBeSelectedRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []);
           const currentSelectedRowIndexes = this._grid.getSelectedRows();
-          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes)) {
+          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes) && this._gridOptions.enablePagination) {
             this._grid.setSelectedRows(shouldBeSelectedRowIndexes);
           }
 

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -177,8 +177,8 @@ export class SortService {
           }
         }
       } else if (this._isBackendGrid) {
-        const backendService = this._gridOptions && this._gridOptions.backendServiceApi && this._gridOptions.backendServiceApi.service;
-        if (backendService && backendService.clearSorters) {
+        const backendService = this._gridOptions?.backendServiceApi?.service;
+        if (backendService?.clearSorters) {
           backendService.clearSorters();
         }
       }

--- a/test/cypress/integration/example07.spec.js
+++ b/test/cypress/integration/example07.spec.js
@@ -71,6 +71,38 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', { retries
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 7}px"] > .slick-cell:nth(1) input[type="checkbox"]:checked`).should('have.length', 1);
   });
 
+  it('should drag row to another position in the grid', () => {
+    cy.get('[style="top:45px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+    cy.get('[style="top:135px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+
+    cy.get('@moveIconTask3').should('have.length', 1);
+
+    cy.get('@moveIconTask3')
+      .trigger('mousedown', { button: 0, force: true })
+      .trigger('mousemove', 'bottomRight');
+
+    cy.get('@moveIconTask1')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 4);
+  });
+
+  it('should expect row to be moved to another row index', () => {
+    cy.get('.slick-viewport-top.slick-viewport-left')
+      .scrollTo('top');
+
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(2)`).should('contain', 'Task 0');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(2)`).should('contain', 'Task 1');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(2)`).should('contain', 'Task 3');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(2)`).should('contain', 'Task 2');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(2)`).should('contain', 'Task 4');
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 4);
+  });
+
   it('should uncheck all rows', () => {
     // click twice to check then uncheck all
     cy.get('.slick-column-name > input[type=checkbox]')
@@ -88,39 +120,7 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', { retries
       });
   });
 
-  it('should drag opened Row Detail to another position in the grid', () => {
-    cy.get('[style="top:45px"] > .slick-cell.cell-reorder').as('moveIconTask1');
-    cy.get('[style="top:135px"] > .slick-cell.cell-reorder').as('moveIconTask3');
-
-    cy.get('@moveIconTask3').should('have.length', 1);
-
-    cy.get('@moveIconTask3')
-      .trigger('mousedown', { button: 0, force: true })
-      .trigger('mousemove', 'bottomRight');
-
-    cy.get('@moveIconTask1')
-      .trigger('mousemove', 'bottomRight')
-      .trigger('mouseup', 'bottomRight', { force: true });
-
-    cy.get('input[type="checkbox"]:checked')
-      .should('have.length', 0);
-  });
-
-  it('should expect row to be moved to another row index', () => {
-    cy.get('.slick-viewport-top.slick-viewport-left')
-      .scrollTo('top');
-
-    cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(2)`).should('contain', 'Task 0');
-    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(2)`).should('contain', 'Task 1');
-    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(2)`).should('contain', 'Task 3');
-    cy.get(`[style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(2)`).should('contain', 'Task 2');
-    cy.get(`[style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(2)`).should('contain', 'Task 4');
-
-    cy.get('input[type="checkbox"]:checked')
-      .should('have.length', 0);
-  });
-
-  it('should select 2 rows (Task 3,4), then move row and expect the 2 rows to still be selected without any others', () => {
+  it('should select 2 rows (Task 3,4), then move the rows and expect both rows to still be selected without any other rows', () => {
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(1)`).click();
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(1)`).click();
 


### PR DESCRIPTION
- grid state should only be allowed to change row selection only when Pagination is enabled
- refactor some part of the code to use more optional chaining (?.) syntax for cleaner and smaller code
- move around some of the Cypress tests so that it makes sure that moving rows will keep row selections