### PR TITLE
fix(context): Copy Cell via Context Menu shouldn't include Tree symbols

### DIFF
--- a/packages/common/src/extensions/contextMenuExtension.ts
+++ b/packages/common/src/extensions/contextMenuExtension.ts
@@ -424,13 +424,16 @@ export class ContextMenuExtension implements Extension {
           textToCopy = this.getCellValueFromQueryFieldGetter(columnDef, dataContext);
         }
 
+        // remove any unwanted Tree Data/Grouping symbols from the beginning of the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
+        const finalTextToCopy = textToCopy.replace(/^([·|⮞|⮟]\s*)|([·|⮞|⮟])\s*/g, '');
+
         // create fake <textarea> (positioned outside of the screen) to copy into clipboard & delete it from the DOM once we're done
         const tmpElem = document.createElement('textarea') as HTMLTextAreaElement;
         if (tmpElem && document.body) {
           tmpElem.style.position = 'absolute';
           tmpElem.style.left = '-1000px';
           tmpElem.style.top = '-1000px';
-          tmpElem.value = textToCopy;
+          tmpElem.value = finalTextToCopy;
           document.body.appendChild(tmpElem);
           tmpElem.select();
           const success = document.execCommand('copy', false, textToCopy);


### PR DESCRIPTION
- since the Context Menu Copy Cell command uses Export Formatter (when defined), it was including extra Tree/Grouping symbols that we don't want to see when doing a Copy Cell, so we should strip these symbols from the start of a string only.

![SzFrQlahz1](https://user-images.githubusercontent.com/643976/135137668-8a971cf1-9bab-4539-b1be-2ad5496e40a1.gif)
