### PR TITLE
fix(subscriptions): unsubscribe every subcriptions on dispose to avoid mem leak

### DIFF
--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -2,6 +2,7 @@ import { FieldType, } from '../enums/index';
 import {
   AutoResizeOption,
   Column,
+  EventSubscription,
   GetSlickEventType,
   GridOption,
   GridSize,
@@ -43,6 +44,7 @@ export class ResizerService {
   protected _timer!: NodeJS.Timeout;
   protected _resizePaused = false;
   protected _resizeObserver!: ResizeObserver;
+  protected _subscriptions: EventSubscription[] = [];
 
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
@@ -85,6 +87,8 @@ export class ResizerService {
   dispose() {
     // unsubscribe all SlickGrid events
     this._eventHandler?.unsubscribeAll();
+    this.pubSubService.unsubscribeAll(this._subscriptions);
+
     if (this._intervalId) {
       clearInterval(this._intervalId);
     }
@@ -138,15 +142,19 @@ export class ResizerService {
     // Events
     if (this.gridOptions.autoResize) {
       // resize by content could be called from the outside by other services via pub/sub event
-      this.pubSubService.subscribe('onFullResizeByContentRequested', () => this.resizeColumnsByCellContent(true));
+      this._subscriptions.push(
+        this.pubSubService.subscribe('onFullResizeByContentRequested', () => this.resizeColumnsByCellContent(true))
+      );
     }
 
     // on double-click resize, should we resize the cell by its cell content?
     // the same action can be called from a double-click and/or from column header menu
     if (this.gridOptions?.enableColumnResizeOnDoubleClick) {
-      this.pubSubService.subscribe('onHeaderMenuColumnResizeByContent', (data => {
-        this.handleSingleColumnResizeByContent(data.columnId);
-      }));
+      this._subscriptions.push(
+        this.pubSubService.subscribe('onHeaderMenuColumnResizeByContent', (data => {
+          this.handleSingleColumnResizeByContent(data.columnId);
+        }))
+      );
 
       const onColumnsResizeDblClickHandler = this._grid.onColumnsResizeDblClick;
       (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onColumnsResizeDblClickHandler>>).subscribe(onColumnsResizeDblClickHandler, (_e, args) => {

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -3,6 +3,7 @@ import { ToggleStateChangeType, ToggleStateChangeTypeString } from '../enums/ind
 import {
   Column,
   ColumnSort,
+  EventSubscription,
   GetSlickEventType,
   GridOption,
   OnClickEventArgs,
@@ -29,6 +30,7 @@ export class TreeDataService {
   protected _currentToggledItems: TreeToggledItem[] = [];
   protected _grid!: SlickGrid;
   protected _eventHandler: SlickEventHandler;
+  protected _subscriptions: EventSubscription[] = [];
 
   constructor(protected readonly pubSubService: PubSubService, protected readonly sharedService: SharedService, protected readonly sortService: SortService) {
     this._eventHandler = new Slick.EventHandler();
@@ -65,9 +67,8 @@ export class TreeDataService {
 
   dispose() {
     // unsubscribe all SlickGrid events
-    if (this._eventHandler?.unsubscribeAll) {
-      this._eventHandler.unsubscribeAll();
-    }
+    this._eventHandler.unsubscribeAll();
+    this.pubSubService.unsubscribeAll(this._subscriptions);
   }
 
   init(grid: SlickGrid) {
@@ -106,7 +107,9 @@ export class TreeDataService {
     }
 
     // when "Clear all Sorting" is triggered by the Grid Menu, we'll resort with `initialSort` when defined (or else by 'id')
-    this.pubSubService.subscribe('onGridMenuClearAllSorting', this.clearSorting.bind(this));
+    this._subscriptions.push(
+      this.pubSubService.subscribe('onGridMenuClearAllSorting', this.clearSorting.bind(this))
+    );
   }
 
   /**


### PR DESCRIPTION
- in order to avoid memory leak, we need to make sure to unsubscribe every subscribed event when disposing (destroying) each services/components