### PR TITLE
fix(formatters): Complex Object Formatter shouldn't throw with null data

### DIFF
--- a/packages/common/src/formatters/__tests__/complexObjectFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/complexObjectFormatter.spec.ts
@@ -2,7 +2,7 @@ import { Column } from '../../interfaces/index';
 import { complexObjectFormatter } from '../complexObjectFormatter';
 
 describe('the ComplexObject Formatter', () => {
-  const allRoles = [{ roleId: 0, name: 'Administrator' }, { roleId: 1, name: 'Regular User', empty: {} }];
+  const allRoles = [{ roleId: 0, name: 'Administrator' }, { roleId: 1, name: 'Regular User', empty: {}, nullable: null }];
 
   const dataset = [
     { id: 0, firstName: 'John', lastName: 'Smith', email: 'john.smith@movie.com', role: allRoles[0] },
@@ -16,7 +16,7 @@ describe('the ComplexObject Formatter', () => {
   });
 
   it('should return empty string when no column definition is provided', () => {
-    const result = complexObjectFormatter(0, 0, 'anything', null as Column, {}, {} as any);
+    const result = complexObjectFormatter(0, 0, 'anything', null as any, {}, {} as any);
     expect(result).toBe('');
   });
 
@@ -48,9 +48,15 @@ describe('the ComplexObject Formatter', () => {
     expect(result).toBe(expectedOutput);
   });
 
-  it('should return an empty string when the value from the complex object when "field" has dot notation and the empty returned from it is an empty object', () => {
+  it('should return an empty string when the value from the complex object when "field" has dot notation and the property returned from it is an empty object', () => {
     const expectedOutput = '';
     const result = complexObjectFormatter(0, 0, 'anything', { field: 'role.empty' } as Column, dataset[1], {} as any);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('should return an empty string when the value from the complex object when "field" has dot notation and the property returned from it is a null value', () => {
+    const expectedOutput = '';
+    const result = complexObjectFormatter(0, 0, 'anything', { field: 'role.nullable' } as Column, dataset[1], {} as any);
     expect(result).toBe(expectedOutput);
   });
 

--- a/packages/common/src/formatters/complexObjectFormatter.ts
+++ b/packages/common/src/formatters/complexObjectFormatter.ts
@@ -32,7 +32,7 @@ export const complexObjectFormatter: Formatter = (_row, _cell, cellValue, column
   // however we also need to make sure that the complex objet exist, else we'll return the cell value (original value)
   if (typeof complexField === 'string' && complexField.indexOf('.') > 0) {
     let outputValue = complexField.split('.').reduce((obj, i) => (obj?.hasOwnProperty(i) ? obj[i] : ''), dataContext);
-    if (typeof outputValue === 'object' && Object.entries(outputValue).length === 0 && !(outputValue instanceof Date)) {
+    if (outputValue === undefined || outputValue === null || (typeof outputValue === 'object' && Object.entries(outputValue).length === 0 && !(outputValue instanceof Date))) {
       outputValue = ''; // return empty string when value ends up being an empty object
     }
     return outputValue;


### PR DESCRIPTION
fixes a bug that was reported in this Stack Overflow question _[angular slick grid complex object with nullable string
](https://stackoverflow.com/questions/68449432/angular-slick-grid-complex-object-with-nullable-string)_