### PR TITLE
feat(backend): add cancellable Pagination change & revert on error

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example09.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example09.html
@@ -10,8 +10,10 @@
 </h3>
 
 <h6 class="title is-6 italic">
-  NOTE: The last column (filter & sort) will always throw an error and its only purpose is to demo what would happen
-  when you encounter a backend server error (the UI should rollback to previous state before you did the action).
+  <span class="has-text-danger">NOTE:</span> For demo purposes, the last column (filter & sort) will always throw an
+  error and its only purpose is to demo what would happen when you encounter a backend server error
+  (the UI should rollback to previous state before you did the action).
+  Also changing Page Size to 50,000 will also throw which again is for demo purposes.
 </h6>
 
 <div class="row">
@@ -26,6 +28,11 @@
   <button class="button is-small" data-test="set-dynamic-sorting" onclick.delegate="setSortingDynamically()">
     Set Sorting Dynamically
   </button>
+  <button class="button is-small is-danger is-outlined" style="margin-left: 75px" data-test="throw-page-error-btn"
+          onclick.delegate="throwPageChangeError()">
+    <span>Throw Error Going to Last Page... </span>
+    <i class="mdi mdi-page-last"></i>
+  </button>
 </div>
 
 <br />
@@ -35,10 +42,10 @@
     <span>
       <label>Programmatically go to first/last page:</label>
       <button class="button is-small" data-test="goto-first-page" onclick.delegate="goToFirstPage()">
-        <i class="fa fa-caret-left fa-lg"></i>&lt;
+        <i class="mdi mdi-page-first"></i>
       </button>
       <button class="button is-small" data-test="goto-last-page" onclick.delegate="goToLastPage()">
-        <i class="fa fa-caret-right fa-lg"></i>&gt;
+        <i class="mdi mdi-page-last"></i>
       </button>
     </span>
 

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example15.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example15.html
@@ -10,9 +10,11 @@
 </h3>
 
 <h6 class="title is-6 italic">
-  NOTE: The last column (filter & sort) will always throw an error and its only purpose is to demo what would happen
-  when you encounter a backend server error (the UI should rollback to previous state before you did the action).
-</h6>
+  <span class="has-text-danger">NOTE:</span> For demo purposes, the last column (filter & sort) will always throw an
+  error and its only purpose is to demo what would happen when you encounter a backend server error
+  (the UI should rollback to previous state before you did the action).
+  Also changing Page Size to 50,000 will also throw which again is for demo purposes.
+</h6>s
 
 <div class="row">
   <button class="button is-small" data-test="clear-filters-sorting"
@@ -30,6 +32,11 @@
           onclick.delegate="addOtherGender()" disabled.bind="isOtherGenderAdded">
     Add Other Gender via RxJS
   </button>
+  <button class="button is-small is-danger is-outlined" style="margin-left: 50px" data-test="throw-page-error-btn"
+          onclick.delegate="throwPageChangeError()">
+    <span>Throw Error Going to Last Page... </span>
+    <i class="mdi mdi-page-last"></i>
+  </button>
 </div>
 
 <br />
@@ -39,10 +46,10 @@
     <span>
       <label>Programmatically go to first/last page:</label>
       <button class="button is-small" data-test="goto-first-page" onclick.delegate="goToFirstPage()">
-        <i class="fa fa-caret-left fa-lg"></i>&lt;
+        <i class="mdi mdi-page-first"></i>
       </button>
       <button class="button is-small" data-test="goto-last-page" onclick.delegate="goToLastPage()">
