### PR TITLE
chore(styling): add polyfill to latest dart-sass warnings with division

### DIFF
--- a/packages/common/src/styles/_private.scss
+++ b/packages/common/src/styles/_private.scss
@@ -1,0 +1,27 @@
+@use 'sass:math';
+@use 'sass:meta';
+@use 'sass:list';
+
+// Private polyfill for the `math.div` function from Sass to be used until we can update the
+// minimum required Sass version to 1.34.0 or above.
+// TODO: replace with `math.div` eventually, maybe in 6 months or a year from now.
+@function private-div($a, $b) {
+  @if (meta.function-exists('div', 'math')) {
+    @return math.div($a, $b);
+  }
+  @else {
+    @return $a / $b;
+  }
+}
+
+// Private polyfill for the `list.slash` function from Sass to be used until we can update the
+// minimum required Sass version to 1.34.0 or above.
+// TODO: replace with `list.slash` eventually, maybe in 6 months or a year from now.
+@function private-slash($a, $b) {
+  @if (meta.function-exists('slash', 'list')) {
+    @return list.slash($a, $b);
+  }
+  @else {
+    @return #{$a}#{' / '}#{$b};
+  }
+}

--- a/packages/common/src/styles/sass-utilities.scss
+++ b/packages/common/src/styles/sass-utilities.scss
@@ -1,4 +1,4 @@
-@use 'sass:math';
+@use './private';
 $svg-icon-vertical-align: bottom !default;
 
 @function encodecolor($string) {
@@ -11,9 +11,9 @@ $svg-icon-vertical-align: bottom !default;
 }
 
 @mixin recolor($color: #000, $opacity: 1) {
-  $r: math.div(red($color), 255);
-  $g: math.div(green($color), 255);
-  $b: math.div(blue($color), 255);
+  $r: private.private-div(red($color), 255);
+  $g: private.private-div(green($color), 255);
+  $b: private.private-div(blue($color), 255);
   $a: $opacity;
 
   // grayscale fallback if SVG from data url is not supported
@@ -43,8 +43,6 @@ $svg-icon-vertical-align: bottom !default;
     display: $display;
     vertical-align: $svg-icon-vertical-align;
     // margin-top: -1px; // small patch to remove padding all around the SVG
-    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{$fill}" viewBox="0 0 #{$viewBox} #{$viewBox}">\
-        <path d="#{$path-drawing}"></path>\
-      </svg>');
+    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{$fill}" viewBox="0 0 #{$viewBox} #{$viewBox}"><path d="#{$path-drawing}"></path></svg>');
   }
 }

--- a/packages/common/src/styles/slick.layout.scss
+++ b/packages/common/src/styles/slick.layout.scss
@@ -1,9 +1,9 @@
-@use 'sass:math';
+@use './private';
 
 /* Medium devices (landscape tablets, 768px and up) */
 @media only screen and (min-width : 768px) {
   @for $i from 1 through 12 {
-    $width: math.div($i, 12) * 100%;
+    $width: private.private-div($i, 12) * 100%;
     .slick-col-medium-#{$i} {
       flex-basis: $width;
     }
@@ -13,7 +13,7 @@
 /* Large devices (laptops/desktops, 992px and up) */
 @media only screen and (min-width : 992px) {
   @for $i from 1 through 12 {
-    $width: math.div($i, 12) * 100%;
+    $width: private.private-div($i, 12) * 100%;
     .slick-col-large-#{$i} {
       flex-basis: $width;
     }
@@ -23,7 +23,7 @@
 /* Extra large devices (large laptops and desktops, 1200px and up) */
 @media only screen and (min-width: 1200px) {
   @for $i from 1 through 12 {
-    $width: math.div($i, 12) * 100%;
+    $width: private.private-div($i, 12) * 100%;
     .slick-col-xlarge-#{$i} {
       flex-basis: $width;
     }


### PR DESCRIPTION
- The latest version of Dart-Sass prints a bunch warnings when the division operator is used. These changes migrate us to the recommended `math.div` function and won't break users that aren't using latest Dart-Sass yet
- use the same technique as Angular UI from shown in this [PR](https://github.com/angular/components/commit/a4043f41f539ed910c80c780e1815f5625282b94) from them