### PR TITLE
fix(menu): toggle filter bar could be out of sync w/horizontal scroll

### DIFF
--- a/packages/common/src/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/packages/common/src/extensions/__tests__/gridMenuExtension.spec.ts
@@ -49,6 +49,7 @@ const gridStub = {
   setTopPanelVisibility: jest.fn(),
   setPreHeaderPanelVisibility: jest.fn(),
   setOptions: jest.fn(),
+  scrollColumnIntoView: jest.fn(),
 } as unknown as SlickGrid;
 
 const mockGridMenuAddon = {
@@ -746,7 +747,8 @@ describe('gridMenuExtension', () => {
 
       it('should call the grid "setHeaderRowVisibility" method when the command triggered is "toggle-filter"', () => {
         gridOptionsMock.showHeaderRow = false;
-        const gridSpy = jest.spyOn(gridStub, 'setHeaderRowVisibility');
+        const setHeaderSpy = jest.spyOn(gridStub, 'setHeaderRowVisibility');
+        const scrollSpy = jest.spyOn(gridStub, 'scrollColumnIntoView');
         const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
         const setColumnSpy = jest.spyOn(gridStub, 'setColumns');
 
@@ -754,14 +756,15 @@ describe('gridMenuExtension', () => {
         instance.onCommand!.notify({ item: { command: 'toggle-filter' }, column: {} as Column, grid: gridStub, command: 'toggle-filter' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(gridSpy).toHaveBeenCalledWith(true);
+        expect(setHeaderSpy).toHaveBeenCalledWith(true);
+        expect(scrollSpy).toHaveBeenCalledWith(0);
         expect(setColumnSpy).toHaveBeenCalledTimes(1);
 
         gridOptionsMock.showHeaderRow = true;
         instance.onCommand!.notify({ item: { command: 'toggle-filter' }, column: {} as Column, grid: gridStub, command: 'toggle-filter' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(gridSpy).toHaveBeenCalledWith(false);
+        expect(setHeaderSpy).toHaveBeenCalledWith(false);
         expect(setColumnSpy).toHaveBeenCalledTimes(1); // same as before, so count won't increase
       });
 

--- a/packages/common/src/extensions/gridMenuExtension.ts
+++ b/packages/common/src/extensions/gridMenuExtension.ts
@@ -477,6 +477,7 @@ export class GridMenuExtension implements Extension {
           // when displaying header row, we'll call "setColumns" which in terms will recreate the header row filters
           if (showHeaderRow === true) {
             this.sharedService.slickGrid.setColumns(this.sharedService.columnDefinitions);
+            this.sharedService.slickGrid.scrollColumnIntoView(0); // quick fix to avoid filter being out of sync with horizontal scroll
           }
           break;
         case 'toggle-toppanel':


### PR DESCRIPTION
- when toggling the filter bar (on and off), the horizontal scroll could become out of sync (the alignment of the filters with the column and its data), this happen because the filters are recreated every time we toggle back the filter bar, for that issue we simply need to move the horizontal scroll back to top-left and that fixes the issue
- this bug was reported in Angular-Slickgrid over Stack Overflow

animated gif of the issue

![0sQTgafZO1](https://user-images.githubusercontent.com/643976/122275609-e4e9e880-ceb1-11eb-99d8-604d7264f3a0.gif)
