### PR TITLE
fix(tree): when Tree Data is filtered then Sort, footer count is invalid

### DIFF
--- a/packages/common/src/services/__tests__/sort.service.spec.ts
+++ b/packages/common/src/services/__tests__/sort.service.spec.ts
@@ -47,11 +47,15 @@ const gridOptionMock = {
 } as unknown as GridOption;
 
 const dataViewStub = {
+  getFilteredItemCount: jest.fn(),
+  getItemCount: jest.fn(),
   getItemMetadata: jest.fn(),
+  getLength: jest.fn(),
   refresh: jest.fn(),
-  sort: jest.fn(),
   reSort: jest.fn(),
+  sort: jest.fn(),
   setItems: jest.fn(),
+  onRowCountChanged: new Slick.Event(),
 } as unknown as SlickDataView;
 
 const backendServiceStub = {

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -412,6 +412,11 @@ export class SortService {
         // we could use the DataView sort but that would require re-sorting again (since the 2nd array that is currently in the DataView would have to be resorted against the 1st array that was sorting from tree sort)
         // it is simply much faster to just replace the entire dataset
         this._dataView.setItems(datasetSortResult.flat, datasetIdPropertyName);
+
+        // also trigger a row count changed to avoid having an invalid filtered item count in the grid footer
+        // basically without this the item count in the footer is incorrect and shows the full dataset length instead of the previous filtered count
+        // that happens because we just overwrote the entire dataset the DataView.refresh() doesn't detect a row count change so we trigger it manually
+        this._dataView.onRowCountChanged.notify({ previous: this._dataView.getFilteredItemCount(), current: this._dataView.getLength(), itemCount: this._dataView.getItemCount(), dataView: this._dataView, callingOnRowsChanged: true });
       } else {
         dataView.sort(this.sortComparers.bind(this, sortColumns));
       }


### PR DESCRIPTION
- use case, if we have filtered data in the grid (any filter is applied and some items are filtered) and we then Sort a column, the item count shown in the Footer was showing the entire dataset count instead of the filtered count. This happens because internally the lib will Sort the hierarchical dataset and then overwrite the DataView flat dataset and when it does that it was changing the footer count.
- the fix is simply to force the `onRowCountChanged` event with the correct count so that it updates the Footer count correctly

![FzAqxrZ64L](https://user-images.githubusercontent.com/643976/134587744-2fd32a5d-1a68-450e-b524-275246db5639.gif)
