### PR TITLE
refactor: add 10ms delay on 1st resize so it's after grid render

### DIFF
--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -148,7 +148,8 @@ export class ResizerService {
     }
 
     // -- 1st resize the datagrid size at first load (we need this because the .on event is not triggered on first load)
-    this.resizeGrid()
+    // -- also we add a slight delay (in ms) so that we resize after the grid render is done
+    this.resizeGrid(10, newSizes)
       .then(() => this.resizeGridWhenStylingIsBrokenUntilCorrected())
       .catch((rejection: any) => console.log('Error:', rejection));
 


### PR DESCRIPTION
- hopefully helps in fixing blank data shown in Angular-Slickgrid