### PR TITLE
fix(resizer): only bind autoresize when enabled

### DIFF
--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -101,9 +101,30 @@ describe('Resizer Service', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should throw an error when there is no grid object defined', () => {
-    service = new ResizerService(eventPubSubService);
-    expect(() => service.init(null as any, divContainer)).toThrowError('[Slickgrid-Universal] Resizer Service requires a valid Grid object and DOM Element Container to be provided.');
+  describe('init method', () => {
+    it('should throw an error when there is no grid object defined', () => {
+      expect(() => service.init(null as any, divContainer)).toThrowError('[Slickgrid-Universal] Resizer Service requires a valid Grid object and DOM Element Container to be provided.');
+    });
+
+    it('should call "bindAutoResizeDataGrid" when autoResize is enabled', () => {
+      mockGridOptions.enableAutoResize = true;
+      jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(null);
+      const bindAutoResizeDataGridSpy = jest.spyOn(service, 'bindAutoResizeDataGrid').mockImplementation();
+
+      service.init(gridStub, divContainer);
+
+      expect(bindAutoResizeDataGridSpy).toHaveBeenCalled();
+    });
+
+    it('should not call "bindAutoResizeDataGrid" when autoResize is not enabled', () => {
+      mockGridOptions.enableAutoResize = false;
+      jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(null);
+      const bindAutoResizeDataGridSpy = jest.spyOn(service, 'bindAutoResizeDataGrid').mockImplementation();
+
+      service.init(gridStub, divContainer);
+
+      expect(bindAutoResizeDataGridSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('resizeGrid method', () => {

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -127,6 +127,21 @@ describe('Resizer Service', () => {
     });
   });
 
+  describe('dispose method', () => {
+    it('should clear resizeGrid timeout', (done) => {
+      service.init(gridStub, divContainer);
+
+      const resizeGridWithDimensionsSpy = jest.spyOn(service, 'resizeGridWithDimensions');
+      service.resizeGrid(1);
+      service.dispose();
+
+      setTimeout(() => {
+        expect(resizeGridWithDimensionsSpy).not.toHaveBeenCalled();
+        done();
+      }, 2);
+    });
+  });
+
   describe('resizeGrid method', () => {
     beforeEach(() => {
       // @ts-ignore

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -117,7 +117,7 @@ export class ResizerService {
       this._fixedWidth = fixedGridSizes.width;
     }
 
-    if (this.gridOptions) {
+    if (this.gridOptions && this.gridOptions.enableAutoResize) {
       this.bindAutoResizeDataGrid();
     }
 
@@ -251,7 +251,7 @@ export class ResizerService {
 
   /**
    * Provide the possibility to pause the resizer for some time, until user decides to re-enabled it later if he wish to.
-   * @param {boolean} isResizePaused are we pausing the resizer?
+   * @param {boolean} isResizePaused are we pausing the resizer?@C
    */
   pauseResizer(isResizePaused: boolean) {
     this._resizePaused = isResizePaused;

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -252,7 +252,7 @@ export class ResizerService {
 
   /**
    * Provide the possibility to pause the resizer for some time, until user decides to re-enabled it later if he wish to.
-   * @param {boolean} isResizePaused are we pausing the resizer?@C
+   * @param {boolean} isResizePaused are we pausing the resizer?
    */
   pauseResizer(isResizePaused: boolean) {
     this._resizePaused = isResizePaused;

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -87,6 +87,7 @@ export class ResizerService {
     if (this._intervalId) {
       clearInterval(this._intervalId);
     }
+    clearTimeout(this._timer);
 
     $(window).off(`resize.grid${this.gridUidSelector}`);
   }


### PR DESCRIPTION
This fixes the bug/exception mentioned here https://github.com/ghiscoding/Angular-Slickgrid/issues/836 and is "PR 1".

Writing this comment I realize that just the `clearTimeout` would have been enough to fix the exception, but since `bindAutoResizeDataGrid` has this comment `Bind an auto resize trigger on the datagrid, if that is enable then it will resize itself to the available space` I think the added check on `this.gridOptions.enableAutoResize` should be done in `init` and is good.  Also when not using auto resize `resizeGrid` is called from `bindResizeHook` in Vanilla, Angular and Aurelia, so this change shouldn't cause noticeable side effects.