### PR TITLE
fix(filters): always find locale  even without TranslaterService

### DIFF
--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -125,7 +125,7 @@ export class DateEditor implements Editor {
       this.defaultDate = (this.args.item) ? this.args.item[this.columnDef.field] : null;
       const inputFormat = mapFlatpickrDateFormatWithFieldType(this.columnEditor.type || this.columnDef.type || FieldType.dateUtc);
       const outputFormat = mapFlatpickrDateFormatWithFieldType(this.columnDef.outputType || this.columnEditor.type || this.columnDef.type || FieldType.dateUtc);
-      let currentLocale = this._translaterService && this._translaterService.getCurrentLanguage && this._translaterService.getCurrentLanguage() || gridOptions.locale || 'en';
+      let currentLocale = this._translaterService?.getCurrentLanguage?.() || gridOptions.locale || 'en';
       if (currentLocale.length > 2) {
         currentLocale = currentLocale.substring(0, 2);
       }

--- a/packages/common/src/filters/compoundDateFilter.ts
+++ b/packages/common/src/filters/compoundDateFilter.ts
@@ -182,8 +182,8 @@ export class CompoundDateFilter implements Filter {
     const userFilterOptions = (this.columnFilter && this.columnFilter.filterOptions || {}) as FlatpickrOption;
 
     // get current locale, if user defined a custom locale just use or get it the Translate Service if it exist else just use English
-    let currentLocale = userFilterOptions?.locale ?? this.translaterService?.getCurrentLanguage() ?? this.gridOptions.locale ?? 'en';
-    if (currentLocale && currentLocale.length > 2) {
+    let currentLocale = (userFilterOptions?.locale ?? this.translaterService?.getCurrentLanguage?.()) || this.gridOptions.locale || 'en';
+    if (currentLocale?.length > 2) {
       currentLocale = currentLocale.substring(0, 2);
     }
 

--- a/packages/common/src/filters/dateRangeFilter.ts
+++ b/packages/common/src/filters/dateRangeFilter.ts
@@ -180,7 +180,7 @@ export class DateRangeFilter implements Filter {
     const userFilterOptions = (this.columnFilter && this.columnFilter.filterOptions || {}) as FlatpickrOption;
 
     // get current locale, if user defined a custom locale just use or get it the Translate Service if it exist else just use English
-    let currentLocale = (userFilterOptions && userFilterOptions.locale) || (this.translaterService && this.translaterService.getCurrentLanguage && this.translaterService.getCurrentLanguage()) || this.gridOptions.locale || 'en';
+    let currentLocale = (userFilterOptions?.locale ?? this.translaterService?.getCurrentLanguage?.()) || this.gridOptions.locale || 'en';
     if (currentLocale.length > 2) {
       currentLocale = currentLocale.substring(0, 2);
     }


### PR DESCRIPTION
- while implementing this in Angular-Slickgrid, I found that the `currentLocale` ended up being an empty string when the Translater Service doesn't exist (it's optional) and user provides only a single Locale. If nothing is found, then we'll use English (`'en'`)