### PR TITLE
fix(addon): providing columnIndexPosition should always work

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
@@ -196,11 +196,17 @@ export class Example7 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      checkboxSelector: {
+        hideSelectAllCheckbox: false, // hide the "Select All" from title bar
+        columnIndexPosition: 1,
+        // row selection should only be usable & displayed on root level 0 (parent item) & grid isn't locked
+      },
       dataView: {
         syncGridSelection: true, // enable this flag so that the row selection follows the row even if we move it to another position
       },
       enableRowMoveManager: true,
       rowMoveManager: {
+        columnIndexPosition: 0,
         // when using Row Move + Row Selection, you want to move only a single row and we will enable the following flags so it doesn't cancel row selection
         singleRowMove: true,
         disableRowSelection: true,

--- a/packages/common/src/extensions/checkboxSelectorExtension.ts
+++ b/packages/common/src/extensions/checkboxSelectorExtension.ts
@@ -42,7 +42,7 @@ export class CheckboxSelectorExtension implements Extension {
         selectionColumn.maxWidth = selectionColumn.width || 30;
 
         // column index position in the grid
-        const columnPosition = gridOptions?.checkboxSelector?.columnIndexPosition || 0;
+        const columnPosition = gridOptions?.checkboxSelector?.columnIndexPosition ?? 0;
         if (columnPosition > 0) {
           columnDefinitions.splice(columnPosition, 0, selectionColumn);
         } else {

--- a/packages/common/src/extensions/rowMoveManagerExtension.ts
+++ b/packages/common/src/extensions/rowMoveManagerExtension.ts
@@ -64,7 +64,7 @@ export class RowMoveManagerExtension implements Extension {
       // only add the new column if it doesn't already exist
       if (!rowMoveColDef && finalRowMoveColumn) {
         // column index position in the grid
-        const columnPosition = gridOptions?.rowMoveManager?.columnIndexPosition || 0;
+        const columnPosition = gridOptions?.rowMoveManager?.columnIndexPosition ?? 0;
         if (columnPosition > 0) {
           columnDefinitions.splice(columnPosition, 0, finalRowMoveColumn);
         } else {


### PR DESCRIPTION
- providing columnIndexPosition should work regardless of when the extension (plugin) is created, basically the previous code was assuming that you will always want the checkbox before the row move plugin but that is not always true and the other way around wasn't possible while this PR fixes it