### PR TITLE
fix(footer): use `getFilteredItemCount` to show correct count, fix #469

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example03.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example03.ts
@@ -297,6 +297,7 @@ export class Example3 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      showCustomFooter: true,
       createPreHeaderPanel: true,
       showPreHeaderPanel: true,
       preHeaderPanelHeight: 35,

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -204,6 +204,7 @@ const mockDataView = {
   destroy: jest.fn(),
   beginUpdate: jest.fn(),
   endUpdate: jest.fn(),
+  getFilteredItemCount: jest.fn(),
   getItem: jest.fn(),
   getItemCount: jest.fn(),
   getItems: jest.fn(),
@@ -1901,6 +1902,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           totalItemCount: 2
         };
         jest.spyOn(mockDataView, 'getItemCount').mockReturnValue(mockData.length);
+        jest.spyOn(mockDataView, 'getFilteredItemCount').mockReturnValue(mockData.length);
 
         component.gridOptions = { enablePagination: false, showCustomFooter: true };
         component.initialization(divContainer, slickEventHandler);
@@ -1920,7 +1922,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           itemCount: 0,
           totalItemCount: 0
         };
-        jest.spyOn(mockDataView, 'getLength').mockReturnValue(0);
+        jest.spyOn(mockDataView, 'getFilteredItemCount').mockReturnValue(0);
 
         component.gridOptions = { enablePagination: false, showCustomFooter: true };
         component.initialization(divContainer, slickEventHandler);
@@ -1946,9 +1948,11 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const dataviewSpy = jest.spyOn(mockDataView, 'mapIdsToRows').mockReturnValue(selectedGridRows);
         const selectRowSpy = jest.spyOn(mockGrid, 'setSelectedRows');
         jest.spyOn(mockGrid, 'getSelectionModel').mockReturnValue(true as any);
+        jest.spyOn(mockDataView, 'getLength').mockReturnValue(mockData.length);
 
         component.gridOptions.enableCheckboxSelector = true;
         component.gridOptions.presets = { rowSelection: { dataContextIds: selectedRowIds } };
+        component.isDatasetInitialized = false;
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1947,8 +1947,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
         const dataviewSpy = jest.spyOn(mockDataView, 'mapIdsToRows').mockReturnValue(selectedGridRows);
         const selectRowSpy = jest.spyOn(mockGrid, 'setSelectedRows');
+        jest.spyOn(mockDataView, 'getLength').mockReturnValue(0);
         jest.spyOn(mockGrid, 'getSelectionModel').mockReturnValue(true as any);
-        jest.spyOn(mockDataView, 'getLength').mockReturnValue(mockData.length);
 
         component.gridOptions.enableCheckboxSelector = true;
         component.gridOptions.presets = { rowSelection: { dataContextIds: selectedRowIds } };

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -833,13 +833,13 @@ export class SlickVanillaGridBundle {
 
       // When data changes in the DataView, we need to refresh the metrics and/or display a warning if the dataset is empty
       const onRowCountChangedHandler = dataView.onRowCountChanged;
-      (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onRowCountChangedHandler>>).subscribe(onRowCountChangedHandler, (_e, args) => {
+      (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onRowCountChangedHandler>>).subscribe(onRowCountChangedHandler, () => {
         grid.invalidate();
-        this.handleOnItemCountChanged(args.current || 0, this.dataView.getItemCount());
+        this.handleOnItemCountChanged(this.dataView.getFilteredItemCount() || 0, this.dataView.getItemCount());
       });
       const onSetItemsCalledHandler = dataView.onSetItemsCalled;
       (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onSetItemsCalledHandler>>).subscribe(onSetItemsCalledHandler, (_e, args) => {
-        this.handleOnItemCountChanged(this.dataView.getLength(), args.itemCount);
+        this.handleOnItemCountChanged(this.dataView.getFilteredItemCount() || 0, args.itemCount);
 
         // when user has resize by content enabled, we'll force a full width calculation since we change our entire dataset
         if (args.itemCount > 0 && (this.gridOptions.autosizeColumnsByCellContentOnFirstLoad || this.gridOptions.enableAutoResizeColumnsByCellContent)) {


### PR DESCRIPTION
- fixes #469
- we should always use DataView `getFilteredItemCount()` since that is really the item count that we want to show in the footer

![image](https://user-images.githubusercontent.com/643976/132393256-f5536250-62ce-47b9-8d9b-19d13c1e618b.png)
