### PR TITLE
feat(backend): add cancellable onBeforeSearchChange & revert on error

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example09.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example09.html
@@ -9,6 +9,11 @@
   </div>
 </h3>
 
+<h6 class="title is-6 italic">
+  NOTE: The last column (filter & sort) will always throw an error and its only purpose is to demo what would happen
+  when you encounter a backend server error (the UI should rollback to previous state before you did the action).
+</h6>
+
 <div class="row">
   <button class="button is-small" data-test="clear-filters-sorting"
           onclick.delegate="clearAllFiltersAndSorts()" title="Clear all Filters & Sorts">

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example09.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example09.ts
@@ -36,9 +36,14 @@ export class Example09 {
     // this._bindingEventService.bind(gridContainerElm, 'onafterexporttoexcel', () => console.log('onAfterExportToExcel'));
     this.sgb = new Slicker.GridBundle(gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, []);
 
-    // you can optionally cancel the sort for whatever reason
+    // you can optionally cancel the Sort, Filter
     // this._bindingEventService.bind(gridContainerElm, 'onbeforesort', (e) => {
     //   e.preventDefault();
+    //   return false;
+    // });
+    // this._bindingEventService.bind(gridContainerElm, 'onbeforesearchchange', (e) => {
+    //   e.preventDefault();
+    //   this.sgb.filterService.resetToPreviousSearchFilters(); // optionally reset filter input value
     //   return false;
     // });
   }
@@ -75,7 +80,7 @@ export class Example09 {
           collection: [{ value: '', label: '' }, { value: 'male', label: 'male' }, { value: 'female', label: 'female' }]
         }
       },
-      { id: 'company', name: 'Company', field: 'company', sortable: true },
+      { id: 'company', name: 'Company', field: 'company', filterable: true, sortable: true },
     ];
 
     this.gridOptions = {
@@ -116,7 +121,8 @@ export class Example09 {
           enableCount: this.isCountEnabled, // add the count in the OData query, which will return a property named "odata.count" (v2) or "@odata.count" (v4)
           version: this.odataVersion        // defaults to 2, the query string is slightly different between OData 2 and 4
         },
-        onError: () => {
+        onError: (error: Error) => {
+          this.errorStatus = error.message;
           this.errorStatusClass = 'visible notification is-light is-danger is-small is-narrow';
           this.displaySpinner(false, true);
         },
@@ -175,7 +181,6 @@ export class Example09 {
    *  in your case the getCustomer() should be a WebAPI function returning a Promise
    */
   getCustomerDataApiMock(query): Promise<any> {
-    this.errorStatus = '';
     this.errorStatusClass = 'hidden';
 
     // the mock is returning a Promise, just like a WebAPI typically does
@@ -226,14 +231,17 @@ export class Example09 {
             const fieldName = filterMatch[1].trim();
             columnFilters[fieldName] = { type: 'ends', term: filterMatch[2].trim() };
           }
+
+          // simular a backend error when trying to sort on the "Company" field
+          if (filterBy.includes('company')) {
+            throw new Error('Cannot filter by the field "Company"');
+          }
         }
       }
 
       // simular a backend error when trying to sort on the "Company" field
       if (orderBy.includes('company')) {
-        const errorMsg = 'Cannot sort by the field "Company"';
-        this.errorStatus = errorMsg;
-        throw new Error(errorMsg);
+        throw new Error('Cannot sort by the field "Company"');
       }
 
       const sort = orderBy.includes('asc')

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example15.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example15.html
@@ -9,6 +9,11 @@
   </div>
 </h3>
 
+<h6 class="title is-6 italic">
+  NOTE: The last column (filter & sort) will always throw an error and its only purpose is to demo what would happen
+  when you encounter a backend server error (the UI should rollback to previous state before you did the action).
+</h6>
+
 <div class="row">
   <button class="button is-small" data-test="clear-filters-sorting"
           onclick.delegate="clearAllFiltersAndSorts()" title="Clear all Filters & Sorts">

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example15.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example15.ts
@@ -83,7 +83,7 @@ export class Example15 {
           }
         }
       },
