### PR TITLE
refactor: reset to previous value when event cancelled enhanced #465

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example09.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example09.ts
@@ -43,7 +43,6 @@ export class Example09 {
     // });
     // this._bindingEventService.bind(gridContainerElm, 'onbeforesearchchange', (e) => {
     //   e.preventDefault();
-    //   this.sgb.filterService.resetToPreviousSearchFilters(); // optionally reset filter input value
     //   return false;
     // });
   }

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -239,6 +239,7 @@ export const GlobalGridOptions: GridOption = {
   rowHeight: 35,
   topPanelHeight: 30,
   translationNamespaceSeparator: ':',
+  resetFilterSearchValueAfterOnBeforeCancellation: true,
   resizeByContentOnlyOnFirstLoad: true,
   resizeByContentOptions: {
     alwaysRecalculateColumnWidth: false,

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -502,6 +502,9 @@ export interface GridOption {
   /** Register any external Resources (Components, Services) like the ExcelExportService, TextExportService, SlickCompositeEditorComponent, ... */
   registerExternalResources?: ExternalResource[];
 
+  /** Defaults to true, should we reset (rollback) the search filter input value to its previous value when the `onBeforeSearchChange` event bubbling is prevented? */
+  resetFilterSearchValueAfterOnBeforeCancellation?: boolean;
+
   /**
    * defaults to true, do we want to resize the grid by content only on the first page or anytime the data changes?
    * Requires `enableAutoResizeColumnsByCellContent` to be set.

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -1195,6 +1195,22 @@ describe('FilterService', () => {
       });
     });
 
+    it('should call "resetToPreviousSearchFilters" when "onBeforeSearchChange" event is prevented from bubbling and "resetFilterSearchValueAfterOnBeforeCancellation" is set to true', async () => {
+      const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish').mockReturnValue(false);
+      const resetPrevSpy = jest.spyOn(service, 'resetToPreviousSearchFilters');
+
+      gridOptionMock.resetFilterSearchValueAfterOnBeforeCancellation = true;
+      service.init(gridStub);
+      service.bindLocalOnFilter(gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs1 as any, new Slick.EventData(), gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs2 as any, new Slick.EventData(), gridStub);
+      await service.updateFilters(mockNewFilters, false, false, true);
+
+      expect(pubSubSpy).toHaveBeenCalledWith('onBeforeSearchChange', expect.toBeObject());
+      expect(resetPrevSpy).toHaveBeenCalled();
+      jest.spyOn(pubSubServiceStub, 'publish').mockReturnValue(true);
+    });
+
     it('should expect filters to be set in ColumnFilters when using "bindLocalOnFilter" without triggering a filter changed event when 2nd flag argument is set to false', async () => {
       const clearSpy = jest.spyOn(service, 'clearFilters');
       const emitSpy = jest.spyOn(service, 'emitFilterChanged');

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -1075,7 +1075,13 @@ export class FilterService {
           parsedSearchTerms,
           grid: this._grid
         } as OnSearchChangeEventArgs;
-        if (this.pubSubService.publish('onBeforeSearchChange', eventArgs) !== false) {
+
+        const onBeforeDispatchResult = this.pubSubService.publish('onBeforeSearchChange', eventArgs);
+        if (onBeforeDispatchResult === false) {
+          if (this._gridOptions.resetFilterSearchValueAfterOnBeforeCancellation) {
+            this.resetToPreviousSearchFilters();
+          }
+        } else {
           this._onSearchChange.notify(eventArgs, eventData);
         }
       }


### PR DESCRIPTION
- this PR enhanced the previous PR #465 and will reset (rollback) the search input value to its previous value when `onBeforeSearchChange` event is prevented, user can optionally cancel that behavior by disabling the flag `resetFilterSearchValueAfterOnBeforeCancellation`