### PR TITLE
feat(aria): add aria-label to all Editors/Filters & other html templates

### DIFF
--- a/packages/common/src/editors/__tests__/InputPasswordEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/InputPasswordEditor.spec.ts
@@ -98,6 +98,13 @@ describe('InputPasswordEditor', () => {
       expect(editor.inputType).toBe('password');
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new InputPasswordEditor(editorArguments);
+      const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Title Input Editor');
+    });
+
     it('should initialize the editor and focus on the element after a small delay', () => {
       editor = new InputPasswordEditor(editorArguments);
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-title').length;

--- a/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
@@ -92,6 +92,13 @@ describe('CheckboxEditor', () => {
       expect(editorCount).toBe(1);
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new CheckboxEditor(editorArguments);
+      const editorElm = divContainer.querySelector('input.editor-checkbox') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Is Active Checkbox Editor');
+    });
+
     it('should initialize the editor even when user define his own editor options', () => {
       (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleteOption;
       editor = new CheckboxEditor(editorArguments);

--- a/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
@@ -110,6 +110,13 @@ describe('DualInputEditor', () => {
       expect(editorCount).toBe(2);
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new DualInputEditor(editorArguments);
+      const editorElm = divContainer.querySelector('input.dual-editor-text.editor-range.left') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Range Input Editor');
+    });
+
     it('should have a placeholder on the left input when defined in its column definition', () => {
       const testValue = 'test placeholder';
       (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.placeholder = testValue;

--- a/packages/common/src/editors/__tests__/floatEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/floatEditor.spec.ts
@@ -98,6 +98,13 @@ describe('FloatEditor', () => {
       expect(editor.inputType).toBe('number');
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new FloatEditor(editorArguments);
+      const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Price Number Editor');
+    });
+
     it('should initialize the editor and focus on the element after a small delay', () => {
       editor = new FloatEditor(editorArguments);
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-price').length;

--- a/packages/common/src/editors/__tests__/inputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputEditor.spec.ts
@@ -98,6 +98,13 @@ describe('InputEditor (TextEditor)', () => {
       expect(editor.inputType).toBe('text');
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new InputEditor(editorArguments, 'text');
+      const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Title Input Editor');
+    });
+
     it('should initialize the editor and focus on the element after a small delay', () => {
       editor = new InputEditor(editorArguments, 'text');
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-title').length;

--- a/packages/common/src/editors/__tests__/integerEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/integerEditor.spec.ts
@@ -98,6 +98,13 @@ describe('IntegerEditor', () => {
       expect(editor.inputType).toBe('number');
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new IntegerEditor(editorArguments);
+      const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Price Slider Editor');
+    });
+
     it('should initialize the editor and focus on the element after a small delay', () => {
       editor = new IntegerEditor(editorArguments);
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-price').length;

--- a/packages/common/src/editors/__tests__/longTextEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/longTextEditor.spec.ts
@@ -128,6 +128,14 @@ describe('LongTextEditor', () => {
       expect(buttonSaveElm.textContent).toBe('Sauvegarder');
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      gridOptionMock.translater = undefined as any;
+      editor = new LongTextEditor(editorArguments);
+      const editorElm = document.body.querySelector('.slick-large-editor-text.editor-title textarea') as HTMLTextAreaElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Title Text Editor');
+    });
+
     it('should initialize the editor with default constant text when translate service is not provided', () => {
       gridOptionMock.translater = undefined as any;
       editor = new LongTextEditor(editorArguments);

--- a/packages/common/src/editors/__tests__/sliderEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/sliderEditor.spec.ts
@@ -92,6 +92,13 @@ describe('SliderEditor', () => {
       expect(editorCount).toBe(1);
     });
 
+    it('should have an aria-label when creating the editor', () => {
+      editor = new SliderEditor(editorArguments);
+      const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;
+
+      expect(editorElm.getAttribute('aria-label')).toBe('Price Slider Editor');
+    });
+
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
       (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;

--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -1,6 +1,6 @@
 import { Constants } from './../constants';
 import { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace } from './../interfaces/index';
-import { getDescendantProperty, setDeepValue } from '../services/utilities';
+import { getDescendantProperty, setDeepValue, toSentenceCase } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
 
 // using external non-typed js libraries
@@ -78,6 +78,7 @@ export class CheckboxEditor implements Editor {
     this._input.title = title;
     this._input.type = 'checkbox';
     this._input.value = 'true';
+    this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Checkbox Editor`);
 
     const cellContainer = this.args?.container;
     if (cellContainer && typeof cellContainer.appendChild === 'function') {

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -15,7 +15,7 @@ import {
   SlickGrid,
   SlickNamespace,
 } from '../interfaces/index';
-import { getDescendantProperty, setDeepValue } from '../services/utilities';
+import { getDescendantProperty, setDeepValue, toSentenceCase } from '../services/utilities';
 import { floatValidator, integerValidator, textValidator } from '../editorValidators';
 import { BindingEventService } from '../services/bindingEvent.service';
 
@@ -199,6 +199,7 @@ export class DualInputEditor implements Editor {
     }
     input.type = fieldType || 'text';
     input.setAttribute('role', 'presentation');
+    input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`);
     input.autocomplete = 'off';
     input.placeholder = editorSideParams.placeholder || '';
     input.title = editorSideParams.title || '';

--- a/packages/common/src/editors/floatEditor.ts
+++ b/packages/common/src/editors/floatEditor.ts
@@ -2,7 +2,7 @@ import { KeyCode } from '../enums/index';
 import { EditorArguments, EditorValidationResult } from '../interfaces/index';
 import { floatValidator } from '../editorValidators/floatValidator';
 import { InputEditor } from './inputEditor';
-import { getDescendantProperty } from '../services/utilities';
+import { getDescendantProperty, toSentenceCase } from '../services/utilities';
 
 const DEFAULT_DECIMAL_PLACES = 0;
 
@@ -28,6 +28,7 @@ export class FloatEditor extends InputEditor {
       this._input.placeholder = placeholder;
       this._input.title = title;
       this._input.step = `${inputStep}`;
+      this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Number Editor`);
       const cellContainer = this.args.container;
       if (cellContainer && typeof cellContainer.appendChild === 'function') {
         cellContainer.appendChild(this._input);

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -1,6 +1,6 @@
 import { KeyCode } from '../enums/keyCode.enum';
 import { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace, } from '../interfaces/index';
-import { getDescendantProperty, setDeepValue } from '../services/utilities';
+import { getDescendantProperty, setDeepValue, toSentenceCase } from '../services/utilities';
 import { textValidator } from '../editorValidators/textValidator';
 import { BindingEventService } from '../services/bindingEvent.service';
 
@@ -92,6 +92,7 @@ export class InputEditor implements Editor {
     this._input.autocomplete = 'off';
     this._input.placeholder = placeholder;
     this._input.title = title;
+    this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`);
     const cellContainer = this.args.container;
     if (cellContainer && typeof cellContainer.appendChild === 'function') {
       cellContainer.appendChild(this._input);

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -2,7 +2,7 @@ import { KeyCode } from '../enums/index';
 import { EditorArguments, EditorValidationResult } from '../interfaces/index';
 import { integerValidator } from '../editorValidators/integerValidator';
 import { InputEditor } from './inputEditor';
-import { getDescendantProperty } from '../services/utilities';
+import { getDescendantProperty, toSentenceCase } from '../services/utilities';
 
 export class IntegerEditor extends InputEditor {
   constructor(protected readonly args: EditorArguments) {
@@ -26,6 +26,7 @@ export class IntegerEditor extends InputEditor {
       this._input.placeholder = placeholder;
       this._input.title = title;
       this._input.step = `${inputStep}`;
+      this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`);
       const cellContainer = this.args.container;
       if (cellContainer && typeof cellContainer.appendChild === 'function') {
         cellContainer.appendChild(this._input);

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -15,7 +15,7 @@ import {
   SlickGrid,
   SlickNamespace,
 } from '../interfaces/index';
-import { getDescendantProperty, getHtmlElementOffset, getTranslationPrefix, setDeepValue, } from '../services/utilities';
+import { getDescendantProperty, getHtmlElementOffset, getTranslationPrefix, setDeepValue, toSentenceCase, } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { TranslaterService } from '../services/translater.service';
 import { textValidator } from '../editorValidators/textValidator';
@@ -135,6 +135,7 @@ export class LongTextEditor implements Editor {
     this._textareaElm.rows = (compositeEditorOptions && textAreaRows > 3) ? 3 : textAreaRows;
     this._textareaElm.placeholder = placeholder;
     this._textareaElm.title = title;
+    this._textareaElm.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Text Editor`);
     this._wrapperElm.appendChild(this._textareaElm);
 
     const editorFooterElm = document.createElement('div');

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -1,5 +1,5 @@
 import { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace } from '../interfaces/index';
-import { getDescendantProperty, setDeepValue } from '../services/utilities';
+import { getDescendantProperty, setDeepValue, toSentenceCase } from '../services/utilities';
 import { sliderValidator } from '../editorValidators/sliderValidator';
 import { BindingEventService } from '../services/bindingEvent.service';
 
@@ -318,6 +318,7 @@ export class SliderEditor implements Editor {
     inputElm.max = `${maxValue}`;
     inputElm.step = `${step}`;
     inputElm.className = `form-control slider-editor-input editor-${columnId} range ${this._elementRangeInputId}`;
+    inputElm.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`);
 
     const divContainerElm = document.createElement('div');
     divContainerElm.className = 'slider-container slider-editor';

--- a/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
@@ -67,6 +67,13 @@ describe('CompoundInputFilter', () => {
     expect(filter.inputType).toBe('text');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-duration input') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
+  });
+
   it('should have a placeholder when defined in its column definition', () => {
     const testValue = 'test placeholder';
     mockColumn.filter!.placeholder = testValue;
@@ -75,6 +82,7 @@ describe('CompoundInputFilter', () => {
     const filterInputElm = divContainer.querySelector('.search-filter.filter-duration input') as HTMLInputElement;
 
     expect(filterInputElm.placeholder).toBe(testValue);
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
   });
 
   it('should call "setValues" and expect that value to be in the callback when triggered', () => {

--- a/packages/common/src/filters/__tests__/compoundInputNumberFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputNumberFilter.spec.ts
@@ -54,6 +54,13 @@ describe('CompoundInputNumberFilter', () => {
     expect(() => filter.init(null as any)).toThrowError('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-duration input') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
+  });
+
   it('should initialize the filter and expect an input of type number', () => {
     filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('.search-filter.filter-duration').length;

--- a/packages/common/src/filters/__tests__/compoundInputPasswordFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputPasswordFilter.spec.ts
@@ -54,6 +54,13 @@ describe('CompoundInputPasswordFilter', () => {
     expect(() => filter.init(null as any)).toThrowError('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-duration input') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
+  });
+
   it('should initialize the filter and expect an input of type password', () => {
     filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('.search-filter.filter-duration').length;

--- a/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
@@ -66,6 +66,13 @@ describe('CompoundSliderFilter', () => {
     expect(filterCount).toBe(1);
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('.input-group.search-filter.filter-duration input') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
+  });
+
   it('should call "setValues" with "operator" set in the filter arguments and expect that value to be in the callback when triggered', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
     const filterArgs = { ...filterArguments, operator: '>' } as FilterArguments;

--- a/packages/common/src/filters/__tests__/inputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputFilter.spec.ts
@@ -59,6 +59,13 @@ describe('InputFilter', () => {
     expect(filter.inputType).toBe('text');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
+  });
+
   it('should have a placeholder when defined in its column definition', () => {
     const testValue = 'test placeholder';
     mockColumn.filter!.placeholder = testValue;

--- a/packages/common/src/filters/__tests__/inputMaskFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputMaskFilter.spec.ts
@@ -64,6 +64,14 @@ describe('InputMaskFilter', () => {
     expect(filter.inputMask).toBe('000-000-0000');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    mockColumn.filter!.params = { mask: '000-000-0000' };
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('input.filter-mask') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Mask Search Filter');
+  });
+
   it('should initialize the filter and define the mask in the column definition instead and get the same output', () => {
     mockColumn.params = { mask: '000-000-0000' };
     filter.init(filterArguments);

--- a/packages/common/src/filters/__tests__/inputNumberFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputNumberFilter.spec.ts
@@ -50,6 +50,13 @@ describe('InputNumberFilter', () => {
     expect(() => filter.init(null as any)).toThrowError('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('input.filter-number') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Number Search Filter');
+  });
+
   it('should initialize the filter and expect an input of type number', () => {
     filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('input.filter-number').length;

--- a/packages/common/src/filters/__tests__/inputPasswordFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputPasswordFilter.spec.ts
@@ -32,7 +32,7 @@ describe('InputPasswordFilter', () => {
     document.body.appendChild(divContainer);
     spyGetHeaderRow = jest.spyOn(gridStub, 'getHeaderRowColumn').mockReturnValue(divContainer);
 
-    mockColumn = { id: 'password', field: 'password', filterable: true, filter: { model: Filters.inputPassword } };
+    mockColumn = { id: 'passwordField', field: 'password', filterable: true, filter: { model: Filters.inputPassword } };
     filterArguments = {
       grid: gridStub,
       columnDef: mockColumn,
@@ -50,9 +50,16 @@ describe('InputPasswordFilter', () => {
     expect(() => filter.init(null as any)).toThrowError('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('input.filter-passwordField') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Password Field Search Filter');
+  });
+
   it('should initialize the filter and expect an input of type password', () => {
     filter.init(filterArguments);
-    const filterCount = divContainer.querySelectorAll('input.filter-password').length;
+    const filterCount = divContainer.querySelectorAll('input.filter-passwordField').length;
 
     expect(spyGetHeaderRow).toHaveBeenCalled();
     expect(filterCount).toBe(1);

--- a/packages/common/src/filters/__tests__/nativeSelectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/nativeSelectFilter.spec.ts
@@ -115,6 +115,14 @@ describe('NativeSelectFilter', () => {
     expect(filterCount).toBe(1);
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    mockColumn.filter!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('select.form-control.search-filter.filter-gender') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Gender Search Filter');
+  });
+
   it('should trigger select change event and expect the callback to be called with the search terms we select from dropdown list', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
     mockColumn.filter!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];

--- a/packages/common/src/filters/__tests__/sliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/sliderFilter.spec.ts
@@ -58,6 +58,13 @@ describe('SliderFilter', () => {
     expect(filterCount).toBe(1);
   });
 
+  it('should have an aria-label when creating the filter', () => {
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('.search-filter.slider-container.filter-duration input') as HTMLInputElement;
+
+    expect(filterInputElm.getAttribute('aria-label')).toBe('Duration Search Filter');
+  });
+
   it('should call "setValues" and expect that value to be in the callback when triggered', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 

--- a/packages/common/src/filters/compoundInputFilter.ts
+++ b/packages/common/src/filters/compoundInputFilter.ts
@@ -12,7 +12,7 @@ import {
   SlickGrid,
 } from '../interfaces/index';
 import { buildSelectOperator } from './filterUtilities';
-import { emptyElement, getTranslationPrefix, mapOperatorToShorthandDesignation } from '../services/utilities';
+import { emptyElement, getTranslationPrefix, mapOperatorToShorthandDesignation, toSentenceCase } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { TranslaterService } from '../services/translater.service';
 
@@ -166,6 +166,7 @@ export class CompoundInputFilter implements Filter {
     inputElm.autocomplete = 'off';
     inputElm.placeholder = placeholder;
     inputElm.setAttribute('role', 'presentation');
+    inputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
 
     return inputElm;
   }

--- a/packages/common/src/filters/compoundSliderFilter.ts
+++ b/packages/common/src/filters/compoundSliderFilter.ts
@@ -12,7 +12,7 @@ import {
 import { Constants } from '../constants';
 import { OperatorString, OperatorType, SearchTerm } from '../enums/index';
 import { buildSelectOperator } from './filterUtilities';
-import { emptyElement, getTranslationPrefix, mapOperatorToShorthandDesignation } from '../services/utilities';
+import { emptyElement, getTranslationPrefix, mapOperatorToShorthandDesignation, toSentenceCase } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { TranslaterService } from '../services/translater.service';
 
@@ -257,6 +257,7 @@ export class CompoundSliderFilter implements Filter {
     this.filterInputElm.max = `${maxValue}`;
     this.filterInputElm.step = `${step}`;
     this.filterInputElm.name = this._elementRangeInputId;
+    this.filterInputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
 
     const divContainerFilterElm = document.createElement('div');
     divContainerFilterElm.className = `form-group search-filter slider-container filter-${columnId}`;

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -9,7 +9,7 @@ import {
 } from '../interfaces/index';
 import { OperatorType, OperatorString, SearchTerm } from '../enums/index';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { emptyElement } from '../services';
+import { emptyElement, toSentenceCase } from '../services';
 
 export class InputFilter implements Filter {
   protected _bindEventService: BindingEventService;
@@ -198,6 +198,7 @@ export class InputFilter implements Filter {
     inputElm.className = `form-control search-filter filter-${columnId}`;
     inputElm.autocomplete = 'off';
     inputElm.placeholder = placeholder;
+    inputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
     inputElm.setAttribute('role', 'presentation');
 
     inputElm.value = (searchTerm ?? '') as string;

--- a/packages/common/src/filters/nativeSelectFilter.ts
+++ b/packages/common/src/filters/nativeSelectFilter.ts
@@ -8,7 +8,7 @@ import {
   SlickGrid,
 } from '../interfaces/index';
 import { OperatorType, OperatorString, SearchTerm } from '../enums/index';
-import { emptyElement } from '../services/utilities';
+import { emptyElement, toSentenceCase } from '../services/utilities';
 import { TranslaterService } from '../services/translater.service';
 import { BindingEventService } from '../services/bindingEvent.service';
 
@@ -144,6 +144,7 @@ export class NativeSelectFilter implements Filter {
   buildFilterSelectFromCollection(collection: any[]): HTMLSelectElement {
     const columnId = this.columnDef?.id ?? '';
     const selectElm = document.createElement('select');
+    selectElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
     selectElm.className = `form-control search-filter filter-${columnId}`;
 
     const labelName = this.columnFilter.customStructure?.label ?? 'label';

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -7,7 +7,7 @@ import {
   FilterCallback,
   SlickGrid,
 } from './../interfaces/index';
-import { emptyElement } from '../services/utilities';
+import { emptyElement, toSentenceCase } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
 
 const DEFAULT_MIN_VALUE = 0;
@@ -188,6 +188,7 @@ export class SliderFilter implements Filter {
     this.filterInputElm.max = `${maxValue}`;
     this.filterInputElm.step = `${step}`;
     this.filterInputElm.name = this._elementRangeInputId;
+    this.filterInputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
 
     const divContainerFilterElm = document.createElement('div');
     divContainerFilterElm.className = `search-filter slider-container filter-${columnId}`;

--- a/packages/common/src/interfaces/columnEditor.interface.ts
+++ b/packages/common/src/interfaces/columnEditor.interface.ts
@@ -17,6 +17,9 @@ export interface ColumnEditor {
    */
   alwaysSaveOnEnterKey?: boolean;
 
+  /** Optionally provide an aria-label for assistive scren reader, defaults to "{inputName} Input Editor" */
+  ariaLabel?: string;
+
   /**
    * Some Editor could support callbacks from their jQuery instance (for now only AutoComplete supports this), for example:
    * editor: { model:{ Editors.autoComplete }, callbacks: { _renderItem: (ul, item) => { ... } }}

--- a/packages/common/src/interfaces/columnFilter.interface.ts
+++ b/packages/common/src/interfaces/columnFilter.interface.ts
@@ -12,6 +12,9 @@ import {
 import { Observable, Subject } from '../services/rxjsFacade';
 
 export interface ColumnFilter {
+  /** Optionally provide an aria-label for assistive scren reader, defaults to "{inputName} Search Filter" */
+  ariaLabel?: string;
+
   /** Do we want to bypass the Backend Query? Commonly used with an OData Backend Service, if we want to filter without calling the regular OData query. */
   bypassBackendQuery?: boolean;
 

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -40,6 +40,7 @@ import {
   titleCase,
   toCamelCase,
   toKebabCase,
+  toSentenceCase,
   toSnakeCase,
   unsubscribeAll,
   uniqueArray,
@@ -1460,6 +1461,37 @@ describe('Service/Utilies', () => {
     it('should return a kebab-case string when input is a sentence that may include numbers with only following char having the dash', () => {
       const output = toKebabCase(sentence + ' 123 ' + ' apples');
       expect(output).toBe('the-quick-brown-fox123-apples');
+    });
+  });
+
+  describe('toSentenceCase method', () => {
+    const camelCaseSentence = 'theQuickBrownFox';
+    const kebabCaseSentence = 'the-quick-brown-fox';
+
+    it('should return empty string when input is empty', () => {
+      const output = toSentenceCase('');
+      expect(output).toBe('');
+    });
+
+    it('should return empty string when input is null', () => {
+      const input = null as any;
+      const output = toSentenceCase(input);
+      expect(output).toBe(null as any);
+    });
+
+    it('should return a sentence case (as Title Case) string when input is camelCase type', () => {
+      const output = toSentenceCase(camelCaseSentence);
+      expect(output).toBe('The Quick Brown Fox');
+    });
+
+    it('should return a sentence case string when input is kebab-case type', () => {
+      const output = toSentenceCase(kebabCaseSentence);
+      expect(output).toBe('The quick brown fox');
+    });
+
+    it('should return a sentence case string when input is a sentence that may include numbers and extra spaces', () => {
+      const output = toSentenceCase(kebabCaseSentence + ' 123 ' + '  apples  ');
+      expect(output).toBe('The quick brown fox 123 apples');
     });
   });
 

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -990,6 +990,19 @@ export function toKebabCase(inputStr: string): string {
 }
 
 /**
+ * Converts a camelCase or kebab-case string to a sentence case, for example "helloWorld" will become "Hello World" and "hello-world" will become "Hello world"
+ * @param str the string to convert
+ * @return the string in kebab case
+ */
+export function toSentenceCase(inputStr: string): string {
+  if (typeof inputStr === 'string') {
+    const result = inputStr.replace(/([A-Z])|(\-)/g, ' $1').replace(/\s+/g, ' ').trim();
+    return result.charAt(0).toUpperCase() + result.slice(1);
+  }
+  return inputStr;
+}
+
+/**
  * Uses the logic function to find an item in an array or returns the default
  * value provided (empty object by default)
  * @param any[] array the array to filter

--- a/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
@@ -1,3 +1,4 @@
+import 'jest-extended';
 import {
   Column,
   CompositeEditorOpenDetailOption,
@@ -703,12 +704,15 @@ describe('CompositeEditorService', () => {
 
       const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterCancelBtnElm = compositeContainerElm.querySelector('.btn-cancel') as HTMLSelectElement;
+      const compositeFooterCloseBtnElm = compositeContainerElm.querySelector('.close') as HTMLSelectElement;
       compositeFooterCancelBtnElm.click();
 
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(compositeContainerElm).toBeTruthy();
       expect(compositeFooterCancelBtnElm).toBeTruthy();
+      expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Cancel');
+      expect(compositeFooterCloseBtnElm.getAttribute('aria-label')).toBe('Close');
       expect(getEditSpy).toHaveBeenCalled();
       expect(cancelSpy).toHaveBeenCalled();
     });
@@ -798,6 +802,8 @@ describe('CompositeEditorService', () => {
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeHeaderElm).toBeTruthy();
         expect(compositeTitleElm).toBeTruthy();
+        expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Cancel');
+        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Clone');
         expect(compositeTitleElm.textContent).toBe('Details');
         expect(productNameLabelElm.textContent).toBe('Product');
         expect(productNameDetailCellElm.classList.contains('modified')).toBe(true);
@@ -1062,6 +1068,7 @@ describe('CompositeEditorService', () => {
         expect(component).toBeTruthy();
         expect(input1ResetButtonElm).toBeTruthy();
         expect(input2ResetButtonElm).toBeTruthy();
+        expect(input1ResetButtonElm.getAttribute('aria-label')).toBe('Reset');
         expect(component.constructor).toBeDefined();
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeHeaderElm).toBeTruthy();
@@ -1499,10 +1506,13 @@ describe('CompositeEditorService', () => {
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
+        const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
 
         expect(component).toBeTruthy();
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeTitleElm.textContent).toBe('Mass Update');
+        expect(compositeFooterSaveBtnElm.textContent).toBe('Mass Update');
+        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Mass Update');
       });
 
       it('should expect to have a header title & modal type representing "mass-selection" when using "auto-mass" type and having some row(s) selected', () => {
@@ -1517,10 +1527,13 @@ describe('CompositeEditorService', () => {
         const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
+        const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
 
         expect(component).toBeTruthy();
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeTitleElm.textContent).toBe('Mass Selection');
+        expect(compositeFooterSaveBtnElm.textContent).toBe('Update Selection');
+        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Update Selection');
       });
 
       it('should activate next available cell with an Editor when current active cell does not have an Editor', () => {
@@ -1867,6 +1880,8 @@ describe('CompositeEditorService', () => {
       expect(productNameLabelElm.textContent).toBe('Produit');
       expect(compositeFooterCancelBtnElm.textContent).toBe('Annuler');
       expect(compositeFooterSaveBtnElm.textContent).toBe('Sauvegarder');
+      expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Annuler');
+      expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Sauvegarder');
     });
 
     it('should have translate text when opening Composite Editor when cloning an Item', () => {
@@ -1899,6 +1914,7 @@ describe('CompositeEditorService', () => {
       expect(productNameLabelElm.textContent).toBe('Produit');
       expect(compositeFooterCancelBtnElm.textContent).toBe('Annuler');
       expect(compositeFooterSaveBtnElm.textContent).toBe('Cloner');
+      expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Cloner');
     });
 
     it('should have translated text when handling a saving of grid changes when "Mass Selection" save button is clicked', (done) => {
@@ -1942,7 +1958,9 @@ describe('CompositeEditorService', () => {
         expect(compositeTitleElm.textContent).toBe('Details');
         expect(field3LabelElm.textContent).toBe('Nom du Groupe - Durée');
         expect(compositeFooterCancelBtnElm.textContent).toBe('Annuler');
+        expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Annuler');
         expect(compositeFooterSaveBtnElm.textContent).toBe('Mettre à jour la sélection');
+        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Mettre à jour la sélection');
         expect(updateItemsSpy).toHaveBeenCalledWith([mockProduct]);
         expect(cancelCommitSpy).toHaveBeenCalled();
         expect(setActiveRowSpy).toHaveBeenCalledWith(0);

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -380,7 +380,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         modalCloseButtonElm.textContent = '×';
         modalCloseButtonElm.className = 'close';
         modalCloseButtonElm.dataset.action = 'close';
-        modalCloseButtonElm.dataset.ariaLabel = 'Close';
+        modalCloseButtonElm.setAttribute('aria-label', 'Close');
         if (this._options.showCloseButtonOutside) {
           modalHeaderTitleElm?.classList?.add('outside');
           modalCloseButtonElm?.classList?.add('outside');
@@ -388,6 +388,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
 
         const modalHeaderElm = document.createElement('div');
         modalHeaderElm.className = 'slick-editor-modal-header';
+        modalHeaderElm.setAttribute('aria-label', 'Close');
         modalHeaderElm.appendChild(modalHeaderTitleElm);
         modalHeaderElm.appendChild(modalCloseButtonElm);
 
@@ -406,7 +407,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         modalCancelButtonElm.type = 'button';
         modalCancelButtonElm.className = 'btn btn-cancel btn-default btn-sm';
         modalCancelButtonElm.dataset.action = 'cancel';
-        modalCancelButtonElm.dataset.ariaLabel = this.getLabelText('cancelButton', 'TEXT_CANCEL', 'Cancel');
+        modalCancelButtonElm.setAttribute('aria-label', this.getLabelText('cancelButton', 'TEXT_CANCEL', 'Cancel'));
         modalCancelButtonElm.textContent = this.getLabelText('cancelButton', 'TEXT_CANCEL', 'Cancel');
 
         let leftFooterText = '';
@@ -439,6 +440,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         this._modalSaveButtonElm.dataset.action = (modalType === 'create' || modalType === 'edit') ? 'save' : modalType;
         this._modalSaveButtonElm.dataset.ariaLabel = saveButtonText;
         this._modalSaveButtonElm.textContent = saveButtonText;
+        this._modalSaveButtonElm.setAttribute('aria-label', saveButtonText);
 
         const footerContainerElm = document.createElement('div');
         footerContainerElm.className = 'footer-buttons';
@@ -651,6 +653,8 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     resetButtonElm.name = columnId;
     resetButtonElm.title = this._options?.labels?.resetFormButton ?? 'Reset Form Input';
     resetButtonElm.className = 'btn btn-xs btn-editor-reset';
+    resetButtonElm.setAttribute('aria-label', 'Reset');
+
     if (this._options?.resetEditorButtonCssClass) {
       const resetBtnClasses = this._options?.resetEditorButtonCssClass.split(' ');
       for (const cssClass of resetBtnClasses) {

--- a/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
@@ -106,7 +106,7 @@ describe('Slick-Pagination Component', () => {
       const pageInfoTotalItems = document.querySelector('.page-info-total-items') as HTMLSpanElement;
 
       expect(translateService.getCurrentLanguage()).toBe('en');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span data-test="item-from" class="item-from">10</span>-<span data-test="item-to" class="item-to">15</span><span class="text-of">of</span>');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span data-test="item-from" class="item-from" aria-label="Page Item From">10</span>-<span data-test="item-to" class="item-to" aria-label="Page Item To">15</span><span class="text-of">of</span>');
       expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items" class="total-items">95</span><span class="text-items">items</span>');
       component.dispose();
     });

--- a/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
@@ -96,7 +96,7 @@ describe('Slick-Pagination Component', () => {
       const itemsPerPage = document.querySelector('.items-per-page') as HTMLSelectElement;
 
       expect(translateService.getCurrentLanguage()).toBe('en');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span data-test="item-from" class="item-from">10</span>-<span data-test="item-to" class="item-to">15</span><span class="text-of">of</span>');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span data-test="item-from" class="item-from" aria-label="Page Item From">10</span>-<span data-test="item-to" class="item-to" aria-label="Page Item To">15</span><span class="text-of">of</span>');
       expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items" class="total-items">95</span><span class="text-items">items</span>');
       expect(itemsPerPage.selectedOptions[0].value).toBe('5');
     });
@@ -262,7 +262,7 @@ describe('with different i18n locale', () => {
       const pageInfoFromTo = document.querySelector('.page-info-from-to') as HTMLSpanElement;
       const pageInfoTotalItems = document.querySelector('.page-info-total-items') as HTMLSpanElement;
       expect(translateService.getCurrentLanguage()).toBe('fr');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span data-test="item-from" class="item-from">10</span>-<span data-test="item-to" class="item-to">15</span><span class="text-of">de</span>`);
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span data-test="item-from" class="item-from" aria-label="Page Item From">10</span>-<span data-test="item-to" class="item-to" aria-label="Page Item To">15</span><span class="text-of">de</span>`);
       expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe(`<span data-test="total-items" class="total-items">95</span><span class="text-items">éléments</span>`);
       done();
     }, 50);

--- a/packages/pagination-component/src/slick-pagination.component.html
+++ b/packages/pagination-component/src/slick-pagination.component.html
@@ -4,38 +4,40 @@
       <nav aria-label="Page navigation">
         <ul class="pagination">
           <li class="page-item seek-first">
-            <a class="page-link icon-seek-first" aria-label="First"></a>
+            <a class="page-link icon-seek-first" aria-label="First Page"></a>
           </li>
           <li class="page-item seek-prev">
-            <a class="page-link icon-seek-prev" aria-label="Previous"></a>
+            <a class="page-link icon-seek-prev" aria-label="Previous Page"></a>
           </li>
         </ul>
       </nav>
 
       <div class="slick-page-number">
         <span class="text-page">Page</span>
-        <input type="text" class="form-control page-number" data-test="page-number-input" value="1" size="1">
+        <input type="text" class="form-control page-number" data-test="page-number-input" aria-label="Page Number"
+               value="1" size="1">
         <span class="text-of">of</span> <span class="page-count" data-test="page-count"></span>
       </div>
 
       <nav aria-label="Page navigation">
         <ul class="pagination">
           <li class="page-item seek-next">
-            <a class="page-link icon-seek-next" aria-label="Next"></a>
+            <a class="page-link icon-seek-next" aria-label="Next Page"></a>
           </li>
           <li class="page-item seek-end">
-            <a class="page-link icon-seek-end" aria-label="Last"></a>
+            <a class="page-link icon-seek-end" aria-label="Last Page"></a>
           </li>
         </ul>
       </nav>
     </div>
     <span class="slick-pagination-settings">
-      <select id="items-per-page-label" class="items-per-page" value="">
+      <select id="items-per-page-label" aria-label="Items per Page Select" class="items-per-page" value="">
       </select>
       <span class="text-item-per-page">items per page</span>,
       <span class="slick-pagination-count">
         <span class="page-info-from-to">
-          <span data-test="item-from" class="item-from"></span>-<span data-test="item-to" class="item-to"></span>
+          <span data-test="item-from" class="item-from" aria-label="Page Item From"></span>-<span data-test="item-to"
+                class="item-to" aria-label="Page Item To"></span>
           <span class="text-of">of</span>
         </span>
         <span class="page-info-total-items">


### PR DESCRIPTION
- for Editors & Filters we can also provide an optional `ariaLabel` directly from its definition (e.g.: `filter: { ariaLabel: 'Duration Filter', model: Filters.slider }`)
- this will help assistive screen reader, it could eventually be enhanced with translated values for now that will do. This is new to me, so I might be wrong in some areas.