### PR TITLE
refactor: expose public translate methods & translate at the source

### DIFF
--- a/packages/custom-footer-component/src/slick-footer.spec.ts
+++ b/packages/custom-footer-component/src/slick-footer.spec.ts
@@ -1,6 +1,7 @@
 import 'jest-extended';
 import { CustomFooterOption, GridOption, SlickGrid } from '@slickgrid-universal/common';
 import { SlickFooterComponent } from './slick-footer.component';
+import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { TranslateServiceStub } from '../../../test/translateServiceStub';
 
 function removeExtraSpaces(text: string) {
@@ -24,12 +25,14 @@ const gridStub = {
 describe('Slick-Footer Component', () => {
   let component: SlickFooterComponent;
   let div: HTMLDivElement;
+  let eventPubSubService: EventPubSubService;
   let translateService: TranslateServiceStub;
   let mockTimestamp: Date;
 
   beforeEach(() => {
     div = document.createElement('div');
     document.body.appendChild(div);
+    eventPubSubService = new EventPubSubService();
     translateService = new TranslateServiceStub();
     mockTimestamp = new Date('2019-05-03T00:00:01');
 
@@ -52,7 +55,7 @@ describe('Slick-Footer Component', () => {
     });
 
     it('should make sure Slick-Footer is being created and rendered', () => {
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
 
       const footerContainerElm = document.querySelector<HTMLSelectElement>('div.slick-custom-footer.slickgrid_123456');
@@ -63,7 +66,7 @@ describe('Slick-Footer Component', () => {
     });
 
     it('should create a the Slick-Footer component in the DOM', () => {
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
 
       const footerContainerElm = document.querySelector('div.slick-custom-footer.slickgrid_123456') as HTMLDivElement;
@@ -80,7 +83,7 @@ describe('Slick-Footer Component', () => {
       (mockGridOptions.customFooterOptions as CustomFooterOption).hideLastUpdateTimestamp = true;
       (mockGridOptions.customFooterOptions as CustomFooterOption).hideMetrics = true;
 
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -96,7 +99,7 @@ describe('Slick-Footer Component', () => {
     });
 
     it('should create a the Slick-Footer component in the DOM with only right side with last update timestamp & items count', () => {
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -120,7 +123,7 @@ describe('Slick-Footer Component', () => {
       (mockGridOptions.customFooterOptions as CustomFooterOption).hideMetrics = false;
       (mockGridOptions.customFooterOptions as CustomFooterOption).hideLastUpdateTimestamp = true;
 
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -143,7 +146,7 @@ describe('Slick-Footer Component', () => {
       (mockGridOptions.customFooterOptions as CustomFooterOption).hideLastUpdateTimestamp = true;
       (mockGridOptions.customFooterOptions as CustomFooterOption).hideTotalItemCount = true;
 
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -164,7 +167,7 @@ describe('Slick-Footer Component', () => {
     it('should create a the Slick-Footer component in the DOM and expect to use default English locale when none of the metricsText are defined', () => {
       (mockGridOptions.customFooterOptions as CustomFooterOption).metricTexts = { items: '', lastUpdate: '', of: '' };
 
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -184,12 +187,19 @@ describe('Slick-Footer Component', () => {
           <span class="text-items">items</span>`));
     });
 
+    it('should throw an error when enabling translate without a Translate Service', () => {
+      mockGridOptions.enableTranslate = true;
+      expect(() => new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, null))
+        .toThrow('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
+    });
+
     it('should create a the Slick-Footer component in the DOM and use different locale when enableTranslate is enabled', () => {
       (mockGridOptions.customFooterOptions as CustomFooterOption).metricTexts = { itemsKey: 'ITEMS', lastUpdateKey: 'LAST_UPDATE', ofKey: 'OF' };
       mockGridOptions.enableTranslate = true;
       translateService.use('fr');
+      eventPubSubService.publish('onLanguageChange', 'fr');
 
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -212,7 +222,7 @@ describe('Slick-Footer Component', () => {
       mockGridOptions.enableCheckboxSelector = true;
       const customFooterOptions = mockGridOptions.customFooterOptions as CustomFooterOption;
       customFooterOptions.leftFooterText = 'initial left footer text';
-      component = new SlickFooterComponent(gridStub, customFooterOptions, translateService);
+      component = new SlickFooterComponent(gridStub, customFooterOptions, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -227,7 +237,7 @@ describe('Slick-Footer Component', () => {
 
     it('should display custom text on the left side footer section when calling the leftFooterText SETTER', () => {
       mockGridOptions.enableCheckboxSelector = true;
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
       component.leftFooterText = 'custom left footer text';
@@ -249,7 +259,7 @@ describe('Slick-Footer Component', () => {
 
     it('should display 1 items selected on the left side footer section after triggering "onSelectedRowsChanged" event', () => {
       mockGridOptions.enableCheckboxSelector = true;
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
       gridStub.onSelectedRowsChanged.notify({ rows: [1], grid: gridStub, previousSelectedRows: [] });
@@ -276,7 +286,7 @@ describe('Slick-Footer Component', () => {
     it('should not not display row selection count after triggering "onSelectedRowsChanged" event when "hideRowSelectionCount" is set to True', () => {
       mockGridOptions.enableCheckboxSelector = true;
       mockGridOptions.customFooterOptions.hideRowSelectionCount = true;
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
       gridStub.onSelectedRowsChanged.notify({ rows: [1], grid: gridStub, previousSelectedRows: [] });
@@ -299,7 +309,7 @@ describe('Slick-Footer Component', () => {
 
     it('should display row selection count on the left side footer section after triggering "onSelectedRowsChanged" event', () => {
       mockGridOptions.enableCheckboxSelector = true;
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       gridStub.onSelectedRowsChanged.notify({ rows: [1], previousSelectedRows: [], grid: gridStub, });
 
@@ -315,7 +325,7 @@ describe('Slick-Footer Component', () => {
       (mockGridOptions.customFooterOptions as CustomFooterOption).metricTexts = { itemsKey: 'ITEMS', itemsSelectedKey: 'ITEMS_SELECTED', lastUpdateKey: 'LAST_UPDATE', ofKey: 'OF' };
       mockGridOptions.enableTranslate = true;
       mockGridOptions.enableCheckboxSelector = true;
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
 
       gridStub.onSelectedRowsChanged.notify({ rows: [1], previousSelectedRows: [], grid: gridStub, });
@@ -337,7 +347,7 @@ describe('Slick-Footer Component', () => {
       mockGridOptions.enableCheckboxSelector = true;
       const customFooterOptions = mockGridOptions.customFooterOptions as CustomFooterOption;
       customFooterOptions.rightFooterText = 'initial right footer text';
-      component = new SlickFooterComponent(gridStub, customFooterOptions, translateService);
+      component = new SlickFooterComponent(gridStub, customFooterOptions, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
 
@@ -353,7 +363,7 @@ describe('Slick-Footer Component', () => {
 
     it('should display custom text on the right side footer section when calling the rightFooterText SETTER', () => {
       mockGridOptions.enableCheckboxSelector = true;
-      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, translateService);
+      component = new SlickFooterComponent(gridStub, mockGridOptions.customFooterOptions as CustomFooterOption, eventPubSubService, translateService);
       component.renderFooter(div);
       component.metrics = { startTime: mockTimestamp, endTime: mockTimestamp, itemCount: 7, totalItemCount: 99 };
       component.rightFooterText = 'custom right footer text';

--- a/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
@@ -254,6 +254,12 @@ describe('with different i18n locale', () => {
     component.renderPagination(div);
   });
 
+  it('should throw an error when enabling translate without a Translate Service', () => {
+    mockGridOptions.enableTranslate = true;
+    expect(() => new SlickPaginationComponent(paginationServiceStub, eventPubSubService, sharedService, null))
+      .toThrow('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
+  });
+
   it('should create a the Slick-Pagination component in the DOM and expect different locale when changed', (done) => {
     translateService.use('fr');
     eventPubSubService.publish('onLanguageChange', 'fr');

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1389,7 +1389,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         component.gridOptions = { enableTranslate: true, createPreHeaderPanel: false, enableDraggableGrouping: false, showCustomFooter: true } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
-        const transCustomFooterSpy = jest.spyOn(component.slickFooter, 'translateCustomFooterTexts'); // footer gets created after init
 
         eventPubSubService.publish('onLanguageChange', { language: 'fr' });
 
@@ -1402,7 +1401,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           expect(transContextMenuSpy).toHaveBeenCalled();
           expect(transGridMenuSpy).toHaveBeenCalled();
           expect(transHeaderMenuSpy).toHaveBeenCalled();
-          expect(transCustomFooterSpy).toHaveBeenCalled();
           done();
         });
       });
@@ -1827,48 +1825,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
               itemsSelected: 'éléments sélectionnés',
               itemsSelectedKey: 'ITEMS_SELECTED',
               of: 'de',
-              ofKey: 'OF',
-            },
-            rightContainerClass: 'col-xs-6 col-sm-7',
-          });
-          done();
-        });
-      });
-
-      it('should have a Custom Footer and custom texts when "showCustomFooter" is enabled with different metricTexts defined', (done) => {
-        const mockColDefs = [{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }];
-
-        component.gridOptions.enableTranslate = false;
-        component.gridOptions.showCustomFooter = true;
-        component.gridOptions.customFooterOptions = {
-          hideRowSelectionCount: false,
-          metricTexts: {
-            items: 'some items',
-            lastUpdate: 'some last update',
-            of: 'some of'
-          }
-        };
-        component.initialization(divContainer, slickEventHandler);
-        component.columnDefinitions = mockColDefs;
-
-        setTimeout(() => {
-          expect(component.columnDefinitions).toEqual(mockColDefs);
-          expect(component.gridOptions.showCustomFooter).toBeTrue();
-          expect(component.gridOptions.customFooterOptions).toEqual({
-            dateFormat: 'YYYY-MM-DD, hh:mm a',
-            hideRowSelectionCount: false,
-            hideLastUpdateTimestamp: true,
-            hideTotalItemCount: false,
-            footerHeight: 25,
-            leftContainerClass: 'col-xs-12 col-sm-5',
-            metricSeparator: '|',
-            metricTexts: {
-              items: 'some items',
-              itemsKey: 'ITEMS',
-              itemsSelected: 'items selected',
-              itemsSelectedKey: 'ITEMS_SELECTED',
-              lastUpdate: 'some last update',
-              of: 'some of',
               ofKey: 'OF',
             },
             rightContainerClass: 'col-xs-6 col-sm-7',

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -583,7 +583,7 @@ export class SlickVanillaGridBundle {
 
     // user could show a custom footer with the data metrics (dataset length and last updated timestamp)
     if (!this.gridOptions.enablePagination && this.gridOptions.showCustomFooter && this.gridOptions.customFooterOptions) {
-      this.slickFooter = new SlickFooterComponent(this.slickGrid, this.gridOptions.customFooterOptions, this.translaterService);
+      this.slickFooter = new SlickFooterComponent(this.slickGrid, this.gridOptions.customFooterOptions, this._eventPubSubService, this.translaterService);
       this.slickFooter.renderFooter(this._gridParentContainerElm);
     }
 
@@ -753,7 +753,6 @@ export class SlickVanillaGridBundle {
     if (gridOptions.enableTranslate) {
       this.translateColumnHeaderTitleKeys();
       this.translateColumnGroupKeys();
-      this.translateCustomFooterTexts();
     }
 
     // on locale change, we have to manually translate the Headers, GridMenu
@@ -766,7 +765,6 @@ export class SlickVanillaGridBundle {
           this.extensionService.translateContextMenu();
           this.extensionService.translateGridMenu();
           this.extensionService.translateHeaderMenu();
-          this.translateCustomFooterTexts();
           this.translateColumnHeaderTitleKeys();
           this.translateColumnGroupKeys();
           if (gridOptions.createPreHeaderPanel && !gridOptions.enableDraggableGrouping) {
@@ -1470,13 +1468,6 @@ export class SlickVanillaGridBundle {
 
       return { ...column, editor: columnEditor?.model, internalColumnEditor: { ...columnEditor } };
     });
-  }
-
-  /** Translate all Custom Footer Texts (footer with metrics) */
-  private translateCustomFooterTexts() {
-    if (this.slickFooter && this.translaterService?.translate) {
-      this.slickFooter?.translateCustomFooterTexts();
-    }
   }
 
   /** translate all columns (including hidden columns) */


### PR DESCRIPTION
- expose translate methods as public so they can be used from the outside
- instead of calling translate from the lib/framework, we can (should) do it directly from within the component by subscribing to the "onLanguageChanged" event