### PR TITLE
feat(services): make everything extendable by using `protected`

### DIFF
--- a/packages/binding/src/binding.service.ts
+++ b/packages/binding/src/binding.service.ts
@@ -111,7 +111,7 @@ export class BindingService {
    * 2- when an event is provided, we will replace the DOM element (by an attribute) every time an event is triggered
    *    2.1- we could also provide an extra callback method to execute when the event gets triggered
    */
-  private bindSingleElement(element: Element | null, attribute: string, eventName?: string, callback?: (val: any) => any) {
+  protected bindSingleElement(element: Element | null, attribute: string, eventName?: string, callback?: (val: any) => any) {
     const binding: ElementBinding | ElementBindingWithListener = { element, attribute };
     if (element) {
       if (eventName) {
@@ -137,7 +137,7 @@ export class BindingService {
     }
   }
 
-  private sanitizeText(dirtyText: string): string {
+  protected sanitizeText(dirtyText: string): string {
     return (DOMPurify?.sanitize) ? DOMPurify.sanitize(dirtyText, {}) : dirtyText;
   }
 }

--- a/packages/common/src/filters/filterFactory.ts
+++ b/packages/common/src/filters/filterFactory.ts
@@ -6,9 +6,9 @@ import { RxJsFacade } from '../services/rxjsFacade';
 
 export class FilterFactory {
   /** The options from the SlickgridConfig */
-  private _options: any;
+  protected _options: any;
 
-  constructor(private config: SlickgridConfig, private readonly translaterService?: TranslaterService, private readonly collectionService?: CollectionService, private rxjs?: RxJsFacade) {
+  constructor(protected config: SlickgridConfig, protected readonly translaterService?: TranslaterService, protected readonly collectionService?: CollectionService, protected rxjs?: RxJsFacade) {
     this._options = this.config?.options ?? {};
   }
 

--- a/packages/common/src/services/backendUtility.service.ts
+++ b/packages/common/src/services/backendUtility.service.ts
@@ -3,7 +3,7 @@ import { BackendServiceApi, GridOption } from '../interfaces/index';
 import { Observable, RxJsFacade, Subject } from './rxjsFacade';
 
 export class BackendUtilityService {
-  constructor(private rxjs?: RxJsFacade) { }
+  constructor(protected rxjs?: RxJsFacade) { }
 
   addRxJsResource(rxjs: RxJsFacade) {
     this.rxjs = rxjs;

--- a/packages/common/src/services/bindingEvent.service.ts
+++ b/packages/common/src/services/bindingEvent.service.ts
@@ -1,7 +1,7 @@
 import { ElementEventListener } from '../interfaces/elementEventListener.interface';
 
 export class BindingEventService {
-  private _boundedEvents: ElementEventListener[] = [];
+  protected _boundedEvents: ElementEventListener[] = [];
 
   /** Bind an event listener to any element */
   bind(element: Element, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) {

--- a/packages/common/src/services/collection.service.ts
+++ b/packages/common/src/services/collection.service.ts
@@ -11,7 +11,7 @@ import { uniqueArray } from './utilities';
 import { TranslaterService } from './translater.service';
 
 export class CollectionService<T = any> {
-  constructor(private translaterService?: TranslaterService) { }
+  constructor(protected readonly translaterService?: TranslaterService) { }
 
   /**
    * Filter 1 or more items from a collection

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -31,30 +31,30 @@ interface ExtensionWithColumnIndexPosition {
 }
 
 export class ExtensionService {
-  private _extensionCreatedList: ExtensionList<any, any> = {} as ExtensionList<any, any>;
-  private _extensionList: ExtensionList<any, any> = {} as ExtensionList<any, any>;
+  protected _extensionCreatedList: ExtensionList<any, any> = {} as ExtensionList<any, any>;
+  protected _extensionList: ExtensionList<any, any> = {} as ExtensionList<any, any>;
 
   get extensionList() {
     return this._extensionList;
   }
 
   constructor(
-    private readonly autoTooltipExtension: AutoTooltipExtension,
-    private readonly cellExternalCopyExtension: CellExternalCopyManagerExtension,
-    private readonly cellMenuExtension: CellMenuExtension,
-    private readonly checkboxSelectorExtension: CheckboxSelectorExtension,
-    private readonly columnPickerExtension: ColumnPickerExtension,
-    private readonly contextMenuExtension: ContextMenuExtension,
-    private readonly draggableGroupingExtension: DraggableGroupingExtension,
-    private readonly gridMenuExtension: GridMenuExtension,
-    private readonly groupItemMetaExtension: GroupItemMetaProviderExtension,
-    private readonly headerButtonExtension: HeaderButtonExtension,
-    private readonly headerMenuExtension: HeaderMenuExtension,
-    private readonly rowDetailViewExtension: RowDetailViewExtension,
-    private readonly rowMoveManagerExtension: RowMoveManagerExtension,
-    private readonly rowSelectionExtension: RowSelectionExtension,
-    private readonly sharedService: SharedService,
-    private readonly translaterService?: TranslaterService,
+    protected readonly autoTooltipExtension: AutoTooltipExtension,
+    protected readonly cellExternalCopyExtension: CellExternalCopyManagerExtension,
+    protected readonly cellMenuExtension: CellMenuExtension,
+    protected readonly checkboxSelectorExtension: CheckboxSelectorExtension,
+    protected readonly columnPickerExtension: ColumnPickerExtension,
+    protected readonly contextMenuExtension: ContextMenuExtension,
+    protected readonly draggableGroupingExtension: DraggableGroupingExtension,
+    protected readonly gridMenuExtension: GridMenuExtension,
+    protected readonly groupItemMetaExtension: GroupItemMetaProviderExtension,
+    protected readonly headerButtonExtension: HeaderButtonExtension,
+    protected readonly headerMenuExtension: HeaderMenuExtension,
+    protected readonly rowDetailViewExtension: RowDetailViewExtension,
+    protected readonly rowMoveManagerExtension: RowMoveManagerExtension,
+    protected readonly rowSelectionExtension: RowSelectionExtension,
+    protected readonly sharedService: SharedService,
+    protected readonly translaterService?: TranslaterService,
   ) { }
 
   /** Dispose of all the controls & plugins */
@@ -424,7 +424,7 @@ export class ExtensionService {
   }
 
   //
-  // private functions
+  // protected functions
   // -------------------
 
   /**
@@ -435,7 +435,7 @@ export class ExtensionService {
    * @param columnDefinitions
    * @param gridOptions
    */
-  private createExtensionByTheirColumnIndex(featureWithIndexPositions: ExtensionWithColumnIndexPosition[], columnDefinitions: Column[], gridOptions: GridOption) {
+  protected createExtensionByTheirColumnIndex(featureWithIndexPositions: ExtensionWithColumnIndexPosition[], columnDefinitions: Column[], gridOptions: GridOption) {
     // 1- first step is to sort them by their index position
     featureWithIndexPositions.sort((feat1, feat2) => feat1.columnIndexPosition - feat2.columnIndexPosition);
 
@@ -452,7 +452,7 @@ export class ExtensionService {
    * Get an Extension that was created by calling its "create" method (there are only 3 extensions which uses this method)
    *  @param name
    */
-  private getCreatedExtensionByName<P extends (SlickControlList | SlickPluginList) = any, E extends Extension = any>(name: ExtensionName): ExtensionModel<P, E> | undefined {
+  protected getCreatedExtensionByName<P extends (SlickControlList | SlickPluginList) = any, E extends Extension = any>(name: ExtensionName): ExtensionModel<P, E> | undefined {
     if (this._extensionCreatedList && this._extensionCreatedList.hasOwnProperty(name)) {
       return this._extensionCreatedList[name];
     }
@@ -464,7 +464,7 @@ export class ExtensionService {
    * @param externalExtension - extension instance
    * @param extensionName - extension name
    */
-  private recreateExternalAddon(externalExtension: Extension, extensionName: ExtensionName) {
+  protected recreateExternalAddon(externalExtension: Extension, extensionName: ExtensionName) {
     externalExtension.dispose();
     const instance = externalExtension.register();
     const extension = this.getExtensionByName(extensionName);
@@ -474,7 +474,7 @@ export class ExtensionService {
   }
 
   /** Translate an array of items from an input key and assign translated value to the output key */
-  private translateItems(items: any[], inputKey: string, outputKey: string) {
+  protected translateItems(items: any[], inputKey: string, outputKey: string) {
     if (this.sharedService.gridOptions && this.sharedService.gridOptions.enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -36,13 +36,13 @@ export class GridService {
   protected _rowSelectionPlugin?: SlickRowSelectionModel;
 
   constructor(
-    protected gridStateService: GridStateService,
-    protected filterService: FilterService,
-    protected pubSubService: PubSubService,
-    protected paginationService: PaginationService,
-    protected sharedService: SharedService,
-    protected sortService: SortService,
-    protected treeDataService: TreeDataService,
+    protected readonly gridStateService: GridStateService,
+    protected readonly filterService: FilterService,
+    protected readonly pubSubService: PubSubService,
+    protected readonly paginationService: PaginationService,
+    protected readonly sharedService: SharedService,
+    protected readonly sortService: SortService,
+    protected readonly treeDataService: TreeDataService,
   ) { }
 
   /** Getter of SlickGrid DataView object */

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -32,17 +32,17 @@ const GridServiceUpdateOptionDefaults: GridServiceUpdateOption = { highlightRow:
 const HideColumnOptionDefaults: HideColumnOption = { autoResizeColumns: true, triggerEvent: true, hideFromColumnPicker: false, hideFromGridMenu: false };
 
 export class GridService {
-  private _grid!: SlickGrid;
-  private _rowSelectionPlugin?: SlickRowSelectionModel;
+  protected _grid!: SlickGrid;
+  protected _rowSelectionPlugin?: SlickRowSelectionModel;
 
   constructor(
-    private gridStateService: GridStateService,
-    private filterService: FilterService,
-    private pubSubService: PubSubService,
-    private paginationService: PaginationService,
-    private sharedService: SharedService,
-    private sortService: SortService,
-    private treeDataService: TreeDataService,
+    protected gridStateService: GridStateService,
+    protected filterService: FilterService,
+    protected pubSubService: PubSubService,
+    protected paginationService: PaginationService,
+    protected sharedService: SharedService,
+    protected sortService: SortService,
+    protected treeDataService: TreeDataService,
   ) { }
 
   /** Getter of SlickGrid DataView object */
@@ -897,11 +897,11 @@ export class GridService {
   }
 
   // --
-  // private functions
+  // protected functions
   // -------------------
 
   /** Check wether the grid has the Row Selection enabled */
-  private hasRowSelectionEnabled() {
+  protected hasRowSelectionEnabled() {
     const selectionModel = this._grid.getSelectionModel();
     const isRowSelectionEnabled = this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector;
     return (isRowSelectionEnabled && selectionModel);

--- a/packages/common/src/services/gridEvent.service.ts
+++ b/packages/common/src/services/gridEvent.service.ts
@@ -13,7 +13,7 @@ import {
 declare const Slick: SlickNamespace;
 
 export class GridEventService {
-  private _eventHandler: SlickEventHandler;
+  protected _eventHandler: SlickEventHandler;
 
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -19,10 +19,10 @@ import { emptyElement } from './utilities';
 declare const Slick: SlickNamespace;
 
 export class GroupingAndColspanService {
-  private _eventHandler: SlickEventHandler;
-  private _grid!: SlickGrid;
+  protected _eventHandler: SlickEventHandler;
+  protected _grid!: SlickGrid;
 
-  constructor(private readonly extensionUtility: ExtensionUtility, private readonly extensionService: ExtensionService, private readonly pubSubService: PubSubService,) {
+  constructor(protected readonly extensionUtility: ExtensionUtility, protected readonly extensionService: ExtensionService, protected readonly pubSubService: PubSubService,) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -37,12 +37,12 @@ export class GroupingAndColspanService {
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
-  private get _gridOptions(): GridOption {
+  protected get _gridOptions(): GridOption {
     return (this._grid?.getOptions) ? this._grid.getOptions() : {};
   }
 
   /** Getter for the Column Definitions pulled through the Grid Object */
-  private get _columnDefinitions(): Column[] {
+  protected get _columnDefinitions(): Column[] {
     return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
   }
 

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -21,25 +21,25 @@ import { Observable, RxJsFacade } from './rxjsFacade';
 declare const Slick: SlickNamespace;
 
 export class PaginationService {
-  private _eventHandler = new Slick.EventHandler();
-  private _initialized = false;
-  private _isLocalGrid = true;
-  private _backendServiceApi: BackendServiceApi | undefined;
-  private _dataFrom = 1;
-  private _dataTo = 1;
-  private _itemsPerPage = 0;
-  private _pageCount = 1;
-  private _pageNumber = 1;
-  private _totalItems = 0;
-  private _availablePageSizes: number[] = [];
-  private _paginationOptions!: Pagination;
-  private _subscriptions: EventSubscription[] = [];
+  protected _eventHandler = new Slick.EventHandler();
+  protected _initialized = false;
+  protected _isLocalGrid = true;
+  protected _backendServiceApi: BackendServiceApi | undefined;
+  protected _dataFrom = 1;
+  protected _dataTo = 1;
+  protected _itemsPerPage = 0;
+  protected _pageCount = 1;
+  protected _pageNumber = 1;
+  protected _totalItems = 0;
+  protected _availablePageSizes: number[] = [];
+  protected _paginationOptions!: Pagination;
+  protected _subscriptions: EventSubscription[] = [];
 
   /** SlickGrid Grid object */
   grid!: SlickGrid;
 
   /** Constructor */
-  constructor(private pubSubService: PubSubService, private sharedService: SharedService, private backendUtilities?: BackendUtilityService, private rxjs?: RxJsFacade) { }
+  constructor(protected pubSubService: PubSubService, protected sharedService: SharedService, protected backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) { }
 
   /** Getter of SlickGrid DataView object */
   get dataView(): SlickDataView | undefined {
@@ -405,7 +405,7 @@ export class PaginationService {
   }
 
   // --
-  // private functions
+  // protected functions
   // --------------------
 
   /**
@@ -415,7 +415,7 @@ export class PaginationService {
    * basically we assume that this offset is fine for the time being,
    * until user does an action which will refresh the data hence the pagination which will then become normal again
    */
-  private processOnItemAddedOrRemoved(items: any | any[], isItemAdded = true) {
+  protected processOnItemAddedOrRemoved(items: any | any[], isItemAdded = true) {
     if (items !== null) {
       const previousDataTo = this._dataTo;
       const itemCount = Array.isArray(items) ? items.length : 1;

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -39,7 +39,7 @@ export class PaginationService {
   grid!: SlickGrid;
 
   /** Constructor */
-  constructor(protected pubSubService: PubSubService, protected sharedService: SharedService, protected backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) { }
+  constructor(protected readonly pubSubService: PubSubService, protected readonly sharedService: SharedService, protected readonly backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) { }
 
   /** Getter of SlickGrid DataView object */
   get dataView(): SlickDataView | undefined {

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -25,23 +25,23 @@ const DATAGRID_MIN_WIDTH = 300;
 const DEFAULT_INTERVAL_RETRY_DELAY = 200;
 
 export class ResizerService {
-  private _autoResizeOptions!: AutoResizeOption;
-  private _grid!: SlickGrid;
-  private _eventHandler: SlickEventHandler;
-  private _fixedHeight?: number | string;
-  private _fixedWidth?: number | string;
-  private _gridDomElm!: any;
-  private _gridContainerElm!: any;
-  private _pageContainerElm!: any;
-  private _gridParentContainerElm!: HTMLElement;
-  private _intervalId!: NodeJS.Timeout;
-  private _intervalRetryDelay = DEFAULT_INTERVAL_RETRY_DELAY;
-  private _isStopResizeIntervalRequested = false;
-  private _hasResizedByContentAtLeastOnce = false;
-  private _lastDimensions?: GridSize;
-  private _totalColumnsWidthByContent = 0;
-  private _timer!: NodeJS.Timeout;
-  private _resizePaused = false;
+  protected _autoResizeOptions!: AutoResizeOption;
+  protected _grid!: SlickGrid;
+  protected _eventHandler: SlickEventHandler;
+  protected _fixedHeight?: number | string;
+  protected _fixedWidth?: number | string;
+  protected _gridDomElm!: any;
+  protected _gridContainerElm!: any;
+  protected _pageContainerElm!: any;
+  protected _gridParentContainerElm!: HTMLElement;
+  protected _intervalId!: NodeJS.Timeout;
+  protected _intervalRetryDelay = DEFAULT_INTERVAL_RETRY_DELAY;
+  protected _isStopResizeIntervalRequested = false;
+  protected _hasResizedByContentAtLeastOnce = false;
+  protected _lastDimensions?: GridSize;
+  protected _totalColumnsWidthByContent = 0;
+  protected _timer!: NodeJS.Timeout;
+  protected _resizePaused = false;
 
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
@@ -73,7 +73,7 @@ export class ResizerService {
     return this.gridOptions?.resizeByContentOptions ?? {};
   }
 
-  constructor(private pubSubService: PubSubService) {
+  constructor(protected pubSubService: PubSubService) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -409,7 +409,7 @@ export class ResizerService {
   }
 
   // --
-  // private functions
+  // protected functions
   // ------------------
 
   /**
@@ -420,7 +420,7 @@ export class ResizerService {
    * @param columnIndexOverride - an optional column index, if provided it will override the column index position
    * @returns - count of items that was read
    */
-  private calculateCellWidthByReadingDataset(columnOrColumns: Column | Column[], columnWidths: { [columnId in string | number]: number; }, maxItemToInspect = 1000, columnIndexOverride?: number) {
+  protected calculateCellWidthByReadingDataset(columnOrColumns: Column | Column[], columnWidths: { [columnId in string | number]: number; }, maxItemToInspect = 1000, columnIndexOverride?: number) {
     const columnDefinitions = Array.isArray(columnOrColumns) ? columnOrColumns : [columnOrColumns];
 
     // const columnDefinitions = this._grid.getColumns();
@@ -457,7 +457,7 @@ export class ResizerService {
    * @param {Number} initialMininalColumnWidth - initial width, could be coming from `minWidth` or a default `width`
    * @returns - column width
    */
-  private calculateCellWidthByContent(item: any, columnDef: Column, rowIdx: number, colIdx: number, initialMininalColumnWidth?: number): number | undefined {
+  protected calculateCellWidthByContent(item: any, columnDef: Column, rowIdx: number, colIdx: number, initialMininalColumnWidth?: number): number | undefined {
     const resizeCellCharWidthInPx = this.resizeByContentOptions.cellCharWidthInPx ?? 7; // width in pixels of a string character, this can vary depending on which font family/size is used & cell padding
 
     if (!columnDef.originalWidth) {
@@ -481,7 +481,7 @@ export class ResizerService {
    * @param {Object} column - column definition to apply the width
    * @param {Number} calculatedColumnWidth - new calculated column width to possibly apply
    */
-  private applyNewCalculatedColumnWidthByReference(column: Column<any>, calculatedColumnWidth: number) {
+  protected applyNewCalculatedColumnWidthByReference(column: Column<any>, calculatedColumnWidth: number) {
     // read a few optional resize by content grid options
     const resizeCellPaddingWidthInPx = this.resizeByContentOptions.cellPaddingWidthInPx ?? 6;
     const resizeFormatterPaddingWidthInPx = this.resizeByContentOptions.formatterPaddingWidthInPx ?? 6;
@@ -521,7 +521,7 @@ export class ResizerService {
     }
   }
 
-  private handleSingleColumnResizeByContent(columnId: string) {
+  protected handleSingleColumnResizeByContent(columnId: string) {
     const columnDefinitions = this._grid.getColumns();
     const columnDefIdx = columnDefinitions.findIndex(col => col.id === columnId);
 
@@ -546,7 +546,7 @@ export class ResizerService {
    * @param {Number} newColumnWidth - calculated column width input
    * @returns boolean
    */
-  private readjustNewColumnWidthWhenOverLimit(column: Column, newColumnWidth: number): number {
+  protected readjustNewColumnWidthWhenOverLimit(column: Column, newColumnWidth: number): number {
     const frozenColumnIdx = this.gridOptions.frozenColumn ?? -1;
     const columnIdx = this._grid.getColumns().findIndex(col => col.id === column.id) ?? 0;
     let adjustedWidth = newColumnWidth;
@@ -580,7 +580,7 @@ export class ResizerService {
    *   2- header titles are lower than the viewport of dataset (this can happen when user change Tab and DOM is not shown),
    * for these cases we'll resize until it's no longer true or until we reach a max time limit (70min)
    */
-  private resizeGridWhenStylingIsBrokenUntilCorrected() {
+  protected resizeGridWhenStylingIsBrokenUntilCorrected() {
     // how many time we want to check before really stopping the resize check?
     // We do this because user might be switching to another tab too quickly for the resize be really finished, so better recheck few times to make sure
     const autoFixResizeTimeout = this.gridOptions?.autoFixResizeTimeout ?? (5 * 60 * 60); // interval is 200ms, so 4x is 1sec, so (4 * 60 * 60 = 60min)

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -73,7 +73,7 @@ export class ResizerService {
     return this.gridOptions?.resizeByContentOptions ?? {};
   }
 
-  constructor(protected pubSubService: PubSubService) {
+  constructor(protected readonly pubSubService: PubSubService) {
     this._eventHandler = new Slick.EventHandler();
   }
 

--- a/packages/common/src/services/shared.service.ts
+++ b/packages/common/src/services/shared.service.ts
@@ -1,18 +1,18 @@
 import { Column, CurrentPagination, GridOption, SlickDataView, SlickGrid, SlickGroupItemMetadataProvider } from '../interfaces/index';
 
 export class SharedService {
-  private _allColumns!: Column[];
-  private _dataView!: SlickDataView;
-  private _groupItemMetadataProvider!: SlickGroupItemMetadataProvider;
-  private _grid!: SlickGrid;
-  private _gridOptions!: GridOption;
-  private _hasColumnsReordered = false;
-  private _currentPagination!: CurrentPagination;
-  private _visibleColumns!: Column[];
-  private _hideHeaderRowAfterPageLoad = false;
-  private _hierarchicalDataset: any[] | undefined;
-  private _externalRegisteredResources!: any[];
-  private _frozenVisibleColumnId!: string | number;
+  protected _allColumns!: Column[];
+  protected _dataView!: SlickDataView;
+  protected _groupItemMetadataProvider!: SlickGroupItemMetadataProvider;
+  protected _grid!: SlickGrid;
+  protected _gridOptions!: GridOption;
+  protected _hasColumnsReordered = false;
+  protected _currentPagination!: CurrentPagination;
+  protected _visibleColumns!: Column[];
+  protected _hideHeaderRowAfterPageLoad = false;
+  protected _hierarchicalDataset: any[] | undefined;
+  protected _externalRegisteredResources!: any[];
+  protected _frozenVisibleColumnId!: string | number;
 
   // --
   // public

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -31,14 +31,14 @@ import { RxJsFacade, Subject } from './rxjsFacade';
 declare const Slick: SlickNamespace;
 
 export class SortService {
-  private _currentLocalSorters: CurrentSorter[] = [];
-  private _eventHandler: SlickEventHandler;
-  private _dataView!: SlickDataView;
-  private _grid!: SlickGrid;
-  private _isBackendGrid = false;
-  private httpCancelRequests$?: Subject<void>; // this will be used to cancel any pending http request
+  protected _currentLocalSorters: CurrentSorter[] = [];
+  protected _eventHandler: SlickEventHandler;
+  protected _dataView!: SlickDataView;
+  protected _grid!: SlickGrid;
+  protected _isBackendGrid = false;
+  protected httpCancelRequests$?: Subject<void>; // this will be used to cancel any pending http request
 
-  constructor(private sharedService: SharedService, private pubSubService: PubSubService, private backendUtilities?: BackendUtilityService, private rxjs?: RxJsFacade) {
+  constructor(protected sharedService: SharedService, protected pubSubService: PubSubService, protected backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) {
     this._eventHandler = new Slick.EventHandler();
     if (this.rxjs) {
       this.httpCancelRequests$ = this.rxjs.createSubject<void>();
@@ -51,12 +51,12 @@ export class SortService {
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
-  private get _gridOptions(): GridOption {
+  protected get _gridOptions(): GridOption {
     return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
   }
 
   /** Getter for the Column Definitions pulled through the Grid Object */
-  private get _columnDefinitions(): Column[] {
+  protected get _columnDefinitions(): Column[] {
     return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
   }
 
@@ -545,7 +545,7 @@ export class SortService {
   }
 
   // --
-  // private functions
+  // protected functions
   // -------------------
 
   /**
@@ -556,7 +556,7 @@ export class SortService {
    * (if we previously deleted these properties we wouldn't be able to change them back since these properties wouldn't exist anymore, hence why we just hide the commands)
    * @param {boolean} isDisabling - are we disabling the sort functionality? Defaults to true
    */
-  private disableAllSortingCommands(isDisabling = true): Column[] {
+  protected disableAllSortingCommands(isDisabling = true): Column[] {
     const columnDefinitions = this._grid.getColumns();
 
     // loop through column definition to hide/show header menu commands

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -38,7 +38,7 @@ export class SortService {
   protected _isBackendGrid = false;
   protected httpCancelRequests$?: Subject<void>; // this will be used to cancel any pending http request
 
-  constructor(protected sharedService: SharedService, protected pubSubService: PubSubService, protected backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) {
+  constructor(protected readonly sharedService: SharedService, protected readonly pubSubService: PubSubService, protected readonly backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) {
     this._eventHandler = new Slick.EventHandler();
     if (this.rxjs) {
       this.httpCancelRequests$ = this.rxjs.createSubject<void>();

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -24,13 +24,13 @@ import { SortService } from './sort.service';
 declare const Slick: SlickNamespace;
 
 export class TreeDataService {
-  private _isLastFullToggleCollapsed = false;
-  private _lastToggleStateChange!: Omit<TreeToggleStateChange, 'fromItemId'>;
-  private _currentToggledItems: TreeToggledItem[] = [];
-  private _grid!: SlickGrid;
-  private _eventHandler: SlickEventHandler;
+  protected _isLastFullToggleCollapsed = false;
+  protected _lastToggleStateChange!: Omit<TreeToggleStateChange, 'fromItemId'>;
+  protected _currentToggledItems: TreeToggledItem[] = [];
+  protected _grid!: SlickGrid;
+  protected _eventHandler: SlickEventHandler;
 
-  constructor(private pubSubService: PubSubService, private sharedService: SharedService, private sortService: SortService) {
+  constructor(protected readonly pubSubService: PubSubService, protected readonly sharedService: SharedService, protected readonly sortService: SortService) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -328,10 +328,10 @@ export class TreeDataService {
   }
 
   // --
-  // private functions
+  // protected functions
   // ------------------
 
-  private handleOnCellClick(event: SlickEventData, args: OnClickEventArgs) {
+  protected handleOnCellClick(event: SlickEventData, args: OnClickEventArgs) {
     if (event && args) {
       const targetElm: any = event.target || {};
       const idPropName = this.gridOptions.datasetIdPropertyName ?? 'id';
@@ -379,7 +379,7 @@ export class TreeDataService {
     }
   }
 
-  private updateToggledItem(item: any, isCollapsed: boolean) {
+  protected updateToggledItem(item: any, isCollapsed: boolean) {
     const dataViewIdIdentifier = this.gridOptions?.datasetIdPropertyName ?? 'id';
     const childrenPropName = this.getTreeDataOptionPropName('childrenPropName');
     const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');

--- a/packages/custom-footer-component/src/slick-footer.component.ts
+++ b/packages/custom-footer-component/src/slick-footer.component.ts
@@ -19,13 +19,13 @@ import { BindingHelper } from '@slickgrid-universal/binding';
 
 declare const Slick: SlickNamespace;
 export class SlickFooterComponent {
-  private _bindingHelper: BindingHelper;
-  private _eventHandler!: SlickEventHandler;
-  private _footerElement!: HTMLDivElement;
-  private _isLeftFooterOriginallyEmpty = true;
-  private _isLeftFooterDisplayingSelectionRowCount = false;
-  private _isRightFooterOriginallyEmpty = true;
-  private _selectedRowCount = 0;
+  protected _bindingHelper: BindingHelper;
+  protected _eventHandler!: SlickEventHandler;
+  protected _footerElement!: HTMLDivElement;
+  protected _isLeftFooterOriginallyEmpty = true;
+  protected _isLeftFooterDisplayingSelectionRowCount = false;
+  protected _isRightFooterOriginallyEmpty = true;
+  protected _selectedRowCount = 0;
 
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
@@ -63,7 +63,7 @@ export class SlickFooterComponent {
     this.renderRightFooterText(text);
   }
 
-  constructor(private grid: SlickGrid, private customFooterOptions: CustomFooterOption, private translaterService?: TranslaterService) {
+  constructor(protected grid: SlickGrid, protected customFooterOptions: CustomFooterOption, protected translaterService?: TranslaterService) {
     this._bindingHelper = new BindingHelper();
     this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
     this._eventHandler = new Slick.EventHandler();
@@ -124,11 +124,11 @@ export class SlickFooterComponent {
   }
 
   // --
-  // private functions
+  // protected functions
   // --------------------
 
   /** Create the Footer Container */
-  private createFooterContainer(gridParentContainerElm: HTMLElement) {
+  protected createFooterContainer(gridParentContainerElm: HTMLElement) {
     const footerElm = document.createElement('div');
     footerElm.className = `slick-custom-footer ${this.gridUid}`;
     footerElm.style.width = '100%';
@@ -150,7 +150,7 @@ export class SlickFooterComponent {
   }
 
   /** Create the Right Section Footer */
-  private createFooterRightContainer(): HTMLDivElement {
+  protected createFooterRightContainer(): HTMLDivElement {
     const rightFooterElm = document.createElement('div');
     rightFooterElm.className = `right-footer ${this.customFooterOptions.rightContainerClass || ''}`;
 
@@ -209,7 +209,7 @@ export class SlickFooterComponent {
   }
 
   /** Create the Right Section Last Update Timestamp */
-  private createFooterLastUpdate(): HTMLSpanElement {
+  protected createFooterLastUpdate(): HTMLSpanElement {
     // get translated text & last timestamp
     const lastUpdateText = this.customFooterOptions?.metricTexts?.lastUpdate ?? 'Last Update';
     const lastUpdateTimestamp = moment(this.metrics?.endTime).format(this.customFooterOptions.dateFormat);
@@ -240,7 +240,7 @@ export class SlickFooterComponent {
    * we will show the row selection count on the bottom left side of the footer (by subscribing to the SlickGrid `onSelectedRowsChanged` event).
    * @param customFooterOptions
    */
-  private registerOnSelectedRowsChangedWhenEnabled(customFooterOptions: CustomFooterOption) {
+  protected registerOnSelectedRowsChangedWhenEnabled(customFooterOptions: CustomFooterOption) {
     const isRowSelectionEnabled = this.gridOptions.enableCheckboxSelector || this.gridOptions.enableRowSelection;
     if (isRowSelectionEnabled && customFooterOptions && (!customFooterOptions.hideRowSelectionCount && this._isLeftFooterOriginallyEmpty)) {
       this._isLeftFooterDisplayingSelectionRowCount = true;

--- a/packages/custom-footer-component/src/slick-footer.component.ts
+++ b/packages/custom-footer-component/src/slick-footer.component.ts
@@ -63,7 +63,7 @@ export class SlickFooterComponent {
     this.renderRightFooterText(text);
   }
 
-  constructor(protected grid: SlickGrid, protected customFooterOptions: CustomFooterOption, protected translaterService?: TranslaterService) {
+  constructor(protected readonly grid: SlickGrid, protected readonly customFooterOptions: CustomFooterOption, protected readonly translaterService?: TranslaterService) {
     this._bindingHelper = new BindingHelper();
     this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
     this._eventHandler = new Slick.EventHandler();

--- a/packages/empty-warning-component/src/slick-empty-warning.component.ts
+++ b/packages/empty-warning-component/src/slick-empty-warning.component.ts
@@ -9,11 +9,11 @@ import {
 } from '@slickgrid-universal/common';
 
 export class SlickEmptyWarningComponent implements ExternalResource {
-  private _warningLeftElement: HTMLDivElement | null = null
-  private _warningRightElement: HTMLDivElement | null = null
-  private grid!: SlickGrid;
-  private isPreviouslyShown = false;
-  private translaterService?: TranslaterService | null;
+  protected _warningLeftElement: HTMLDivElement | null = null
+  protected _warningRightElement: HTMLDivElement | null = null
+  protected grid!: SlickGrid;
+  protected isPreviouslyShown = false;
+  protected translaterService?: TranslaterService | null;
 
 
   /** Getter for the Grid Options pulled through the Grid Object */

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -6,8 +6,8 @@ interface PubSubEvent {
 }
 
 export class EventPubSubService implements PubSubService {
-  private _elementSource: Element;
-  private _subscribedEvents: PubSubEvent[] = [];
+  protected _elementSource: Element;
+  protected _subscribedEvents: PubSubEvent[] = [];
 
   eventNamingStyle = EventNamingStyle.camelCase;
 

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -44,27 +44,27 @@ const DEFAULT_EXPORT_OPTIONS: ExcelExportOption = {
 };
 
 export class ExcelExportService implements ExternalResource, BaseExcelExportService {
-  private _fileFormat = FileType.xlsx;
-  private _grid!: SlickGrid;
-  private _locales!: Locale;
-  private _groupedColumnHeaders?: Array<KeyTitlePair>;
-  private _columnHeaders: Array<KeyTitlePair> = [];
-  private _hasColumnTitlePreHeader = false;
-  private _hasGroupedItems = false;
-  private _excelExportOptions!: ExcelExportOption;
-  private _sheet!: ExcelWorksheet;
-  private _stylesheet!: ExcelStylesheet;
-  private _stylesheetFormats: any;
-  private _pubSubService: PubSubService | null = null;
-  private _translaterService: TranslaterService | undefined;
-  private _workbook!: ExcelWorkbook;
+  protected _fileFormat = FileType.xlsx;
+  protected _grid!: SlickGrid;
+  protected _locales!: Locale;
+  protected _groupedColumnHeaders?: Array<KeyTitlePair>;
+  protected _columnHeaders: Array<KeyTitlePair> = [];
+  protected _hasColumnTitlePreHeader = false;
+  protected _hasGroupedItems = false;
+  protected _excelExportOptions!: ExcelExportOption;
+  protected _sheet!: ExcelWorksheet;
+  protected _stylesheet!: ExcelStylesheet;
+  protected _stylesheetFormats: any;
+  protected _pubSubService: PubSubService | null = null;
+  protected _translaterService: TranslaterService | undefined;
+  protected _workbook!: ExcelWorkbook;
 
   /** ExcelExportService class name which is use to find service instance in the external registered services */
   readonly className = 'ExcelExportService';
 
   constructor() { }
 
-  private get _datasetIdPropName(): string {
+  protected get _datasetIdPropName(): string {
     return this._gridOptions?.datasetIdPropertyName ?? 'id';
   }
 
@@ -74,7 +74,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
-  private get _gridOptions(): GridOption {
+  protected get _gridOptions(): GridOption {
     return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
   }
 
@@ -277,10 +277,10 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
   }
 
   // -----------------------
-  // Private functions
+  // protected functions
   // -----------------------
 
-  private getDataOutput(): Array<string[] | ExcelCellFormat[]> {
+  protected getDataOutput(): Array<string[] | ExcelCellFormat[]> {
     const columns = this._grid && this._grid.getColumns && this._grid.getColumns() || [];
 
     // data variable which will hold all the fields data of a row
@@ -310,7 +310,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
   }
 
   /** Get each column style including a style for the width of each column */
-  private getColumnStyles(columns: Column[]): any[] {
+  protected getColumnStyles(columns: Column[]): any[] {
     const grouping = this._dataView.getGrouping();
     const columnStyles = [];
     if (Array.isArray(grouping) && grouping.length > 0) {
@@ -339,7 +339,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
    * @param {Object} metadata - Excel metadata
    * @returns {Object} array of Excel cell format
    */
-  private getColumnGroupedHeaderTitlesData(columns: Column[], metadata: ExcelMetadata): Array<ExcelCellFormat> {
+  protected getColumnGroupedHeaderTitlesData(columns: Column[], metadata: ExcelMetadata): Array<ExcelCellFormat> {
     let outputGroupedHeaderTitles: Array<ExcelCellFormat> = [];
 
     // get all Column Header Titles
@@ -367,7 +367,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
   }
 
   /** Get all column headers and format them in Bold */
-  private getColumnHeaderData(columns: Column[], metadata: ExcelMetadata): Array<ExcelCellFormat> {
+  protected getColumnHeaderData(columns: Column[], metadata: ExcelMetadata): Array<ExcelCellFormat> {
     let outputHeaderTitles: Array<ExcelCellFormat> = [];
 
     // get all Column Header Titles
@@ -386,7 +386,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
     return outputHeaderTitles;
   }
 
-  private getGroupColumnTitle(): string | null {
+  protected getGroupColumnTitle(): string | null {
     // Group By text, it could be set in the export options or from translation or if nothing is found then use the English constant text
     let groupByColumnHeader = this._excelExportOptions.groupingColumnHeaderTitle;
     if (!groupByColumnHeader && this._gridOptions.enableTranslate && this._translaterService?.translate) {
@@ -411,7 +411,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
  * Get all Grouped Header Titles and their keys, translate the title when required.
  * @param {Array<object>} columns of the grid
  */
-  private getColumnGroupedHeaderTitles(columns: Column[]): Array<KeyTitlePair> {
+  protected getColumnGroupedHeaderTitles(columns: Column[]): Array<KeyTitlePair> {
     const groupedColumnHeaders: Array<KeyTitlePair> = [];
 
     if (columns && Array.isArray(columns)) {
@@ -441,7 +441,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
    * Get all header titles and their keys, translate the title when required.
    * @param {Array<object>} columns of the grid
    */
-  private getColumnHeaders(columns: Column[]): Array<KeyTitlePair> | null {
+  protected getColumnHeaders(columns: Column[]): Array<KeyTitlePair> | null {
     const columnHeaders: Array<KeyTitlePair> = [];
 
     if (columns && Array.isArray(columns)) {
@@ -470,7 +470,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
   /**
    * Get all the grid row data and return that as an output string
    */
-  private pushAllGridRowDataToArray(originalDaraArray: Array<string[] | ExcelCellFormat[]>, columns: Column[]): Array<string[] | ExcelCellFormat[]> {
+  protected pushAllGridRowDataToArray(originalDaraArray: Array<string[] | ExcelCellFormat[]>, columns: Column[]): Array<string[] | ExcelCellFormat[]> {
     const lineCount = this._dataView.getLength();
 
     // loop through all the grid rows of data
@@ -502,7 +502,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
    * @param {Number} row - row index
    * @param {Object} itemObj - item datacontext object
    */
-  private readRegularRowData(columns: Column[], row: number, itemObj: any): string[] {
+  protected readRegularRowData(columns: Column[], row: number, itemObj: any): string[] {
     let idx = 0;
     const rowOutputStrings = [];
     const columnsLn = columns.length;
@@ -594,7 +594,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
    * Get the grouped title(s) and its group title formatter, for example if we grouped by salesRep, the returned result would be:: 'Sales Rep: John Dow (2 items)'
    * @param itemObj
    */
-  private readGroupedRowTitle(itemObj: any): string {
+  protected readGroupedRowTitle(itemObj: any): string {
     const groupName = sanitizeHtmlToText(itemObj.title);
 
     if (this._excelExportOptions && this._excelExportOptions.addGroupIndentation) {
@@ -611,7 +611,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
    * For example if we grouped by "salesRep" and we have a Sum Aggregator on "sales", then the returned output would be:: ["Sum 123$"]
    * @param itemObj
    */
-  private readGroupedTotalRows(columns: Column[], itemObj: any): string[] {
+  protected readGroupedTotalRows(columns: Column[], itemObj: any): string[] {
     const groupingAggregatorRowText = this._excelExportOptions.groupingAggregatorRowText || '';
     const outputStrings = [groupingAggregatorRowText];
 

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -41,12 +41,12 @@ const DEFAULT_ITEMS_PER_PAGE = 25;
 const DEFAULT_PAGE_SIZE = 20;
 
 export class GraphqlService implements BackendService {
-  private _currentFilters: ColumnFilters | CurrentFilter[] = [];
-  private _currentPagination: CurrentPagination | null = null;
-  private _currentSorters: CurrentSorter[] = [];
-  private _columnDefinitions?: Column[];
-  private _grid: SlickGrid | undefined;
-  private _datasetIdPropName = 'id';
+  protected _currentFilters: ColumnFilters | CurrentFilter[] = [];
+  protected _currentPagination: CurrentPagination | null = null;
+  protected _currentSorters: CurrentSorter[] = [];
+  protected _columnDefinitions?: Column[];
+  protected _grid: SlickGrid | undefined;
+  protected _datasetIdPropName = 'id';
   options: GraphqlServiceOption | undefined;
   pagination: Pagination | undefined;
   defaultPaginationOptions: GraphqlPaginationOption | GraphqlCursorPaginationOption = {
@@ -60,7 +60,7 @@ export class GraphqlService implements BackendService {
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
-  private get _gridOptions(): GridOption {
+  protected get _gridOptions(): GridOption {
     return (this._grid?.getOptions) ? this._grid.getOptions() : {};
   }
 
@@ -613,13 +613,13 @@ export class GraphqlService implements BackendService {
   }
 
   //
-  // private functions
+  // protected functions
   // -------------------
   /**
    * Cast provided filters (could be in multiple formats) into an array of CurrentFilter
    * @param columnFilters
    */
-  private castFilterToColumnFilters(columnFilters: ColumnFilters | CurrentFilter[]): CurrentFilter[] {
+  protected castFilterToColumnFilters(columnFilters: ColumnFilters | CurrentFilter[]): CurrentFilter[] {
     // keep current filters & always save it as an array (columnFilters can be an object when it is dealt by SlickGrid Filter)
     const filtersArray: ColumnFilter[] = (typeof columnFilters === 'object') ? Object.keys(columnFilters).map(key => (columnFilters as any)[key]) : columnFilters;
 
@@ -640,7 +640,7 @@ export class GraphqlService implements BackendService {
   }
 
   /** Normalizes the search value according to field type. */
-  private normalizeSearchValue(fieldType: typeof FieldType[keyof typeof FieldType], searchValue: any): any {
+  protected normalizeSearchValue(fieldType: typeof FieldType[keyof typeof FieldType], searchValue: any): any {
     switch (fieldType) {
       case FieldType.date:
       case FieldType.string:

--- a/packages/graphql/src/services/graphqlQueryBuilder.ts
+++ b/packages/graphql/src/services/graphqlQueryBuilder.ts
@@ -14,7 +14,7 @@ export default class GraphqlQueryBuilder {
 
   /* Constructor, query/mutator you wish to use, and an alias or filter arguments. */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  constructor(private queryFnName: string, aliasOrFilter?: string | object) {
+  constructor(protected queryFnName: string, aliasOrFilter?: string | object) {
     if (typeof aliasOrFilter === 'string') {
       this.alias = aliasOrFilter;
     } else if (typeof aliasOrFilter === 'object') {
@@ -80,10 +80,10 @@ export default class GraphqlQueryBuilder {
   }
 
   // --
-  // PRIVATE FUNCTIONS
-  // -----------------
+  // protected functions
+  // --------------------
 
-  private parceFind(_levelA: any[]) {
+  protected parceFind(_levelA: any[]) {
     const propsA = _levelA.map((_currentValue, index) => {
       const itemX = _levelA[index];
 
@@ -111,7 +111,7 @@ export default class GraphqlQueryBuilder {
     return propsA.join(',');
   }
 
-  private getGraphQLValue(value: any) {
+  protected getGraphQLValue(value: any) {
     if (typeof value === 'string') {
       value = JSON.stringify(value);
     } else if (Array.isArray(value)) {
@@ -127,7 +127,7 @@ export default class GraphqlQueryBuilder {
     return value;
   }
 
-  private objectToString(obj: any) {
+  protected objectToString(obj: any) {
     const sourceA = [];
 
     for (const prop of Object.keys(obj)) {

--- a/packages/odata/src/services/grid-odata.service.ts
+++ b/packages/odata/src/services/grid-odata.service.ts
@@ -36,12 +36,12 @@ const DEFAULT_ITEMS_PER_PAGE = 25;
 const DEFAULT_PAGE_SIZE = 20;
 
 export class GridOdataService implements BackendService {
-  private _currentFilters: CurrentFilter[] = [];
-  private _currentPagination: CurrentPagination | null = null;
-  private _currentSorters: CurrentSorter[] = [];
-  private _columnDefinitions: Column[] = [];
-  private _grid: SlickGrid | undefined;
-  private _odataService: OdataQueryBuilderService;
+  protected _currentFilters: CurrentFilter[] = [];
+  protected _currentPagination: CurrentPagination | null = null;
+  protected _currentSorters: CurrentSorter[] = [];
+  protected _columnDefinitions: Column[] = [];
+  protected _grid: SlickGrid | undefined;
+  protected _odataService: OdataQueryBuilderService;
   options?: Partial<OdataOption>;
   pagination: Pagination | undefined;
   defaultOptions: OdataOption = {
@@ -61,7 +61,7 @@ export class GridOdataService implements BackendService {
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
-  private get _gridOptions(): GridOption {
+  protected get _gridOptions(): GridOption {
     return (this._grid?.getOptions) ? this._grid.getOptions() : {};
   }
 
@@ -513,13 +513,13 @@ export class GridOdataService implements BackendService {
   }
 
   //
-  // private functions
+  // protected functions
   // -------------------
   /**
    * Cast provided filters (could be in multiple format) into an array of ColumnFilter
    * @param columnFilters
    */
-  private castFilterToColumnFilters(columnFilters: ColumnFilters | CurrentFilter[]): CurrentFilter[] {
+  protected castFilterToColumnFilters(columnFilters: ColumnFilters | CurrentFilter[]): CurrentFilter[] {
     // keep current filters & always save it as an array (columnFilters can be an object when it is dealt by SlickGrid Filter)
     const filtersArray: ColumnFilter[] = (typeof columnFilters === 'object') ? Object.keys(columnFilters).map(key => (columnFilters as any)[key]) : columnFilters;
 
@@ -542,7 +542,7 @@ export class GridOdataService implements BackendService {
   /**
    * Filter by a range of searchTerms (2 searchTerms OR 1 string separated by 2 dots "value1..value2")
    */
-  private filterBySearchTermRange(fieldName: string, operator: OperatorType | OperatorString, searchTerms: SearchTerm[]) {
+  protected filterBySearchTermRange(fieldName: string, operator: OperatorType | OperatorString, searchTerms: SearchTerm[]) {
     let query = '';
     if (Array.isArray(searchTerms) && searchTerms.length === 2) {
       if (operator === OperatorType.rangeInclusive) {
@@ -567,7 +567,7 @@ export class GridOdataService implements BackendService {
   /**
    * Normalizes the search value according to field type and oData version.
    */
-  private normalizeSearchValue(fieldType: typeof FieldType[keyof typeof FieldType], searchValue: any, version: number) {
+  protected normalizeSearchValue(fieldType: typeof FieldType[keyof typeof FieldType], searchValue: any, version: number) {
     switch (fieldType) {
       case FieldType.date:
         searchValue = parseUtcDate(searchValue as string, true);

--- a/packages/odata/src/services/odataQueryBuilder.service.ts
+++ b/packages/odata/src/services/odataQueryBuilder.service.ts
@@ -139,10 +139,10 @@ export class OdataQueryBuilderService {
   }
 
   //
-  // private functions
+  // protected functions
   // -------------------
 
-  private addToFilterQueueWhenNotExists(filterStr: string) {
+  protected addToFilterQueueWhenNotExists(filterStr: string) {
     if (this._odataOptions.filterQueue && this._odataOptions.filterQueue.indexOf(filterStr) === -1) {
       this._odataOptions.filterQueue.push(filterStr);
     }

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -14,11 +14,11 @@ import {
 import { BindingHelper } from '@slickgrid-universal/binding';
 
 export class SlickPaginationComponent {
-  private _bindingHelper: BindingHelper;
-  private _paginationElement!: HTMLDivElement;
-  private _enableTranslate = false;
-  private _locales: Locale;
-  private _subscriptions: Subscription[] = [];
+  protected _bindingHelper: BindingHelper;
+  protected _paginationElement!: HTMLDivElement;
+  protected _enableTranslate = false;
+  protected _locales: Locale;
+  protected _subscriptions: Subscription[] = [];
   currentPagination: ServicePagination;
   firstButtonClasses = '';
   lastButtonClasses = '';
@@ -31,7 +31,7 @@ export class SlickPaginationComponent {
   textOf = 'of';
   textPage = 'Page';
 
-  constructor(private readonly paginationService: PaginationService, private readonly pubSubService: PubSubService, private readonly sharedService: SharedService, private readonly translaterService?: TranslaterService) {
+  constructor(protected readonly paginationService: PaginationService, protected readonly pubSubService: PubSubService, protected readonly sharedService: SharedService, protected readonly translaterService?: TranslaterService) {
     this._bindingHelper = new BindingHelper();
     this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
 
@@ -220,10 +220,10 @@ export class SlickPaginationComponent {
   }
 
   // --
-  // private functions
+  // protected functions
   // --------------------
 
-  private updatePageButtonsUsability() {
+  protected updatePageButtonsUsability() {
     this.firstButtonClasses = this.isLeftPaginationDisabled ? 'page-item seek-first disabled' : 'page-item seek-first';
     this.prevButtonClasses = this.isLeftPaginationDisabled ? 'page-item seek-prev disabled' : 'page-item seek-prev';
     this.lastButtonClasses = this.isRightPaginationDisabled ? 'page-item seek-end disabled' : 'page-item seek-end';
@@ -231,7 +231,7 @@ export class SlickPaginationComponent {
   }
 
   /** Translate all the texts shown in the UI, use ngx-translate service when available or custom locales when service is null */
-  private translatePaginationTexts(locales: Locale) {
+  protected translatePaginationTexts(locales: Locale) {
     if (this._enableTranslate && this.translaterService?.translate) {
       const translationPrefix = getTranslationPrefix(this.gridOptions);
       this.textItemsPerPage = this.translaterService.translate(`${translationPrefix}ITEMS_PER_PAGE`);

--- a/packages/text-export/src/textExport.service.ts
+++ b/packages/text-export/src/textExport.service.ts
@@ -43,25 +43,25 @@ type ExportTextDownloadOption = {
 };
 
 export class TextExportService implements ExternalResource, BaseTextExportService {
-  private _delimiter = ',';
-  private _exportQuoteWrapper = '';
-  private _exportOptions!: TextExportOption;
-  private _fileFormat = FileType.csv;
-  private _lineCarriageReturn = '\n';
-  private _grid!: SlickGrid;
-  private _groupedColumnHeaders?: Array<KeyTitlePair>;
-  private _columnHeaders: Array<KeyTitlePair> = [];
-  private _hasGroupedItems = false;
-  private _locales!: Locale;
-  private _pubSubService!: PubSubService | null;
-  private _translaterService: TranslaterService | undefined;
+  protected _delimiter = ',';
+  protected _exportQuoteWrapper = '';
+  protected _exportOptions!: TextExportOption;
+  protected _fileFormat = FileType.csv;
+  protected _lineCarriageReturn = '\n';
+  protected _grid!: SlickGrid;
+  protected _groupedColumnHeaders?: Array<KeyTitlePair>;
+  protected _columnHeaders: Array<KeyTitlePair> = [];
+  protected _hasGroupedItems = false;
+  protected _locales!: Locale;
+  protected _pubSubService!: PubSubService | null;
+  protected _translaterService: TranslaterService | undefined;
 
   /** ExcelExportService class name which is use to find service instance in the external registered services */
   readonly className = 'TextExportService';
 
   constructor() { }
 
-  private get _datasetIdPropName(): string {
+  protected get _datasetIdPropName(): string {
     return this._gridOptions && this._gridOptions.datasetIdPropertyName || 'id';
   }
 
@@ -71,7 +71,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
-  private get _gridOptions(): GridOption {
+  protected get _gridOptions(): GridOption {
     return (this._grid?.getOptions) ? this._grid.getOptions() : {};
   }
 
@@ -184,10 +184,10 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
   }
 
   // -----------------------
-  // Private functions
+  // protected functions
   // -----------------------
 
-  private getDataOutput(): string {
+  protected getDataOutput(): string {
     const columns = this._grid.getColumns() || [];
 
     // Group By text, it could be set in the export options or from translation or if nothing is found then use the English constant text
@@ -241,7 +241,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
   /**
    * Get all the grid row data and return that as an output string
    */
-  private getAllGridRowData(columns: Column[], lineCarriageReturn: string): string {
+  protected getAllGridRowData(columns: Column[], lineCarriageReturn: string): string {
     const outputDataStrings = [];
     const lineCount = this._dataView.getLength();
 
@@ -273,7 +273,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * Get all Grouped Header Titles and their keys, translate the title when required.
    * @param {Array<object>} columns of the grid
    */
-  private getColumnGroupedHeaderTitles(columns: Column[]): Array<KeyTitlePair> {
+  protected getColumnGroupedHeaderTitles(columns: Column[]): Array<KeyTitlePair> {
     const groupedColumnHeaders: KeyTitlePair[] = [];
 
     if (columns && Array.isArray(columns)) {
@@ -303,7 +303,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * Get all header titles and their keys, translate the title when required.
    * @param {Array<object>} columns of the grid
    */
-  private getColumnHeaders(columns: Column[]): Array<KeyTitlePair> {
+  protected getColumnHeaders(columns: Column[]): Array<KeyTitlePair> {
     const columnHeaders: Array<KeyTitlePair> = [];
 
     if (columns && Array.isArray(columns)) {
@@ -335,7 +335,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * @param {Number} row - row index
    * @param {Object} itemObj - item datacontext object
    */
-  private readRegularRowData(columns: Column[], row: number, itemObj: any) {
+  protected readRegularRowData(columns: Column[], row: number, itemObj: any) {
     let idx = 0;
     const rowOutputStrings = [];
     const exportQuoteWrapper = this._exportQuoteWrapper;
@@ -406,7 +406,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * Get the grouped title(s) and its group title formatter, for example if we grouped by salesRep, the returned result would be:: 'Sales Rep: John Dow (2 items)'
    * @param itemObj
    */
-  private readGroupedTitleRow(itemObj: any) {
+  protected readGroupedTitleRow(itemObj: any) {
     let groupName = sanitizeHtmlToText(itemObj.title);
     const exportQuoteWrapper = this._exportQuoteWrapper;
 
@@ -425,7 +425,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * For example if we grouped by "salesRep" and we have a Sum Aggregator on "sales", then the returned output would be:: ["Sum 123$"]
    * @param itemObj
    */
-  private readGroupedTotalRow(columns: Column[], itemObj: any) {
+  protected readGroupedTotalRow(columns: Column[], itemObj: any) {
     const delimiter = this._exportOptions.delimiter;
     const format = this._exportOptions.format;
     const groupingAggregatorRowText = this._exportOptions.groupingAggregatorRowText || '';


### PR DESCRIPTION
- it was mentioned by a user of Angular-Slickgrid that it would be nice to extend some of the Services and so I decided to make them all extendable by using `protected` instead of `private` 