### PR TITLE
feat(styling): add support for CSS Variables

### DIFF
--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -81,13 +81,16 @@ $header-padding-top:                                  4px !default;
 $header-padding-right:                                4px !default;
 $header-padding-bottom:                               4px !default;
 $header-padding-left:                                 4px !default;
+$header-padding:                                      $header-padding-top $header-padding-right $header-padding-bottom $header-padding-left !default;
 $header-input-height:                                 27px !default;                        // height of the filter form element (input, textarea, select)
-$header-input-width:                                  none !default;                        // width of the filter form element (input, textarea, select)
+$header-input-width:                                  100% !default;                        // width of the filter form element (input, textarea, select)
 $header-input-padding:                                0 6px !default;                       // padding of the filter form element (input, textarea, select)
 $header-row-background-color:                         #ffffff !default;
 $header-row-count:                                    2 !default;                           // how many rows to display on the header
 $header-row-filter-padding:                           4px !default;
 $header-column-height:                                calc(17px * #{$header-row-count}) !default;  // header is calculated by rows to show
+$header-column-background-active:                     darken($grid-header-background, 5%) !default;
+$header-column-background-hover:                      darken($grid-header-background, 2%) !default;
 $header-border-top:                                   0 none !default;                      // header, column titles, that is without the Filters
 $header-border-right:                                 0 none !default;
 $header-border-bottom:                                0 none !default;
@@ -149,6 +152,7 @@ $autocomplete-border-radius:	                        4px !default;
 $autocomplete-box-shadow:	                            0 6px 12px rgba(0, 0, 0, 0.175) !default;
 $autocomplete-hover-color:	                          #262626 !default;
 $autocomplete-hover-bg-color:	                        darken($row-mouse-hover-color, 3%) !default;
+$autocomplete-hover-border-color:	                    1px solid #{$autocomplete-hover-bg-color} !default;
 $autocomplete-loading-input-bg-color:                 transparent !default;
 $autocomplete-loading-icon:                           "\f021" !default;
 $autocomplete-loading-icon-color:                     $icon-color !default;
@@ -283,8 +287,10 @@ $column-picker-title-width:                           calc(100% - #{$column-pick
 /** Detail View Plugin */
 $detail-view-icon-collapse:                           "\f056" !default;
 $detail-view-icon-collapse-color:                     $primary-color !default;
+$detail-view-icon-collapse-color-hover:               darken($detail-view-icon-collapse-color, 10%) !default;
 $detail-view-icon-expand:                             "\f055" !default;
 $detail-view-icon-expand-color:                       lighten($primary-color, 25%) !default;
+$detail-view-icon-expand-color-hover:                 darken($detail-view-icon-expand-color, 10%) !default;
 $detail-view-icon-size:                               calc(#{$icon-font-size} + 2px) !default;
 $detail-view-container-bgcolor:                       #f7f7f7 !default;
 $detail-view-container-border:                        1px solid #c0c0c0 !default;
@@ -446,6 +452,7 @@ $header-button-vertical-align:                        top !default;
 
 /* Header Menu Plugin */
 $header-menu-bg-color:                                #ffffff !default;
+$header-menu-bg:                                      none repeat scroll 0 0 #{$header-menu-bg-color} !default;
 $header-menu-button-bg-color:                         #ffffff !default;
 $header-menu-border:                                  1px solid #BFBDBD !default;
 $header-menu-button-border:                           $header-menu-border !default;
@@ -815,11 +822,17 @@ $multiselect-ok-button-width:                         100% !default;
 $multiselect-ok-button-text-align:                    center !default;
 
 /* pagination variables */
-$pagination-button-hover-color:                       #E6E6E6 !default;
+$pagination-border-color:                             #ddd !default;
+$pagination-button-border-color:                      #acacac !default;
 $pagination-button-border-radius:                     4px !default;
 $pagination-button-height:                            32px !default;
+$pagination-button-hover-color:                       #E6E6E6 !default;
 $pagination-button-padding:                           6px 12px !default;
-$pagination-border-color:                             #ddd !default;
+$pagination-button-border:                            1px solid #{$pagination-button-border-color} !default;
+$pagination-border-top:                               0 none !default;
+$pagination-border-right:                             0 none !default;
+$pagination-border-bottom:                            0 none !default;
+$pagination-border-left:                              0 none !default;
 $pagination-count-margin-left:                        2px !default;
 $pagination-font-size:                                calc(#{$font-size-base} - 1px) !default;
 $pagination-height:                                   40px !default;
@@ -836,11 +849,6 @@ $pagination-icon-seek-end-width:                      initial !default;
 $pagination-icon-seek-next-width:                     initial !default;
 $pagination-icon-seek-prev-width:                     initial !default;
 $pagination-icon-seek-text-stroke:                    0.4px !default;
-$pagination-button-border:                            1px solid #acacac !default;
-$pagination-border-top:                               0 none !default;
-$pagination-border-right:                             0 none !default;
-$pagination-border-bottom:                            0 none !default;
-$pagination-border-left:                              0 none !default;
 $pagination-page-input-border-radius:                 4px !default;
 $pagination-page-input-bgcolor:                       #fafbed !default;
 $pagination-page-input-height:                        26px !default;

--- a/packages/common/src/styles/jquery-ui.scss
+++ b/packages/common/src/styles/jquery-ui.scss
@@ -1,4 +1,5 @@
-$autocomplete-hover-bg-color: #f0f0f0 !default;
+$autocomplete-hover-bg-color:   #f0f0f0 !default;
+$autocomplete-hover-border-color:	1px solid #{$autocomplete-hover-bg-color} !default;
 
 /*! jQuery UI - v1.12.1 - 2016-09-14
 * http://jqueryui.com
@@ -257,14 +258,14 @@ a.ui-button:focus {
 a.ui-button:active,
 .ui-button:active,
 .ui-button.ui-state-active:hover {
-	border: 1px solid #{$autocomplete-hover-bg-color};
-	background: $autocomplete-hover-bg-color;
+	border: var(--slick-autocomplete-hover-border-color, $autocomplete-hover-border-color);
+	background: var(--slick-autocomplete-hover-bg-color, $autocomplete-hover-bg-color);
 	font-weight: normal;
 	color: #ffffff;
 }
 .ui-icon-background,
 .ui-state-active .ui-icon-background {
-	border: $autocomplete-hover-bg-color;
+	border: var(--slick-autocomplete-hover-bg-color, $autocomplete-hover-bg-color);
 	background-color: #ffffff;
 }
 .ui-state-active a,

--- a/packages/common/src/styles/slick-bootstrap.scss
+++ b/packages/common/src/styles/slick-bootstrap.scss
@@ -2,38 +2,38 @@
 @import './variables';
 
 @-webkit-keyframes highlight-start {
-  to {background: $row-highlight-background-color;}
-  from {background: none;}
+  to { background: var(--slick-row-highlight-background-color, $row-highlight-background-color); }
+  from { background: none; }
 }
 
 @keyframes highlight-start {
-  to {background: $row-highlight-background-color;}
-  from {background: none;}
+  to { background: var(--slick-row-highlight-background-color, $row-highlight-background-color); }
+  from { background: none; }
 }
 
 @-webkit-keyframes highlight-end {
-  from {background: $row-highlight-fade-out-animation;}
-  to {background: none;}
+  from { background: var(--slick-row-highlight-fade-out-animation, $row-highlight-fade-out-animation); }
+  to { background: none; }
 }
 
 @keyframes highlight-end {
-  from {background: $row-highlight-fade-out-animation;}
-  to {background: none;}
+  from { background: var(--slick-row-highlight-fade-out-animation, $row-highlight-fade-out-animation); }
+  to { background: none; }
 }
 
 .slickgrid-container {
-  border-top: $container-border-top;
-  border-bottom: $container-border-bottom;
-  border-left: $container-border-left;
-  border-right: $container-border-right;
+  border-top: var(--slick-container-border-top, $container-border-top);
+  border-bottom: var(--slick-container-border-bottom, $container-border-bottom);
+  border-left: var(--slick-container-border-left, $container-border-left);
+  border-right: var(--slick-container-border-right, $container-border-right);
   position: relative;
-  font-family: $font-family;
+  font-family: var(--slick-font-family, $font-family);
 
   @mixin resetSlickCell() {
-    padding: $cell-padding;
-    font-size: $font-size-base;
+    padding: var(--slick-cell-padding, $cell-padding);
+    font-size: var(--slick-font-size-base, $font-size-base);
     td {
-      font-size: $font-size-base;
+      font-size: var(--slick-font-size-base, $font-size-base);
     }
     body & {
       line-height: 20px;
@@ -50,54 +50,54 @@
   }
 
   .slick-viewport {
-    border-top: $viewport-border-top;
-    border-bottom: $viewport-border-bottom;
-    border-left: $viewport-border-left;
-    border-right: $viewport-border-right;
+    border-top: var(--slick-viewport-border-top, $viewport-border-top);
+    border-bottom: var(--slick-viewport-border-bottom, $viewport-border-bottom);
+    border-left: var(--slick-viewport-border-left, $viewport-border-left);
+    border-right: var(--slick-viewport-border-right, $viewport-border-right);
   }
 
   .grid-canvas {
     .slick-row {
       position: absolute;
       width: 100%;
-      color: $cell-text-color;
-      font-family: $cell-font-family;
-      font-weight: $cell-font-weight;
+      color: var(--slick-cell-text-color, $cell-text-color);
+      font-family: var(--slick-cell-font-family, $cell-font-family);
+      font-weight: var(--slick-cell-font-weight, $cell-font-weight);
 
       &:hover {
-        background-color: $row-mouse-hover-color;
-        box-shadow: $row-mouse-hover-box-shadow;
-        z-index: $row-mouse-hover-z-index;
+        background-color: var(--slick-row-mouse-hover-color, $row-mouse-hover-color);
+        box-shadow: var(--slick-row-mouse-hover-box-shadow, $row-mouse-hover-box-shadow);
+        z-index: var(--slick-row-mouse-hover-z-index, $row-mouse-hover-z-index);
       }
       &.active {
-        padding: $cell-padding;
+        padding: var(--slick-cell-padding, $cell-padding);
       }
       &.highlight {
-        background-color: $row-highlight-background-color;
+        background-color: var(--slick-row-highlight-background-color, $row-highlight-background-color);
         animation: highlight-start $row-highlight-fade-animation;
         .slick-cell {
           &.copied {
-            background: $copied-cell-bg-color-transition;
-            transition: $copied-cell-transition;
+            background: var(--slick-copied-cell-bg-color-transition, $copied-cell-bg-color-transition);
+            transition: var(--slick-copied-cell-transition, $copied-cell-transition);
           }
         }
         &.odd {
-          background-color: $row-highlight-background-color;
-          animation: highlight-start $row-highlight-fade-animation;
+          background-color: var(--slick-row-highlight-background-color, $row-highlight-background-color);
+          animation: highlight-start #{var(--slick-row-highlight-fade-animation, $row-highlight-fade-animation)};
         }
         &.odd .slick-cell {
           &.copied {
-            background: $copied-cell-bg-color-transition;
-            transition: $copied-cell-transition;
+            background: var(--slick-copied-cell-bg-color-transition, $copied-cell-bg-color-transition);
+            transition: var(--slick-copied-cell-transition, $copied-cell-transition);
           }
         }
       }
       &.highlight-end {
-        background-color: $row-highlight-background-color;
-        animation: highlight-end $row-highlight-fade-animation;
+        background-color: var(--slick-row-highlight-background-color, $row-highlight-background-color);
+        animation: highlight-end #{var(--slick-row-highlight-fade-animation, $row-highlight-fade-animation)};
         &.odd {
-          background-color: $row-highlight-background-color;
-          animation: highlight-end $row-highlight-fade-animation;
+          background-color: var(--slick-row-highlight-background-color, $row-highlight-background-color);
+          animation: highlight-end #{var(--slick-row-highlight-fade-animation, $row-highlight-fade-animation)};
         }
       }
       &.highlighter {
@@ -107,53 +107,53 @@
         transition-timing-function: ease-in;
       }
       &.copied {
-        background: $copied-cell-bg-color-transition;
-        transition: $copied-cell-transition;
+        background: var(--slick-copied-cell-bg-color-transition, $copied-cell-bg-color-transition);
+        transition: var(--slick-copied-cell-transition, $copied-cell-transition);
       }
       &.odd {
-        background-color: $cell-odd-background-color;
+        background-color: var(--slick-cell-odd-background-color, $cell-odd-background-color);
         &:hover {
-          background-color: $row-mouse-hover-color;
+          background-color: var(--slick-row-mouse-hover-color, $row-mouse-hover-color);
         }
       }
       &.odd .slick-cell {
         &.selected {
-          background-color: $row-selected-color;
+          background-color: var(--slick-row-selected-color, $row-selected-color);
         }
         &.copied {
-          background: $copied-cell-bg-color-transition;
-          transition: $copied-cell-transition;
+          background: var(--slick-copied-cell-bg-color-transition, $copied-cell-bg-color-transition);
+          transition: var(--slick-copied-cell-transition, $copied-cell-transition);
         }
         background: inherit;
       }
       &.odd .slick-cell {
         &.selected {
-          background-color: $row-selected-color;
+          background-color: var(--slick-row-selected-color, $row-selected-color);
         }
         &.copied {
-          background: $copied-cell-bg-color-transition;
-          transition: $copied-cell-transition;
+          background: var(--slick-copied-cell-bg-color-transition, $copied-cell-bg-color-transition);
+          transition: var(--slick-copied-cell-transition, $copied-cell-transition);
         }
         background: inherit;
       }
       &.slick-group-totals {
-        color: $group-totals-formatter-color;
-        background: $group-totals-formatter-bgcolor;
+        color: var(--slick-group-totals-formatter-color, $group-totals-formatter-color);
+        background: var(--slick-group-totals-formatter-bgcolor, $group-totals-formatter-bgcolor);
         .slick-cell {
-          font-size: $group-totals-formatter-font-size;
+          font-size: var(--slick-group-totals-formatter-font-size, $group-totals-formatter-font-size);
         }
       }
     }
     .slick-cell, .slick-headerrow-column {
-      border-top: $cell-border-top;
-      border-bottom: $cell-border-bottom;
-      border-left: $cell-border-left;
-      border-right: $cell-border-right;
-      box-shadow: $cell-box-shadow;
+      border-top: var(--slick-cell-border-top, $cell-border-top);
+      border-bottom: var(--slick-cell-border-bottom, $cell-border-bottom);
+      border-left: var(--slick-cell-border-left, $cell-border-left);
+      border-right: var(--slick-cell-border-right, $cell-border-right);
+      box-shadow: var(--slick-cell-box-shadow, $cell-box-shadow);
     }
 
     .even {
-      background-color: $cell-even-background-color;
+      background-color: var(--slick-cell-even-background-color, $cell-even-background-color);
     }
 
 
@@ -161,10 +161,10 @@
       @include resetSlickCell();
 
       a, a:visited, .ui-widget-content a, .ui-widget-content a:visited {
-        color: $link-color;
+        color: var(--slick-link-color, $link-color);
       }
       a:hover, .ui-widget-content a:hover {
-        color: $link-color-hover;
+        color: var(--slick-link-color-hover, $link-color-hover);
         border-bottom: none;
       }
       table {
@@ -178,78 +178,78 @@
         text-align: left;
       }
       &.selected {
-        background-color: $row-selected-color;
+        background-color: var(--slick-row-selected-color, $row-selected-color);
       }
       &.copied {
-        background: $copied-cell-bg-color-transition;
-        transition: $copied-cell-transition;
+        background: var(--slick-copied-cell-bg-color-transition, $copied-cell-bg-color-transition);
+        transition: var(--slick-copied-cell-transition, $copied-cell-transition);
       }
       select:not([multiple]).form-control {
         height: 100%;
         padding: 0;
       }
       .slick-group-title {
-        height: $draggable-group-title-height;
-        line-height: $draggable-group-title-line-height;
-        vertical-align: $draggable-group-title-vertical-align;
+        height: var(--slick-draggable-group-title-height, $draggable-group-title-height);
+        line-height: var(--slick-draggable-group-title-line-height, $draggable-group-title-line-height);
+        vertical-align: var(--slick-draggable-group-title-vertical-align, $draggable-group-title-vertical-align);
       }
       .slick-group-toggle {
-        color: $icon-group-color;
-        font-weight: $icon-group-font-weight;
-        width: $icon-group-width;
-        height: $icon-group-height;
-        margin-right: $icon-group-margin-right;
+        color: var(--slick-icon-group-color, $icon-group-color);
+        font-weight: var(--slick-icon-group-font-weight, $icon-group-font-weight);
+        width: var(--slick-icon-group-width, $icon-group-width);
+        height: var(--slick-icon-group-height, $icon-group-height);
+        margin-right: var(--slick-icon-group-margin-right, $icon-group-margin-right);
         cursor: pointer;
 
         &.expanded:before {
           display: inline-block;
-          content: $icon-group-expanded;
-          font-family: $icon-font-family;
-          font-size: $icon-group-font-size;
-          width: $icon-group-width;
-          vertical-align: $icon-group-vertical-align;
+          content: var(--slick-icon-group-expanded, $icon-group-expanded);
+          font-family: var(--slick-icon-font-family, $icon-font-family);
+          font-size: var(--slick-icon-group-font-size, $icon-group-font-size);
+          width: var(--slick-icon-group-width, $icon-group-width);
+          vertical-align: var(--slick-icon-group-vertical-align, $icon-group-vertical-align);
         }
 
         &.collapsed:before {
           display: inline-block;
-          content: $icon-group-collapsed;
-          font-family: $icon-font-family;
-          font-size: $icon-group-font-size;
-          width: $icon-group-width;
-          vertical-align: $icon-group-vertical-align;
+          content: var(--slick-icon-group-collapsed, $icon-group-collapsed);
+          font-family: var(--slick-icon-font-family, $icon-font-family);
+          font-size: var(--slick-icon-group-font-size, $icon-group-font-size);
+          width: var(--slick-icon-group-width, $icon-group-width);
+          vertical-align: var(--slick-icon-group-vertical-align, $icon-group-vertical-align);
         }
       }
     }
   }
 
   .slick-header {
-    border-top: $header-border-top;
-    border-right: $header-border-right;
-    border-bottom: $header-border-bottom;
-    border-left: $header-border-left;
+    border-top: var(--slick-header-border-top, $header-border-top);
+    border-right: var(--slick-header-border-right, $header-border-right);
+    border-bottom: var(--slick-header-border-bottom, $header-border-bottom);
+    border-left: var(--slick-header-border-left, $header-border-left);
     width: 100%;
     box-shadow: none !important;
   }
 
   .slick-headerrow {
-    border-bottom: $header-filter-row-border-bottom;
-    border-top: $header-filter-row-border-top;
-    border-left: $header-filter-row-border-left;
-    border-right: $header-filter-row-border-right;
+    border-bottom: var(--slick-header-filter-row-border-bottom, $header-filter-row-border-bottom);
+    border-top: var(--slick-header-filter-row-border-top, $header-filter-row-border-top);
+    border-left: var(--slick-header-filter-row-border-left, $header-filter-row-border-left);
+    border-right: var(--slick-header-filter-row-border-right, $header-filter-row-border-right);
 
     .slick-headerrow-columns {
       .slick-headerrow-column {
         border: none;
-        padding: $header-row-filter-padding;
-        background: $header-row-background-color;
+        padding: var(--slick-header-row-filter-padding, $header-row-filter-padding);
+        background: var(--slick-header-row-background-color, $header-row-background-color);
       }
       .slick-headerrow-column input,
       .slick-headerrow-column select,
       .slick-headerrow-column textarea {
         margin-right: 0;
-        padding: $header-input-padding;
-        width: $header-input-width;
-        height: $header-input-height;
+        padding: var(--slick-header-input-padding, $header-input-padding);
+        width: var(--slick-header-input-width, $header-input-width);
+        height: var(--slick-header-input-height, $header-input-height);
         -moz-box-sizing: border-box;
         -webkit-box-sizing: border-box;
         box-sizing: border-box;
@@ -259,9 +259,8 @@
 
   .slick-header-columns {
     background: none;
-    background-color: $header-background-color;
-    width: calc(100% - #{$header-scroll-width-to-remove});
-    // height: calc(#{$preheader-height} + #{$cell-padding-top-bottom} - #{$preheader-border-top} - #{$preheader-border-bottom});
+    background-color: var(--slick-header-background-color, $header-background-color);
+    width: calc(100% - #{var(--slick-header-scroll-width-to-remove, $header-scroll-width-to-remove)});
 
     [id$="checkbox_selector"] {
       justify-content: center;
@@ -274,33 +273,33 @@
       }
     }
     .slick-header-column {
-      height: $header-column-height;
-      line-height: $font-size-base;
+      height: var(--slick-header-column-height, $header-column-height);
+      line-height: var(--slick-font-size-base, $font-size-base);
       margin: 0;
-      border-top: $header-column-border-top;
-      border-right: $header-column-border-right;
-      border-bottom: $header-column-border-bottom;
-      border-left: $header-column-border-left;
+      border-top: var(--slick-header-column-border-top, $header-column-border-top);
+      border-right: var(--slick-header-column-border-right, $header-column-border-right);
+      border-bottom: var(--slick-header-column-border-bottom, $header-column-border-bottom);
+      border-left: var(--slick-header-column-border-left, $header-column-border-left);
       white-space: normal;
       &.ui-state-default {
         @include resetSlickCell();
       }
 
-      $slickgridHoverHeaderColor: $text-color;
-      $slickgridSortingHeaderColor: $text-color;
+      $slickgridHoverHeaderColor: var(--slick-text-color, $text-color);
+      $slickgridSortingHeaderColor: var(--slick-text-color, $text-color);
 
       @mixin ResetColumns () {
         /* like TH  */
-        background: $header-background-color;
-        font-family: $font-family;
-        color: $header-text-color;
-        font-size: $header-font-size;
-        font-weight: $header-font-weight;
+        background: var(--slick-header-background-color, $header-background-color);
+        font-family: var(--slick-font-family, $font-family);
+        color: var(--slick-header-text-color, $header-text-color);
+        font-size: var(--slick-header-font-size, $header-font-size);
+        font-weight: var(--slick-header-font-weight, $header-font-weight);
         a, a:visited {
-          color: $text-color;
+          color: var(--slick-text-color, $text-color);
         }
         a:hover {
-          color: $slickgridHoverHeaderColor;
+          color: var(--slick-slickgridHoverHeaderColor, $slickgridHoverHeaderColor);
         }
       }
 
@@ -311,63 +310,63 @@
 
       &.slick-header-column-sorted {
         font-style: normal;
-        color: $slickgridSortingHeaderColor;
+        color: var(--slick-slickgridSortingHeaderColor, $slickgridSortingHeaderColor);
       }
       &:hover {
-        color: $slickgridHoverHeaderColor;
+        color: var(--slick-slickgridHoverHeaderColor, $slickgridHoverHeaderColor);
       }
 
       /* when sorting is possible and there's not yet a sort applied on the column
        we could display the sort ascending icon (with an opacity) as a hint */
       &.ui-sortable-handle.ui-state-hover:not(.slick-header-column-sorted) {
         .slick-sort-indicator:before {
-          content: $icon-sort-asc;
-          font-family: $icon-font-family;
-          font-size: $icon-sort-font-size;
-          opacity: $sort-indicator-hint-opacity;
+          content: var(--slick-icon-sort-asc, $icon-sort-asc);
+          font-family: var(--slick-icon-font-family, $icon-font-family);
+          font-size: var(--slick-icon-sort-font-size, $icon-sort-font-size);
+          opacity: var(--slick-sort-indicator-hint-opacity, $sort-indicator-hint-opacity);
           display: inline-block;
-          width: $icon-sort-width;
+          width: var(--slick-icon-sort-width, $icon-sort-width);
         }
       }
 
       .slick-sort-indicator {
         background: none;
-        font-family: $icon-font-family;
-        font-size: $icon-font-size;
+        font-family: var(--slick-icon-font-family, $icon-font-family);
+        font-size: var(--slick-icon-font-size, $icon-font-size);
         position: absolute;
         display: inline-block;
-        color: $icon-sort-color;
+        color: var(--slick-icon-sort-color, $icon-sort-color);
         width: 8px;
         height: 5px;
         left: auto;
-        right: $icon-sort-position-right;
-        top: $icon-sort-position-top;
+        right: var(--slick-icon-sort-position-right, $icon-sort-position-right);
+        top: var(--slick-icon-sort-position-top, $icon-sort-position-top);
       }
       .slick-sort-indicator-numbered {
-        font-family: $font-family;
-        font-size: $sort-indicator-number-font-size;
+        font-family: var(--slick-font-family, $font-family);
+        font-size: var(--slick-sort-indicator-number-font-size, $sort-indicator-number-font-size);
         position: absolute;
         display: inline-block;
-        color: $icon-sort-color;
-        width: $sort-indicator-number-width;
-        left: $sort-indicator-number-left;
-        right: $sort-indicator-number-right;
-        top: $sort-indicator-number-top;
+        color: var(--slick-icon-sort-color, $icon-sort-color);
+        width: var(--slick-sort-indicator-number-width, $sort-indicator-number-width);
+        left: var(--slick-sort-indicator-number-left, $sort-indicator-number-left);
+        right: var(--slick-sort-indicator-number-right, $sort-indicator-number-right);
+        top: var(--slick-sort-indicator-number-top, $sort-indicator-number-top);
       }
       .slick-sort-indicator-asc:before {
-          content: $icon-sort-asc;
-          font-family: $icon-font-family;
-          font-size: $icon-sort-font-size;
+          content: var(--slick-icon-sort-asc, $icon-sort-asc);
+          font-family: var(--slick-icon-font-family, $icon-font-family);
+          font-size: var(--slick-icon-sort-font-size, $icon-sort-font-size);
           opacity: 1;
           display: inline-block;
-          width: $icon-sort-width;
+          width: var(--slick-icon-sort-width, $icon-sort-width);
       }
       .slick-sort-indicator-desc:before {
-        content: $icon-sort-desc;
+        content: var(--slick-icon-sort-desc, $icon-sort-desc);
         display: inline-block;
         opacity: 1;
-        font-size: $icon-sort-font-size;
-        width: $icon-sort-width;
+        font-size: var(--slick-icon-sort-font-size, $icon-sort-font-size);
+        width: var(--slick-icon-sort-width, $icon-sort-width);
       }
       .slick-resizable-handle {
         width: 7px;
@@ -375,40 +374,40 @@
         z-index: 1;
       }
       .slick-resizable-handle:hover {
-        border-bottom: $header-resizable-hover-border-bottom;
-        border-left: $header-resizable-hover-border-left;
-        border-right: $header-resizable-hover-border-right;
-        border-top: $header-resizable-hover-border-top;
-        width: $header-resizable-hover-width;
-        border-radius: $header-resizable-hover-border-radius;
-        right: $header-resizable-hover-right;
-        height: $header-resizable-hover-height;
-        top: $header-resizable-hover-top;
-        opacity: $header-resizable-hover-opacity;
+        border-bottom: var(--slick-header-resizable-hover-border-bottom, $header-resizable-hover-border-bottom);
+        border-left: var(--slick-header-resizable-hover-border-left, $header-resizable-hover-border-left);
+        border-right: var(--slick-header-resizable-hover-border-right, $header-resizable-hover-border-right);
+        border-top: var(--slick-header-resizable-hover-border-top, $header-resizable-hover-border-top);
+        width: var(--slick-header-resizable-hover-width, $header-resizable-hover-width);
+        border-radius: var(--slick-header-resizable-hover-border-radius, $header-resizable-hover-border-radius);
+        right: var(--slick-header-resizable-hover-right, $header-resizable-hover-right);
+        height: var(--slick-header-resizable-hover-height, $header-resizable-hover-height);
+        top: var(--slick-header-resizable-hover-top, $header-resizable-hover-top);
+        opacity: var(--slick-header-resizable-hover-opacity, $header-resizable-hover-opacity);
       }
     }
   }
 
   /** Header Grouping **/
   .slick-preheader-panel.ui-state-default  {
-    border-bottom: $preheader-border-bottom;
+    border-bottom: var(--slick-preheader-border-bottom, $preheader-border-bottom);
 
     .slick-header-columns {
-      border-top: $preheader-border-top;
+      border-top: var(--slick-preheader-border-top, $preheader-border-top);
 
       .slick-header-column {
-        height: $preheader-height;
-        border-left: $preheader-border-left;
-        border-right: $preheader-border-right;
-        font-size: $preheader-font-size;
-        justify-content: $preheader-grouped-title-justify;
-        display: $preheader-grouped-title-display;
+        height: var(--slick-preheader-height, $preheader-height);
+        border-left: var(--slick-preheader-border-left, $preheader-border-left);
+        border-right: var(--slick-preheader-border-right, $preheader-border-right);
+        font-size: var(--slick-preheader-font-size, $preheader-font-size);
+        justify-content: var(--slick-preheader-grouped-title-justify, $preheader-grouped-title-justify);
+        display: var(--slick-preheader-grouped-title-display, $preheader-grouped-title-display);
       }
       .slick-header-column:first-child {
-        border-left: $preheader-border-left-first-element;
+        border-left: var(--slick-preheader-border-left-first-element, $preheader-border-left-first-element);
       }
       .slick-header-column:last-child {
-        border-right: $preheader-border-right-last-element;
+        border-right: var(--slick-preheader-border-right-last-element, $preheader-border-right-last-element);
       }
     }
   }
@@ -417,25 +416,25 @@
 
   .slick-row .slick-cell.frozen:last-child,
   .slick-footerrow-column.frozen:last-child {
-    border-right: $frozen-border-right;
+    border-right: var(--slick-frozen-border-right, $frozen-border-right);
   }
   .slick-header-column.frozen:last-child {
-    border-right: $frozen-header-row-border-right;
+    border-right: var(--slick-frozen-header-row-border-right, $frozen-header-row-border-right);
   }
   .slick-pane-left {
     .slick-preheader-panel .slick-header-column.frozen:last-child {
-      border-right: $frozen-preheader-row-border-right;
+      border-right: var(--slick-frozen-preheader-row-border-right, $frozen-preheader-row-border-right);
     }
   }
   .slick-headerrow-column.frozen:last-child {
-    border-right: $frozen-filter-row-border-right;
+    border-right: var(--slick-frozen-filter-row-border-right, $frozen-filter-row-border-right);
   }
 
   .slick-pane-bottom {
-    border-top: $frozen-border-bottom;
+    border-top: var(--slick-frozen-border-bottom, $frozen-border-bottom);
   }
   .slick-viewport-bottom.slick-viewport-right {
-    overflow-y: $frozen-overflow-right !important;
+    overflow-y: var(--slick-frozen-overflow-right, $frozen-overflow-right) !important;
   }
   .input-group {
     > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {

--- a/packages/common/src/styles/slick-component.scss
+++ b/packages/common/src/styles/slick-component.scss
@@ -6,35 +6,35 @@
 // ----------------------------------------------
 
 .slick-custom-footer {
-  color: $footer-text-color;
-  padding: $footer-padding;
-  background-color: $footer-bg-color;
-  font-size: $footer-font-size;
-  font-style: $footer-font-style;
-  font-weight: $footer-font-weight;
-  height: $footer-height;
+  color: var(--slick-footer-text-color, $footer-text-color);
+  padding: var(--slick-footer-padding, $footer-padding);
+  background-color: var(--slick-footer-bg-color, $footer-bg-color);
+  font-size: var(--slick-footer-font-size, $footer-font-size);
+  font-style: var(--slick-footer-font-style, $footer-font-style);
+  font-weight: var(--slick-footer-font-weight, $footer-font-weight);
+  height: var(--slick-footer-height, $footer-height);
 
   .left-footer {
-    color: $footer-left-text-color;
-    font-style: $footer-left-font-style;
-    font-weight: $footer-left-font-weight;
-    text-align: $footer-left-text-align;
-    padding: $footer-left-padding;
-    width: $footer-left-width;
-    float: $footer-left-float;
+    color: var(--slick-footer-left-text-color, $footer-left-text-color);
+    font-style: var(--slick-footer-left-font-style, $footer-left-font-style);
+    font-weight: var(--slick-footer-left-font-weight, $footer-left-font-weight);
+    text-align: var(--slick-footer-left-text-align, $footer-left-text-align);
+    padding: var(--slick-footer-left-padding, $footer-left-padding);
+    width: var(--slick-footer-left-width, $footer-left-width);
+    float: var(--slick-footer-left-float, $footer-left-float);
   }
 
   .right-footer {
-    color: $footer-right-text-color;
-    text-align: $footer-right-text-align;
-    font-style: $footer-right-font-style;
-    font-weight: $footer-right-font-weight;
-    text-align: $footer-right-text-align;
-    padding: $footer-right-padding;
-    width: $footer-right-width;
-    float: $footer-right-float;
+    color: var(--slick-footer-right-text-color, $footer-right-text-color);
+    text-align: var(--slick-footer-right-text-align, $footer-right-text-align);
+    font-style: var(--slick-footer-right-font-style, $footer-right-font-style);
+    font-weight: var(--slick-footer-right-font-weight, $footer-right-font-weight);
+    text-align: var(--slick-footer-right-text-align, $footer-right-text-align);
+    padding: var(--slick-footer-right-padding, $footer-right-padding);
+    width: var(--slick-footer-right-width, $footer-right-width);
+    float: var(--slick-footer-right-float, $footer-right-float);
     &.metrics .separator {
-      margin: $footer-right-separator-margin;
+      margin: var(--slick-footer-right-separator-margin, $footer-right-separator-margin);
     }
   }
 }
@@ -46,14 +46,14 @@
 
 .slick-empty-data-warning {
   position: relative;
-  color: $empty-data-warning-color;
-  font-family: $empty-data-warning-font-family;
-  font-size: $empty-data-warning-font-size;
-  font-style: $empty-data-warning-font-style;
-  line-height: $empty-data-warning-line-height;
-  margin: $empty-data-warning-margin;
-  padding: $empty-data-warning-padding;
-  z-index: $empty-data-warning-z-index;
+  color: var(--slick-empty-data-warning-color, $empty-data-warning-color);
+  font-family: var(--slick-empty-data-warning-font-family, $empty-data-warning-font-family);
+  font-size: var(--slick-empty-data-warning-font-size, $empty-data-warning-font-size);
+  font-style: var(--slick-empty-data-warning-font-style, $empty-data-warning-font-style);
+  line-height: var(--slick-empty-data-warning-line-height, $empty-data-warning-line-height);
+  margin: var(--slick-empty-data-warning-margin, $empty-data-warning-margin);
+  padding: var(--slick-empty-data-warning-padding, $empty-data-warning-padding);
+  z-index: var(--slick-empty-data-warning-z-index, $empty-data-warning-z-index);
 }
 
 
@@ -62,18 +62,18 @@
 // ----------------------------------------------
 
 .slick-pagination {
-  border-top: $pagination-border-top;
-  border-right: $pagination-border-right;
-  border-bottom: $pagination-border-bottom;
-  border-left: $pagination-border-left;
+  border-top: var(--slick-pagination-border-top, $pagination-border-top);
+  border-right: var(--slick-pagination-border-right, $pagination-border-right);
+  border-bottom: var(--slick-pagination-border-bottom, $pagination-border-bottom);
+  border-left: var(--slick-pagination-border-left, $pagination-border-left);
   width: 100%;
-  height: $pagination-height;
+  height: var(--slick-pagination-height, $pagination-height);
   padding-top: 4px;
   vertical-align: middle;
-  font-family: $font-family;
-  font-size: $pagination-font-size;
+  font-family: var(--slick-font-family, $font-family);
+  font-size: var(--slick-pagination-font-size, $pagination-font-size);
   font-weight: 400;
-  color: $pagination-text-color;
+  color: var(--slick-pagination-text-color, $pagination-text-color);
 
   .slick-pagination-status {
     display: inline-block;
@@ -82,7 +82,7 @@
 
   .ui-icon-container {
     display: inline-block;
-    border-color: $pagination-border-color;
+    border-color: var(--slick-pagination-border-color, $pagination-border-color);
   }
 
   .slick-pagination-nav {
@@ -101,11 +101,11 @@
       padding: 0 5px;
 
       input {
-        background-color: $pagination-page-input-bgcolor;
-        height: $pagination-page-input-height;
-        width: $pagination-page-input-width;
-        padding: $pagination-page-input-padding;
-        border-radius: $pagination-page-input-border-radius;
+        background-color: var(--slick-pagination-page-input-bgcolor, $pagination-page-input-bgcolor);
+        height: var(--slick-pagination-page-input-height, $pagination-page-input-height);
+        width: var(--slick-pagination-page-input-width, $pagination-page-input-width);
+        padding: var(--slick-pagination-page-input-padding, $pagination-page-input-padding);
+        border-radius: var(--slick-pagination-page-input-border-radius, $pagination-page-input-border-radius);
         display: inline-block;
       }
     }
@@ -117,70 +117,70 @@
       .page-link {
         display: flex;
         align-items: center;
-        font-size: $pagination-icon-font-size;
-        border: $pagination-button-border;
-        height: $pagination-button-height;
+        font-size: var(--slick-pagination-icon-font-size, $pagination-icon-font-size);
+        border: var(--slick-pagination-button-border, $pagination-button-border);
+        height: var(--slick-pagination-button-height, $pagination-button-height);
       }
 
       .page-item {
         cursor: pointer;
 
         a[class*="icon-seek-"] {
-            border-color: $pagination-button-border;
-            color: $pagination-icon-color;
+            border-color: var(--slick-pagination-button-border-color, $pagination-button-border-color);
+            color: var(--slick-pagination-icon-color, $pagination-icon-color);
             text-decoration: none;
-            font-family: $icon-font-family;
-            line-height: $pagination-icon-line-height;
-            -webkit-text-stroke: $pagination-icon-seek-text-stroke;
-            padding: $pagination-button-padding;
+            font-family: var(--slick-icon-font-family, $icon-font-family);
+            line-height: var(--slick-pagination-icon-line-height, $pagination-icon-line-height);
+            -webkit-text-stroke: var(--slick-pagination-icon-seek-text-stroke, $pagination-icon-seek-text-stroke);
+            padding: var(--slick-pagination-button-padding, $pagination-button-padding);
         }
         a[class*="icon-seek-"]:hover {
-          background-color: $pagination-button-hover-color;
+          background-color: var(--slick-pagination-button-hover-color, $pagination-button-hover-color);
         }
 
         &:first-child {
           a, span {
-            border-top-left-radius: $pagination-button-border-radius;
-            border-bottom-left-radius: $pagination-button-border-radius;
+            border-top-left-radius: var(--slick-pagination-button-border-radius, $pagination-button-border-radius);
+            border-bottom-left-radius: var(--slick-pagination-button-border-radius, $pagination-button-border-radius);
           }
         }
         &:last-child {
           a, span {
-            border-top-right-radius: $pagination-button-border-radius;
-            border-bottom-right-radius: $pagination-button-border-radius;
+            border-top-right-radius: var(--slick-pagination-button-border-radius, $pagination-button-border-radius);
+            border-bottom-right-radius: var(--slick-pagination-button-border-radius, $pagination-button-border-radius);
           }
         }
 
         .icon-seek-first {
           &:before {
-            content: $pagination-icon-seek-first;
+            content: var(--slick-pagination-icon-seek-first, $pagination-icon-seek-first);
             display: block;
-            height: $pagination-icon-height;
-            width: $pagination-icon-seek-first-width;
+            height: var(--slick-pagination-icon-height, $pagination-icon-height);
+            width: var(--slick-pagination-icon-seek-first-width, $pagination-icon-seek-first-width);
           }
         }
         .icon-seek-prev {
           &:before {
-            content: $pagination-icon-seek-prev;
+            content: var(--slick-pagination-icon-seek-prev, $pagination-icon-seek-prev);
             display: block;
-            height: $pagination-icon-height;
-            width: $pagination-icon-seek-prev-width;
+            height: var(--slick-pagination-icon-height, $pagination-icon-height);
+            width: var(--slick-pagination-icon-seek-prev-width, $pagination-icon-seek-prev-width);
           }
         }
         .icon-seek-next {
           &:before {
-            content: $pagination-icon-seek-next;
+            content: var(--slick-pagination-icon-seek-next, $pagination-icon-seek-next);
             display: block;
-            height: $pagination-icon-height;
-            width: $pagination-icon-seek-next-width;
+            height: var(--slick-pagination-icon-height, $pagination-icon-height);
+            width: var(--slick-pagination-icon-seek-next-width, $pagination-icon-seek-next-width);
           }
         }
         .icon-seek-end {
           &:before {
-            content: $pagination-icon-seek-end;
+            content: var(--slick-pagination-icon-seek-end, $pagination-icon-seek-end);
             display: block;
-            height: $pagination-icon-height;
-            width: $pagination-icon-seek-end-width;
+            height: var(--slick-pagination-icon-height, $pagination-icon-height);
+            width: var(--slick-pagination-icon-seek-end-width, $pagination-icon-seek-end-width);
           }
         }
       }
@@ -203,17 +203,17 @@
     padding: 2px;
 
     select {
-      font-size: $pagination-page-select-font-size;
+      font-size: var(--slick-pagination-page-select-font-size, $pagination-page-select-font-size);
       line-height: 1.5;
-      height: $pagination-page-select-height;
-      width: $pagination-page-select-width;
-      padding: $pagination-page-select-padding;
-      border: $pagination-button-border;
-      border-radius: $pagination-page-select-border-radius;
+      height: var(--slick-pagination-page-select-height, $pagination-page-select-height);
+      width: var(--slick-pagination-page-select-width, $pagination-page-select-width);
+      padding: var(--slick-pagination-page-select-padding, $pagination-page-select-padding);
+      border: var(--slick-pagination-button-border, $pagination-button-border);
+      border-radius: var(--slick-pagination-page-select-border-radius, $pagination-page-select-border-radius);
     }
 
     .slick-pagination-count {
-      margin-left: $pagination-count-margin-left;
+      margin-left: var(--slick-pagination-count-margin-left, $pagination-count-margin-left);
     }
   }
 }

--- a/packages/common/src/styles/slick-controls.scss
+++ b/packages/common/src/styles/slick-controls.scss
@@ -6,14 +6,14 @@
 // ----------------------------------------------
 
 .slick-columnpicker {
-  font-family:  $font-family;
-  background-color: $column-picker-background-color;
-  border: $column-picker-border;
-  border-radius: $column-picker-border-radius;
+  font-family: var(--slick-font-family, $font-family);
+  background-color: var(--slick-column-picker-background-color, $column-picker-background-color);
+  border: var(--slick-column-picker-border, $column-picker-border);
+  border-radius: var(--slick-column-picker-border-radius, $column-picker-border-radius);
   padding: 6px;
   -moz-box-shadow: 2px 2px 2px silver;
   -webkit-box-shadow: 2px 2px 2px silver;
-  box-shadow: $column-picker-box-shadow;
+  box-shadow: var(--slick-column-picker-box-shadow, $column-picker-box-shadow);
   min-width: 150px;
   cursor: default;
   position: absolute;
@@ -21,29 +21,30 @@
 	overflow: auto;
   resize: both;
   width: auto;
-  padding-right: $column-picker-padding-right-patch; /* trick to cheat the width to include extra scrollbar width in addition to auto width */
+  /* trick to cheat the width to include extra scrollbar width in addition to auto width */
+  padding-right: var(--slick-column-picker-padding-right-patch, $column-picker-padding-right-patch);
 
   > .close {
     float: right;
     position: absolute;
-    color: $column-picker-close-btn-color;
-    cursor: $column-picker-close-btn-cursor;
-    width: $column-picker-close-btn-width;
-    height: $column-picker-close-btn-height;
-    margin: $column-picker-close-btn-margin;
-    padding: $column-picker-close-btn-padding;
-    font-family: $column-picker-close-btn-font-family;
-    font-size: $column-picker-close-btn-font-size;
-    background-color: $column-picker-close-btn-bg-color;
-    border: $column-picker-close-btn-border;
-    right: $column-picker-close-btn-position-right;
-    top: $column-picker-close-btn-position-top;
+    color: var(--slick-column-picker-close-btn-color, $column-picker-close-btn-color);
+    cursor: var(--slick-column-picker-close-btn-cursor, $column-picker-close-btn-cursor);
+    width: var(--slick-column-picker-close-btn-width, $column-picker-close-btn-width);
+    height: var(--slick-column-picker-close-btn-height, $column-picker-close-btn-height);
+    margin: var(--slick-column-picker-close-btn-margin, $column-picker-close-btn-margin);
+    padding: var(--slick-column-picker-close-btn-padding, $column-picker-close-btn-padding);
+    font-family: var(--slick-column-picker-close-btn-font-family, $column-picker-close-btn-font-family);
+    font-size: var(--slick-column-picker-close-btn-font-size, $column-picker-close-btn-font-size);
+    background-color: var(--slick-column-picker-close-btn-bg-color, $column-picker-close-btn-bg-color);
+    border: var(--slick-column-picker-close-btn-border, $column-picker-close-btn-border);
+    right: var(--slick-column-picker-close-btn-position-right, $column-picker-close-btn-position-right);
+    top: var(--slick-column-picker-close-btn-position-top, $column-picker-close-btn-position-top);
 
     &:hover {
-      color: $column-picker-close-btn-color-hover;
+      color: var(--slick-column-picker-close-btn-color-hover, $column-picker-close-btn-color-hover);
     }
     > span {
-      opacity: $column-picker-close-btn-opacity;
+      opacity: var(--slick-column-picker-close-btn-opacity, $column-picker-close-btn-opacity);
     }
   }
 
@@ -58,22 +59,22 @@
       padding: 4px;
       font-weight: bold;
       &:hover {
-        background-color: $column-picker-link-background-color;
+        background-color: var(--slick-column-picker-link-background-color, $column-picker-link-background-color);
       }
     }
     label {
-      font-weight: $column-picker-label-font-weight;
+      font-weight: var(--slick-column-picker-label-font-weight, $column-picker-label-font-weight);
       input {
-        margin: $column-picker-label-margin;
+        margin: var(--slick-column-picker-label-margin, $column-picker-label-margin);
       }
     }
   }
   div.title {
-    font-size: $column-picker-title-font-size;
-    font-weight: $column-picker-title-font-weight;
-    width: $column-picker-title-width;
-    border-bottom: $column-picker-title-border-bottom;
-    margin-bottom: $column-picker-title-margin-bottom;
+    font-size: var(--slick-column-picker-title-font-size, $column-picker-title-font-size);
+    font-weight: var(--slick-column-picker-title-font-weight, $column-picker-title-font-weight);
+    width: var(--slick-column-picker-title-width, $column-picker-title-width);
+    border-bottom: var(--slick-column-picker-title-border-bottom, $column-picker-title-border-bottom);
+    margin-bottom: var(--slick-column-picker-title-margin-bottom, $column-picker-title-margin-bottom);
   }
 }
 
@@ -85,14 +86,14 @@
 
   li {
     width: calc(100% + 24px - 6px); /* trick to cheat the width to include extra scrollbar width in addition to auto width */
-    border: $column-picker-item-border;
-    border-radius: $column-picker-item-border-radius;
-    padding: $column-picker-item-padding;
+    border: var(--slick-column-picker-item-border, $column-picker-item-border);
+    border-radius: var(--slick-column-picker-item-border-radius, $column-picker-item-border-radius);
+    padding: var(--slick-column-picker-item-padding, $column-picker-item-padding);
     list-style: none outside none;
     margin: 0;
     &:hover {
-      border: $column-picker-item-hover-border;
-      background-color: $column-picker-item-hover-color;
+      border: var(--slick-column-picker-item-hover-border, $column-picker-item-hover-border);
+      background-color: var(--slick-column-picker-item-hover-color, $column-picker-item-hover-color);
     }
     label {
       cursor: pointer;
@@ -105,7 +106,7 @@
     margin: 6px 0;
     border: 0;
     border-top: 1px solid #d5d5d5;
-    width: $column-picker-divider-width;
+    width: var(--slick-column-picker-divider-width, $column-picker-divider-width);
     margin-left: auto;
     margin-right: auto;
   }
@@ -119,25 +120,25 @@
 
   input[type=checkbox] + label:before {
     cursor: pointer;
-    content: $column-picker-checkbox-icon-unchecked;
-    color: $column-picker-checkbox-color;
+    content: var(--slick-column-picker-checkbox-icon-unchecked, $column-picker-checkbox-icon-unchecked);
+    color: var(--slick-column-picker-checkbox-color, $column-picker-checkbox-color);
     display: inline-block;
-    font-weight: $column-picker-checkbox-font-weight;
-    font-family: $icon-font-family;
-    font-size: $column-picker-checkbox-size;
-    opacity: $column-picker-checkbox-opacity; /* unchecked icon */
+    font-weight: var(--slick-column-picker-checkbox-font-weight, $column-picker-checkbox-font-weight);
+    font-family: var(--slick-icon-font-family, $icon-font-family);
+    font-size: var(--slick-column-picker-checkbox-size, $column-picker-checkbox-size);
+    opacity: var(--slick-column-picker-checkbox-opacity, $column-picker-checkbox-opacity); /* unchecked icon */
     margin-right: 4px;
-    width: $column-picker-checkbox-width;
+    width: var(--slick-column-picker-checkbox-width, $column-picker-checkbox-width);
   }
 
   input[type=checkbox] + label:hover:before {
-    opacity: $column-picker-checkbox-opacity-hover;
+    opacity: var(--slick-column-picker-checkbox-opacity-hover, $column-picker-checkbox-opacity-hover);
   }
 
   input[type=checkbox]:checked + label:before {
     opacity: 1; /* checked icon */
-    content: $column-picker-checkbox-icon-checked;
-    width: $column-picker-checkbox-width;
+    content: var(--slick-column-picker-checkbox-icon-checked, $column-picker-checkbox-icon-checked);
+    width: var(--slick-column-picker-checkbox-width, $column-picker-checkbox-width);
   }
 }
 
@@ -147,13 +148,13 @@
 // ----------------------------------------------
 
 .slick-gridmenu {
-  font-family:  $font-family;
-  background-color: $grid-menu-background-color;
-  border: $grid-menu-border;
-  border-radius: $grid-menu-border-radius;
+  font-family: var(--slick-font-family, $font-family);
+  background-color: var(--slick-grid-menu-background-color, $grid-menu-background-color);
+  border: var(--slick-grid-menu-border, $grid-menu-border);
+  border-radius: var(--slick-grid-menu-border-radius, $grid-menu-border-radius);
   padding: 6px;
-  box-shadow: $grid-menu-box-shadow;
-  min-width: $grid-menu-min-width;
+  box-shadow: var(--slick-grid-menu-box-shadow, $grid-menu-box-shadow);
+  min-width: var(--slick-grid-menu-min-width, $grid-menu-min-width);
   cursor: default;
   position:absolute;
   z-index: 2000;
@@ -163,33 +164,33 @@
   > .close {
     float: right;
     position: absolute;
-    color: $grid-menu-close-btn-color;
-    cursor: $grid-menu-close-btn-cursor;
-    width: $grid-menu-close-btn-width;
-    height: $grid-menu-close-btn-height;
-    margin: $grid-menu-close-btn-margin;
-    padding: $grid-menu-close-btn-padding;
-    font-family: $grid-menu-close-btn-font-family;
-    font-size: $grid-menu-close-btn-font-size;
-    background-color: $grid-menu-close-btn-bg-color;
-    border: $grid-menu-close-btn-border;
-    right: $grid-menu-close-btn-position-right;
-    top: $grid-menu-close-btn-position-top;
+    color: var(--slick-grid-menu-close-btn-color, $grid-menu-close-btn-color);
+    cursor: var(--slick-grid-menu-close-btn-cursor, $grid-menu-close-btn-cursor);
+    width: var(--slick-grid-menu-close-btn-width, $grid-menu-close-btn-width);
+    height: var(--slick-grid-menu-close-btn-height, $grid-menu-close-btn-height);
+    margin: var(--slick-grid-menu-close-btn-margin, $grid-menu-close-btn-margin);
+    padding: var(--slick-grid-menu-close-btn-padding, $grid-menu-close-btn-padding);
+    font-family: var(--slick-grid-menu-close-btn-font-family, $grid-menu-close-btn-font-family);
+    font-size: var(--slick-grid-menu-close-btn-font-size, $grid-menu-close-btn-font-size);
+    background-color: var(--slick-grid-menu-close-btn-bg-color, $grid-menu-close-btn-bg-color);
+    border: var(--slick-grid-menu-close-btn-border, $grid-menu-close-btn-border);
+    right: var(--slick-grid-menu-close-btn-position-right, $grid-menu-close-btn-position-right);
+    top: var(--slick-grid-menu-close-btn-position-top, $grid-menu-close-btn-position-top);
 
     &:hover {
-      color: $grid-menu-close-btn-color-hover;
+      color: var(--slick-grid-menu-close-btn-color-hover, $grid-menu-close-btn-color-hover);
     }
     > span {
-      opacity: $grid-menu-close-btn-opacity;
+      opacity: var(--slick-grid-menu-close-btn-opacity, $grid-menu-close-btn-opacity);
     }
   }
 
   div.title {
-    font-size: $grid-menu-title-font-size;
-    font-weight: $grid-menu-title-font-weight;
-    width: $grid-menu-title-width;
-    border-bottom: $grid-menu-title-border-bottom;
-    margin-bottom: $grid-menu-title-margin-bottom;
+    font-size: var(--slick-grid-menu-title-font-size, $grid-menu-title-font-size);
+    font-weight: var(--slick-grid-menu-title-font-weight, $grid-menu-title-font-weight);
+    width: var(--slick-grid-menu-title-width, $grid-menu-title-width);
+    border-bottom: var(--slick-grid-menu-title-border-bottom, $grid-menu-title-border-bottom);
+    margin-bottom: var(--slick-grid-menu-title-margin-bottom, $grid-menu-title-margin-bottom);
   }
 
   li {
@@ -202,13 +203,13 @@
       padding: 4px;
       font-weight: bold;
       &:hover {
-        background-color: $grid-menu-link-background-color;
+        background-color: var(--slick-grid-menu-link-background-color, $grid-menu-link-background-color);
       }
     }
     label {
-      font-weight: $grid-menu-label-font-weight;
+      font-weight: var(--slick-grid-menu-label-font-weight, $grid-menu-label-font-weight);
       input {
-        margin: $grid-menu-label-margin;
+        margin: var(--slick-grid-menu-label-margin, $grid-menu-label-margin);
       }
     }
   }
@@ -221,12 +222,12 @@
   position: absolute;
   cursor: pointer;
   right: 0;
-  padding: $grid-menu-button-padding;
-  margin-top: $grid-menu-icon-top-margin;
+  padding: var(--slick-grid-menu-button-padding, $grid-menu-button-padding);
+  margin-top: var(--slick-grid-menu-icon-top-margin, $grid-menu-icon-top-margin);
   background-color: transparent;
   border: 0;
   width: 22px;
-  font-size: $grid-menu-icon-font-size;
+  font-size: var(--slick-grid-menu-icon-font-size, $grid-menu-icon-font-size);
   z-index: 2;
 }
 
