### PR TITLE
fix(filter): refreshTreeDataFilters only when Tree is enabled

### DIFF
--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -1721,6 +1721,31 @@ describe('FilterService', () => {
         expect(preFilterSpy).toHaveBeenCalledWith(dataset, { ...columnFilters, file: { ...columnFilters.file, operator: 'Contains', parsedSearchTerms: ['unknown'], type: 'string' } }); // it will use Contains by default
         expect(preFilterSpy).toHaveReturnedWith([]);
       });
+
+      it('should return False also when called by "updateSingleFilter" and when item is not found in the dataset', async () => {
+        const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
+        const preFilterSpy = jest.spyOn(service, 'preFilterTreeData');
+        jest.spyOn(dataViewStub, 'getItemById').mockReturnValueOnce({ ...dataset[4] as any })
+          .mockReturnValueOnce(dataset[5])
+          .mockReturnValueOnce(dataset[6]);
+
+        const mockItem1 = { __parentId: 4, id: 5, file: 'unknown.pdf', dateModified: '2015-05-21T10:22:00.123Z', size: 3.1 };
+
+        service.init(gridStub);
+        service.bindLocalOnFilter(gridStub);
+        gridStub.onHeaderRowCellRendered.notify(mockArgs1 as any, new Slick.EventData(), gridStub);
+        gridStub.onHeaderRowCellRendered.notify(mockArgs2 as any, new Slick.EventData(), gridStub);
+
+        const columnFilters = { file: { columnDef: mockColumn1, columnId: 'file', searchTerms: ['unknown'], type: FieldType.string } } as ColumnFilters;
+        await service.updateSingleFilter({ columnId: 'file', operator: 'Contains', searchTerms: ['unknown'] }, true, true);
+        const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+        expect(pubSubSpy).toHaveBeenCalledWith(`onBeforeFilterChange`, [{ columnId: 'file', operator: 'Contains', searchTerms: ['unknown'] }]);
+        expect(pubSubSpy).toHaveBeenCalledWith(`onFilterChanged`, [{ columnId: 'file', operator: 'Contains', searchTerms: ['unknown'] }]);
+        expect(output).toBe(false);
+        expect(preFilterSpy).toHaveBeenCalledWith(dataset, { ...columnFilters, file: { ...columnFilters.file, operator: 'Contains', parsedSearchTerms: ['unknown'], type: 'string' } }); // it will use Contains by default
+        expect(preFilterSpy).toHaveReturnedWith([]);
+      });
     });
   });
 });

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -717,7 +717,9 @@ export class FilterService {
       });
 
       // when we have a Filter Presets on a Tree Data View grid, we need to call the pre-filtering of tree data
-      this.refreshTreeDataFilters();
+      if (this._gridOptions?.enableTreeData) {
+        this.refreshTreeDataFilters();
+      }
     }
     return this._columnDefinitions;
   }
@@ -728,7 +730,7 @@ export class FilterService {
    * @param {Array<Object>} [items] - optional flat array of parent/child items to use while redoing the full sort & refresh
    */
   refreshTreeDataFilters(items?: any[]) {
-    const inputItems = items ?? this._dataView.getItems() ?? [];
+    const inputItems = items ?? this._dataView?.getItems?.() ?? [];
 
     if (this._dataView && this._gridOptions?.enableTreeData && inputItems.length > 0) {
       this._tmpPreFilteredData = this.preFilterTreeData(inputItems, this._columnFilters);
@@ -917,7 +919,9 @@ export class FilterService {
         });
 
         // when using Tree Data, we also need to refresh the filters because of the tree structure with recursion
-        this.refreshTreeDataFilters();
+        if (this._gridOptions?.enableTreeData) {
+          this.refreshTreeDataFilters();
+        }
 
         this._dataView.refresh();
       }


### PR DESCRIPTION
- also make sure DataView object exist before trying to get items array
- fixes a rare bug reported in Angular-Slickgrid