### PR TITLE
fix(tree): Grid State should have Tree Data initial sort

### DIFF
--- a/packages/common/src/services/__tests__/sort.service.spec.ts
+++ b/packages/common/src/services/__tests__/sort.service.spec.ts
@@ -1157,6 +1157,19 @@ describe('SortService', () => {
         sharedService.hierarchicalDataset = dataset;
       });
 
+      it('should sort the hierarchical dataset and expect event emitted when passing True as 3rd argument', () => {
+        const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
+        const sortTreeDataSpy = jest.spyOn(service, 'sortTreeData');
+        const emitSortChangedSpy = jest.spyOn(service, 'emitSortChanged');
+
+        const result = service.sortHierarchicalDataset(dataset, [{ columnId: 'file', sortAsc: true, sortCol: mockColumns[0] }], true);
+
+        expect(result).toBeTruthy();
+        expect(pubSubSpy).toHaveBeenCalledWith('onSortChanged', [{ columnId: 'file', direction: 'ASC' }]);
+        expect(sortTreeDataSpy).toHaveBeenCalled();
+        expect(emitSortChangedSpy).toHaveBeenCalled();
+      });
+
       it('should call onLocalSortChanged with a hierarchical dataset and expect DataView "setItems" method be called once with sorted ASC dataset', (done) => {
         gridOptionMock.enableTreeData = true;
         gridOptionMock.treeDataOptions = { columnId: 'file', childrenPropName: 'files', };

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -435,12 +435,22 @@ export class SortService {
   }
 
   /** Takes a hierarchical dataset and sort it recursively,  */
-  sortHierarchicalDataset<T>(hierarchicalDataset: T[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>) {
+  sortHierarchicalDataset<T>(hierarchicalDataset: T[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>, emitSortChanged = false) {
     this.sortTreeData(hierarchicalDataset, sortColumns);
     const dataViewIdIdentifier = this._gridOptions?.datasetIdPropertyName ?? 'id';
     const treeDataOpt: TreeDataOption = this._gridOptions?.treeDataOptions ?? { columnId: '' };
     const treeDataOptions = { ...treeDataOpt, identifierPropName: treeDataOpt.identifierPropName ?? dataViewIdIdentifier, shouldAddTreeLevelNumber: true };
     const sortedFlatArray = flattenToParentChildArray(hierarchicalDataset, treeDataOptions);
+
+    if (emitSortChanged) {
+      // update current sorters
+      this._currentLocalSorters = [];
+      for (const sortCol of sortColumns) {
+        this._currentLocalSorters.push({ columnId: sortCol.columnId, direction: sortCol.sortAsc ? 'ASC' : 'DESC' });
+      }
+      const emitterType = this._gridOptions?.backendServiceApi ? EmitterType.remote : EmitterType.local;
+      this.emitSortChanged(emitterType);
+    }
 
     return { hierarchical: hierarchicalDataset, flat: sortedFlatArray };
   }

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -271,7 +271,7 @@ export class TreeDataService {
     // 2- sort the hierarchical array recursively by an optional "initialSort" OR if nothing is provided we'll sort by the column defined as the Tree column
     // also note that multi-column is not currently supported with Tree Data
     const columnSort = this.getInitialSort(columnDefinitions, gridOptions);
-    const datasetSortResult = this.sortService.sortHierarchicalDataset(datasetHierarchical, [columnSort]);
+    const datasetSortResult = this.sortService.sortHierarchicalDataset(datasetHierarchical, [columnSort], true);
 
     // and finally add the sorting icon (this has to be done manually in SlickGrid) to the column we used for the sorting
     this._grid?.setSortColumns([columnSort]);


### PR DESCRIPTION
- since Tree Data can have an optional `initialSort`, we should make sure to update the Grid State with this new Sort. Prior to this change, the Grid State was returning empty Sort even though we did have an `initialSort`