### PR TITLE
fix(tree): exclude the correct type from interface argument

### DIFF
--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -114,7 +114,7 @@ export class TreeDataService {
    * @param {Boolean} shouldPreProcessFullToggle - should we pre-process a full toggle on all items? defaults to True
    * @param {Boolean} shouldTriggerEvent - should we trigger a toggled item event? defaults to False
    */
-  applyToggledItemStateChanges(treeToggledItems: TreeToggledItem[], previousFullToggleType?: Exclude<ToggleStateChangeType, 'toggle'> | Exclude<ToggleStateChangeTypeString, 'toggle'>, shouldPreProcessFullToggle = true, shouldTriggerEvent = false) {
+  applyToggledItemStateChanges(treeToggledItems: TreeToggledItem[], previousFullToggleType?: Exclude<ToggleStateChangeType, 'toggle-collapse' | 'toggle-expand'> | Exclude<ToggleStateChangeTypeString, 'toggle-collapse' | 'toggle-expand'>, shouldPreProcessFullToggle = true, shouldTriggerEvent = false) {
     if (Array.isArray(treeToggledItems)) {
       const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');
       const hasChildrenPropName = this.getTreeDataOptionPropName('hasChildrenPropName');


### PR DESCRIPTION
- at some point in time the `exclude` got split and renamed into 2 new types to better identify if it's collapsed or expanded, so the 2 types are: `toggle-expand` and `toggle-collapse` but it seems that TypeScript is not able to identify when the type to exclude is valid or not.