### PR TITLE
feat(context): expose 3 events for Tree/Grouping clear/collapse/expand

### DIFF
--- a/packages/common/src/extensions/__tests__/contextMenuExtension.spec.ts
+++ b/packages/common/src/extensions/__tests__/contextMenuExtension.spec.ts
@@ -887,25 +887,29 @@ describe('contextMenuExtension', () => {
         const dataviewSpy = jest.spyOn(SharedService.prototype.dataView, 'setGrouping');
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         extension.register();
 
         const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'clear-grouping') as MenuCommandItem;
         menuItemCommand.action!(new CustomEvent('change'), { command: 'clear-grouping', cell: 0, row: 0 } as any);
 
         expect(dataviewSpy).toHaveBeenCalledWith([]);
-        expect(pubSpy).toHaveBeenCalledWith('contextMenu:clearGrouping', true);
+        expect(pubSpy).toHaveBeenCalledWith('onContextMenuClearGrouping');
+        expect(pubSubSpy).toHaveBeenCalledWith('onContextMenuClearGrouping');
       });
 
       it('should call "collapseAllGroups" from the DataView when Grouping is enabled and the command triggered is "collapse-all-groups"', () => {
         const dataviewSpy = jest.spyOn(SharedService.prototype.dataView, 'collapseAllGroups');
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideCollapseAllGroups: false } } as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         extension.register();
 
         const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'collapse-all-groups') as MenuCommandItem;
         menuItemCommand.action!(new CustomEvent('change'), { command: 'collapse-all-groups', cell: 0, row: 0 } as any);
 
         expect(dataviewSpy).toHaveBeenCalledWith();
+        expect(pubSubSpy).toHaveBeenCalledWith('onContextMenuCollapseAllGroups');
       });
 
       it('should call "collapseAllGroups" from the DataView when Tree Data is enabled and the command triggered is "collapse-all-groups"', () => {
@@ -925,12 +929,14 @@ describe('contextMenuExtension', () => {
         const dataviewSpy = jest.spyOn(SharedService.prototype.dataView, 'expandAllGroups');
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideExpandAllGroups: false } } as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
         extension.register();
 
         const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'expand-all-groups') as MenuCommandItem;
         menuItemCommand.action!(new CustomEvent('change'), { command: 'expand-all-groups', cell: 0, row: 0 } as any);
 
         expect(dataviewSpy).toHaveBeenCalledWith();
+        expect(pubSubSpy).toHaveBeenCalledWith('onContextMenuExpandAllGroups');
       });
 
       it('should call "expandAllGroups" from the DataView when Tree Data is enabled and the command triggered is "expand-all-groups"', () => {

--- a/packages/common/src/extensions/__tests__/draggableGroupingExtension.spec.ts
+++ b/packages/common/src/extensions/__tests__/draggableGroupingExtension.spec.ts
@@ -139,7 +139,7 @@ describe('draggableGroupingExtension', () => {
       const addon = extension.register();
       const clearSpy = jest.spyOn(addon, 'clearDroppedGroups');
 
-      fnCallbacks['contextMenu:clearGrouping'](true);
+      fnCallbacks['onContextMenuClearGrouping'](true);
 
       expect(clearSpy).toHaveBeenCalled();
     });

--- a/packages/common/src/extensions/contextMenuExtension.ts
+++ b/packages/common/src/extensions/contextMenuExtension.ts
@@ -323,7 +323,7 @@ export class ContextMenuExtension implements Extension {
               positionOrder: 55,
               action: () => {
                 dataView.setGrouping([]);
-                this.pubSubService.publish('contextMenu:clearGrouping', true);
+                this.pubSubService.publish('onContextMenuClearGrouping');
               },
               itemUsabilityOverride: () => {
                 // only enable the command when there's an actually grouping in play
@@ -352,6 +352,7 @@ export class ContextMenuExtension implements Extension {
                 } else {
                   dataView.collapseAllGroups();
                 }
+                this.pubSubService.publish('onContextMenuCollapseAllGroups');
               },
               itemUsabilityOverride: () => {
                 if (gridOptions.enableTreeData) {
@@ -383,6 +384,7 @@ export class ContextMenuExtension implements Extension {
                 } else {
                   dataView.expandAllGroups();
                 }
+                this.pubSubService.publish('onContextMenuExpandAllGroups');
               },
               itemUsabilityOverride: () => {
                 if (gridOptions.enableTreeData) {

--- a/packages/common/src/extensions/draggableGroupingExtension.ts
+++ b/packages/common/src/extensions/draggableGroupingExtension.ts
@@ -74,7 +74,7 @@ export class DraggableGroupingExtension implements Extension {
         }
 
         // we also need to subscribe to a possible user clearing the grouping via the Context Menu, we need to clear the pre-header bar as well
-        this.pubSubService.subscribe('contextMenu:clearGrouping', () => this._addon?.clearDroppedGroups?.());
+        this.pubSubService.subscribe('onContextMenuClearGrouping', () => this._addon?.clearDroppedGroups?.());
       }
 
       return this._addon;


### PR DESCRIPTION
- for our use case, we have an external CollapseAll/ExpandAll button that needs to be flipped even when user is using the toggle from the context menu instead of that external button (in other words, they both have to be in sync)