### PR TITLE
fix(styling): List bullets shouldn't show in any frameworks, fixes #487

### DIFF
--- a/packages/common/src/styles/slick-bootstrap.scss
+++ b/packages/common/src/styles/slick-bootstrap.scss
@@ -21,6 +21,10 @@
   to { background: none; }
 }
 
+ul {
+  list-style-type: none;
+}
+
 .slickgrid-container {
   border-top: var(--slick-container-border-top, $container-border-top);
   border-bottom: var(--slick-container-border-bottom, $container-border-bottom);

--- a/packages/common/src/styles/slick-component.scss
+++ b/packages/common/src/styles/slick-component.scss
@@ -62,6 +62,7 @@
 // ----------------------------------------------
 
 .slick-pagination {
+  list-style-type: none;
   border-top: var(--slick-pagination-border-top, $pagination-border-top);
   border-right: var(--slick-pagination-border-right, $pagination-border-right);
   border-bottom: var(--slick-pagination-border-bottom, $pagination-border-bottom);

--- a/packages/common/src/styles/slick-controls.scss
+++ b/packages/common/src/styles/slick-controls.scss
@@ -6,6 +6,7 @@
 // ----------------------------------------------
 
 .slick-columnpicker {
+  list-style-type: none;
   font-family: var(--slick-font-family, $font-family);
   background-color: var(--slick-column-picker-background-color, $column-picker-background-color);
   border: var(--slick-column-picker-border, $column-picker-border);
@@ -148,6 +149,7 @@
 // ----------------------------------------------
 
 .slick-gridmenu {
+  list-style-type: none;
   font-family: var(--slick-font-family, $font-family);
   background-color: var(--slick-grid-menu-background-color, $grid-menu-background-color);
   border: var(--slick-grid-menu-border, $grid-menu-border);

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -6,6 +6,7 @@
 // ----------------------------------------------
 
 .slick-cell-menu {
+  list-style-type: none;
   position: absolute;
   font-family:  $font-family;
   background: var(--slick-cell-menu-bg-color, $cell-menu-bg-color);
@@ -141,6 +142,7 @@
 // ----------------------------------------------
 
 .slick-context-menu {
+  list-style-type: none;
   position: absolute;
   background: var(--slick-context-menu-bg-color, $context-menu-bg-color);
   border: var(--slick-context-menu-border, $context-menu-border);


### PR DESCRIPTION
- fixes #487
- List bullet dots shouldn't show up in any framework (Material-UI was showing the bullet dots for that user)

![Untitled](https://user-images.githubusercontent.com/12414216/133701952-d633ca25-65d3-4956-bc01-fafe4851086a.png)