### PR TITLE
chore(ci): only deploy GitHub page demo on master & commit is a release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,8 +76,12 @@ jobs:
           name: cypress-screenshots
           path: cypress/screenshots
 
+      # deploy (re-publish) GitHub demo page with a Prod build but only when merging to "master" branch
+      # and the commit message contains the text "chore(release)"
       - name: Deploy to gh-pages
-        if: github.ref == 'refs/heads/master'
+        if: |
+          github.ref == 'refs/heads/master' &&
+          contains(github.event.head_commit.message, 'chore(release)')
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- we shouldn't refresh (publish) GitHub demo page on every PR merge, we should instead only redeploy on a release of a new version