### PR TITLE
fix(styling): header title should show ellipsis if too long

### DIFF
--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -209,7 +209,7 @@
     text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: #{$header-row-count};
   }
 
   .slick-resizable-handle {

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -207,6 +207,9 @@
 
   .slick-column-name {
     text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
 
   .slick-resizable-handle {


### PR DESCRIPTION
- column header titles that are too long should show the "..." ellipsis and that was not working because it's a bit different with text over multiple lines
 
![image](https://user-images.githubusercontent.com/643976/123171944-67425180-d44a-11eb-8560-54210387dc07.png)
