### PR TITLE
chore: revisit all querySelector to prefer local element selector

### DIFF
--- a/packages/common/src/filters/compoundSliderFilter.ts
+++ b/packages/common/src/filters/compoundSliderFilter.ts
@@ -313,9 +313,8 @@ export class CompoundSliderFilter implements Filter {
   protected handleInputChange(event: Event) {
     const value = (event?.target as HTMLInputElement).value;
     if (value !== undefined && value !== null) {
-      const element = document.querySelector(`.${this._elementRangeOutputId || ''}`);
-      if (element?.textContent) {
-        element.textContent = value;
+      if (this.filterNumberElm?.textContent) {
+        this.filterNumberElm.textContent = value;
       }
     }
   }

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -222,7 +222,6 @@ export class SliderFilter implements Filter {
       this.divContainerFilterElm.appendChild(divGroupAppendElm);
     }
 
-    // this.filterNumberElm.html(searchTermInput);
     this.divContainerFilterElm.dataset.columnid = `${columnId}`;
 
     // if there's a search term, we will add the "filled" class for styling purposes
@@ -239,9 +238,8 @@ export class SliderFilter implements Filter {
   protected handleInputChange(event: Event) {
     const value = (event?.target as HTMLInputElement).value;
     if (value !== undefined && value !== null) {
-      const element = document.querySelector(`.${this._elementRangeOutputId || ''}`);
-      if (element?.textContent) {
-        element.textContent = value;
+      if (this.filterNumberElm?.textContent) {
+        this.filterNumberElm.textContent = value;
       }
     }
   }

--- a/packages/common/src/filters/sliderRangeFilter.ts
+++ b/packages/common/src/filters/sliderRangeFilter.ts
@@ -132,8 +132,8 @@ export class SliderRangeFilter implements Filter {
    */
   renderSliderValues(lowestValue: number | string, highestValue: number | string) {
     const columnId = this.columnDef?.id ?? '';
-    const lowerElm = document.querySelector(`.lowest-range-${columnId}`);
-    const highestElm = document.querySelector(`.highest-range-${columnId}`);
+    const lowerElm = this.$filterContainerElm.get(0)?.querySelector(`.lowest-range-${columnId}`);
+    const highestElm = this.$filterContainerElm.get(0)?.querySelector(`.highest-range-${columnId}`);
     if (lowerElm?.textContent) {
       lowerElm.textContent = lowestValue.toString();
     }

--- a/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
@@ -287,6 +287,9 @@ describe('Composite Editor Factory', () => {
   });
 
   it('should instantiate the factory and expect "validate" to be called and return True when all editors are valid', () => {
+    const modalElm = document.createElement('div');
+    modalElm.className = 'slick-editor-modal';
+
     for (const column of columnsMock) {
       if (column.editor) {
         const validationEditorElm = document.createElement('div');
@@ -295,11 +298,12 @@ describe('Composite Editor Factory', () => {
         labelEditorElm.className = `item-details-label editor-${column.id}`;
         const inputEditorElm = document.createElement('input');
         inputEditorElm.dataset.editorid = `${column.id}`;
-        document.body.appendChild(validationEditorElm);
-        document.body.appendChild(labelEditorElm);
-        document.body.appendChild(inputEditorElm);
+        modalElm.appendChild(validationEditorElm);
+        modalElm.appendChild(labelEditorElm);
+        modalElm.appendChild(inputEditorElm);
       }
     }
+    document.body.appendChild(modalElm);
 
     const output = new factory(textEditorArgs);
     const editorValidateSpy = jest.spyOn(output, 'validate');
@@ -319,6 +323,9 @@ describe('Composite Editor Factory', () => {
   });
 
   it('should instantiate the factory and expect "validate" to be called and return True when at least 1 editor is invalid', () => {
+    const modalElm = document.createElement('div');
+    modalElm.className = 'slick-editor-modal';
+
     for (const column of columnsMock) {
       if (column.editor) {
         const validationEditorElm = document.createElement('div');
@@ -327,11 +334,12 @@ describe('Composite Editor Factory', () => {
         labelEditorElm.className = `item-details-label editor-${column.id}`;
         const inputEditorElm = document.createElement('input');
         inputEditorElm.dataset.editorid = `${column.id}`;
-        document.body.appendChild(validationEditorElm);
-        document.body.appendChild(labelEditorElm);
-        document.body.appendChild(inputEditorElm);
+        modalElm.appendChild(validationEditorElm);
+        modalElm.appendChild(labelEditorElm);
+        modalElm.appendChild(inputEditorElm);
       }
     }
+    document.body.appendChild(modalElm);
 
     const output = new factory(textEditorArgs);
     const editorValidateSpy = jest.spyOn(output, 'validate');

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -181,9 +181,10 @@ export function CompositeEditor(this: any, columns: Column[], containers: Array<
       while (idx < editors.length) {
         const columnDef = editors[idx].args?.column;
         if (columnDef?.id !== undefined) {
-          let validationElm = document.querySelector(`.item-details-validation.editor-${columnDef.id}`);
-          let labelElm = document.querySelector(`.item-details-label.editor-${columnDef.id}`);
-          let editorElm = document.querySelector(`[data-editorid=${columnDef.id}]`);
+          const compositeModalElm = document.querySelector(`.slick-editor-modal`);
+          let validationElm = compositeModalElm?.querySelector(`.item-details-validation.editor-${columnDef.id}`);
+          let labelElm = compositeModalElm?.querySelector(`.item-details-label.editor-${columnDef.id}`);
+          let editorElm = compositeModalElm?.querySelector(`[data-editorid=${columnDef.id}]`);
           const validationMsgPrefix = options?.validationMsgPrefix ?? '';
 
           if (!targetElm || editorElm?.contains(targetElm)) {

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -906,7 +906,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     this._itemDataContext = editor?.dataContext ?? {}; // keep reference of the item data context
 
     // add extra css styling to the composite editor input(s) that got modified
-    const editorElm = document.querySelector(`[data-editorid=${columnId}]`);
+    const editorElm = document.querySelector(`.slick-editor-modal [data-editorid=${columnId}]`);
     if (editorElm?.classList) {
       if (isEditorValueTouched) {
         editorElm.classList.add('modified');

--- a/packages/custom-footer-component/src/slick-footer.component.ts
+++ b/packages/custom-footer-component/src/slick-footer.component.ts
@@ -31,8 +31,12 @@ export class SlickFooterComponent {
     return this._eventHandler;
   }
 
+  /** Getter for the grid uid */
   get gridUid(): string {
     return this.grid?.getUID() ?? '';
+  }
+  get gridUidSelector(): string {
+    return this.gridUid ? `.${this.gridUid}` : '';
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
@@ -50,14 +54,14 @@ export class SlickFooterComponent {
   }
 
   get leftFooterText(): string {
-    return document.querySelector('div.left-footer')?.textContent ?? '';
+    return document.querySelector(`.slick-custom-footer${this.gridUidSelector} .left-footer`)?.textContent ?? '';
   }
   set leftFooterText(text: string) {
     this.renderLeftFooterText(text);
   }
 
   get rightFooterText(): string {
-    return document.querySelector('div.right-footer')?.textContent ?? '';
+    return document.querySelector(`.slick-custom-footer${this.gridUidSelector} .right-footer`)?.textContent ?? '';
   }
   set rightFooterText(text: string) {
     this.renderRightFooterText(text);


### PR DESCRIPTION
- revisit all `document.querySelector` and make sure that we use localized selector instead of querying against the entire DOM tree