### PR TITLE
feat(sorts): option to ignore accent while sorting text

### DIFF
--- a/packages/common/src/filter-conditions/__tests__/stringFilterCondition.spec.ts
+++ b/packages/common/src/filter-conditions/__tests__/stringFilterCondition.spec.ts
@@ -171,4 +171,19 @@ describe('executeStringFilterCondition method', () => {
     const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
     expect(output).toBe(false);
   });
+  
+  it('should return True when input value contains accent is searchTerms value does not contain accent when "ignoreAccentOnStringFilterAndSort" is set in grid options', () => {
+    const searchTerms = ['jose'];
+    const options = { dataKey: '', operator: 'EQ', cellValue: 'José', fieldType: FieldType.string, ignoreAccentOnStringFilterAndSort: true} as FilterConditionOption;
+    const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
+    expect(output).toBe(true);
+  });
+
+  it('should return False when input value contains accent is searchTerms value does not contain accent when "ignoreAccentOnStringFilterAndSort" is not set in grid options', () => {
+    const searchTerms = ['jose'];
+    const options = { dataKey: '', operator: 'EQ', cellValue: 'José', fieldType: FieldType.string, ignoreAccentOnStringFilterAndSort: false} as FilterConditionOption;
+    const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
+    expect(output).toBe(false);
+  });
+
 });