-      { id: 'company', name: 'Company', field: 'company', sortable: true },
+      { id: 'company', name: 'Company', field: 'company', filterable: true, sortable: true },
     ];
 
     this.gridOptions = {
@@ -129,7 +129,8 @@ export class Example15 {
           enableCount: this.isCountEnabled, // add the count in the OData query, which will return a property named "odata.count" (v2) or "@odata.count" (v4)
           version: this.odataVersion        // defaults to 2, the query string is slightly different between OData 2 and 4
         },
-        onError: () => {
+        onError: (error: Error) => {
+          this.errorStatus = error.message;
           this.errorStatusClass = 'visible notification is-light is-danger is-small is-narrow';
           this.displaySpinner(false, true);
         },
@@ -265,14 +266,17 @@ export class Example15 {
             const fieldName = filterMatch[1].trim();
             columnFilters[fieldName] = { type: 'ends', term: filterMatch[2].trim() };
           }
+
+          // simular a backend error when trying to sort on the "Company" field
+          if (filterBy.includes('company')) {
+            throw new Error('Cannot filter by the field "Company"');
+          }
         }
       }
 
       // simular a backend error when trying to sort on the "Company" field
       if (orderBy.includes('company')) {
-        const errorMsg = 'Cannot sort by the field "Company"';
-        this.errorStatus = errorMsg;
-        throw new Error(errorMsg);
+        throw new Error('Cannot sort by the field "Company"');
       }
 
       const sort = orderBy.includes('asc')

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -565,7 +565,11 @@ describe('FilterService', () => {
         gridOptionMock.backendServiceApi!.onError = () => jest.fn();
         const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         const spyOnError = jest.spyOn(gridOptionMock.backendServiceApi as BackendServiceApi, 'onError');
+        const updateFilterSpy = jest.spyOn(service, 'updateFilters');
         jest.spyOn(gridOptionMock.backendServiceApi as BackendServiceApi, 'process');
+
+        // get previous filters before calling the query that will fail
+        const previousFilters = service.getPreviousFilters();
 
         service.clearFilters();
         expect(pubSubSpy).toHaveBeenCalledWith(`onBeforeFilterClear`, true, 0);
@@ -573,6 +577,7 @@ describe('FilterService', () => {
         setTimeout(() => {
           expect(pubSubSpy).toHaveBeenCalledWith(`onFilterCleared`, true);
           expect(spyOnError).toHaveBeenCalledWith(errorExpected);
+          expect(updateFilterSpy).toHaveBeenCalledWith(previousFilters, false, false, false);
           done();
         });
       });
@@ -970,7 +975,7 @@ describe('FilterService', () => {
     });
 
     it('should throw an error when grid argument is an empty object', (done) => {
-      service.onBackendFilterChange(undefined as any, {}).catch((error) => {
+      service.onBackendFilterChange(undefined as any, {} as any).catch((error) => {
         expect(error.message).toContain(`Something went wrong when trying to bind the "onBackendFilterChange(event, args)" function`);
         done();
       });
@@ -979,7 +984,7 @@ describe('FilterService', () => {
     it('should throw an error when backendServiceApi is undefined', (done) => {
       gridOptionMock.backendServiceApi = undefined;
 
-      service.onBackendFilterChange(undefined as any, { grid: gridStub }).catch((error) => {
+      service.onBackendFilterChange(undefined as any, { grid: gridStub } as any).catch((error) => {
         expect(error.message).toContain(`BackendServiceApi requires at least a "process" function and a "service" defined`);
         done();
       });
@@ -989,7 +994,7 @@ describe('FilterService', () => {
       const spy = jest.spyOn(gridOptionMock.backendServiceApi as BackendServiceApi, 'preProcess');
 
       service.init(gridStub);
-      service.onBackendFilterChange(undefined as any, { grid: gridStub });
+      service.onBackendFilterChange(undefined as any, { grid: gridStub } as any);
 
       expect(spy).toHaveBeenCalled();
     });

--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -28,10 +28,11 @@ describe('EventPubSub Service', () => {
       const dispatchSpy = jest.spyOn(service, 'dispatchCustomEvent');
       const getEventNameSpy = jest.spyOn(service, 'getEventNameByNamingConvention');
 
-      service.publish('onClick', { name: 'John' });
+      const publishResult = service.publish('onClick', { name: 'John' });
 
+      expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, false);
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true);
     });
 
     it('should call publish method and expect it to return it a simple boolean (without delay argument provided)', () => {
@@ -42,7 +43,7 @@ describe('EventPubSub Service', () => {
 
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, false);
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true);
     });
 
     it('should call publish method and expect it to return it a boolean in a Promise when a delay is provided', async () => {
@@ -53,7 +54,7 @@ describe('EventPubSub Service', () => {
 
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, false);
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true);
     });
 
     it('should define a different event name styling and expect "dispatchCustomEvent" and "getEventNameByNamingConvention" to be called', () => {
@@ -61,10 +62,11 @@ describe('EventPubSub Service', () => {
       const getEventNameSpy = jest.spyOn(service, 'getEventNameByNamingConvention');
 
       service.eventNamingStyle = EventNamingStyle.lowerCase;
-      service.publish('onClick', { name: 'John' });
+      const publishResult = service.publish('onClick', { name: 'John' });
 
+      expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onclick', { name: 'John' }, true, false);
+      expect(dispatchSpy).toHaveBeenCalledWith('onclick', { name: 'John' }, true, true);
     });
   });
 

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -27,9 +27,10 @@ export class EventPubSubService implements PubSubService {
 
   /**
    * Method to publish a message via a dispatchEvent.
-   * We return the dispatched event in a Promise with a delayed cycle and we do this because
-   * most framework require a cycle before the binding is processed and binding a spinner end up showing too late
-   * for example this is used for these events: onBeforeFilterClear, onBeforeFilterChange, onBeforeToggleTreeCollapse, onBeforeSortChange
+   * Return is a Boolean (from the event dispatch) unless a delay is provided if so we'll return the dispatched event in a Promise with a delayed cycle
+   * The delay is rarely use and is only used when we want to make sure that certain events have the time to execute
+   * and we do this because most framework require a cycle before the binding is processed and binding a spinner end up showing too late
+   * for example this is used for the following events: onBeforeFilterClear, onBeforeFilterChange, onBeforeToggleTreeCollapse, onBeforeSortChange
    * @param {String} event - The event or channel to publish to.
    * @param {*} data - The data to publish on the channel.
    * @param {Number} delay - optional argument to delay the publish event
@@ -40,11 +41,11 @@ export class EventPubSubService implements PubSubService {
 
     if (delay) {
       return new Promise(resolve => {
-        const isDispatched = this.dispatchCustomEvent<T>(eventNameByConvention, data, true, false);
+        const isDispatched = this.dispatchCustomEvent<T>(eventNameByConvention, data, true, true);
         setTimeout(() => resolve(isDispatched), delay);
       });
     } else {
-      return this.dispatchCustomEvent<T>(eventNameByConvention, data, true, false);
+      return this.dispatchCustomEvent<T>(eventNameByConvention, data, true, true);
     }
   }
 

--- a/test/cypress/integration/example09.spec.js
+++ b/test/cypress/integration/example09.spec.js
@@ -670,5 +670,46 @@ describe('Example 09 - OData Grid', { retries: 1 }, () => {
           expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(startswith(Name, 'A') and Gender eq 'female')`);
         });
     });
+
+    it('should try the "Company" filter and expect an error to throw and also expect the filter to reset to empty after the error is displayed', () => {
+      cy.get('input.search-filter.filter-company')
+        .type('Core');
+
+      // wait for the query to finish
+      cy.get('[data-test=error-status]').should('contain', 'Cannot filter by the field "Company"');
+      cy.get('[data-test=status]').should('contain', 'ERROR!!');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(startswith(Name, 'A') and Gender eq 'female')`);
+        });
+
+      cy.get('.grid9')
+        .find('.slick-row')
+        .should('have.length', 1);
+    });
+
+    it('should clear the "Name" filter and expect query to be successfull with just 1 filter "Gender" to be filled but without the previous failed filter', () => {
+      cy.get('.grid9')
+        .find('.slick-header-left .slick-header-column:nth(1)')
+        .trigger('mouseover')
+        .children('.slick-header-menubutton')
+        .click();
+
+      cy.get('.slick-header-menu')
+        .should('be.visible')
+        .children('.slick-header-menuitem:nth-child(6)')
+        .children('.slick-header-menucontent')
+        .should('contain', 'Remove Filter')
+        .click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'finished');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+    });
   });
 });

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -773,5 +773,47 @@ describe('Example 15 - OData Grid using RxJS', { retries: 1 }, () => {
           expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(startswith(Name, 'A') and Gender eq 'female')`);
         });
     });
+
+    it('should try the "Company" filter and expect an error to throw and also expect the filter to reset to empty after the error is displayed', () => {
+      cy.get('input.search-filter.filter-company')
+        .type('Core');
+
+      // wait for the query to finish
+      cy.get('[data-test=error-status]').should('contain', 'Cannot filter by the field "Company"');
+      cy.get('[data-test=status]').should('contain', 'ERROR!!');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(startswith(Name, 'A') and Gender eq 'female')`);
+        });
+
+      cy.get('.grid15')
+        .find('.slick-row')
+        .should('have.length', 1);
+    });
+
+    it('should clear the "Name" filter and expect query to be successfull with just 1 filter "Gender" to be filled but without the previous failed filter', () => {
+      cy.get('.grid15')
+        .find('.slick-header-left .slick-header-column:nth(1)')
+        .trigger('mouseover')
+        .children('.slick-header-menubutton')
+        .invoke('show')
+        .click();
+
+      cy.get('.slick-header-menu')
+        .should('be.visible')
+        .children('.slick-header-menuitem:nth-child(6)')
+        .children('.slick-header-menucontent')
+        .should('contain', 'Remove Filter')
+        .click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'finished');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+    });
   });
 });


### PR DESCRIPTION
- this enhancement idea came from this [Discussion](https://github.com/ghiscoding/slickgrid-universal/discussions/337)
- in previous code, if an error happens on the backend server while querying, the search input values would still be changed and we had no clue of the previous value, this PR bring this functionality that if an error occurs it will rollback to previous filter input values.
- this PR also adds the option to prevent bubbling of `onBeforeSearchChange` (a new event) to optionally cancel the search query (the search input value would still be applied because you can't cancel that part but you can call `filterService.resetToPreviousSearchFilters()` to rollback the last search)
- for a demo, you can look at previous PR #463 