@@ -238,14 +239,14 @@
 .slick-gridmenu-item {
   cursor: pointer;
   display: block;
-  border: $grid-menu-item-border;
-  border-radius: $grid-menu-item-border-radius;
-  padding: $grid-menu-item-padding;
+  border: var(--slick-grid-menu-item-border, $grid-menu-item-border);
+  border-radius: var(--slick-grid-menu-item-border-radius, $grid-menu-item-border-radius);
+  padding: var(--slick-grid-menu-item-padding, $grid-menu-item-padding);
   list-style: none outside none;
   margin: 0;
   &:hover {
-    border: $grid-menu-item-hover-border;
-    background-color: $grid-menu-item-hover-color;
+    border: var(--slick-grid-menu-item-hover-border, $grid-menu-item-hover-border);
+    background-color: var(--slick-grid-menu-item-hover-color, $grid-menu-item-hover-color);
   }
 
   &.slick-gridmenu-item-divider {
@@ -253,30 +254,30 @@
     border: none;
     overflow: hidden;
     padding: 0;
-    height: $grid-menu-divider-height;
-    margin: $grid-menu-divider-margin;
-    background-color: $grid-menu-divider-color;
-    width: $grid-menu-divider-width;
+    height: var(--slick-grid-menu-divider-height, $grid-menu-divider-height);
+    margin: var(--slick-grid-menu-divider-margin, $grid-menu-divider-margin);
+    background-color: var(--slick-grid-menu-divider-color, $grid-menu-divider-color);
+    width: var(--slick-grid-menu-divider-width, $grid-menu-divider-width);
     margin-left: auto;
     margin-right: auto;
 
     &:hover {
       border: none;
-      background-color: $grid-menu-item-disabled-color;
+      background-color: var(--slick-grid-menu-item-disabled-color, $grid-menu-item-disabled-color);
     }
   }
 }
 .slick-gridmenu-item-divider.slick-gridmenu-item:hover {
-  background-color: $grid-menu-divider-color;
+  background-color: var(--slick-grid-menu-divider-color, $grid-menu-divider-color);
 }
 
 .slick-gridmenu-item-disabled {
   cursor: inherit;
   border-color: transparent !important;
   background: inherit !important;
-  color: $grid-menu-item-disabled-color;
+  color: var(--slick-grid-menu-item-disabled-color, $grid-menu-item-disabled-color);
   .slick-gridmenu-icon, .slick-gridmenu-content {
-    color: $grid-menu-item-disabled-color;
+    color: var(--slick-grid-menu-item-disabled-color, $grid-menu-item-disabled-color);
   }
 }
 .slick-gridmenu-item-hidden {
@@ -285,10 +286,10 @@
 
 .slick-gridmenu-icon {
   display: inline-block;
-  font-size: $grid-menu-icon-font-size;
-  line-height: $grid-menu-icon-line-height;
-  margin-right: $grid-menu-icon-margin-right;
-  width: $grid-menu-icon-width;
+  font-size: var(--slick-grid-menu-icon-font-size, $grid-menu-icon-font-size);
+  line-height: var(--slick-grid-menu-icon-line-height, $grid-menu-icon-line-height);
+  margin-right: var(--slick-grid-menu-icon-margin-right, $grid-menu-icon-margin-right);
+  width: var(--slick-grid-menu-icon-width, $grid-menu-icon-width);
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: center center;
@@ -307,14 +308,14 @@
 
   li {
     width: auto;
-    border: $grid-menu-item-border;
-    border-radius: $grid-menu-item-border-radius;
-    padding: $grid-menu-item-padding;
+    border: var(--slick-grid-menu-item-border, $grid-menu-item-border);
+    border-radius: var(--slick-grid-menu-item-border-radius, $grid-menu-item-border-radius);
+    padding: var(--slick-grid-menu-item-padding, $grid-menu-item-padding);
     list-style: none outside none;
     margin: 0;
     &:hover {
-      border: $grid-menu-item-hover-border;
-      background-color: $grid-menu-item-hover-color;
+      border: var(--slick-grid-menu-item-hover-border, $grid-menu-item-hover-border);
+      background-color: var(--slick-grid-menu-item-hover-color, $grid-menu-item-hover-color);
     }
     label {
       cursor: pointer;
@@ -327,38 +328,38 @@
     margin: 6px 0;
     border: 0;
     border-top: 1px solid #dddddd;
-    width: $grid-menu-divider-width;
+    width: var(--slick-grid-menu-divider-width, $grid-menu-divider-width);
     margin-left: auto;
     margin-right: auto;
   }
 
   /* replace checkboxes by Font-Awesome icons */
   input[type=checkbox] {
-    display:none;  /* to hide the checkbox itself */
+    display:none; /* to hide the checkbox itself */
     margin-left: 4px;
     margin-top: 3px;
   }
 
   input[type=checkbox] + label:before {
     cursor: pointer;
-    content: $grid-menu-checkbox-icon-unchecked;
-    color: $grid-menu-checkbox-color;
+    content: var(--slick-grid-menu-checkbox-icon-unchecked, $grid-menu-checkbox-icon-unchecked);
+    color: var(--slick-grid-menu-checkbox-color, $grid-menu-checkbox-color);
     display: inline-block;
-    font-weight: $grid-menu-checkbox-font-weight;
-    font-family: $icon-font-family;
-    font-size: $grid-menu-checkbox-size;
-    opacity: $grid-menu-checkbox-opacity; /* unchecked icon */
-    margin-right: $grid-menu-checkbox-margin-right;
-    width: $grid-menu-checkbox-width;
+    font-weight: var(--slick-grid-menu-checkbox-font-weight, $grid-menu-checkbox-font-weight);
+    font-family: var(--slick-icon-font-family, $icon-font-family);
+    font-size: var(--slick-grid-menu-checkbox-size, $grid-menu-checkbox-size);
+    opacity: var(--slick-grid-menu-checkbox-opacity, $grid-menu-checkbox-opacity); /* unchecked icon */
+    margin-right: var(--slick-grid-menu-checkbox-margin-right, $grid-menu-checkbox-margin-right);
+    width: var(--slick-grid-menu-checkbox-width, $grid-menu-checkbox-width);
   }
 
   input[type=checkbox] + label:hover:before {
-    opacity: $grid-menu-checkbox-opacity-hover;
+    opacity: var(--slick-grid-menu-checkbox-opacity-hover, $grid-menu-checkbox-opacity-hover);
   }
 
   input[type=checkbox]:checked + label:before {
-    content: $grid-menu-checkbox-icon-checked;
+    content: var(--slick-grid-menu-checkbox-icon-checked, $grid-menu-checkbox-icon-checked);
     opacity: 1; /* checked icon */
-    width: $grid-menu-checkbox-width;
+    width: var(--slick-grid-menu-checkbox-width, $grid-menu-checkbox-width);
   }
 }

--- a/packages/common/src/styles/slick-default-theme.scss
+++ b/packages/common/src/styles/slick-default-theme.scss
@@ -22,11 +22,11 @@
    }
 
    .slick-header-column:hover {
-     background: darken($grid-header-background, 2%);
+     background: $header-column-background-hover
    }
 
    .slick-header-column-active {
-     background: darken($grid-header-background, 5%) !important;
+     background: $header-column-background-active !important;
    }
 
    .slick-headerrow {

--- a/packages/common/src/styles/slick-editors.scss
+++ b/packages/common/src/styles/slick-editors.scss
@@ -4,17 +4,17 @@
 .slick-cell  {
   input.dual-editor-text,
   input.editor-text {
-    border: $text-editor-border;
-    border-radius: $text-editor-border-radius;
-    background: $text-editor-background;
-    padding-bottom: $text-editor-padding-bottom;
-    padding-left: $text-editor-padding-left;
-    padding-right: $text-editor-padding-right;
-    padding-top: $text-editor-padding-top;
-    margin-left: $text-editor-margin-left;
-    margin-bottom: $text-editor-margin-bottom;
-    margin-right: $text-editor-margin-right;
-    margin-top: $text-editor-margin-top;
+    border: var(--slick-text-editor-border, $text-editor-border);
+    border-radius: var(--slick-text-editor-border-radius, $text-editor-border-radius);
+    background: var(--slick-text-editor-background, $text-editor-background);
+    padding-bottom: var(--slick-text-editor-padding-bottom, $text-editor-padding-bottom);
+    padding-left: var(--slick-text-editor-padding-left, $text-editor-padding-left);
+    padding-right: var(--slick-text-editor-padding-right, $text-editor-padding-right);
+    padding-top: var(--slick-text-editor-padding-top, $text-editor-padding-top);
+    margin-left: var(--slick-text-editor-margin-left, $text-editor-margin-left);
+    margin-bottom: var(--slick-text-editor-margin-bottom, $text-editor-margin-bottom);
+    margin-right: var(--slick-text-editor-margin-right, $text-editor-margin-right);
+    margin-top: var(--slick-text-editor-margin-top, $text-editor-margin-top);
     outline: 0;
     height: 100%;
     max-width: 100%;
@@ -24,27 +24,27 @@
     }
     &:focus {
       outline: 0;
-      border-color: $text-editor-focus-border-color;
-      box-shadow: $text-editor-focus-box-shadow;
+      border-color: var(--slick-text-editor-focus-border-color, $text-editor-focus-border-color);
+      box-shadow: var(--slick-text-editor-focus-box-shadow, $text-editor-focus-box-shadow);
     }
 
     &.right {
-      margin-left: $text-editor-right-input-margin-left;
+      margin-left: var(--slick-text-editor-right-input-margin-left, $text-editor-right-input-margin-left);
     }
 
     &[readonly] {
-      background-color: $text-editor-readonly-color;
+      background-color: var(--slick-text-editor-readonly-color, $text-editor-readonly-color);
     }
   }
 
   .slider-editor {
-    height: $slider-editor-height;
+    height: var(--slick-slider-editor-height, $slider-editor-height);
     .slider-editor-input {
-      height: $slider-editor-height;
+      height: var(--slick-slider-editor-height, $slider-editor-height);
       &:focus {
         outline: 0;
-        border-color: $slider-editor-focus-border-color;
-        box-shadow: $slider-editor-focus-box-shadow;
+        border-color: var(--slick-slider-editor-focus-border-color, $slider-editor-focus-border-color);
+        box-shadow: var(--slick-slider-editor-focus-box-shadow, $slider-editor-focus-box-shadow);
       }
     }
   }
@@ -57,53 +57,53 @@
   }
 
   .ms-filter.select-editor {
-    transform: $multiselect-editor-transform;
-    height: $multiselect-editor-height;
+    transform: var(--slick-multiselect-editor-transform, $multiselect-editor-transform);
+    height: var(--slick-multiselect-editor-height, $multiselect-editor-height);
     button.ms-choice {
-      height: $multiselect-editor-height;
+      height: var(--slick-multiselect-editor-height, $multiselect-editor-height);
     }
   }
 
   .autocomplete-container.input-group,
   .flatpickr.input-group {
-    height: $date-editor-height;
+    height: var(--slick-date-editor-height, $date-editor-height);
     .input-group-btn {
       .btn {
         background-color: #eeeeee;
         border: 1px solid #cccccc;
-        padding: $editor-input-group-clear-btn-icon-padding;
-        border-top-right-radius: $text-editor-border-radius;
-        border-bottom-right-radius: $text-editor-border-radius;
+        padding: var(--slick-editor-input-group-clear-btn-icon-padding, $editor-input-group-clear-btn-icon-padding);
+        border-top-right-radius: var(--slick-text-editor-border-radius, $text-editor-border-radius);
+        border-bottom-right-radius: var(--slick-text-editor-border-radius, $text-editor-border-radius);
         cursor: pointer;
-        height: $date-editor-height;
+        height: var(--slick-date-editor-height, $date-editor-height);
         &.icon-clear:before {
-          font-family: $icon-font-family;
-          font-size: $editor-input-group-clear-btn-icon-size;
-          content: $editor-input-group-clear-btn-icon;
-          vertical-align: $editor-input-group-clear-btn-icon-vertical-align;
+          font-family: var(--slick-icon-font-family, $icon-font-family);
+          font-size: var(--slick-editor-input-group-clear-btn-icon-size, $editor-input-group-clear-btn-icon-size);
+          content: var(--slick-editor-input-group-clear-btn-icon, $editor-input-group-clear-btn-icon);
+          vertical-align: var(--slick-editor-input-group-clear-btn-icon-vertical-align, $editor-input-group-clear-btn-icon-vertical-align);
           display: inline-block;
-          height: $editor-input-group-clear-btn-icon-height;
-          width: $editor-input-group-clear-btn-icon-width;
-          margin-top: $editor-input-group-clear-btn-icon-margin-top;
+          height: var(--slick-editor-input-group-clear-btn-icon-height, $editor-input-group-clear-btn-icon-height);
+          width: var(--slick-editor-input-group-clear-btn-icon-width, $editor-input-group-clear-btn-icon-width);
+          margin-top: var(--slick-editor-input-group-clear-btn-icon-margin-top, $editor-input-group-clear-btn-icon-margin-top);
         }
       }
     }
   }
   .flatpickr-alt-input {
     cursor: pointer;
-    height: $date-editor-height;
-    border-top-left-radius: $text-editor-border-radius !important;
-    border-bottom-left-radius: $text-editor-border-radius !important;
-    padding: $date-editor-input-padding;
+    height: var(--slick-date-editor-height, $date-editor-height);
+    border-top-left-radius: var(--slick-text-editor-border-radius, $text-editor-border-radius) !important;
+    border-bottom-left-radius: var(--slick-text-editor-border-radius, $text-editor-border-radius) !important;
+    padding: var(--slick-date-editor-input-padding, $date-editor-input-padding);
 
     &.editor-text {
       cursor: pointer;
-      background-color: $flatpickr-bgcolor;
+      background-color: var(--slick-flatpickr-bgcolor, $flatpickr-bgcolor);
 
       &:focus {
         outline: 0;
-        border-color: $date-editor-focus-border-color;
-        box-shadow: $date-editor-focus-box-shadow;
+        border-color: var(--slick-date-editor-focus-border-color, $date-editor-focus-border-color);
+        box-shadow: var(--slick-date-editor-focus-box-shadow, $date-editor-focus-box-shadow);
       }
     }
   }
@@ -113,31 +113,31 @@
 .slick-large-editor-text {
   z-index: 10000;
   position: absolute;
-  background: $large-editor-background-color;
-  padding: $large-editor-text-padding;
-  border: $large-editor-border;
-  border-radius: $large-editor-border-radius;
+  background: var(--slick-large-editor-background-color, $large-editor-background-color);
+  padding: var(--slick-large-editor-text-padding, $large-editor-text-padding);
+  border: var(--slick-large-editor-border, $large-editor-border);
+  border-radius: var(--slick-large-editor-border-radius, $large-editor-border-radius);
 
   .editor-footer {
-    text-align: $large-editor-button-text-align;
+    text-align: var(--slick-large-editor-button-text-align, $large-editor-button-text-align);
     button {
-      margin-left: $large-editor-footer-spacing;
-      border-radius: $large-editor-button-border-radius;
+      margin-left: var(--slick-large-editor-footer-spacing, $large-editor-footer-spacing);
+      border-radius: var(--slick-large-editor-button-border-radius, $large-editor-button-border-radius);
     }
   }
 
   textarea {
-    background: $large-editor-background-color;
+    background: var(--slick-large-editor-background-color, $large-editor-background-color);
     border: 0;
     outline: 0;
   }
 
   .counter {
     float: left;
-    font-size: $large-editor-count-font-size;
-    margin-top: $large-editor-count-margin-top;
+    font-size: var(--slick-large-editor-count-font-size, $large-editor-count-font-size);
+    margin-top: var(--slick-large-editor-count-margin-top, $large-editor-count-margin-top);
     .separator {
-      margin: $large-editor-count-separator-margin;
+      margin: var(--slick-large-editor-count-separator-margin, $large-editor-count-separator-margin);
     }
   }
 }
@@ -154,25 +154,25 @@
   bottom: 0;
   left: 0;
   opacity: 1;
-  background: $editor-modal-backdrop-transition-background;
-  z-index: $editor-modal-container-z-index;
-  transition: $editor-modal-backdrop-transition-start;
+  background: var(--slick-editor-modal-backdrop-transition-background, $editor-modal-backdrop-transition-background);
+  z-index: var(--slick-editor-modal-container-z-index, $editor-modal-container-z-index);
+  transition: var(--slick-editor-modal-backdrop-transition-start, $editor-modal-backdrop-transition-start);
 
   .slick-editor-modal-content {
     display: inline-block;
     position: absolute;
-    border-radius: $editor-modal-container-radius;
-    font-family: $font-family;
-    border: $editor-modal-container-border;
-    margin: $editor-modal-container-margin;
-    background-color: $editor-modal-container-bg-color;
-    box-shadow: $editor-modal-container-box-shadow;
-    width: $editor-modal-container-width;
-    min-width: $editor-modal-container-min-width;
-    top: $editor-modal-container-top;
-    left: $editor-modal-container-left;
-    transform: $editor-modal-container-transform;
-    transition: $editor-modal-backdrop-transition-end;
+    border-radius: var(--slick-editor-modal-container-radius, $editor-modal-container-radius);
+    font-family: var(--slick-font-family, $font-family);
+    border: var(--slick-editor-modal-container-border, $editor-modal-container-border);
+    margin: var(--slick-editor-modal-container-margin, $editor-modal-container-margin);
+    background-color: var(--slick-editor-modal-container-bg-color, $editor-modal-container-bg-color);
+    box-shadow: var(--slick-editor-modal-container-box-shadow, $editor-modal-container-box-shadow);
+    width: var(--slick-editor-modal-container-width, $editor-modal-container-width);
+    min-width: var(--slick-editor-modal-container-min-width, $editor-modal-container-min-width);
+    top: var(--slick-editor-modal-container-top, $editor-modal-container-top);
+    left: var(--slick-editor-modal-container-left, $editor-modal-container-left);
+    transform: var(--slick-editor-modal-container-transform, $editor-modal-container-transform);
+    transition: var(--slick-editor-modal-backdrop-transition-end, $editor-modal-backdrop-transition-end);
     transition-property: opacity,transform;
 
     @media only screen and (min-width : 768px) {
@@ -208,22 +208,22 @@
     .btn-editor-reset,
     .reset-form.btn,
     .footer-buttons .btn {
-      margin: $editor-modal-footer-btn-margin;
-      height: $editor-modal-footer-btn-height;
-      border: $editor-modal-footer-btn-border;
-      border-radius: $editor-modal-footer-btn-radius;
+      margin: var(--slick-editor-modal-footer-btn-margin, $editor-modal-footer-btn-margin);
+      height: var(--slick-editor-modal-footer-btn-height, $editor-modal-footer-btn-height);
+      border: var(--slick-editor-modal-footer-btn-border, $editor-modal-footer-btn-border);
+      border-radius: var(--slick-editor-modal-footer-btn-radius, $editor-modal-footer-btn-radius);
       &:hover {
-        border-color: $editor-modal-footer-btn-border-hover;
+        border-color: var(--slick-editor-modal-footer-btn-border-hover, $editor-modal-footer-btn-border-hover);
       }
       &:disabled {
-        background-color: $button-primary-bg-color-disabled;
+        background-color: var(--slick-button-primary-bg-color-disabled, $button-primary-bg-color-disabled);
       }
     }
 
     .btn-editor-reset {
-      height: $editor-modal-editor-btn-reset-height;
-      background-color: $editor-modal-editor-btn-reset-bg-color;
-      margin: $editor-modal-editor-btn-reset-margin;
+      height: var(--slick-editor-modal-editor-btn-reset-height, $editor-modal-editor-btn-reset-height);
+      background-color: var(--slick-editor-modal-editor-btn-reset-bg-color, $editor-modal-editor-btn-reset-bg-color);
+      margin: var(--slick-editor-modal-editor-btn-reset-margin, $editor-modal-editor-btn-reset-margin);
     }
 
     .close {
@@ -231,43 +231,43 @@
       position: absolute;
       float: right;
       line-height: 0;
-      background-color: $editor-modal-close-btn-bg-color;
-      opacity: $editor-modal-close-btn-opacity;
-      border: $editor-modal-close-btn-border;
-      color: $editor-modal-close-btn-color;
-      font-family: $editor-modal-close-btn-font-family;
-      font-size: $editor-modal-close-btn-font-size;
-      font-weight: $editor-modal-close-btn-font-weight;
-      height: $editor-modal-close-btn-height;
-      margin: $editor-modal-close-btn-margin;
-      padding: $editor-modal-close-btn-padding;
-      width: $editor-modal-close-btn-width;
-      right: $editor-modal-close-btn-right;
-      top: $editor-modal-close-btn-top;
+      background-color: var(--slick-editor-modal-close-btn-bg-color, $editor-modal-close-btn-bg-color);
+      opacity: var(--slick-editor-modal-close-btn-opacity, $editor-modal-close-btn-opacity);
+      border: var(--slick-editor-modal-close-btn-border, $editor-modal-close-btn-border);
+      color: var(--slick-editor-modal-close-btn-color, $editor-modal-close-btn-color);
+      font-family: var(--slick-editor-modal-close-btn-font-family, $editor-modal-close-btn-font-family);
+      font-size: var(--slick-editor-modal-close-btn-font-size, $editor-modal-close-btn-font-size);
+      font-weight: var(--slick-editor-modal-close-btn-font-weight, $editor-modal-close-btn-font-weight);
+      height: var(--slick-editor-modal-close-btn-height, $editor-modal-close-btn-height);
+      margin: var(--slick-editor-modal-close-btn-margin, $editor-modal-close-btn-margin);
+      padding: var(--slick-editor-modal-close-btn-padding, $editor-modal-close-btn-padding);
+      width: var(--slick-editor-modal-close-btn-width, $editor-modal-close-btn-width);
+      right: var(--slick-editor-modal-close-btn-right, $editor-modal-close-btn-right);
+      top: var(--slick-editor-modal-close-btn-top, $editor-modal-close-btn-top);
       &:hover {
-        color: $editor-modal-close-btn-color-hover;
+        color: var(--slick-editor-modal-close-btn-color-hover, $editor-modal-close-btn-color-hover);
       }
       &.outside {
         @media only screen and (min-width: 769px) {
-          color: $editor-modal-close-btn-outside-color;
+          color: var(--slick-editor-modal-close-btn-outside-color, $editor-modal-close-btn-outside-color);
           &:hover {
-            color: $editor-modal-close-btn-outside-color-hover;
+            color: var(--slick-editor-modal-close-btn-outside-color-hover, $editor-modal-close-btn-outside-color-hover);
           }
-          font-size: $editor-modal-close-btn-outside-font-size;
-          right: $editor-modal-close-btn-outside-right;
-          top: $editor-modal-close-btn-outside-top;
+          font-size: var(--slick-editor-modal-close-btn-outside-font-size, $editor-modal-close-btn-outside-font-size);
+          right: var(--slick-editor-modal-close-btn-outside-right, $editor-modal-close-btn-outside-right);
+          top: var(--slick-editor-modal-close-btn-outside-top, $editor-modal-close-btn-outside-top);
         }
       }
     }
 
     .slick-editor-modal-title {
-      font-size: $editor-modal-title-font-size;
-      font-weight: $editor-modal-title-font-weight;
-      line-height: $editor-modal-title-line-height;
-      color: $editor-modal-title-font-color;
-      height: $editor-modal-title-height;
+      font-size: var(--slick-editor-modal-title-font-size, $editor-modal-title-font-size);
+      font-weight: var(--slick-editor-modal-title-font-weight, $editor-modal-title-font-weight);
+      line-height: var(--slick-editor-modal-title-line-height, $editor-modal-title-line-height);
+      color: var(--slick-editor-modal-title-font-color, $editor-modal-title-font-color);
+      height: var(--slick-editor-modal-title-height, $editor-modal-title-height);
       overflow: hidden auto;
-      text-align: $editor-modal-title-text-align;
+      text-align: var(--slick-editor-modal-title-text-align, $editor-modal-title-text-align);
       text-overflow: ellipsis;
       width: calc(100% - #{$editor-modal-close-btn-width} - #{$editor-modal-close-btn-right});
       white-space: nowrap;
@@ -277,10 +277,10 @@
     }
 
     .slick-editor-modal-body {
-      padding: $editor-modal-body-padding;
-      min-height: $editor-modal-body-min-height;
-      max-height: $editor-modal-body-max-height;
-      overflow: $editor-modal-body-overflow;
+      padding: var(--slick-editor-modal-body-padding, $editor-modal-body-padding);
+      min-height: var(--slick-editor-modal-body-min-height, $editor-modal-body-min-height);
+      max-height: var(--slick-editor-modal-body-max-height, $editor-modal-body-max-height);
+      overflow: var(--slick-editor-modal-body-overflow, $editor-modal-body-overflow);
       display: flex;
       flex-wrap: wrap;
 
@@ -289,175 +289,175 @@
       }
 
       .validation-summary {
-        padding: $editor-modal-validation-summary-padding;
-        color: $editor-modal-validation-summary-color;
-        width: $editor-modal-validation-summary-width;
-        margin-bottom: $editor-modal-validation-summary-margin-bottom;
-        font-size: $editor-modal-validation-summary-font-size;
-        font-style: $editor-modal-validation-summary-font-style;
+        padding: var(--slick-editor-modal-validation-summary-padding, $editor-modal-validation-summary-padding);
+        color: var(--slick-editor-modal-validation-summary-color, $editor-modal-validation-summary-color);
+        width: var(--slick-editor-modal-validation-summary-width, $editor-modal-validation-summary-width);
+        margin-bottom: var(--slick-editor-modal-validation-summary-margin-bottom, $editor-modal-validation-summary-margin-bottom);
+        font-size: var(--slick-editor-modal-validation-summary-font-size, $editor-modal-validation-summary-font-size);
+        font-style: var(--slick-editor-modal-validation-summary-font-style, $editor-modal-validation-summary-font-style);
       }
     }
 
     .slick-editor-modal-header {
-      padding: $editor-modal-header-padding;
-      height: $editor-modal-header-height;
-      border-bottom: $editor-modal-header-border-bottom;
-      background-color: $editor-modal-header-bg-color;
+      padding: var(--slick-editor-modal-header-padding, $editor-modal-header-padding);
+      height: var(--slick-editor-modal-header-height, $editor-modal-header-height);
+      border-bottom: var(--slick-editor-modal-header-border-bottom, $editor-modal-header-border-bottom);
+      background-color: var(--slick-editor-modal-header-bg-color, $editor-modal-header-bg-color);
     }
 
     .slick-editor-modal-footer {
-      background-color: $editor-modal-footer-bg-color;
-      border-top: $editor-modal-footer-border-top;
-      min-height: $editor-modal-footer-height;
-      padding: $editor-modal-footer-padding;
-      line-height: $editor-modal-footer-line-height;
+      background-color: var(--slick-editor-modal-footer-bg-color, $editor-modal-footer-bg-color);
+      border-top: var(--slick-editor-modal-footer-border-top, $editor-modal-footer-border-top);
+      min-height: var(--slick-editor-modal-footer-height, $editor-modal-footer-height);
+      padding: var(--slick-editor-modal-footer-padding, $editor-modal-footer-padding);
+      line-height: var(--slick-editor-modal-footer-line-height, $editor-modal-footer-line-height);
 
       .footer-buttons {
         float: right;
         text-align: right;
-        width: $editor-modal-footer-buttons-width;
+        width: var(--slick-editor-modal-footer-buttons-width, $editor-modal-footer-buttons-width);
 
         button {
-          max-width: $editor-modal-footer-btn-max-width;
+          max-width: var(--slick-editor-modal-footer-btn-max-width, $editor-modal-footer-btn-max-width);
           overflow: hidden;
           text-overflow: ellipsis;
         }
 
         .saving:before {
-          height: $editor-modal-footer-btn-saving-icon-height;
-          width: $editor-modal-footer-btn-saving-icon-width;
-          display: $editor-modal-footer-btn-saving-icon-display;
-          vertical-align: $editor-modal-footer-btn-saving-icon-vertical-align;
-          margin: $editor-modal-footer-btn-saving-icon-margin;
-          animation: $editor-modal-footer-btn-saving-icon-animation;
-          content: $editor-modal-footer-btn-saving-icon-content;
+          height: var(--slick-editor-modal-footer-btn-saving-icon-height, $editor-modal-footer-btn-saving-icon-height);
+          width: var(--slick-editor-modal-footer-btn-saving-icon-width, $editor-modal-footer-btn-saving-icon-width);
+          display: var(--slick-editor-modal-footer-btn-saving-icon-display, $editor-modal-footer-btn-saving-icon-display);
+          vertical-align: var(--slick-editor-modal-footer-btn-saving-icon-vertical-align, $editor-modal-footer-btn-saving-icon-vertical-align);
+          margin: var(--slick-editor-modal-footer-btn-saving-icon-margin, $editor-modal-footer-btn-saving-icon-margin);
+          animation: var(--slick-editor-modal-footer-btn-saving-icon-animation, $editor-modal-footer-btn-saving-icon-animation);
+          content: var(--slick-editor-modal-footer-btn-saving-icon-content, $editor-modal-footer-btn-saving-icon-content);
         }
       }
       .footer-status-text {
         float: left;
         text-align: left;
-        width: $editor-modal-footer-status-text-width;
-        font-size: $editor-modal-status-text-font-size;
-        color: $editor-modal-status-text-color;
+        width: var(--slick-editor-modal-footer-status-text-width, $editor-modal-footer-status-text-width);
+        font-size: var(--slick-editor-modal-status-text-font-size, $editor-modal-status-text-font-size);
+        color: var(--slick-editor-modal-status-text-color, $editor-modal-status-text-color);
       }
     }
 
     .item-details-label {
       display: block;
-      margin: $editor-modal-detail-label-margin;
-      font-size: $editor-modal-detail-label-font-size;
-      font-style: $editor-modal-detail-label-font-style;
-      font-weight: $editor-modal-detail-label-font-weight;
+      margin: var(--slick-editor-modal-detail-label-margin, $editor-modal-detail-label-margin);
+      font-size: var(--slick-editor-modal-detail-label-font-size, $editor-modal-detail-label-font-size);
+      font-style: var(--slick-editor-modal-detail-label-font-style, $editor-modal-detail-label-font-style);
+      font-weight: var(--slick-editor-modal-detail-label-font-weight, $editor-modal-detail-label-font-weight);
       &.invalid {
-        color: $editor-modal-detail-label-color-invalid;
+        color: var(--slick-editor-modal-detail-label-color-invalid, $editor-modal-detail-label-color-invalid);
       }
     }
 
     .item-details-editor-container {
       display: block;
       box-sizing: border-box;
-      border: $editor-modal-detail-container-border;
-      border-radius: $editor-modal-detail-container-border-radius;
-      line-height: $editor-modal-detail-container-line-height;
-      margin: $editor-modal-detail-container-margin;
-      padding: $editor-modal-detail-container-padding;
+      border: var(--slick-editor-modal-detail-container-border, $editor-modal-detail-container-border);
+      border-radius: var(--slick-editor-modal-detail-container-border-radius, $editor-modal-detail-container-border-radius);
+      line-height: var(--slick-editor-modal-detail-container-line-height, $editor-modal-detail-container-line-height);
+      margin: var(--slick-editor-modal-detail-container-margin, $editor-modal-detail-container-margin);
+      padding: var(--slick-editor-modal-detail-container-padding, $editor-modal-detail-container-padding);
 
       input {
-        height: $editor-modal-input-editor-height;
-        margin: $editor-modal-input-editor-margin;
-        border: $editor-modal-input-editor-border;
-        padding: $editor-modal-input-editor-padding;
+        height: var(--slick-editor-modal-input-editor-height, $editor-modal-input-editor-height);
+        margin: var(--slick-editor-modal-input-editor-margin, $editor-modal-input-editor-margin);
+        border: var(--slick-editor-modal-input-editor-border, $editor-modal-input-editor-border);
+        padding: var(--slick-editor-modal-input-editor-padding, $editor-modal-input-editor-padding);
         &:focus {
-          border-color: $text-editor-focus-border-color;
-          box-shadow: $text-editor-focus-box-shadow;
+          border-color: var(--slick-text-editor-focus-border-color, $text-editor-focus-border-color);
+          box-shadow: var(--slick-text-editor-focus-box-shadow, $text-editor-focus-box-shadow);
         }
         &:disabled {
-          background-color: $editor-input-disabled-color;
+          background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
         }
       }
       .input-group {
         position: relative;
-        height: $editor-modal-input-editor-height;
+        height: var(--slick-editor-modal-input-editor-height, $editor-modal-input-editor-height);
         input {
-          height: $editor-modal-input-editor-height;
+          height: var(--slick-editor-modal-input-editor-height, $editor-modal-input-editor-height);
         }
       }
       .slick-large-editor-text {
-        border: $editor-modal-large-editor-border;
-        border-radius: $editor-modal-large-editor-border-radius;
-        padding: $editor-modal-large-editor-padding;
+        border: var(--slick-editor-modal-large-editor-border, $editor-modal-large-editor-border);
+        border-radius: var(--slick-editor-modal-large-editor-border-radius, $editor-modal-large-editor-border-radius);
+        padding: var(--slick-editor-modal-large-editor-padding, $editor-modal-large-editor-padding);
         &:focus-within {
-          border-color: $text-editor-focus-border-color;
-          box-shadow: $text-editor-focus-box-shadow;
+          border-color: var(--slick-text-editor-focus-border-color, $text-editor-focus-border-color);
+          box-shadow: var(--slick-text-editor-focus-box-shadow, $text-editor-focus-box-shadow);
         }
         textarea {
           width: 100%;
           height: 100%;
           &:disabled {
-            background-color: $editor-input-disabled-color;
+            background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
           }
         }
         .editor-footer {
-          height: $editor-modal-large-editor-footer-height;
-          line-height: $editor-modal-large-editor-footer-line-height;
-          color: $editor-modal-large-editor-count-color;
+          height: var(--slick-editor-modal-large-editor-footer-height, $editor-modal-large-editor-footer-height);
+          line-height: var(--slick-editor-modal-large-editor-footer-line-height, $editor-modal-large-editor-footer-line-height);
+          color: var(--slick-editor-modal-large-editor-count-color, $editor-modal-large-editor-count-color);
           .counter {
-            font-size: $editor-modal-large-editor-count-font-size;
-            margin: $editor-modal-large-editor-count-margin;
+            font-size: var(--slick-editor-modal-large-editor-count-font-size, $editor-modal-large-editor-count-font-size);
+            margin: var(--slick-editor-modal-large-editor-count-margin, $editor-modal-large-editor-count-margin);
           }
         }
 
         &.invalid {
-          border: $editor-modal-detail-container-border-invalid;
+          border: var(--slick-editor-modal-detail-container-border-invalid, $editor-modal-detail-container-border-invalid);
         }
         &:disabled, &.disabled {
-          background-color: $editor-input-disabled-color;
+          background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
         }
       }
       button.ms-choice {
-        height: $editor-modal-multiselect-editor-height;
+        height: var(--slick-editor-modal-multiselect-editor-height, $editor-modal-multiselect-editor-height);
         &:disabled {
-          background-color: $editor-input-disabled-color;
+          background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
         }
       }
       .checkbox-editor-container {
-        padding: $editor-modal-checkbox-editor-padding;
-        border: $editor-modal-checkbox-editor-border;
-        border-radius: $editor-modal-checkbox-editor-border-radius;
-        height: $editor-modal-input-editor-height;
+        padding: var(--slick-editor-modal-checkbox-editor-padding, $editor-modal-checkbox-editor-padding);
+        border: var(--slick-editor-modal-checkbox-editor-border, $editor-modal-checkbox-editor-border);
+        border-radius: var(--slick-editor-modal-checkbox-editor-border-radius, $editor-modal-checkbox-editor-border-radius);
+        height: var(--slick-editor-modal-input-editor-height, $editor-modal-input-editor-height);
         input {
           height: inherit;
         }
         &.disabled {
-          background-color: $editor-input-disabled-color;
+          background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
         }
       }
 
       .autocomplete-container.input-group,
       .flatpickr.input-group {
-        height: $date-editor-height;
+        height: var(--slick-date-editor-height, $date-editor-height);
         .input-group-btn {
           min-width: 28px;
           .btn {
             min-width: 28px;
-            border-left: $editor-modal-close-btn-border-left;
-            height: $editor-modal-input-editor-height;
-            border-radius: $editor-modal-close-btn-border-radius;
+            border-left: var(--slick-editor-modal-close-btn-border-left, $editor-modal-close-btn-border-left);
+            height: var(--slick-editor-modal-input-editor-height, $editor-modal-input-editor-height);
+            border-radius: var(--slick-editor-modal-close-btn-border-radius, $editor-modal-close-btn-border-radius);
           }
         }
       }
       .flatpickr-input.form-control, .flatpickr-alt-input[readonly] {
-        background-color: $flatpickr-bgcolor;
+        background-color: var(--slick-flatpickr-bgcolor, $flatpickr-bgcolor);
         &:disabled {
-          background-color: $editor-input-disabled-color;
+          background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
           cursor: initial;
         }
       }
       .slider-value {
-        height: $editor-modal-slider-editor-value-height;
+        height: var(--slick-editor-modal-slider-editor-value-height, $editor-modal-slider-editor-value-height);
         min-width: 28px;
         .input-group-text {
-          min-height: $editor-modal-slider-editor-value-min-height;
+          min-height: var(--slick-editor-modal-slider-editor-value-min-height, $editor-modal-slider-editor-value-min-height);
           min-width: 28px;
           display: flex;
           justify-content: center;
@@ -467,28 +467,28 @@
 
       &.modified {
         input, .slick-large-editor-text, .ms-choice, .checkbox-editor-container {
-          border: $editor-modal-detail-container-border-modified;
-          border-width: $editor-modal-detail-container-border-width-modified;
+          border: var(--slick-editor-modal-detail-container-border-modified, $editor-modal-detail-container-border-modified);
+          border-width: var(--slick-editor-modal-detail-container-border-width-modified, $editor-modal-detail-container-border-width-modified);
         }
       }
       &.invalid {
         input, .slick-large-editor-text {
-          border: $editor-modal-detail-container-border-invalid;
+          border: var(--slick-editor-modal-detail-container-border-invalid, $editor-modal-detail-container-border-invalid);
         }
       }
       &.disabled {
-        background-color: $editor-input-disabled-color;
+        background-color: var(--slick-editor-input-disabled-color, $editor-input-disabled-color);
       }
     }
 
     .item-details-validation {
-      color: $editor-modal-validation-color;
-      font-size: $editor-modal-validation-font-size;
-      font-style: $editor-modal-validation-font-style;
-      font-weight: $editor-modal-validation-font-weight;
-      line-height: $editor-modal-validation-line-height;
-      margin-left: $editor-modal-validation-margin-left;
-      min-height: $editor-modal-validation-min-height;
+      color: var(--slick-editor-modal-validation-color, $editor-modal-validation-color);
+      font-size: var(--slick-editor-modal-validation-font-size, $editor-modal-validation-font-size);
+      font-style: var(--slick-editor-modal-validation-font-style, $editor-modal-validation-font-style);
+      font-weight: var(--slick-editor-modal-validation-font-weight, $editor-modal-validation-font-weight);
+      line-height: var(--slick-editor-modal-validation-line-height, $editor-modal-validation-line-height);
+      margin-left: var(--slick-editor-modal-validation-margin-left, $editor-modal-validation-margin-left);
+      min-height: var(--slick-editor-modal-validation-min-height, $editor-modal-validation-min-height);
     }
   }
 }

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -61,13 +61,13 @@
 
   .slick-pane-header {
     display: block;
-    background-color: $header-background-color;
-    border-bottom: $header-border-bottom;
+    background-color: var(--slick-header-background-color, $header-background-color);
+    border-bottom: var(--slick-header-border-bottom, $header-border-bottom);
   }
 
   .slick-pane-top {
     box-sizing: border-box;
-    border-top: $slick-pane-top-border-top;
+    border-top: var(--slick-slick-pane-top-border-top, $slick-pane-top-border-top);
   }
 
   .slick-viewport {
@@ -156,12 +156,12 @@
 
   .slick-cell {
     box-sizing: border-box;
-    border-style: $grid-border-style;
+    border-style: var(--slick-grid-border-style, $grid-border-style);
     padding: 1px 2px 1px 2px;
   }
 
   .slick-header-column {
-    padding: $header-padding-top $header-padding-right $header-padding-bottom $header-padding-left;
+    padding: var(--slick-header-padding, $header-padding);
   }
 
   .grid-canvas {
@@ -231,9 +231,6 @@
     background: silver;
   }
 
-  .slick-group {
-  }
-
   .slick-group-toggle {
     display: inline-block;
   }
@@ -297,7 +294,7 @@
 .interact-placeholder {
   background: red !important;
   display: inline-block;
-  float:left;
+  float: left;
   transform: translate(0px, -100%);
 }
 

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -8,11 +8,11 @@
 .slick-cell-menu {
   position: absolute;
   font-family:  $font-family;
-  background: $cell-menu-bg-color;
-  border: $cell-menu-border;
-  border-radius: $cell-menu-border-radius;
-  min-width: $cell-menu-min-width;
-  padding: $cell-menu-padding;
+  background: var(--slick-cell-menu-bg-color, $cell-menu-bg-color);
+  border: var(--slick-cell-menu-border, $cell-menu-border);
+  border-radius: var(--slick-cell-menu-border-radius, $cell-menu-border-radius);
+  min-width: var(--slick-cell-menu-min-width, $cell-menu-min-width);
+  padding: var(--slick-cell-menu-padding, $cell-menu-padding);
   z-index: 100000;
   cursor: default;
   display: inline-block;
@@ -29,32 +29,32 @@
   > .close {
     float: right;
     cursor: pointer;
-    color: $cell-menu-close-btn-color;
-    background-color: $cell-menu-close-btn-bg-color;
-    width: $cell-menu-close-btn-width;
-    height: $cell-menu-close-btn-height;
-    margin: $cell-menu-close-btn-margin;
-    padding: $cell-menu-close-btn-padding;
-    border: $cell-menu-close-btn-border;
-    font-family: $cell-menu-close-btn-font-family;
-    font-size: $cell-menu-close-btn-font-size;
+    color: var(--slick-cell-menu-close-btn-color, $cell-menu-close-btn-color);
+    background-color: var(--slick-cell-menu-close-btn-bg-color, $cell-menu-close-btn-bg-color);
+    width: var(--slick-cell-menu-close-btn-width, $cell-menu-close-btn-width);
+    height: var(--slick-cell-menu-close-btn-height, $cell-menu-close-btn-height);
+    margin: var(--slick-cell-menu-close-btn-margin, $cell-menu-close-btn-margin);
+    padding: var(--slick-cell-menu-close-btn-padding, $cell-menu-close-btn-padding);
+    border: var(--slick-cell-menu-close-btn-border, $cell-menu-close-btn-border);
+    font-family: var(--slick-cell-menu-close-btn-font-family, $cell-menu-close-btn-font-family);
+    font-size: var(--slick-cell-menu-close-btn-font-size, $cell-menu-close-btn-font-size);
 
     &:hover {
-      color: $cell-menu-close-btn-color-hover;
+      color: var(--slick-cell-menu-close-btn-color-hover, $cell-menu-close-btn-color-hover);
     }
     > span {
-      opacity: $cell-menu-close-btn-opacity;
+      opacity: var(--slick-cell-menu-close-btn-opacity, $cell-menu-close-btn-opacity);
     }
   }
 
   .slick-cell-menu-option-list,
   .slick-cell-menu-command-list {
     .title {
-      font-size: $cell-menu-title-font-size;
-      font-weight: $cell-menu-title-font-weight;
-      width: $cell-menu-title-width;
-      border-bottom: $cell-menu-title-border-bottom;
-      margin-bottom: $cell-menu-title-margin-bottom;
+      font-size: var(--slick-cell-menu-title-font-size, $cell-menu-title-font-size);
+      font-weight: var(--slick-cell-menu-title-font-weight, $cell-menu-title-font-weight);
+      width: var(--slick-cell-menu-title-width, $cell-menu-title-width);
+      border-bottom: var(--slick-cell-menu-title-border-bottom, $cell-menu-title-border-bottom);
+      margin-bottom: var(--slick-cell-menu-title-margin-bottom, $cell-menu-title-margin-bottom);
     }
   }
 
@@ -62,18 +62,18 @@
     cursor: pointer;
     display: flex;
     align-items: center;
-    border: $cell-menu-item-border;
-    border-radius: $cell-menu-item-border-radius;
-    font-size: $cell-menu-item-font-size;
-    padding: $cell-menu-item-padding;
+    border: var(--slick-cell-menu-item-border, $cell-menu-item-border);
+    border-radius: var(--slick-cell-menu-item-border-radius, $cell-menu-item-border-radius);
+    font-size: var(--slick-cell-menu-item-font-size, $cell-menu-item-font-size);
+    padding: var(--slick-cell-menu-item-padding, $cell-menu-item-padding);
     list-style: none outside none;
     margin: 0;
-    width: $cell-menu-item-width;
-    height: $cell-menu-item-height;
+    width: var(--slick-cell-menu-item-width, $cell-menu-item-width);
+    height: var(--slick-cell-menu-item-height, $cell-menu-item-height);
 
     &:hover {
-      border: $cell-menu-item-hover-border;
-      background-color: $cell-menu-item-hover-color;
+      border: var(--slick-cell-menu-item-hover-border, $cell-menu-item-hover-border);
+      background-color: var(--slick-cell-menu-item-hover-color, $cell-menu-item-hover-color);
     }
 
     &.slick-cell-menu-item-divider {
@@ -81,28 +81,28 @@
       border: none;
       overflow: hidden;
       padding: 0;
-      height: $cell-menu-divider-height;
-      margin: $cell-menu-divider-margin;
-      background-color: $cell-menu-divider-color;
-      width: $cell-menu-divider-width;
+      height: var(--slick-cell-menu-divider-height, $cell-menu-divider-height);
+      margin: var(--slick-cell-menu-divider-margin, $cell-menu-divider-margin);
+      background-color: var(--slick-cell-menu-divider-color, $cell-menu-divider-color);
+      width: var(--slick-cell-menu-divider-width, $cell-menu-divider-width);
       margin-left: auto;
       margin-right: auto;
 
       &:hover {
         border: none;
-        background-color: $cell-menu-divider-color;
+        background-color: var(--slick-cell-menu-divider-color, $cell-menu-divider-color);
       }
     }
 
     .slick-cell-menu-icon {
-      font-size: $cell-menu-icon-font-size;
+      font-size: var(--slick-cell-menu-icon-font-size, $cell-menu-icon-font-size);
       background-position: center center;
       background-repeat: no-repeat;
       display: inline-block;
-      line-height: $cell-menu-icon-line-height;
-      margin-right: $cell-menu-icon-margin-right;
+      line-height: var(--slick-cell-menu-icon-line-height, $cell-menu-icon-line-height);
+      margin-right: var(--slick-cell-menu-icon-margin-right, $cell-menu-icon-margin-right);
       vertical-align: middle;
-      width: $cell-menu-icon-width;
+      width: var(--slick-cell-menu-icon-width, $cell-menu-icon-width);
     }
 
     .slick-cell-menu-content {
@@ -114,10 +114,10 @@
     &.slick-cell-menu-item-disabled {
       border-color: transparent !important;
       background: inherit !important;
-      color: $cell-menu-item-disabled-color;
+      color: var(--slick-cell-menu-item-disabled-color, $cell-menu-item-disabled-color);
       cursor: inherit;
       .slick-cell-menu-icon, .slick-cell-menu-content {
-        color: $cell-menu-item-disabled-color;
+        color: var(--slick-cell-menu-item-disabled-color, $cell-menu-item-disabled-color);
       }
     }
     &.slick-cell-menu-item-hidden {
@@ -126,13 +126,13 @@
   }
 
   .slick-cell-menu-option-list {
-    margin-bottom: $cell-menu-option-list-margin-bottom;
+    margin-bottom: var(--slick-cell-menu-option-list-margin-bottom, $cell-menu-option-list-margin-bottom);
   }
 
   /* resize cell menu item width when there's a close button on same line */
   button + .slick-cell-menu-command-list .slick-cell-menu-item:first-child,
   button + .slick-cell-menu-option-list .slick-cell-menu-item:first-child {
-    width: $cell-menu-item-width-when-button;
+    width: var(--slick-cell-menu-item-width-when-button, $cell-menu-item-width-when-button);
   }
 }
 
@@ -142,11 +142,11 @@
 
 .slick-context-menu {
   position: absolute;
-  background: $context-menu-bg-color;
-  border: $context-menu-border;
-  border-radius: $context-menu-border-radius;
-  min-width: $context-menu-min-width;
-  padding: $context-menu-padding;
+  background: var(--slick-context-menu-bg-color, $context-menu-bg-color);
+  border: var(--slick-context-menu-border, $context-menu-border);
+  border-radius: var(--slick-context-menu-border-radius, $context-menu-border-radius);
+  min-width: var(--slick-context-menu-min-width, $context-menu-min-width);
+  padding: var(--slick-context-menu-padding, $context-menu-padding);
   z-index: 100000;
   cursor: default;
   display: inline-block;
@@ -162,45 +162,45 @@
 
   > .close {
     float: right;
-    color: $context-menu-close-btn-color;
-    background-color: $context-menu-close-btn-bg-color;
-    width: $context-menu-close-btn-width;
-    height: $context-menu-close-btn-height;
-    margin: $context-menu-close-btn-margin;
-    padding: $context-menu-close-btn-padding;
-    border: $context-menu-close-btn-border;
-    font-family: $context-menu-close-btn-font-family;
-    font-size: $context-menu-close-btn-font-size;
+    color: var(--slick-context-menu-close-btn-color, $context-menu-close-btn-color);
+    background-color: var(--slick-context-menu-close-btn-bg-color, $context-menu-close-btn-bg-color);
+    width: var(--slick-context-menu-close-btn-width, $context-menu-close-btn-width);
+    height: var(--slick-context-menu-close-btn-height, $context-menu-close-btn-height);
+    margin: var(--slick-context-menu-close-btn-margin, $context-menu-close-btn-margin);
+    padding: var(--slick-context-menu-close-btn-padding, $context-menu-close-btn-padding);
+    border: var(--slick-context-menu-close-btn-border, $context-menu-close-btn-border);
+    font-family: var(--slick-context-menu-close-btn-font-family, $context-menu-close-btn-font-family);
+    font-size: var(--slick-context-menu-close-btn-font-size, $context-menu-close-btn-font-size);
 
     &:hover {
-      color: $context-menu-close-btn-color-hover;
+      color: var(--slick-context-menu-close-btn-color-hover, $context-menu-close-btn-color-hover);
     }
     > span {
-      opacity: $context-menu-close-btn-opacity;
+      opacity: var(--slick-context-menu-close-btn-opacity, $context-menu-close-btn-opacity);
     }
   }
 
   .title {
-    font-size: $context-menu-title-font-size;
-    font-weight: $context-menu-title-font-weight;
-    width: $context-menu-title-width;
-    border-bottom: $context-menu-title-border-bottom;
-    margin-bottom: $context-menu-title-margin-bottom;
+    font-size: var(--slick-context-menu-title-font-size, $context-menu-title-font-size);
+    font-weight: var(--slick-context-menu-title-font-weight, $context-menu-title-font-weight);
+    width: var(--slick-context-menu-title-width, $context-menu-title-width);
+    border-bottom: var(--slick-context-menu-title-border-bottom, $context-menu-title-border-bottom);
+    margin-bottom: var(--slick-context-menu-title-margin-bottom, $context-menu-title-margin-bottom);
   }
 
   .slick-context-menu-item {
     cursor: pointer;
-    border: $context-menu-item-border;
-    border-radius: $context-menu-item-border-radius;
-    font-size: $context-menu-item-font-size;
-    padding: $context-menu-item-padding;
+    border: var(--slick-context-menu-item-border, $context-menu-item-border);
+    border-radius: var(--slick-context-menu-item-border-radius, $context-menu-item-border-radius);
+    font-size: var(--slick-context-menu-item-font-size, $context-menu-item-font-size);
+    padding: var(--slick-context-menu-item-padding, $context-menu-item-padding);
     list-style: none outside none;
     margin: 0;
-    width: $context-menu-item-width;
+    width: var(--slick-context-menu-item-width, $context-menu-item-width);
 
     &:hover {
-      border: $context-menu-item-hover-border;
-      background-color: $context-menu-item-hover-color;
+      border: var(--slick-context-menu-item-hover-border, $context-menu-item-hover-border);
+      background-color: var(--slick-context-menu-item-hover-color, $context-menu-item-hover-color);
     }
 
     &.slick-context-menu-item-divider {
@@ -209,16 +209,16 @@
       border: none;
       overflow: hidden;
       padding: 0;
-      height: $context-menu-divider-height;
-      margin: $context-menu-divider-margin;
-      background-color: $context-menu-divider-color;
-      width: $context-menu-divider-width;
+      height: var(--slick-context-menu-divider-height, $context-menu-divider-height);
+      margin: var(--slick-context-menu-divider-margin, $context-menu-divider-margin);
+      background-color: var(--slick-context-menu-divider-color, $context-menu-divider-color);
+      width: var(--slick-context-menu-divider-width, $context-menu-divider-width);
       margin-left: auto;
       margin-right: auto;
 
       &:hover {
         border: none;
-        background-color: $context-menu-divider-color;
+        background-color: var(--slick-context-menu-divider-color, $context-menu-divider-color);
       }
     }
 
@@ -226,12 +226,12 @@
       background-position: center center;
       background-repeat: no-repeat;
       display: inline-block;
-      font-size: $context-menu-icon-font-size;
-      height: $context-menu-icon-height;
-      line-height: $context-menu-icon-line-height;
-      margin-right: $context-menu-icon-margin-right;
+      font-size: var(--slick-context-menu-icon-font-size, $context-menu-icon-font-size);
+      height: var(--slick-context-menu-icon-height, $context-menu-icon-height);
+      line-height: var(--slick-context-menu-icon-line-height, $context-menu-icon-line-height);
+      margin-right: var(--slick-context-menu-icon-margin-right, $context-menu-icon-margin-right);
       vertical-align: middle;
-      width: $context-menu-icon-width;
+      width: var(--slick-context-menu-icon-width, $context-menu-icon-width);
     }
 
     .slick-context-menu-content {
@@ -243,10 +243,10 @@
     &.slick-context-menu-item-disabled {
       border-color: transparent !important;
       background: inherit !important;
-      color: $context-menu-item-disabled-color;
+      color: var(--slick-context-menu-item-disabled-color, $context-menu-item-disabled-color);
       cursor: inherit;
       .slick-context-menu-icon, .slick-context-menu-content {
-        color: $context-menu-item-disabled-color;
+        color: var(--slick-context-menu-item-disabled-color, $context-menu-item-disabled-color);
       }
     }
     &.slick-context-menu-item-hidden {
@@ -255,13 +255,13 @@
   }
 
   .slick-context-menu-option-list {
-    margin-bottom: $context-menu-option-list-margin-bottom;
+    margin-bottom: var(--slick-context-menu-option-list-margin-bottom, $context-menu-option-list-margin-bottom);
   }
 
   /* resize context menu item width when there's a close button on same line */
   button + .slick-context-menu-command-list .slick-context-menu-item:first-child,
   button + .slick-context-menu-option-list .slick-context-menu-item:first-child {
-    width: $context-menu-item-width-when-button;
+    width: var(--slick-context-menu-item-width-when-button, $context-menu-item-width-when-button);
   }
 }
 
@@ -284,11 +284,11 @@
   * This makes all "float:right" elements after it that spill over to the next line
   * display way below the lower boundary of the column thus hiding them.
   */
-  float: $header-button-float;
-  vertical-align: $header-button-vertical-align;
-  margin: $header-button-margin;
-  height: $header-button-height;
-  width: $header-button-width;
+  float: var(--slick-header-button-float, $header-button-float);
+  vertical-align: var(--slick-header-button-vertical-align, $header-button-vertical-align);
+  margin: var(--slick-header-button-margin, $header-button-margin);
+  height: var(--slick-header-button-height, $header-button-height);
+  width: var(--slick-header-button-width, $header-button-width);
   background-repeat: no-repeat;
   background-position: center center;
   cursor: pointer;
@@ -296,12 +296,12 @@
 
 .slick-header-button-hidden {
   width: 0;
-  margin-right: $header-button-hidden-margin-right;
+  margin-right: var(--slick-header-button-hidden-margin-right, $header-button-hidden-margin-right);
   transition: 0.2s width;
 }
 
 .slick-header-column:hover > .slick-header-button {
-  width: $header-button-width;
+  width: var(--slick-header-button-width, $header-button-width);
 }
 
 // ----------------------------------------------
@@ -314,31 +314,31 @@
   cursor: pointer;
   display: none;
   position: absolute;
-  height: $header-menu-button-height;
-  border: $header-menu-button-border;
-  border-width: $header-menu-button-border-width;
-  padding: $header-menu-button-padding;
-  color: $header-menu-button-icon-color;
+  height: var(--slick-header-menu-button-height, $header-menu-button-height);
+  border: var(--slick-header-menu-button-border, $header-menu-button-border);
+  border-width: var(--slick-header-menu-button-border-width, $header-menu-button-border-width);
+  padding: var(--slick-header-menu-button-padding, $header-menu-button-padding);
+  color: var(--slick-header-menu-button-icon-color, $header-menu-button-icon-color);
 
   // The next few items are already defined in the slick-headermenu file and it should stay that way, *unless* you also replace the button image included there.
   bottom: 0;
-  right: $header-menu-button-margin-right;
+  right: var(--slick-header-menu-button-margin-right, $header-menu-button-margin-right);
   top: 0;
-  width: $header-menu-button-width;
+  width: var(--slick-header-menu-button-width, $header-menu-button-width);
 }
 .slick-header-menubutton:before {
   display: inline-block;
-  content: $header-menu-button-icon;
-  font-family: $icon-font-family;
-  font-size: $header-menu-button-icon-font-size;
-  font-weight: $header-menu-button-icon-font-weight;
-  width: $header-menu-button-icon-width;
+  content: var(--slick-header-menu-button-icon, $header-menu-button-icon);
+  font-family: var(--slick-icon-font-family, $icon-font-family);
+  font-size: var(--slick-header-menu-button-icon-font-size, $header-menu-button-icon-font-size);
+  font-weight: var(--slick-header-menu-button-icon-font-weight, $header-menu-button-icon-font-weight);
+  width: var(--slick-header-menu-button-icon-width, $header-menu-button-icon-width);
 }
 
 .slick-header-column {
   // if user when to show header menu only while hovering, then the display var will be "none" else it could be "inline-block"
   .slick-header-menubutton {
-    display: $header-menu-display;
+    display: var(--slick-header-menu-display, $header-menu-display);
   }
   &:hover {
     .slick-header-menubutton {
@@ -350,11 +350,11 @@
 .slick-header-menu {
   position: absolute;
   margin: 0;
-  background: none repeat scroll 0 0 $header-menu-bg-color;
-  border: $header-menu-border;
-  border-radius: $header-menu-border-radius;
-  min-width: $header-menu-min-width;
-  padding: $header-menu-padding;
+  background: var(--slick-header-menu-bg, $header-menu-bg);
+  border: var(--slick-header-menu-border, $header-menu-border);
+  border-radius: var(--slick-header-menu-border-radius, $header-menu-border-radius);
+  min-width: var(--slick-header-menu-min-width, $header-menu-min-width);
+  padding: var(--slick-header-menu-padding, $header-menu-padding);
   z-index: 100000;
   cursor: default;
   display: inline-block;
@@ -386,14 +386,14 @@
 .slick-header-menuitem {
   cursor: pointer;
   display: block;
-  border: $header-menu-item-border;
-  border-radius: $header-menu-item-border-radius;
-  padding: $header-menu-item-padding;
+  border: var(--slick-header-menu-item-border, $header-menu-item-border);
+  border-radius: var(--slick-header-menu-item-border-radius, $header-menu-item-border-radius);
+  padding: var(--slick-header-menu-item-padding, $header-menu-item-padding);
   list-style: none outside none;
   margin: 0;
   &:hover {
-    border: $header-menu-item-hover-border;
-    background-color: $header-menu-item-hover-color;
+    border: var(--slick-header-menu-item-hover-border, $header-menu-item-hover-border);
+    background-color: var(--slick-header-menu-item-hover-color, $header-menu-item-hover-color);
   }
 
   &.slick-header-menuitem-divider {
@@ -401,21 +401,21 @@
     border: none;
     overflow: hidden;
     padding: 0;
-    height: $header-menu-divider-height;
-    margin: $header-menu-divider-margin;
-    background-color: $header-menu-divider-color;
-    width: $header-menu-divider-width;
+    height: var(--slick-header-menu-divider-height, $header-menu-divider-height);
+    margin: var(--slick-header-menu-divider-margin, $header-menu-divider-margin);
+    background-color: var(--slick-header-menu-divider-color, $header-menu-divider-color);
+    width: var(--slick-header-menu-divider-width, $header-menu-divider-width);
     margin-left: auto;
     margin-right: auto;
 
     &:hover {
       border: none;
-      background-color: $header-menu-item-disabled-color;
+      background-color: var(--slick-header-menu-item-disabled-color, $header-menu-item-disabled-color);
     }
   }
 }
 .slick-header-menuitem-divider.slick-header-menuitem:hover {
-  background-color: $header-menu-divider-color;
+  background-color: var(--slick-header-menu-divider-color, $header-menu-divider-color);
 }
 
 
@@ -423,14 +423,14 @@
   background-position: center center;
   background-repeat: no-repeat;
   display: inline-block;
-  color: $header-menu-icon-font-color;
-  font-size: $header-menu-icon-font-size;
-  font-weight: $header-menu-icon-font-weight;
-  line-height: $header-menu-icon-line-height;
-  height: $header-menu-icon-height;
-  margin-right: $header-menu-icon-margin-right;
+  color: var(--slick-header-menu-icon-font-color, $header-menu-icon-font-color);
+  font-size: var(--slick-header-menu-icon-font-size, $header-menu-icon-font-size);
+  font-weight: var(--slick-header-menu-icon-font-weight, $header-menu-icon-font-weight);
+  line-height: var(--slick-header-menu-icon-line-height, $header-menu-icon-line-height);
+  height: var(--slick-header-menu-icon-height, $header-menu-icon-height);
+  margin-right: var(--slick-header-menu-icon-margin-right, $header-menu-icon-margin-right);
   vertical-align: middle;
-  width: $header-menu-icon-width;
+  width: var(--slick-header-menu-icon-width, $header-menu-icon-width);
 
   /* Font Awesome sorting icons are not aligned in middle, let's align them ourselves */
   &.fa-sort-asc {
@@ -450,10 +450,10 @@
 .slick-header-menuitem-disabled {
   border-color: transparent !important;
   background: inherit !important;
-  color: $header-menu-item-disabled-color;
+  color: var(--slick-header-menu-item-disabled-color, $header-menu-item-disabled-color);
   cursor: inherit;
   .slick-header-menuicon, .slick-header-menucontent {
-    color: $header-menu-item-disabled-color;
+    color: var(--slick-header-menu-item-disabled-color, $header-menu-item-disabled-color);
   }
 }
 .slick-header-menuitem-hidden {
@@ -465,14 +465,14 @@
 // ----------------------------------------------
 .slick-cell.cell-reorder:before {
   display: inline-block;
-  font-family: $icon-font-family;
-  font-size: $row-move-plugin-size;
-  content: $row-move-plugin-icon;
-  width: $row-move-plugin-icon-width;
-  vertical-align: $row-move-plugin-icon-vertical-align;
+  font-family: var(--slick-icon-font-family, $icon-font-family);
+  font-size: var(--slick-row-move-plugin-size, $row-move-plugin-size);
+  content: var(--slick-row-move-plugin-icon, $row-move-plugin-icon);
+  width: var(--slick-row-move-plugin-icon-width, $row-move-plugin-icon-width);
+  vertical-align: var(--slick-row-move-plugin-icon-vertical-align, $row-move-plugin-icon-vertical-align);
 }
 .slick-cell.cell-reorder {
-  cursor: $row-move-plugin-cursor;
+  cursor: var(--slick-row-move-plugin-cursor, $row-move-plugin-cursor);
 }
 
 // ----------------------------------------------
@@ -503,35 +503,35 @@
   input[type=checkbox] + label:before,
   #filter-checkbox-selectall-container > input[type=checkbox] + label:before {
     cursor: pointer;
-    content: $checkbox-selector-icon-unchecked;
-    background-color: $checkbox-selector-icon-bg-color;
-    color: $checkbox-selector-unchecked-color;
+    content: var(--slick-checkbox-selector-icon-unchecked, $checkbox-selector-icon-unchecked);
+    background-color: var(--slick-checkbox-selector-icon-bg-color, $checkbox-selector-icon-bg-color);
+    color: var(--slick-checkbox-selector-unchecked-color, $checkbox-selector-unchecked-color);
     display: inline-block;
-    font-weight: $checkbox-selector-icon-font-weight;
-    font-family: $icon-font-family;
-    font-size: $checkbox-selector-size;
-    opacity: $checkbox-selector-opacity; /* unchecked icon */
-    height: $checkbox-selector-icon-height;
-    width: $checkbox-selector-icon-width;
-    border: $checkbox-selector-icon-border;
-    border-radius: $checkbox-selector-icon-border-radius;
-    margin: $checkbox-selector-icon-margin;
+    font-weight: var(--slick-checkbox-selector-icon-font-weight, $checkbox-selector-icon-font-weight);
+    font-family: var(--slick-icon-font-family, $icon-font-family);
+    font-size: var(--slick-checkbox-selector-size, $checkbox-selector-size);
+    opacity: var(--slick-checkbox-selector-opacity, $checkbox-selector-opacity); /* unchecked icon */
+    height: var(--slick-checkbox-selector-icon-height, $checkbox-selector-icon-height);
+    width: var(--slick-checkbox-selector-icon-width, $checkbox-selector-icon-width);
+    border: var(--slick-checkbox-selector-icon-border, $checkbox-selector-icon-border);
+    border-radius: var(--slick-checkbox-selector-icon-border-radius, $checkbox-selector-icon-border-radius);
+    margin: var(--slick-checkbox-selector-icon-margin, $checkbox-selector-icon-margin);
   }
 
   input[type=checkbox] + label:hover:before,
   #filter-checkbox-selectall-container > input[type=checkbox] + label:hover:before {
-    opacity: $checkbox-selector-opacity-hover;
+    opacity: var(--slick-checkbox-selector-opacity-hover, $checkbox-selector-opacity-hover);
   }
 
   input[type=checkbox]:checked + label:before,
   #filter-checkbox-selectall-container > input[type=checkbox]:checked + label:before {
-    content: $checkbox-selector-icon-checked;
-    color: $checkbox-selector-checked-color;
+    content: var(--slick-checkbox-selector-icon-checked, $checkbox-selector-icon-checked);
+    color: var(--slick-checkbox-selector-checked-color, $checkbox-selector-checked-color);
     opacity: 1; /* checked icon */
-    height: $checkbox-selector-icon-height;
-    width: $checkbox-selector-icon-width;
-    border-radius: $checkbox-selector-icon-border;
-    border-radius: $checkbox-selector-icon-border-radius;
+    height: var(--slick-checkbox-selector-icon-height, $checkbox-selector-icon-height);
+    width: var(--slick-checkbox-selector-icon-width, $checkbox-selector-icon-width);
+    border-radius: var(--slick-checkbox-selector-icon-border, $checkbox-selector-icon-border);
+    border-radius: var(--slick-checkbox-selector-icon-border-radius, $checkbox-selector-icon-border-radius);
   }
 }
 
@@ -546,44 +546,44 @@
 // ----------------------------------------------
 .search-filter {
   :focus {
-    outline-color: $focus-color;
+    outline-color: var(--slick-focus-color, $focus-color);
   }
 }
 .ms-choice {
-  border: $multiselect-input-filter-border;
+  border: var(--slick-multiselect-input-filter-border, $multiselect-input-filter-border);
   background-color: transparent;
-  font-size: $header-font-size;
+  font-size: var(--slick-header-font-size, $header-font-size);
 
   div {
     &:before {
-      font-family: $icon-font-family;
-      font-size: $multiselect-icon-arrow-font-size;
+      font-family: var(--slick-icon-font-family, $icon-font-family);
+      font-size: var(--slick-multiselect-icon-arrow-font-size, $multiselect-icon-arrow-font-size);
     }
     &.open {
       &:before {
-        font-family: $icon-font-family;
-        font-size: $multiselect-icon-arrow-font-size;
+        font-family: var(--slick-icon-font-family, $icon-font-family);
+        font-size: var(--slick-multiselect-icon-arrow-font-size, $multiselect-icon-arrow-font-size);
       }
     }
   }
 
   span {
-    font-size: $multiselect-input-filter-font-size;
-    font-family: $multiselect-input-filter-font-family;
+    font-size: var(--slick-multiselect-input-filter-font-size, $multiselect-input-filter-font-size);
+    font-family: var(--slick-multiselect-input-filter-font-family, $multiselect-input-filter-font-family);
   }
   .placeholder {
-    font-family: $multiselect-placeholder-font-family;
-    font-size: $header-font-size;
-    color: $editor-placeholder-color !important;
+    font-family: var(--slick-multiselect-placeholder-font-family, $multiselect-placeholder-font-family);
+    font-size: var(--slick-header-font-size, $header-font-size);
+    color: var(--slick-editor-placeholder-color, $editor-placeholder-color) !important;
   }
 }
 .ms-filter.search-filter {
   width: 100% !important;
 }
 .ms-drop {
-  max-width: $multiselect-dropdown-max-width;
-  border: $multiselect-dropdown-border;
-  z-index: $multiselect-dropdown-z-index;
+  max-width: var(--slick-multiselect-dropdown-max-width, $multiselect-dropdown-max-width);
+  border: var(--slick-multiselect-dropdown-border, $multiselect-dropdown-border);
+  z-index: var(--slick-multiselect-dropdown-z-index, $multiselect-dropdown-z-index);
 
   input[type="checkbox"],
   input[type="radio"] {
@@ -593,100 +593,100 @@
 
     & + span:before {
       cursor: pointer;
-      color: $multiselect-icon-unchecked-color;
-      content: $multiselect-icon-unchecked;
+      color: var(--slick-multiselect-icon-unchecked-color, $multiselect-icon-unchecked-color);
+      content: var(--slick-multiselect-icon-unchecked, $multiselect-icon-unchecked);
       display: inline-block;
-      font-family: $icon-font-family;
-      font-size: $multiselect-icon-font-size;
+      font-family: var(--slick-icon-font-family, $icon-font-family);
+      font-size: var(--slick-multiselect-icon-font-size, $multiselect-icon-font-size);
       font-weight: normal;
-      height: $multiselect-icon-height;
-      width: $multiselect-icon-width;
-      border: $multiselect-icon-border;
-      border-radius: $multiselect-icon-border-radius;
-      margin: $multiselect-icon-margin;
-      opacity: $multiselect-unchecked-opacity;
-      vertical-align: $multiselect-icon-vertical-align;
+      height: var(--slick-multiselect-icon-height, $multiselect-icon-height);
+      width: var(--slick-multiselect-icon-width, $multiselect-icon-width);
+      border: var(--slick-multiselect-icon-border, $multiselect-icon-border);
+      border-radius: var(--slick-multiselect-icon-border-radius, $multiselect-icon-border-radius);
+      margin: var(--slick-multiselect-icon-margin, $multiselect-icon-margin);
+      opacity: var(--slick-multiselect-unchecked-opacity, $multiselect-unchecked-opacity);
+      vertical-align: var(--slick-multiselect-icon-vertical-align, $multiselect-icon-vertical-align);
     }
 
     &:checked + span:before {
-      content: $multiselect-icon-checked;
+      content: var(--slick-multiselect-icon-checked, $multiselect-icon-checked);
       opacity: 1;
-      height: $multiselect-icon-height;
-      width: $multiselect-icon-width;
-      border: $multiselect-icon-border;
-      border-radius: $multiselect-icon-border-radius;
-      margin: $multiselect-icon-margin;
+      height: var(--slick-multiselect-icon-height, $multiselect-icon-height);
+      width: var(--slick-multiselect-icon-width, $multiselect-icon-width);
+      border: var(--slick-multiselect-icon-border, $multiselect-icon-border);
+      border-radius: var(--slick-multiselect-icon-border-radius, $multiselect-icon-border-radius);
+      margin: var(--slick-multiselect-icon-margin, $multiselect-icon-margin);
     }
   }
   input[type="radio"] {
     & + span:before {
-      content: $multiselect-icon-radio-unchecked;
-      height: $multiselect-icon-radio-height;
-      width: $multiselect-icon-radio-width;
-      border: $multiselect-icon-radio-border;
-      border-radius: $multiselect-icon-radio-border-radius;
-      margin: $multiselect-icon-radio-margin;
+      content: var(--slick-multiselect-icon-radio-unchecked, $multiselect-icon-radio-unchecked);
+      height: var(--slick-multiselect-icon-radio-height, $multiselect-icon-radio-height);
+      width: var(--slick-multiselect-icon-radio-width, $multiselect-icon-radio-width);
+      border: var(--slick-multiselect-icon-radio-border, $multiselect-icon-radio-border);
+      border-radius: var(--slick-multiselect-icon-radio-border-radius, $multiselect-icon-radio-border-radius);
+      margin: var(--slick-multiselect-icon-radio-margin, $multiselect-icon-radio-margin);
     }
     &:checked + span:before {
-      content: $multiselect-icon-radio-checked;
-      color: $multiselect-icon-radio-color;
-      height: $multiselect-icon-radio-height;
-      width: $multiselect-icon-radio-width;
-      border: $multiselect-icon-radio-border;
-      border-radius: $multiselect-icon-radio-border-radius;
-      margin: $multiselect-icon-radio-margin;
+      content: var(--slick-multiselect-icon-radio-checked, $multiselect-icon-radio-checked);
+      color: var(--slick-multiselect-icon-radio-color, $multiselect-icon-radio-color);
+      height: var(--slick-multiselect-icon-radio-height, $multiselect-icon-radio-height);
+      width: var(--slick-multiselect-icon-radio-width, $multiselect-icon-radio-width);
+      border: var(--slick-multiselect-icon-radio-border, $multiselect-icon-radio-border);
+      border-radius: var(--slick-multiselect-icon-radio-border-radius, $multiselect-icon-radio-border-radius);
+      margin: var(--slick-multiselect-icon-radio-margin, $multiselect-icon-radio-margin);
     }
   }
   label {
-    margin-bottom: $multiselect-label-margin-bottom;
-    line-height: $multiselect-label-line-height;
+    margin-bottom: var(--slick-multiselect-label-margin-bottom, $multiselect-label-margin-bottom);
+    line-height: var(--slick-multiselect-label-line-height, $multiselect-label-line-height);
 
     span {
       cursor: pointer;
-      margin-left: $multiselect-checkbox-margin-left;
+      margin-left: var(--slick-multiselect-checkbox-margin-left, $multiselect-checkbox-margin-left);
       position: relative;
       top: 1px;
     }
     &:hover {
       cursor: pointer;
-      background-color: $multiselect-checkbox-hover-bg-color;
+      background-color: var(--slick-multiselect-checkbox-hover-bg-color, $multiselect-checkbox-hover-bg-color);
     }
   }
   .ms-select-all {
-    border-bottom: $multiselect-select-all-border-bottom;
+    border-bottom: var(--slick-multiselect-select-all-border-bottom, $multiselect-select-all-border-bottom);
     label {
       display: inline-block;
       font-weight: normal;
       padding: 5px 8px;
-      color: $multiselect-select-all-text-color;
+      color: var(--slick-multiselect-select-all-text-color, $multiselect-select-all-text-color);
       &:hover {
-        color: $multiselect-select-all-text-hover-color;
+        color: var(--slick-multiselect-select-all-text-hover-color, $multiselect-select-all-text-hover-color);
       }
     }
   }
   .ms-ok-button {
     cursor: pointer;
     display: block;
-    width: $multiselect-ok-button-width;
-    height: $multiselect-ok-button-height;
+    width: var(--slick-multiselect-ok-button-width, $multiselect-ok-button-width);
+    height: var(--slick-multiselect-ok-button-height, $multiselect-ok-button-height);
     padding: 0;
-    border: $multiselect-ok-button-border;
-    text-align: $multiselect-ok-button-text-align;
-    color: $multiselect-ok-button-text-color;
-    font-weight: $multiselect-ok-button-font-weight;
+    border: var(--slick-multiselect-ok-button-border, $multiselect-ok-button-border);
+    text-align: var(--slick-multiselect-ok-button-text-align, $multiselect-ok-button-text-align);
+    color: var(--slick-multiselect-ok-button-text-color, $multiselect-ok-button-text-color);
+    font-weight: var(--slick-multiselect-ok-button-font-weight, $multiselect-ok-button-font-weight);
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
-    background-color: $multiselect-ok-button-bg-color;
+    background-color: var(--slick-multiselect-ok-button-bg-color, $multiselect-ok-button-bg-color);
     &:hover {
-      background-color: $multiselect-ok-button-bg-hover-color;
-      color: $multiselect-ok-button-text-hover-color;
+      background-color: var(--slick-multiselect-ok-button-bg-hover-color, $multiselect-ok-button-bg-hover-color);
+      color: var(--slick-multiselect-ok-button-text-hover-color, $multiselect-ok-button-text-hover-color);
     }
   }
   .ms-search {
     &:before {
-      font-family: $icon-font-family;
-      font-size: $multiselect-icon-font-size;
-      right: $multiselect-icon-search-margin-right;
+      font-family: var(--slick-icon-font-family, $icon-font-family);
+      font-size: var(--slick-multiselect-icon-font-size, $multiselect-icon-font-size);
+      right: var(--slick-multiselect-icon-search-margin-right, $multiselect-icon-search-margin-right);
       position: absolute;
     }
   }
@@ -702,20 +702,20 @@
   border: none;
 
   .form-control {
-    border-radius: $compound-filter-operator-border-radius;
+    border-radius: var(--slick-compound-filter-operator-border-radius, $compound-filter-operator-border-radius);
     // border-right: none;
-    padding: $compound-filter-text-padding !important;
-    font-size: $compound-filter-text-font-size;
-    color: $compound-filter-text-color;
-    font-weight: $compound-filter-text-weight;
-    background-color: $compound-filter-bgcolor;
+    padding: var(--slick-compound-filter-text-padding, $compound-filter-text-padding) !important;
+    font-size: var(--slick-compound-filter-text-font-size, $compound-filter-text-font-size);
+    color: var(--slick-compound-filter-text-color, $compound-filter-text-color);
+    font-weight: var(--slick-compound-filter-text-weight, $compound-filter-text-weight);
+    background-color: var(--slick-compound-filter-bgcolor, $compound-filter-bgcolor);
   }
 
   select {
-    font-family: $compound-filter-operator-select-font-family;
-    font-size: $compound-filter-operator-select-font-size;
-    border: $compound-filter-operator-select-border;
-    width: $compound-filter-operator-select-width;
+    font-family: var(--slick-compound-filter-operator-select-font-family, $compound-filter-operator-select-font-family);
+    font-size: var(--slick-compound-filter-operator-select-font-size, $compound-filter-operator-select-font-size);
+    border: var(--slick-compound-filter-operator-select-border, $compound-filter-operator-select-border);
+    width: var(--slick-compound-filter-operator-select-width, $compound-filter-operator-select-width);
 
     &.form-control {
       cursor: pointer;
@@ -735,16 +735,16 @@
 }
 
 input.search-filter {
-  font-family: $filter-placeholder-font-family;
+  font-family: var(--slick-filter-placeholder-font-family, $filter-placeholder-font-family);
 }
 .search-filter {
   input {
-    font-family: $filter-placeholder-font-family;
+    font-family: var(--slick-filter-placeholder-font-family, $filter-placeholder-font-family);
     &.compound-input {
-      border-radius: $compound-filter-border-radius !important;
+      border-radius: var(--slick-compound-filter-border-radius, $compound-filter-border-radius) !important;
       border-left: none;
       &::placeholder {
-        color: $editor-placeholder-color;
+        color: var(--slick-editor-placeholder-color, $editor-placeholder-color);
       }
     }
   }
@@ -775,7 +775,7 @@ input.search-filter {
   input.form-control {
     border-left: none;
     &::placeholder {
-      color: $editor-placeholder-color;
+      color: var(--slick-editor-placeholder-color, $editor-placeholder-color);
     }
   }
 }
@@ -786,29 +786,29 @@ input.search-filter {
 
   input.flatpickr.form-control,
   .flatpickr-input.form-control {
-    background-color: $flatpickr-bgcolor;
-    font-family: $filter-placeholder-font-family;
-    font-size: $font-size-base;
-    border-radius: $compound-filter-border-radius;
+    background-color: var(--slick-flatpickr-bgcolor, $flatpickr-bgcolor);
+    font-family: var(--slick-filter-placeholder-font-family, $filter-placeholder-font-family);
+    font-size: var(--slick-font-size-base, $font-size-base);
+    border-radius: var(--slick-compound-filter-border-radius, $compound-filter-border-radius);
     width: 100%;
     &[readonly] {
-      background-color: $flatpickr-bgcolor;
+      background-color: var(--slick-flatpickr-bgcolor, $flatpickr-bgcolor);
     }
   }
   .form-control[readonly],
   .flatpickr.form-control[readonly] {
     cursor: pointer;
-    background-color: $flatpickr-bgcolor;
+    background-color: var(--slick-flatpickr-bgcolor, $flatpickr-bgcolor);
   }
 }
 input.flatpickr-input.form-control,
 input.flatpickr.form-control {
   cursor: pointer;
-  font-family: $filter-placeholder-font-family;
-  font-size: $font-size-base;
-  border-radius: $date-range-filter-border-radius;
+  font-family: var(--slick-filter-placeholder-font-family, $filter-placeholder-font-family);
+  font-size: var(--slick-font-size-base, $font-size-base);
+  border-radius: var(--slick-date-range-filter-border-radius, $date-range-filter-border-radius);
   &[readonly] {
-    background-color: $flatpickr-bgcolor;
+    background-color: var(--slick-flatpickr-bgcolor, $flatpickr-bgcolor);
   }
 }
 
@@ -818,35 +818,35 @@ input.flatpickr.form-control {
 
 .slick-preheader-panel {
   .ui-droppable, .ui-droppable-hover {
-    padding: $draggable-group-drop-padding;
-    height: $draggable-group-drop-height;
-    border-top: $draggable-group-drop-border-top !important;
-    border-left: $draggable-group-drop-border-left !important;
-    border-right: $draggable-group-drop-border-right !important;
-    border-bottom: $draggable-group-drop-border-bottom !important;
-    width: $draggable-group-drop-width !important;
-    border-radius: $draggable-group-drop-radius;
-    background-color: $draggable-group-drop-bgcolor;
+    padding: var(--slick-draggable-group-drop-padding, $draggable-group-drop-padding);
+    height: var(--slick-draggable-group-drop-height, $draggable-group-drop-height);
+    border-top: var(--slick-draggable-group-drop-border-top, $draggable-group-drop-border-top) !important;
+    border-left: var(--slick-draggable-group-drop-border-left, $draggable-group-drop-border-left) !important;
+    border-right: var(--slick-draggable-group-drop-border-right, $draggable-group-drop-border-right) !important;
+    border-bottom: var(--slick-draggable-group-drop-border-bottom, $draggable-group-drop-border-bottom) !important;
+    width: var(--slick-draggable-group-drop-width, $draggable-group-drop-width) !important;
+    border-radius: var(--slick-draggable-group-drop-radius, $draggable-group-drop-radius);
+    background-color: var(--slick-draggable-group-drop-bgcolor, $draggable-group-drop-bgcolor);
 
     .slick-placeholder {
-      font-style: $draggable-group-placeholder-font-style;
-      color: $draggable-group-placeholder-color;
+      font-style: var(--slick-draggable-group-placeholder-font-style, $draggable-group-placeholder-font-style);
+      color: var(--slick-draggable-group-placeholder-color, $draggable-group-placeholder-color);
     }
 
     .slick-group-toggle-all {
       position: absolute;
       cursor: pointer;
-      font-family: $icon-font-family;
-      color: $draggable-group-toggle-all-color;
-      display: $draggable-group-toggle-all-display !important;
-      top: $draggable-group-toggle-all-pos-top;
-      right: $draggable-group-toggle-all-pos-right;
+      font-family: var(--slick-icon-font-family, $icon-font-family);
+      color: var(--slick-draggable-group-toggle-all-color, $draggable-group-toggle-all-color);
+      display: var(--slick-draggable-group-toggle-all-display, $draggable-group-toggle-all-display) !important;
+      top: var(--slick-draggable-group-toggle-all-pos-top, $draggable-group-toggle-all-pos-top);
+      right: var(--slick-draggable-group-toggle-all-pos-right, $draggable-group-toggle-all-pos-right);
 
       &.expanded:before {
-        content: $draggable-group-toggle-expanded-icon;
+        content: var(--slick-draggable-group-toggle-expanded-icon, $draggable-group-toggle-expanded-icon);
       }
       &.collapsed:before {
-        content: $draggable-group-toggle-collapsed-icon;
+        content: var(--slick-draggable-group-toggle-collapsed-icon, $draggable-group-toggle-collapsed-icon);
       }
     }
 
@@ -859,21 +859,21 @@ input.flatpickr.form-control {
     .slick-groupby-remove {
       cursor: pointer;
       display: inline-flex;
-      color: $draggable-group-delete-color;
-      font-size: $draggable-group-delete-font-size;
-      padding-left: $draggable-group-delete-padding-left;
-      padding-right: $draggable-group-delete-padding-right;
-      vertical-align: $draggable-group-delete-vertical-align;
+      color: var(--slick-draggable-group-delete-color, $draggable-group-delete-color);
+      font-size: var(--slick-draggable-group-delete-font-size, $draggable-group-delete-font-size);
+      padding-left: var(--slick-draggable-group-delete-padding-left, $draggable-group-delete-padding-left);
+      padding-right: var(--slick-draggable-group-delete-padding-right, $draggable-group-delete-padding-right);
+      vertical-align: var(--slick-draggable-group-delete-vertical-align, $draggable-group-delete-vertical-align);
       &:hover {
-        color: $draggable-group-delete-hover-color;
+        color: var(--slick-draggable-group-delete-hover-color, $draggable-group-delete-hover-color);
       }
     }
   }
   .ui-droppable-active {
-    background-color: $draggable-group-droppable-active-bgcolor;
+    background-color: var(--slick-draggable-group-droppable-active-bgcolor, $draggable-group-droppable-active-bgcolor);
   }
   .ui-droppable-hover {
-    background-color: $draggable-group-droppable-hover-bgcolor;
+    background-color: var(--slick-draggable-group-droppable-hover-bgcolor, $draggable-group-droppable-hover-bgcolor);
   }
 }
 
@@ -881,11 +881,11 @@ input.flatpickr.form-control {
   .slick-header-columns {
     .slick-column-groupable {
       display: inline-block;
-      font-weight: $draggable-group-column-icon-font-weight;
-      color: $draggable-group-column-icon-color;
-      width: $draggable-group-column-icon-width;
-      height: $draggable-group-column-icon-height;
-      margin-left: $draggable-group-column-icon-margin-left;
+      font-weight: var(--slick-draggable-group-column-icon-font-weight, $draggable-group-column-icon-font-weight);
+      color: var(--slick-draggable-group-column-icon-color, $draggable-group-column-icon-color);
+      width: var(--slick-draggable-group-column-icon-width, $draggable-group-column-icon-width);
+      height: var(--slick-draggable-group-column-icon-height, $draggable-group-column-icon-height);
+      margin-left: var(--slick-draggable-group-column-icon-margin-left, $draggable-group-column-icon-margin-left);
     }
   }
 }
@@ -900,67 +900,67 @@ input.slider-editor-input[type=range],
 input.slider-filter-input[type=range] {
   /*removes default webkit styles*/
   -webkit-appearance: none;
-  height: $slider-filter-height;
+  height: var(--slick-slider-filter-height, $slider-filter-height);
   flex: 1;
 
-  padding: $slider-filter-runnable-track-padding;
+  padding: var(--slick-slider-filter-runnable-track-padding, $slider-filter-runnable-track-padding);
 
   /* change runnable track color while in focus on all browsers */
   &:focus {
     outline: none;
 
     &::-webkit-slider-runnable-track {
-      background: $slider-filter-runnable-track-bgcolor;
+      background: var(--slick-slider-filter-runnable-track-bgcolor, $slider-filter-runnable-track-bgcolor);
     }
     &::-moz-range-track {
-      background: $slider-filter-runnable-track-bgcolor;
+      background: var(--slick-slider-filter-runnable-track-bgcolor, $slider-filter-runnable-track-bgcolor);
     }
     &::-ms-fill-lower {
-      background: $slider-filter-fill-focus-lower-color;
+      background: var(--slick-slider-filter-fill-focus-lower-color, $slider-filter-fill-focus-lower-color);
     }
     &::-ms-fill-upper {
-      background: $slider-filter-runnable-track-bgcolor;
+      background: var(--slick-slider-filter-runnable-track-bgcolor, $slider-filter-runnable-track-bgcolor);
     }
   }
 
   /* WebKit specific (Opera/Chrome/Safari) */
   &::-webkit-slider-runnable-track {
-    height: $slider-filter-runnable-track-height;
-    background: $slider-filter-bgcolor;
+    height: var(--slick-slider-filter-runnable-track-height, $slider-filter-runnable-track-height);
+    background: var(--slick-slider-filter-bgcolor, $slider-filter-bgcolor);
     border: none;
     border-radius: 3px;
   }
   &::-webkit-slider-thumb {
-    cursor: $slider-filter-thumb-cursor;
+    cursor: var(--slick-slider-filter-thumb-cursor, $slider-filter-thumb-cursor);
     -webkit-appearance: none;
     border: none;
-    height: $slider-filter-thumb-size;
-    width: $slider-filter-thumb-size;
-    border-radius: $slider-filter-thumb-border-radius;
-    border: $slider-filter-thumb-border;
-    background: $slider-filter-thumb-color;
+    height: var(--slick-slider-filter-thumb-size, $slider-filter-thumb-size);
+    width: var(--slick-slider-filter-thumb-size, $slider-filter-thumb-size);
+    border-radius: var(--slick-slider-filter-thumb-border-radius, $slider-filter-thumb-border-radius);
+    border: var(--slick-slider-filter-thumb-border, $slider-filter-thumb-border);
+    background: var(--slick-slider-filter-thumb-color, $slider-filter-thumb-color);
     margin-top: -4px;
   }
 
   /* Mozilla Firefox specific */
 
   /*fix for FF unable to apply focus style bug */
-  border: $slider-filter-border;
+  border: var(--slick-slider-filter-border, $slider-filter-border);
 
   &::-moz-range-track {
-    height: $slider-filter-runnable-track-height;
-    background: $slider-filter-bgcolor;
+    height: var(--slick-slider-filter-runnable-track-height, $slider-filter-runnable-track-height);
+    background: var(--slick-slider-filter-bgcolor, $slider-filter-bgcolor);
     border: none;
     border-radius: 3px;
   }
   &::-moz-range-thumb {
     border: none;
-    cursor: $slider-filter-thumb-cursor;
-    height: $slider-filter-thumb-height;
-    width: $slider-filter-thumb-width;
-    border-radius: $slider-filter-thumb-border-radius;
-    border: $slider-filter-thumb-border;
-    background: $slider-filter-thumb-color;
+    cursor: var(--slick-slider-filter-thumb-cursor, $slider-filter-thumb-cursor);
+    height: var(--slick-slider-filter-thumb-height, $slider-filter-thumb-height);
+    width: var(--slick-slider-filter-thumb-width, $slider-filter-thumb-width);
+    border-radius: var(--slick-slider-filter-thumb-border-radius, $slider-filter-thumb-border-radius);
+    border: var(--slick-slider-filter-thumb-border, $slider-filter-thumb-border);
+    background: var(--slick-slider-filter-thumb-color, $slider-filter-thumb-color);
   }
 
   /*hide the outline behind the border*/
@@ -971,7 +971,7 @@ input.slider-filter-input[type=range] {
 
   /* Microsoft IE specific */
   &::-ms-track {
-    height: $slider-filter-runnable-track-height;
+    height: var(--slick-slider-filter-runnable-track-height, $slider-filter-runnable-track-height);
 
     /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
     background: transparent;
@@ -984,21 +984,21 @@ input.slider-filter-input[type=range] {
     color: transparent;
   }
   &::-ms-fill-lower {
-    background: $slider-filter-fill-lower-color;
+    background: var(--slick-slider-filter-fill-lower-color, $slider-filter-fill-lower-color);
     border-radius: 10px;
   }
   &::-ms-fill-upper {
-    background: $slider-filter-bgcolor;
+    background: var(--slick-slider-filter-bgcolor, $slider-filter-bgcolor);
     border-radius: 10px;
   }
   &::-ms-thumb {
     border: none;
-    cursor: $slider-filter-thumb-cursor;
-    height: $slider-filter-thumb-height;
-    width: $slider-filter-thumb-width;
-    border-radius: $slider-filter-thumb-border-radius;
-    border: $slider-filter-thumb-border;
-    background: $slider-filter-thumb-color;
+    cursor: var(--slick-slider-filter-thumb-cursor, $slider-filter-thumb-cursor);
+    height: var(--slick-slider-filter-thumb-height, $slider-filter-thumb-height);
+    width: var(--slick-slider-filter-thumb-width, $slider-filter-thumb-width);
+    border-radius: var(--slick-slider-filter-thumb-border-radius, $slider-filter-thumb-border-radius);
+    border: var(--slick-slider-filter-thumb-border, $slider-filter-thumb-border);
+    background: var(--slick-slider-filter-thumb-color, $slider-filter-thumb-color);
     margin-top: 1px;
   }
   &::-ms-tooltip {
@@ -1006,10 +1006,10 @@ input.slider-filter-input[type=range] {
   }
 }
 .search-filter {
-  height: $header-input-height;
+  height: var(--slick-header-input-height, $header-input-height);
 
   &::placeholder {
-    color: $editor-placeholder-color;
+    color: var(--slick-editor-placeholder-color, $editor-placeholder-color);
   }
 
   .slider-value {
@@ -1017,30 +1017,30 @@ input.slider-filter-input[type=range] {
     height: 100%;
 
     .input-group-text {
-      padding: $slider-filter-number-padding;
-      font-size: $slider-filter-number-font-size;
+      padding: var(--slick-slider-filter-number-padding, $slider-filter-number-padding);
+      font-size: var(--slick-slider-filter-number-font-size, $slider-filter-number-font-size);
     }
   }
 }
 input.slider-filter-input[type=range] {
-  padding: $slider-filter-runnable-track-padding;
-  height: $slider-filter-height;
+  padding: var(--slick-slider-filter-runnable-track-padding, $slider-filter-runnable-track-padding);
+  height: var(--slick-slider-filter-height, $slider-filter-height);
 }
 
 /* Slider Editor */
 input.slider-editor-input[type=range] {
-  padding: $slider-editor-runnable-track-padding;
-  height: $slider-editor-height;
+  padding: var(--slick-slider-editor-runnable-track-padding, $slider-editor-runnable-track-padding);
+  height: var(--slick-slider-editor-height, $slider-editor-height);
 }
 
 .slider-editor {
   .slider-value {
     padding: 0;
-    height: $slider-editor-height;
+    height: var(--slick-slider-editor-height, $slider-editor-height);
     .input-group-text {
-      padding: $slider-editor-number-padding;
-      font-size: $slider-filter-number-font-size;
-      height: $slider-editor-height;
+      padding: var(--slick-slider-editor-number-padding, $slider-editor-number-padding);
+      font-size: var(--slick-slider-filter-number-font-size, $slider-filter-number-font-size);
+      height: var(--slick-slider-editor-height, $slider-editor-height);
     }
   }
 }
@@ -1049,21 +1049,21 @@ input.slider-editor-input[type=range] {
 // Input Slider Range Filter (using jQuery UI)
 // ----------------------------------------------
 .slider-range-container {
-  height: $slider-range-filter-height;
-  padding: $slider-range-filter-padding;
+  height: var(--slick-slider-range-filter-height, $slider-range-filter-height);
+  padding: var(--slick-slider-range-filter-padding, $slider-range-filter-padding);
 
   .ui-slider {
     position: relative;
 
     .ui-slider-handle {
       position: absolute;
-      top: $slider-range-filter-thumb-top;
-      border-radius: $slider-range-filter-thumb-border-radius;
-      cursor: $slider-range-filter-thumb-cursor;
-      border: $slider-range-filter-thumb-border;
-      height: $slider-range-filter-thumb-size;
-      width: $slider-range-filter-thumb-size;
-      background-color: $slider-range-filter-thumb-color;
+      top: var(--slick-slider-range-filter-thumb-top, $slider-range-filter-thumb-top);
+      border-radius: var(--slick-slider-range-filter-thumb-border-radius, $slider-range-filter-thumb-border-radius);
+      cursor: var(--slick-slider-range-filter-thumb-cursor, $slider-range-filter-thumb-cursor);
+      border: var(--slick-slider-range-filter-thumb-border, $slider-range-filter-thumb-border);
+      height: var(--slick-slider-range-filter-thumb-size, $slider-range-filter-thumb-size);
+      width: var(--slick-slider-range-filter-thumb-size, $slider-range-filter-thumb-size);
+      background-color: var(--slick-slider-range-filter-thumb-color, $slider-range-filter-thumb-color);
 
       &:focus {
         outline: none;
@@ -1072,9 +1072,9 @@ input.slider-editor-input[type=range] {
   }
 
   .ui-slider-horizontal {
-    top: $slider-range-filter-runnable-track-top;
-    height: $slider-range-filter-runnable-track-height;
-    background-color: $slider-range-filter-bgcolor;
+    top: var(--slick-slider-range-filter-runnable-track-top, $slider-range-filter-runnable-track-top);
+    height: var(--slick-slider-range-filter-runnable-track-height, $slider-range-filter-runnable-track-height);
+    background-color: var(--slick-slider-range-filter-bgcolor, $slider-range-filter-bgcolor);
   }
   .input-group-text {
     border: 0;
@@ -1085,24 +1085,24 @@ input.slider-editor-input[type=range] {
   padding: 0;
   .ui-slider-horizontal {
     flex: 1;
-    width: $slider-range-filter-values-slider-width;
-    top: $slider-range-filter-values-slider-top;
-    margin: $slider-range-filter-values-slider-margin;
+    width: var(--slick-slider-range-filter-values-slider-width, $slider-range-filter-values-slider-width);
+    top: var(--slick-slider-range-filter-values-slider-top, $slider-range-filter-values-slider-top);
+    margin: var(--slick-slider-range-filter-values-slider-margin, $slider-range-filter-values-slider-margin);
   }
   .slider-range-value {
     padding: 0;
     border: 0;
     height: 100%;
     .input-group-text {
-      padding: $slider-filter-number-padding;
-      font-size: $slider-filter-number-font-size;
+      padding: var(--slick-slider-filter-number-padding, $slider-filter-number-padding);
+      font-size: var(--slick-slider-filter-number-font-size, $slider-filter-number-font-size);
     }
   }
   .input-group-prepend.slider-range-value {
-    border-right: $slider-range-filter-border;
+    border-right: var(--slick-slider-range-filter-border, $slider-range-filter-border);
   }
   .input-group-append.slider-range-value {
-    border-left: $slider-range-filter-border;
+    border-left: var(--slick-slider-range-filter-border, $slider-range-filter-border);
   }
 }
 
@@ -1117,27 +1117,27 @@ input.slider-editor-input[type=range] {
 
     &.expand {
       display: inline-block;
-      color: $detail-view-icon-expand-color;
+      color: var(--slick-detail-view-icon-expand-color, $detail-view-icon-expand-color);
 
       &:hover {
-        color: darken($detail-view-icon-expand-color, 10%);
+        color: var(--slick-detail-view-icon-expand-color-hover, $detail-view-icon-expand-color-hover);
       }
       &:before {
-        font-family: $icon-font-family;
-        font-size: $detail-view-icon-size;
-        content: $detail-view-icon-expand;
+        font-family: var(--slick-icon-font-family, $icon-font-family);
+        font-size: var(--slick-detail-view-icon-size, $detail-view-icon-size);
+        content: var(--slick-detail-view-icon-expand, $detail-view-icon-expand);
       }
     }
     &.collapse {
       display: inline-block;
-      color: $detail-view-icon-collapse-color;
+      color: var(--slick-detail-view-icon-collapse-color, $detail-view-icon-collapse-color);
       &:hover {
-        color: darken($detail-view-icon-collapse-color, 10%);
+        color: var(--slick-detail-view-icon-collapse-color-hover, $detail-view-icon-collapse-color-hover);
       }
       &:before {
-        font-family: $icon-font-family;
-        font-size: $detail-view-icon-size;
-        content: $detail-view-icon-collapse;
+        font-family: var(--slick-icon-font-family, $icon-font-family);
+        font-size: var(--slick-detail-view-icon-size, $detail-view-icon-size);
+        content: var(--slick-detail-view-icon-collapse, $detail-view-icon-collapse);
       }
     }
   }
@@ -1146,10 +1146,10 @@ input.slider-editor-input[type=range] {
     position:           absolute;
     width:              100%;
     overflow:           auto;
-    border:             $detail-view-container-border;
-    background-color:   $detail-view-container-bgcolor;
-    padding:            $detail-view-container-padding;
-    z-index:            $detail-view-container-z-index;
+    border:             var(--slick-detail-view-container-border, $detail-view-container-border);
+    background-color:   var(--slick-detail-view-container-bgcolor, $detail-view-container-bgcolor);
+    padding:            var(--slick-detail-view-container-padding, $detail-view-container-padding);
+    z-index:            var(--slick-detail-view-container-z-index, $detail-view-container-z-index);
 
     :first-child {
       vertical-align:     middle;

--- a/packages/common/src/styles/slick-without-bootstrap-min-styling.scss
+++ b/packages/common/src/styles/slick-without-bootstrap-min-styling.scss
@@ -1,10 +1,13 @@
 @import './variables';
 
+$form-control-focus-border-color: lighten($primary-color, 10%) !default;
+$form-control-focus-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px rgba(lighten($primary-color, 3%), .3) !default;
+
 /** Bootstrap buttons styling copied and changed slightly for Material Design */
 .slick-editor-modal, .slick-large-editor-text {
   .btn {
     cursor: pointer;
-    font-family:  $font-family;
+    font-family: var(--slick-font-family, $font-family);
     display: inline-block;
     margin-bottom: 0;
     text-align: center;
@@ -15,14 +18,14 @@
   }
 
   .btn-default {
-    color: $button-primary-color;
+    color: var(--slick-button-primary-color, $button-primary-color);
     background-color: #fff;
     border-color: #ccc;
   }
 
   .btn-primary {
     color: #fff;
-    background-color: $button-primary-bg-color;
+    background-color: var(--slick-button-primary-bg-color, $button-primary-bg-color);
   }
 
   .btn-xs,
@@ -41,12 +44,12 @@
 }
 
 .gridPane, .grid-pane, .slick-editor-modal {
-  font-family:  $font-family;
+  font-family: var(--slick-font-family, $font-family);
 
   .form-control {
     display: block;
     width: 100%;
-    font-size: $font-size-base;
+    font-size: var(--slick-font-size-base, $font-size-base);
     line-height: 1.42857143;
     color: #555;
     background-color: #fff;
@@ -54,7 +57,7 @@
     border: 1px solid #ccc;
     border-radius: 4px;
     box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   }
 
   .input-group .form-control {
@@ -132,10 +135,10 @@
     box-sizing: border-box;
   }
 
-  .form-control:focus{
+  .form-control:focus {
     outline: 0;
-    border-color: lighten($primary-color, 10%);
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px rgba(lighten($primary-color, 3%), .3);
+    border-color: var(--slick-form-control-focus-border-color, $form-control-focus-border-color);
+    box-shadow: var(--slick-form-control-focus-box-shadow, $form-control-focus-box-shadow);
   }
 
   .slick-pagination {

--- a/packages/common/src/styles/slickgrid-theme-material.lite.scss
+++ b/packages/common/src/styles/slickgrid-theme-material.lite.scss
@@ -25,6 +25,6 @@
 @import './material-svg-icons';
 @import './material-svg-utilities';
 
-$link-color: $primary-color !default;
+$link-color: var(--slick-primary-color, $primary-color) !default;
 @import './colors.scss';
 @import './extra-styling.scss';

--- a/packages/common/src/styles/slickgrid-theme-material.scss
+++ b/packages/common/src/styles/slickgrid-theme-material.scss
@@ -27,6 +27,6 @@
  @import './material-svg-icons';
  @import './material-svg-utilities';
 
- $link-color: $primary-color !default;
+ $link-color: var(--slick-primary-color, $primary-color) !default;
  @import './colors.scss';
  @import './extra-styling.scss';

--- a/packages/common/src/styles/slickgrid-theme-salesforce.lite.scss
+++ b/packages/common/src/styles/slickgrid-theme-salesforce.lite.scss
@@ -24,6 +24,6 @@
 @import './material-svg-icons';
 @import './material-svg-utilities';
 
-$link-color: $primary-color !default;
+$link-color: var(--slick-primary-color, $primary-color) !default;
 @import './colors.scss';
 @import './extra-styling';

--- a/packages/common/src/styles/slickgrid-theme-salesforce.scss
+++ b/packages/common/src/styles/slickgrid-theme-salesforce.scss
@@ -40,13 +40,13 @@ $editor-grid-cell-border-width-modified: 1px 6px 1px 1px !default;
   .slick-row, .slick-row.odd {
     /* editable field with blue background */
     .slick-cell.editable-field, .slick-cell.selected.editable-field {
-      background-color: $editable-field-bg-color;
+      background-color: var(--slick-editable-field-bg-color, $editable-field-bg-color);
       &:hover:after {
-        content: $editable-field-hover-icon;
+        content: var(--slick-editable-field-hover-icon, $editable-field-hover-icon);
         position: absolute;
-        top: $editable-field-hover-icon-margin-top;
-        right: $editable-field-hover-icon-margin-right;
-        width: $editable-field-hover-icon-width;
+        top: var(--slick-editable-field-hover-icon-margin-top, $editable-field-hover-icon-margin-top);
+        right: var(--slick-editable-field-hover-icon-margin-right, $editable-field-hover-icon-margin-right);
+        width: var(--slick-editable-field-hover-icon-width, $editable-field-hover-icon-width);
       }
       &.active:hover:after {
         content: none;
@@ -72,11 +72,11 @@ $editor-grid-cell-border-width-modified: 1px 6px 1px 1px !default;
         clear: both;
       }
       &:hover:after {
-        content: $editable-field-hover-icon;
+        content: var(--slick-editable-field-hover-icon, $editable-field-hover-icon);
         position: absolute;
-        top: $editable-field-hover-icon-margin-top;
-        right: $editable-field-hover-icon-margin-right;
-        width: $editable-field-hover-icon-width;
+        top: var(--slick-editable-field-hover-icon-margin-top, $editable-field-hover-icon-margin-top);
+        right: var(--slick-editable-field-hover-icon-margin-right, $editable-field-hover-icon-margin-right);
+        width: var(--slick-editable-field-hover-icon-width, $editable-field-hover-icon-width);
       }
       &.active:hover:after {
         content: none;
@@ -85,14 +85,14 @@ $editor-grid-cell-border-width-modified: 1px 6px 1px 1px !default;
 
     .slick-cell.unsaved-editable-field {
       .editing-field {
-        border: $editor-modal-detail-container-border-modified;
-        border-width: $editor-grid-cell-border-width-modified;
+        border: var(--slick-editor-modal-detail-container-border-modified, $editor-modal-detail-container-border-modified);
+        border-width: var(--slick-editor-grid-cell-border-width-modified, $editor-grid-cell-border-width-modified);
       }
     }
   }
 }
 
-$link-color: $primary-color !default;
+$link-color: var(--slick-primary-color, $primary-color) !default;
 @import './colors';
 @import './colors-from-filters';
 @import './extra-styling';

--- a/packages/common/src/styles/ui-autocomplete.scss
+++ b/packages/common/src/styles/ui-autocomplete.scss
@@ -9,13 +9,13 @@
 }
 .ui-autocomplete {
   .ui-menu-item {
-    color: $autocomplete-text-color;
+    color: var(--slick-autocomplete-text-color, $autocomplete-text-color);
     .ui-state-active {
-      color: $autocomplete-text-color;
+      color: var(--slick-autocomplete-text-color, $autocomplete-text-color);
       &:hover {
         margin: 0;
         border: 0;
-        color: $autocomplete-text-color;
+        color: var(--slick-autocomplete-text-color, $autocomplete-text-color);
       }
     }
   }
@@ -23,27 +23,27 @@
 .ui-autocomplete {
   background: none;
   position: absolute;
-  z-index: $autocomplete-z-index;
+  z-index: var(--slick-autocomplete-z-index, $autocomplete-z-index);
   padding: 0;
   margin-top: 2px;
   list-style: none;
-  background-color: $autocomplete-bg-color;
-  border: $autocomplete-border;
-  border-radius: $autocomplete-border-radius;
-  box-shadow: $autocomplete-box-shadow;
+  background-color: var(--slick-autocomplete-bg-color, $autocomplete-bg-color);
+  border: var(--slick-autocomplete-border, $autocomplete-border);
+  border-radius: var(--slick-autocomplete-border-radius, $autocomplete-border-radius);
+  box-shadow: var(--slick-autocomplete-box-shadow, $autocomplete-box-shadow);
   background-clip: padding-box;
-  max-height: $autocomplete-max-height;
-  min-height: $autocomplete-min-height;
-  min-width: $autocomplete-min-width;
-  overflow-y: $autocomplete-overflow-y;
-  overflow-x: $autocomplete-overflow-x;
-  text-overflow: $autocomplete-text-overflow;
+  max-height: var(--slick-autocomplete-max-height, $autocomplete-max-height);
+  min-height: var(--slick-autocomplete-min-height, $autocomplete-min-height);
+  min-width: var(--slick-autocomplete-min-width, $autocomplete-min-width);
+  overflow-y: var(--slick-autocomplete-overflow-y, $autocomplete-overflow-y);
+  overflow-x: var(--slick-autocomplete-overflow-x, $autocomplete-overflow-x);
+  text-overflow: var(--slick-autocomplete-text-overflow, $autocomplete-text-overflow);
 
   li {
     div {
       display: block;
-      color: $autocomplete-text-color;
-      padding: $autocomplete-text-padding;
+      color: var(--slick-autocomplete-text-color, $autocomplete-text-color);
+      padding: var(--slick-autocomplete-text-padding, $autocomplete-text-padding);
       font-weight: normal;
       line-height: 1.42857143;
       white-space: nowrap;
@@ -58,18 +58,18 @@
   100% { transform: rotate(360deg); }
 }
 .ui-autocomplete-loading {
-  background-color: $autocomplete-loading-input-bg-color !important;
+  background-color: var(--slick-autocomplete-loading-input-bg-color, $autocomplete-loading-input-bg-color) !important;
 
   & + span:after {
     animation: md-spin 2s infinite linear;
     display: inline-block;
-    font-family: $icon-font-family;
-    color: $autocomplete-loading-icon-color;
-    content: $autocomplete-loading-icon !important; /* important is required to override default jquery-ui styling */
-    width: $autocomplete-loading-icon-width;
-    margin: $autocomplete-loading-icon-margin;
-    line-height: $autocomplete-loading-icon-line-height;
-    vertical-align: $autocomplete-loading-icon-vertical-align;
+    font-family: var(--slick-icon-font-family, $icon-font-family);
+    color: var(--slick-autocomplete-loading-icon-color, $autocomplete-loading-icon-color);
+    content: var(--slick-autocomplete-loading-icon, $autocomplete-loading-icon) !important; /* important is required to override default jquery-ui styling */
+    width: var(--slick-autocomplete-loading-icon-width, $autocomplete-loading-icon-width);
+    margin: var(--slick-autocomplete-loading-icon-margin, $autocomplete-loading-icon-margin);
+    line-height: var(--slick-autocomplete-loading-icon-line-height, $autocomplete-loading-icon-line-height);
+    vertical-align: var(--slick-autocomplete-loading-icon-vertical-align, $autocomplete-loading-icon-vertical-align);
   }
 }
 
@@ -78,8 +78,8 @@
 .ui-state-focus {
   cursor: pointer;
   text-decoration: none;
-  color: $autocomplete-hover-color;
-  background-color: $autocomplete-hover-bg-color;
+  color: var(--slick-autocomplete-hover-color, $autocomplete-hover-color);
+  background-color: var(--slick-autocomplete-hover-bg-color, $autocomplete-hover-bg-color);
 }
 
 .ui-helper-hidden-accessible {
@@ -99,11 +99,11 @@
 
 /* autocomplete custom styling */
 .ui-autocomplete.autocomplete-custom-four-corners {
-  width: $autocomplete-tpl4-width;
+  width: var(--slick-autocomplete-tpl4-width, $autocomplete-tpl4-width);
 }
 .ui-autocomplete.autocomplete-custom-four-corners li div.autocomplete-container-list {
-  width: $autocomplete-tpl4-container-list-width;
-  padding: $autocomplete-tpl4-container-list-padding;
+  width: var(--slick-autocomplete-tpl4-container-list-width, $autocomplete-tpl4-container-list-width);
+  padding: var(--slick-autocomplete-tpl4-container-list-padding, $autocomplete-tpl4-container-list-padding);
 
   div {
     margin: 0;
@@ -119,19 +119,19 @@
   }
 
   .autocomplete-left > img {
-    height: $autocomplete-tpl4-icon-left-height;
-    width: $autocomplete-tpl4-icon-left-width;
+    height: var(--slick-autocomplete-tpl4-icon-left-height, $autocomplete-tpl4-icon-left-height);
+    width: var(--slick-autocomplete-tpl4-icon-left-width, $autocomplete-tpl4-icon-left-width);
     margin-top: 0px;
     background-color: #ffffff;
     background-clip: content-box;
   }
 
   .autocomplete-bottom-left {
-    color: $autocomplete-tpl4-bottom-left-text-color;
-    font-size: $autocomplete-tpl4-bottom-left-font-size;
-    font-style: $autocomplete-tpl4-bottom-left-font-style;
-    font-weight: $autocomplete-tpl4-bottom-left-font-weight;
-    max-width: $autocomplete-tpl4-bottom-left-max-width;
+    color: var(--slick-autocomplete-tpl4-bottom-left-text-color, $autocomplete-tpl4-bottom-left-text-color);
+    font-size: var(--slick-autocomplete-tpl4-bottom-left-font-size, $autocomplete-tpl4-bottom-left-font-size);
+    font-style: var(--slick-autocomplete-tpl4-bottom-left-font-style, $autocomplete-tpl4-bottom-left-font-style);
+    font-weight: var(--slick-autocomplete-tpl4-bottom-left-font-weight, $autocomplete-tpl4-bottom-left-font-weight);
+    max-width: var(--slick-autocomplete-tpl4-bottom-left-max-width, $autocomplete-tpl4-bottom-left-max-width);
     display: inline-block;
     /*margin-left: 30px;*/
     overflow: hidden;
@@ -141,21 +141,21 @@
   .autocomplete-bottom-right {
     // margin-right: 12px;
     float: right;
-    color: $autocomplete-tpl4-bottom-right-text-color;
-    font-size: $autocomplete-tpl4-bottom-right-font-size;
-    font-style: $autocomplete-tpl4-bottom-right-font-style;
-    font-weight: $autocomplete-tpl4-bottom-right-font-weight;
+    color: var(--slick-autocomplete-tpl4-bottom-right-text-color, $autocomplete-tpl4-bottom-right-text-color);
+    font-size: var(--slick-autocomplete-tpl4-bottom-right-font-size, $autocomplete-tpl4-bottom-right-font-size);
+    font-style: var(--slick-autocomplete-tpl4-bottom-right-font-style, $autocomplete-tpl4-bottom-right-font-style);
+    font-weight: var(--slick-autocomplete-tpl4-bottom-right-font-weight, $autocomplete-tpl4-bottom-right-font-weight);
     /*margin-left: 30px;*/
     text-overflow: ellipsis;
-    max-width: $autocomplete-tpl4-bottom-right-max-width;
+    max-width: var(--slick-autocomplete-tpl4-bottom-right-max-width, $autocomplete-tpl4-bottom-right-max-width);
   }
 
   .autocomplete-top-left {
-    color: $autocomplete-tpl4-top-left-text-color;
-    font-style: $autocomplete-tpl4-top-left-font-style;
-    font-size: $autocomplete-tpl4-top-left-font-size;
-    font-weight: $autocomplete-tpl4-top-left-font-weight;
-    max-width: $autocomplete-tpl4-top-left-max-width;
+    color: var(--slick-autocomplete-tpl4-top-left-text-color, $autocomplete-tpl4-top-left-text-color);
+    font-style: var(--slick-autocomplete-tpl4-top-left-font-style, $autocomplete-tpl4-top-left-font-style);
+    font-size: var(--slick-autocomplete-tpl4-top-left-font-size, $autocomplete-tpl4-top-left-font-size);
+    font-weight: var(--slick-autocomplete-tpl4-top-left-font-weight, $autocomplete-tpl4-top-left-font-weight);
+    max-width: var(--slick-autocomplete-tpl4-top-left-max-width, $autocomplete-tpl4-top-left-max-width);
     display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -165,11 +165,11 @@
   .autocomplete-top-right {
     // margin-right: 12px;
     float: right;
-    color: $autocomplete-tpl4-top-right-text-color;
-    font-style: $autocomplete-tpl4-top-right-font-style;
-    font-size: $autocomplete-tpl4-top-right-font-size;
-    font-weight: $autocomplete-tpl4-top-right-font-weight;
-    max-width: $autocomplete-tpl4-top-right-max-width;
+    color: var(--slick-autocomplete-tpl4-top-right-text-color, $autocomplete-tpl4-top-right-text-color);
+    font-style: var(--slick-autocomplete-tpl4-top-right-font-style, $autocomplete-tpl4-top-right-font-style);
+    font-size: var(--slick-autocomplete-tpl4-top-right-font-size, $autocomplete-tpl4-top-right-font-size);
+    font-weight: var(--slick-autocomplete-tpl4-top-right-font-weight, $autocomplete-tpl4-top-right-font-weight);
+    max-width: var(--slick-autocomplete-tpl4-top-right-max-width, $autocomplete-tpl4-top-right-max-width);
   }
 }
 
@@ -180,11 +180,11 @@
 
 /* autocomplete custom styling */
 .ui-autocomplete.autocomplete-custom-two-rows {
-  width: $autocomplete-tpl2-width;
+  width: var(--slick-autocomplete-tpl2-width, $autocomplete-tpl2-width);
 }
 .ui-autocomplete.autocomplete-custom-two-rows li div.autocomplete-container-list {
-  width: $autocomplete-tpl2-container-list-width;
-  padding: $autocomplete-tpl2-container-list-padding;
+  width: var(--slick-autocomplete-tpl2-container-list-width, $autocomplete-tpl2-container-list-width);
+  padding: var(--slick-autocomplete-tpl2-container-list-padding, $autocomplete-tpl2-container-list-padding);
 
   div {
     margin: 0;
@@ -194,8 +194,8 @@
 
   .autocomplete-left {
     float: left;
-    height: $autocomplete-tpl2-icon-left-height;
-    width: $autocomplete-tpl2-icon-left-width;
+    height: var(--slick-autocomplete-tpl2-icon-left-height, $autocomplete-tpl2-icon-left-height);
+    width: var(--slick-autocomplete-tpl2-icon-left-width, $autocomplete-tpl2-icon-left-width);
     padding-right: 3px;
   }
 
@@ -207,11 +207,11 @@
   }
 
   .autocomplete-bottom-left {
-    color: $autocomplete-tpl2-bottom-left-text-color;
-    font-size: $autocomplete-tpl2-bottom-left-font-size;
-    font-style: $autocomplete-tpl2-bottom-left-font-style;
-    font-weight: $autocomplete-tpl2-bottom-left-font-weight;
-    max-width: $autocomplete-tpl2-bottom-left-max-width;
+    color: var(--slick-autocomplete-tpl2-bottom-left-text-color, $autocomplete-tpl2-bottom-left-text-color);
+    font-size: var(--slick-autocomplete-tpl2-bottom-left-font-size, $autocomplete-tpl2-bottom-left-font-size);
+    font-style: var(--slick-autocomplete-tpl2-bottom-left-font-style, $autocomplete-tpl2-bottom-left-font-style);
+    font-weight: var(--slick-autocomplete-tpl2-bottom-left-font-weight, $autocomplete-tpl2-bottom-left-font-weight);
+    max-width: var(--slick-autocomplete-tpl2-bottom-left-max-width, $autocomplete-tpl2-bottom-left-max-width);
     /*margin-left: 30px;*/
     display: inline-block;
     overflow: hidden;
@@ -219,11 +219,11 @@
   }
 
   .autocomplete-top-left {
-    color: $autocomplete-tpl2-top-left-text-color;
-    font-style: $autocomplete-tpl2-top-left-font-style;
-    font-size: $autocomplete-tpl2-top-left-font-size;
-    font-weight: $autocomplete-tpl2-top-left-font-weight;
-    max-width: $autocomplete-tpl2-top-left-max-width;
+    color: var(--slick-autocomplete-tpl2-top-left-text-color, $autocomplete-tpl2-top-left-text-color);
+    font-style: var(--slick-autocomplete-tpl2-top-left-font-style, $autocomplete-tpl2-top-left-font-style);
+    font-size: var(--slick-autocomplete-tpl2-top-left-font-size, $autocomplete-tpl2-top-left-font-size);
+    font-weight: var(--slick-autocomplete-tpl2-top-left-font-weight, $autocomplete-tpl2-top-left-font-weight);
+    max-width: var(--slick-autocomplete-tpl2-top-left-max-width, $autocomplete-tpl2-top-left-max-width);
     display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
- add support to CSS Variables, however keep the original SASS styling and make the CSS Variable as first option with fallback to SASS. This approach will make both CSS Variables and SASS work and CSS Variables will have priority over SASS since SASS is a fallback (2nd argument to each CSS Variable is the fallback)

For example (see new [Wiki](https://github.com/ghiscoding/slickgrid-universal/wiki/SVG-Icons#using-css-variables-instead-of-sass)):
```css
:root {
    --slick-header-menu-display: inline-block;
    --slick-primary-color-dark: pink;
    --slick-header-filter-row-border-bottom: 2px solid pink;
}
```