### PR TITLE
feat(resizer): add option to detect container resize

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example14.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example14.html
@@ -68,7 +68,8 @@
   </div>
 </div>
 
-<div style="width: 1000px" class="grid-container">
+<!-- https://www.w3docs.com/snippets/html/how-to-make-a-div-fill-the-height-of-the-remaining-space.html -->
+<div style="width: 1000px; height: calc(100vh - 320px)" class="grid-container">
   <div class="grid14">
   </div>
 </div>

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example14.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example14.ts
@@ -354,7 +354,7 @@ export class Example14 {
       autoCommitEdit: true,
       autoResize: {
         container: '.grid-container',
-        useResizeObserver: true
+        resizeDetection: 'container',
       },
       enableAutoResize: true,
 

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example14.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example14.ts
@@ -354,6 +354,7 @@ export class Example14 {
       autoCommitEdit: true,
       autoResize: {
         container: '.grid-container',
+        useResizeObserver: true
       },
       enableAutoResize: true,
 

--- a/packages/common/src/interfaces/resizerOption.interface.ts
+++ b/packages/common/src/interfaces/resizerOption.interface.ts
@@ -2,10 +2,7 @@ export interface ResizerOption {
   /** Defaults to false, do we want to apply the resized dimentions to the grid container as well? */
   applyResizeToContainer?: boolean;
 
-  /**
-   * Defaults to 'window', which DOM element are we using to calculate the available size for the grid?
-   * When {@link useResizeObserver}=true the {@link container} is used and this option is ignored.
-   */
+  /** Defaults to 'window', which DOM element are we using to calculate the available size for the grid? */
   calculateAvailableSizeBy?: 'container' | 'window';
 
   /** bottom padding of the grid in pixels */
@@ -41,16 +38,12 @@ export interface ResizerOption {
   rightPadding?: number;
 
   /**
-   * Use a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to detect resizes on the {@link container} element instead of window resize events.
+   * Defaults to 'window', how are resizes detected?
    *
-   * Remarks:
+   * When set to 'container':
    * * Requires {@link container} to be set.
-   *
-   * * ResizeObserver is not supported on older browsers like Internet Explorer. If you need the support you need to install a
-   * polyfill like [resize-observer-polyfill](https://www.npmjs.com/package/resize-observer-polyfill) yourself.
-   *
    * * If you get 'ResizeObserver loop limit exceeded' errors in automated tests take a look
-   * [here](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded).
+   *   [here](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded).
    */
-  useResizeObserver?: boolean;
+  resizeDetection?: 'container' | 'window';
 }

--- a/packages/common/src/interfaces/resizerOption.interface.ts
+++ b/packages/common/src/interfaces/resizerOption.interface.ts
@@ -2,14 +2,20 @@ export interface ResizerOption {
   /** Defaults to false, do we want to apply the resized dimentions to the grid container as well? */
   applyResizeToContainer?: boolean;
 
-  /** Defaults to 'window', which DOM element are we using to calculate the available size for the grid? */
+  /**
+   * Defaults to 'window', which DOM element are we using to calculate the available size for the grid?
+   * When {@link useResizeObserver}=true the {@link container} is used and this option is ignored.
+   */
   calculateAvailableSizeBy?: 'container' | 'window';
 
   /** bottom padding of the grid in pixels */
   bottomPadding?: number;
 
-  /** Page Container selector, for example '.page-container' or '#page-container', basically what element in the page will be used to calculate the available space */
-  container?: string;
+  /**
+   * Page Container. Either selector (for example '.page-container' or '#page-container'), or an HTMLElement.
+   * Basically what element in the page will be used to calculate the available space.
+   */
+  container?: string | HTMLElement;
 
   /**
    * Grid Container selector, for example '.myGrid' or '#myGrid', this is provided by the lib internally.
@@ -33,4 +39,18 @@ export interface ResizerOption {
 
   /** padding on the right side of the grid (pixels) */
   rightPadding?: number;
+
+  /**
+   * Use a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to detect resizes on the {@link container} element instead of window resize events.
+   *
+   * Remarks:
+   * * Requires {@link container} to be set.
+   *
+   * * ResizeObserver is not supported on older browsers like Internet Explorer. If you need the support you need to install a
+   * polyfill like [resize-observer-polyfill](https://www.npmjs.com/package/resize-observer-polyfill) yourself.
+   *
+   * * If you get 'ResizeObserver loop limit exceeded' errors in automated tests take a look
+   * [here](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded).
+   */
+  useResizeObserver?: boolean;
 }

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -160,7 +160,7 @@ describe('Resizer Service', () => {
       mockGridOptions.autoResize.resizeDetection = 'container';
       mockGridOptions.autoResize.container = '#doesnotexist';
 
-      expect(() => service.init(gridStub, divContainer)).toThrowError('[Slickgrid-Universal] Resizer Service requires a container when gridOption.autoResize.useResizeObserver=true');
+      expect(() => service.init(gridStub, divContainer)).toThrowError('[Slickgrid-Universal] Resizer Service requires a container when gridOption.autoResize.resizeDetection="container"');
     });
 
     it('should execute "resizeGrid" when "resizeDetection" is "container"', () => {

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -140,9 +140,9 @@ describe('Resizer Service', () => {
       expect(bindAutoResizeDataGridSpy).not.toHaveBeenCalled();
     });
 
-    it('should observe resize events on the container element when "useResizeObserver" is true', () => {
+    it('should observe resize events on the container element when "resizeDetection" is "container"', () => {
       mockGridOptions.enableAutoResize = true;
-      mockGridOptions.autoResize.useResizeObserver = true;
+      mockGridOptions.autoResize.resizeDetection = 'container';
       const resizeContainer = document.createElement('div');
       mockGridOptions.autoResize.container = resizeContainer;
 
@@ -155,17 +155,17 @@ describe('Resizer Service', () => {
       expect(observerInstance.observe).toHaveBeenCalledWith(resizeContainer);
     });
 
-    it('should throw an error when container element is not valid and "useResizeObserver" is true', () => {
+    it('should throw an error when container element is not valid and "resizeDetection" is "container"', () => {
       mockGridOptions.enableAutoResize = true;
-      mockGridOptions.autoResize.useResizeObserver = true;
+      mockGridOptions.autoResize.resizeDetection = 'container';
       mockGridOptions.autoResize.container = '#doesnotexist';
 
       expect(() => service.init(gridStub, divContainer)).toThrowError('[Slickgrid-Universal] Resizer Service requires a container when gridOption.autoResize.useResizeObserver=true');
     });
 
-    it('should execute "resizeGrid" when "useResizeObserver" is true', () => {
+    it('should execute "resizeGrid" when "resizeDetection" is "container"', () => {
       mockGridOptions.enableAutoResize = true;
-      mockGridOptions.autoResize.useResizeObserver = true;
+      mockGridOptions.autoResize.resizeDetection = "container";
       const resizeContainer = document.createElement('div');
       mockGridOptions.autoResize.container = resizeContainer;
 
@@ -176,9 +176,9 @@ describe('Resizer Service', () => {
       expect(resizeGridSpy).toHaveBeenCalledWith();
     });
 
-    it('should not execute "resizeGrid" when "useResizeObserver" is true and the resizer is paused', () => {
+    it('should not execute "resizeGrid" when "resizeDetection" is "container" and the resizer is paused', () => {
       mockGridOptions.enableAutoResize = true;
-      mockGridOptions.autoResize.useResizeObserver = true;
+      mockGridOptions.autoResize.resizeDetection = "container";
       const resizeContainer = document.createElement('div');
       mockGridOptions.autoResize.container = resizeContainer;
 
@@ -206,9 +206,9 @@ describe('Resizer Service', () => {
       }, 2);
     });
 
-    it('should disconnect from resize events on the container element when "useResizeObserver" is true', () => {
+    it('should disconnect from resize events on the container element when "resizeDetection" is "container"', () => {
       mockGridOptions.enableAutoResize = true;
-      mockGridOptions.autoResize.useResizeObserver = true;
+      mockGridOptions.autoResize.resizeDetection = "container";
       const resizeContainer = document.createElement('div');
       mockGridOptions.autoResize.container = resizeContainer;
 

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -5,6 +5,8 @@ import { FieldType, } from '../../enums/index';
 import { Column, GridOption, SlickGrid, SlickNamespace, } from '../../interfaces/index';
 import { ResizerService } from '../resizer.service';
 
+import 'jest-extended';
+
 declare const Slick: SlickNamespace;
 const DATAGRID_MIN_HEIGHT = 180;
 const DATAGRID_MIN_WIDTH = 300;
@@ -63,11 +65,23 @@ describe('Resizer Service', () => {
   let service: ResizerService;
   let divContainer: HTMLDivElement;
   let mockGridOptions: GridOption;
+  let resizeObserverMock: jest.Mock<ResizeObserver, [callback: ResizeObserverCallback]>;
 
   beforeEach(() => {
     divContainer = document.createElement('div');
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
+
+    resizeObserverMock = jest.fn(function (callback: ResizeObserverCallback): ResizeObserver {
+      this.observe = jest.fn().mockImplementation(() => {
+        callback([], this); // Execute the callback on observe, similar to the window.ResizeObserver.
+      });
+      this.unobserve = jest.fn();
+      this.disconnect = jest.fn();
+      return this;
+    });
+
+    global.ResizeObserver = resizeObserverMock;
 
     eventPubSubService = new EventPubSubService();
     service = new ResizerService(eventPubSubService);
@@ -125,6 +139,57 @@ describe('Resizer Service', () => {
 
       expect(bindAutoResizeDataGridSpy).not.toHaveBeenCalled();
     });
+
+    it('should observe resize events on the container element when "useResizeObserver" is true', () => {
+      mockGridOptions.enableAutoResize = true;
+      mockGridOptions.autoResize.useResizeObserver = true;
+      const resizeContainer = document.createElement('div');
+      mockGridOptions.autoResize.container = resizeContainer;
+
+      service.init(gridStub, divContainer);
+
+      expect(resizeObserverMock.mock.instances.length).toBe(1);
+      const observerInstance = resizeObserverMock.mock.instances[0];
+
+      expect(observerInstance.observe).toHaveBeenCalledTimes(1);
+      expect(observerInstance.observe).toHaveBeenCalledWith(resizeContainer);
+    });
+
+    it('should throw an error when container element is not valid and "useResizeObserver" is true', () => {
+      mockGridOptions.enableAutoResize = true;
+      mockGridOptions.autoResize.useResizeObserver = true;
+      mockGridOptions.autoResize.container = '#doesnotexist';
+
+      expect(() => service.init(gridStub, divContainer)).toThrowError('[Slickgrid-Universal] Resizer Service requires a container when gridOption.autoResize.useResizeObserver=true');
+    });
+
+    it('should execute "resizeGrid" when "useResizeObserver" is true', () => {
+      mockGridOptions.enableAutoResize = true;
+      mockGridOptions.autoResize.useResizeObserver = true;
+      const resizeContainer = document.createElement('div');
+      mockGridOptions.autoResize.container = resizeContainer;
+
+      const resizeGridSpy = jest.spyOn(service, 'resizeGrid');
+
+      service.init(gridStub, divContainer);
+
+      expect(resizeGridSpy).toHaveBeenCalledWith();
+    });
+
+    it('should not execute "resizeGrid" when "useResizeObserver" is true and the resizer is paused', () => {
+      mockGridOptions.enableAutoResize = true;
+      mockGridOptions.autoResize.useResizeObserver = true;
+      const resizeContainer = document.createElement('div');
+      mockGridOptions.autoResize.container = resizeContainer;
+
+      const resizeGridSpy = jest.spyOn(service, 'resizeGrid');
+
+      service.pauseResizer(true);
+
+      service.init(gridStub, divContainer);
+
+      expect(resizeGridSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('dispose method', () => {
@@ -139,6 +204,22 @@ describe('Resizer Service', () => {
         expect(resizeGridWithDimensionsSpy).not.toHaveBeenCalled();
         done();
       }, 2);
+    });
+
+    it('should disconnect from resize events on the container element when "useResizeObserver" is true', () => {
+      mockGridOptions.enableAutoResize = true;
+      mockGridOptions.autoResize.useResizeObserver = true;
+      const resizeContainer = document.createElement('div');
+      mockGridOptions.autoResize.container = resizeContainer;
+
+      service.init(gridStub, divContainer);
+
+      service.dispose();
+
+      expect(resizeObserverMock.mock.instances.length).toBe(1);
+      const observerInstance = resizeObserverMock.mock.instances[0];
+
+      expect(observerInstance.disconnect).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -42,7 +42,7 @@ export class ResizerService {
   protected _totalColumnsWidthByContent = 0;
   protected _timer!: NodeJS.Timeout;
   protected _resizePaused = false;
-  protected readonly _resizeObserver: ResizeObserver = new ResizeObserver(() => this.resizeObserverCallback());
+  protected _resizeObserver!: ResizeObserver;
 
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
@@ -91,7 +91,9 @@ export class ResizerService {
     clearTimeout(this._timer);
 
     if (this.gridOptions.autoResize?.resizeDetection === 'container') {
-      this._resizeObserver.disconnect();
+      if (this._resizeObserver) {
+        this._resizeObserver.disconnect();
+      }
     } else {
       $(window).off(`resize.grid${this.gridUidSelector}`);
     }
@@ -160,8 +162,11 @@ export class ResizerService {
     if (this.gridOptions.autoResize?.resizeDetection === 'container') {
       if (!this._pageContainerElm || !this._pageContainerElm[0]) {
         throw new Error(`
-          [Slickgrid-Universal] Resizer Service requires a container when gridOption.autoResize.useResizeObserver=true
+          [Slickgrid-Universal] Resizer Service requires a container when gridOption.autoResize.resizeDetection="container"
           You can fix this by setting your gridOption.autoResize.container`);
+      }
+      if (!this._resizeObserver) {
+        this._resizeObserver = new ResizeObserver(() => this.resizeObserverCallback());
       }
       this._resizeObserver.observe(this._pageContainerElm[0]);
     } else {


### PR DESCRIPTION
This PR builds on top of https://github.com/ghiscoding/slickgrid-universal/pull/489 and adds the `ResizeObserver` mentioned here https://github.com/ghiscoding/Angular-Slickgrid/issues/836 and is the "PR 3" mentioned there.

This PR adds the `gridOptions.autoResize.resizeDetection`. It's `'window'` by default, when set to `'container'` it observes the set `gridOptions.autoResize.container` element for resize events. When a resize event is observed it resizes the grid with the available height/width based on that container's dimensions.

The `gridOptions.autoResize.container` got changed from `string` to `string | HtmlElement` so that it's possible to provide an element directly which saves me in my project for having to create a unique id. I think this change is backwards compatible. 

Changed example-14 in the Slickgrid universal demo vanilla to use the `ResizeObserver`. I used a simple approach for letting the (resize) container div take all available space in the y-axis.

BTW I tested from my project by:
* creating a symlink:
`C:\repos\MyProject\src\node_modules\@slickgrid-universal\common>mklink /J dist C:\repos\slickgrid-universal\packages\common\dist`
* running a build watch from @slickgrid-universal/common: `C:\repos\slickgrid-universal>lerna run build:watch --stream`
* and then running `ng serve` / `ng test` from my project.

 I first tried the `npm link` route, but couldn't get that to work. Would love to hear if there is a better solution than symlinks...

