### PR TITLE
fix(filters): filtering with IN_CONTAINS should also work with spaces

### DIFF
--- a/packages/common/src/filter-conditions/__tests__/filterUtilities.spec.ts
+++ b/packages/common/src/filter-conditions/__tests__/filterUtilities.spec.ts
@@ -187,6 +187,11 @@ describe('filterUtilities', () => {
       expect(output).toBeTruthy();
     });
 
+    it('should return True when value1 is "IN_CONTAINS" value2 collection even if there is extra spaces in the string', () => {
+      const output = testFilterCondition('IN_CONTAINS', 'Task2,  Task3 ', ['Task2', 'Task3']);
+      expect(output).toBeTruthy();
+    });
+
     it('should return False when value1 is not "IN_CONTAINS" value2 collection', () => {
       const output = testFilterCondition('IN_CONTAINS', 'Task11,Task4', ['Task 1', 'Task2', 'Task3']);
       expect(output).toBeFalsy();
@@ -212,7 +217,15 @@ describe('filterUtilities', () => {
       expect(output1).toBeFalsy();
       expect(output2).toBeFalsy();
     });
-    
+
+    it('should return False when value1 is not "NOT_IN_CONTAINS" value2 collection even if there is extra spaces in the string', () => {
+      const output1 = testFilterCondition('NIN_CONTAINS', 'Task2,  Task3 ', ['Task2', 'Task3']);
+      const output2 = testFilterCondition('NOT_IN_CONTAINS', 'Task2,  Task3', ['Task2', 'Task3']);
+
+      expect(output1).toBeFalsy();
+      expect(output2).toBeFalsy();
+    });
+
     it('should return False when value2 is not a collection', () => {
       const output = testFilterCondition('NOT_IN_CONTAINS', 'Task2,Task3', 'Task2');
       expect(output).toBeFalsy();

--- a/packages/common/src/filter-conditions/filterUtilities.ts
+++ b/packages/common/src/filter-conditions/filterUtilities.ts
@@ -75,13 +75,13 @@ export const testFilterCondition = (operator: OperatorString, value1: any, value
       return ((value2 && Array.isArray(value2 as string[])) ? (!value2.includes(value1)) : false);
     case 'IN_CONTAINS':
       if (value2 && Array.isArray(value2) && typeof value1 === 'string') {
-        return value2.some(item => value1.split(/[\s,]+/).includes(item));
+        return value2.some(item => value1.split(/[\s,]+/).map(val => (val.trim())).includes(item));
       }
       return false;
     case 'NIN_CONTAINS':
     case 'NOT_IN_CONTAINS':
       if (value2 && Array.isArray(value2) && typeof value1 === 'string') {
-        return !value2.some(item => value1.split(/[\s,]+/).includes(item));
+        return !value2.some(item => value1.split(/[\s,]+/).map(val => (val.trim())).includes(item));
       }
       return false;
     case 'IN_COLLECTION':


### PR DESCRIPTION
- fixes a bug reported in SlickGrid [issue 611](https://github.com/6pac/SlickGrid/issues/611)

with the fix, it now returns the correct rows in the grid, but without the fix this was returning nothing

![image](https://user-images.githubusercontent.com/643976/120535129-a253e680-c3b0-11eb-98e2-85f8e2805415.png)