--- a/packages/common/src/filter-conditions/stringFilterCondition.ts
+++ b/packages/common/src/filter-conditions/stringFilterCondition.ts
@@ -15,12 +15,12 @@ export const executeStringFilterCondition: FilterCondition = ((options: FilterCo
   options.cellValue = (options.cellValue === undefined || options.cellValue === null) ? '' : options.cellValue.toString();
 
   // make both the cell value and search value lower for case insensitive comparison
-  const cellValue = options?.ignoreAccentOnStringFilter ? removeAccentFromText(options.cellValue, true) : options.cellValue.toLowerCase();
+  const cellValue = options?.ignoreAccentOnStringFilterAndSort ? removeAccentFromText(options.cellValue, true) : options.cellValue.toLowerCase();
   if (typeof searchValue1 === 'string') {
-    searchValue1 = options?.ignoreAccentOnStringFilter ? removeAccentFromText(searchValue1, true) : searchValue1.toLowerCase();
+    searchValue1 = options?.ignoreAccentOnStringFilterAndSort ? removeAccentFromText(searchValue1, true) : searchValue1.toLowerCase();
   }
   if (typeof searchValue2 === 'string') {
-    searchValue2 = options?.ignoreAccentOnStringFilter ? removeAccentFromText(searchValue2, true) : searchValue2.toLowerCase();
+    searchValue2 = options?.ignoreAccentOnStringFilterAndSort ? removeAccentFromText(searchValue2, true) : searchValue2.toLowerCase();
   }
 
   if (searchValue1 !== undefined && searchValue2 !== undefined) {

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -216,7 +216,7 @@ export const GlobalGridOptions: GridOption = {
     hideFreezeColumnsCommand: true, // opt-in command
     hideSortCommands: false
   },
-  ignoreAccentOnStringFilter: false,
+  ignoreAccentOnStringFilterAndSort: false,
   multiColumnSort: true,
   numberedMultiColumnSort: true,
   tristateMultiColumnSort: false,

--- a/packages/common/src/interfaces/filterConditionOption.interface.ts
+++ b/packages/common/src/interfaces/filterConditionOption.interface.ts
@@ -23,7 +23,7 @@ export interface FilterConditionOption {
   filterSearchType?: typeof FieldType[keyof typeof FieldType];
 
   /** should we ignore any accent while filtering text? */
-  ignoreAccentOnStringFilter?: any;
+  ignoreAccentOnStringFilterAndSort?: any;
 
   /**
    * Parsed Search Terms is similar to SearchTerms but is already parsed in the correct format,

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -462,6 +462,12 @@ export interface GridOption {
   ignoreAccentOnStringFilter?: boolean;
 
   /**
+   * Defaults to false, should we ignore any accent while sorting text?
+   * For example if our text is "José" and we type "Jose" then it won't return unless we use this flag because "é" is not equal to "e"
+   */
+  ignoreAccentOnStringSort?: boolean;
+
+  /**
    * When using custom Locales (that is when user is NOT using a Translate Service, this property does nothing when used with Translate Service),
    * This is useful so that every component of the lib knows the locale.
    * For example, not providing this will make the Date Filter/Editor use English by default even if we use different "locales",

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -456,16 +456,10 @@ export interface GridOption {
   headerMenu?: HeaderMenu;
 
   /**
-   * Defaults to false, should we ignore any accent while filtering text?
+   * Defaults to false, should we ignore any accent while filtering and sorting text?
    * For example if our text is "José" and we type "Jose" then it won't return unless we use this flag because "é" is not equal to "e"
    */
-  ignoreAccentOnStringFilter?: boolean;
-
-  /**
-   * Defaults to false, should we ignore any accent while sorting text?
-   * For example if our text is "José" and we type "Jose" then it won't return unless we use this flag because "é" is not equal to "e"
-   */
-  ignoreAccentOnStringSort?: boolean;
+  ignoreAccentOnStringFilterAndSort?: boolean;
 
   /**
    * When using custom Locales (that is when user is NOT using a Translate Service, this property does nothing when used with Translate Service),

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -515,7 +515,7 @@ export class FilterService {
       operator: operator as OperatorString,
       searchInputLastChar: columnFilter.searchInputLastChar,
       filterSearchType: columnDef.filterSearchType,
-      ignoreAccentOnStringFilter: this._gridOptions.ignoreAccentOnStringFilter ?? false,
+      ignoreAccentOnStringFilterAndSort: this._gridOptions.ignoreAccentOnStringFilterAndSort ?? false,
       defaultFilterRangeOperator: this._gridOptions.defaultFilterRangeOperator,
     } as FilterConditionOption;
   }

--- a/packages/common/src/sortComparers/__tests__/stringSortComparer.spec.ts
+++ b/packages/common/src/sortComparers/__tests__/stringSortComparer.spec.ts
@@ -80,4 +80,22 @@ describe('the String SortComparer', () => {
     inputArray.sort((value1, value2) => stringSortComparer(value1, value2, direction, columnDef, { cellValueCouldBeUndefined: true } as GridOption));
     expect(inputArray).toEqual(['zebra', 'amazon', 'abc', 'John', 'Abe', '@at', '', undefined, undefined]);
   });
+
+  it('should return a sorted ascending array ignore any accent when "ignoreAccentOnStringFilterAndSort" is set in the grid options', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name' } as Column;
+    const direction = SortDirectionNumber.asc;
+    const inputArray = ['Jose Silva', 'José', 'amazon', 'zebra' , 'Chêvre', '', '@at', 'John', 'Abe', 'abc', 'Ângelo'];
+    inputArray.sort((value1, value2) => stringSortComparer(value1, value2, direction, columnDef, { ignoreAccentOnStringFilterAndSort: true } as GridOption));
+    expect(inputArray).toEqual(['', '@at', 'Abe', 'Ângelo', 'Chêvre', 'John', 'José', 'Jose Silva', 'abc', 'amazon', 'zebra']);
+  });
+
+  it('should return a sorted descending array ignore any accent when "ignoreAccentOnStringFilterAndSort" is set in the grid options', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name' } as Column;
+    const direction = SortDirectionNumber.desc;
+    const inputArray = ['Jose Silva', 'José', 'amazon', 'zebra' , 'Chêvre', '', '@at', 'John', 'Abe', 'abc', 'Ângelo'];
+    inputArray.sort((value1, value2) => stringSortComparer(value1, value2, direction, columnDef, { ignoreAccentOnStringFilterAndSort: true } as GridOption));
+    expect(inputArray).toEqual(['zebra', 'amazon', 'abc', 'Jose Silva', 'José', 'John', 'Chêvre', 'Ângelo', 'Abe', '@at', '']);
+  });
 });

--- a/packages/common/src/sortComparers/stringSortComparer.ts
+++ b/packages/common/src/sortComparers/stringSortComparer.ts
@@ -16,7 +16,7 @@ export const stringSortComparer: SortComparer = (value1: any, value2: any, sortD
   } else if (value2 === null || (checkForUndefinedValues && value2 === undefined)) {
     position = 1;
   } else {
-    if (gridOptions?.ignoreAccentOnStringSort){
+    if (gridOptions?.ignoreAccentOnStringFilterAndSort){
       value1 = removeAccentFromText(value1, false);
       value2 = removeAccentFromText(value2, false);
     }

--- a/packages/common/src/sortComparers/stringSortComparer.ts
+++ b/packages/common/src/sortComparers/stringSortComparer.ts
@@ -1,5 +1,6 @@
 import { Column, GridOption, SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
+import { removeAccentFromText } from '../services/utilities';
 
 export const stringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => {
   if (sortDirection === undefined || sortDirection === null) {
@@ -14,10 +15,16 @@ export const stringSortComparer: SortComparer = (value1: any, value2: any, sortD
     position = -1;
   } else if (value2 === null || (checkForUndefinedValues && value2 === undefined)) {
     position = 1;
-  } else if (sortDirection) {
-    position = value1 < value2 ? -1 : 1;
   } else {
-    position = value1 < value2 ? 1 : -1;
+    if (gridOptions?.ignoreAccentOnStringSort){
+      value1 = removeAccentFromText(value1, false);
+      value2 = removeAccentFromText(value2, false);
+    }
+    if (sortDirection) {
+      position = value1 < value2 ? -1 : 1;
+    } else {
+      position = value1 < value2 ? 1 : -1;
+    }
   }
   return sortDirection * position;
 };


### PR DESCRIPTION
@ghiscoding 

add a Grid Option to sort text by ignoring any accent by normalizing the text, the option is set to false by default