-        <i class="fa fa-caret-right fa-lg"></i>&gt;
+        <i class="mdi mdi-page-last"></i>
       </button>
     </span>
 

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example15.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example15.ts
@@ -26,6 +26,7 @@ export class Example15 {
   status = '';
   statusClass = 'is-success';
   isOtherGenderAdded = false;
+  isPageErrorTest = false;
   genderCollection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
   constructor() {
@@ -108,7 +109,7 @@ export class Example15 {
       enableRowSelection: true,
       enablePagination: true, // you could optionally disable the Pagination
       pagination: {
-        pageSizes: [10, 20, 50, 100, 500],
+        pageSizes: [10, 20, 50, 100, 500, 50000],
         pageSize: defaultPageSize,
       },
       presets: {
@@ -227,9 +228,17 @@ export class Example15 {
       let countTotalItems = 100;
       const columnFilters = {};
 
+      if (this.isPageErrorTest) {
+        this.isPageErrorTest = false;
+        throw new Error('Server timed out trying to retrieve data for the last page');
+      }
+
       for (const param of queryParams) {
         if (param.includes('$top=')) {
           top = +(param.substring('$top='.length));
+          if (top === 50000) {
+            throw new Error('Server timed out retrieving 50,000 rows');
+          }
         }
         if (param.includes('$skip=')) {
           skip = +(param.substring('$skip='.length));
@@ -269,14 +278,14 @@ export class Example15 {
 
           // simular a backend error when trying to sort on the "Company" field
           if (filterBy.includes('company')) {
-            throw new Error('Cannot filter by the field "Company"');
+            throw new Error('Server could not filter using the field "Company"');
           }
         }
       }
 
       // simular a backend error when trying to sort on the "Company" field
       if (orderBy.includes('company')) {
-        throw new Error('Cannot sort by the field "Company"');
+        throw new Error('Server could not sort using the field "Company"');
       }
 
       const sort = orderBy.includes('asc')
@@ -376,6 +385,11 @@ export class Example15 {
     this.sgb?.sortService.updateSorting([
       { columnId: 'name', direction: 'DESC' },
     ]);
+  }
+
+  throwPageChangeError() {
+    this.isPageErrorTest = true;
+    this.sgb.paginationService.goToLastPage();
   }
 
   // THE FOLLOWING METHODS ARE ONLY FOR DEMO PURPOSES DO NOT USE THIS CODE

--- a/packages/common/src/services/backendUtility.service.ts
+++ b/packages/common/src/services/backendUtility.service.ts
@@ -43,7 +43,7 @@ export class BackendUtilityService {
 
   /** On a backend service api error, we will run the "onError" if there is 1 provided or just throw back the error when nothing is provided */
   onBackendError(e: any, backendApi: BackendServiceApi) {
-    if (backendApi?.onError) {
+    if (typeof backendApi?.onError === 'function') {
       backendApi.onError(e);
     } else {
       throw e;

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -37,15 +37,15 @@ export class SlickPaginationComponent {
     this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
 
     this.currentPagination = this.paginationService.getFullPagination();
-    this._enableTranslate = this.gridOptions && this.gridOptions.enableTranslate || false;
-    this._locales = this.gridOptions && this.gridOptions.locales || Constants.locales;
+    this._enableTranslate = this.gridOptions?.enableTranslate ?? false;
+    this._locales = this.gridOptions?.locales ?? Constants.locales;
 
     if (this._enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
     this.translatePaginationTexts(this._locales);
 
-    if (this._enableTranslate && this.pubSubService && this.pubSubService.subscribe) {
+    if (this._enableTranslate && this.pubSubService?.subscribe) {
       const translateEventName = this.translaterService?.eventName ?? 'onLanguageChange';
       this._subscriptions.push(
         this.pubSubService.subscribe(translateEventName, () => this.translatePaginationTexts(this._locales))

--- a/test/cypress/integration/example09.spec.js
+++ b/test/cypress/integration/example09.spec.js
@@ -640,7 +640,7 @@ describe('Example 09 - OData Grid', { retries: 1 }, () => {
         .should('not.exist');
 
       // wait for the query to finish
-      cy.get('[data-test=error-status]').should('contain', 'Cannot sort by the field "Company"');
+      cy.get('[data-test=error-status]').should('contain', 'Server could not sort using the field "Company"');
       cy.get('[data-test=status]').should('contain', 'ERROR!!');
 
       // same query string as prior test
@@ -676,7 +676,7 @@ describe('Example 09 - OData Grid', { retries: 1 }, () => {
         .type('Core');
 
       // wait for the query to finish
-      cy.get('[data-test=error-status]').should('contain', 'Cannot filter by the field "Company"');
+      cy.get('[data-test=error-status]').should('contain', 'Server could not filter using the field "Company"');
       cy.get('[data-test=status]').should('contain', 'ERROR!!');
 
       cy.get('[data-test=odata-query-result]')
@@ -710,6 +710,107 @@ describe('Example 09 - OData Grid', { retries: 1 }, () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
         });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+    });
+
+    it('should display error when clicking on the "Throw Error..." button and not expect query and page to change', () => {
+      cy.get('[data-test="throw-page-error-btn"]').click({ force: true });
+      cy.wait(50);
+
+      cy.get('[data-test=error-status]').should('contain', 'Server timed out trying to retrieve data for the last page');
+      cy.get('[data-test=status]').should('contain', 'ERROR!!');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+    });
+
+    it('should display error when trying to change items per to 50,000 items and expect query & page to remain the same', () => {
+      cy.get('#items-per-page-label').select('50000');
+
+      cy.get('[data-test=error-status]').should('contain', 'Server timed out retrieving 50,000 rows');
+      cy.get('[data-test=status]').should('contain', 'ERROR!!');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+    });
+
+    it('should now go to next page without anymore problems and query & page should change as normal', () => {
+      cy.get('.icon-seek-next').click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'finished');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$skip=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('2'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('11');
+
+      cy.get('[data-test=item-to]')
+        .contains('20');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
     });
   });
 });

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -743,7 +743,7 @@ describe('Example 15 - OData Grid using RxJS', { retries: 1 }, () => {
         .should('not.exist');
 
       // wait for the query to finish
-      cy.get('[data-test=error-status]').should('contain', 'Cannot sort by the field "Company"');
+      cy.get('[data-test=error-status]').should('contain', 'Server could not sort using the field "Company"');
       cy.get('[data-test=status]').should('contain', 'ERROR!!');
 
       // same query string as prior test
@@ -779,7 +779,7 @@ describe('Example 15 - OData Grid using RxJS', { retries: 1 }, () => {
         .type('Core');
 
       // wait for the query to finish
-      cy.get('[data-test=error-status]').should('contain', 'Cannot filter by the field "Company"');
+      cy.get('[data-test=error-status]').should('contain', 'Server could not filter using the field "Company"');
       cy.get('[data-test=status]').should('contain', 'ERROR!!');
 
       cy.get('[data-test=odata-query-result]')
@@ -814,6 +814,107 @@ describe('Example 15 - OData Grid using RxJS', { retries: 1 }, () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
         });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+    });
+
+    it('should display error when clicking on the "Throw Error..." button and not expect query and page to change', () => {
+      cy.get('[data-test="throw-page-error-btn"]').click({ force: true });
+      cy.wait(50);
+
+      cy.get('[data-test=error-status]').should('contain', 'Server timed out trying to retrieve data for the last page');
+      cy.get('[data-test=status]').should('contain', 'ERROR!!');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+    });
+
+    it('should display error when trying to change items per to 50,000 items and expect query & page to remain the same', () => {
+      cy.get('#items-per-page-label').select('50000');
+
+      cy.get('[data-test=error-status]').should('contain', 'Server timed out retrieving 50,000 rows');
+      cy.get('[data-test=status]').should('contain', 'ERROR!!');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+    });
+
+    it('should now go to next page without anymore problems and query & page should change as normal', () => {
+      cy.get('.icon-seek-next').click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'finished');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$skip=10&$orderby=Name desc&$filter=(Gender eq 'female')`);
+        });
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('2'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('11');
+
+      cy.get('[data-test=item-to]')
+        .contains('20');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
     });
   });
 });


### PR DESCRIPTION
- this enhancement idea came from this [Discussion](https://github.com/ghiscoding/slickgrid-universal/discussions/337)
- in previous code, if an error happens on the backend server while querying, the Pagination would still be changed and we had no clue of the previous page number (or page size change), this PR bring this functionality that if an error occurs it will rollback to previous Pagination
- when using a Backend Service, you can prevent the Pagination via `onBeforePaginationChange` while on a local (in-memory) it would be via the DataView `onBeforePagingInfoChanged` event
- for a demo, you can look at previous PR #463 

cancellable event code sample
```ts
// for a local (in-memory) grid, you need to use the DataView event
gridContainerElm.addEventListener('onBeforePagingInfoChanged', (e) => {
  e.preventDefault();
  return false;
});

// for a Backend Service API, you can use 
gridContainerElm.addEventListener('onBeforePaginationChange', (e) => {
  e.preventDefault();
  return false;
});
```