### PR TITLE
fix(state): Grid View/Columns dynamically should work w/row selection

### DIFF
--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -114,10 +114,12 @@ export class GridStateService {
 
       if (gridColumns && Array.isArray(gridColumns) && gridColumns.length > 0) {
         // make sure that the checkbox selector is still visible in the list when it is enabled
-        if (this._gridOptions.enableCheckboxSelector) {
-          const checkboxColumn = (Array.isArray(this.sharedService.allColumns) && this.sharedService.allColumns.length > 0) ? this.sharedService.allColumns[0] : null;
-          if (checkboxColumn?.id === '_checkbox_selector' && gridColumns[0].id !== '_checkbox_selector') {
-            gridColumns.unshift(checkboxColumn);
+        if (this._gridOptions.enableCheckboxSelector && Array.isArray(this.sharedService.allColumns)) {
+          const checkboxColumnIdx = this.sharedService.allColumns.findIndex(col => col.id === '_checkbox_selector');
+          const associatedGridCheckboxColumnIdx = gridColumns.findIndex(col => col.id === '_checkbox_selector');
+          if (checkboxColumnIdx >= 0 && associatedGridCheckboxColumnIdx === -1) {
+            const checkboxColumn = this.sharedService.allColumns[checkboxColumnIdx];
+            checkboxColumnIdx === 0 ? gridColumns.unshift(checkboxColumn) : gridColumns.splice(checkboxColumnIdx, 0, checkboxColumn);
           }
         }
 


### PR DESCRIPTION
- the issue found was with Row Selection when it is not at position 0, the previous code was always assuming that it was at column index 0 but sometime it's not (like our LIG project). Since Row Selection column is added dynamically, this code make sure that when we change dynamically the column position, we will still include the row selection column if it wasn't part of the array provided