### PR TITLE
fix(context): when copying use opacity 0 on temp element

### DIFF
--- a/packages/common/src/extensions/contextMenuExtension.ts
+++ b/packages/common/src/extensions/contextMenuExtension.ts
@@ -433,8 +433,7 @@ export class ContextMenuExtension implements Extension {
         const tmpElem = document.createElement('textarea') as HTMLTextAreaElement;
         if (tmpElem && document.body) {
           tmpElem.style.position = 'absolute';
-          tmpElem.style.left = '-1000px';
-          tmpElem.style.top = '-1000px';
+          tmpElem.style.opacity = '0';
           tmpElem.value = finalTextToCopy;
           document.body.appendChild(tmpElem);
           tmpElem.select();


### PR DESCRIPTION
- we can just use `opacity: 0` (transparent) instead of `left: -1000px` because on computer with high resolution DPI, it might end up showing the temp element we use to copy and we wouldn't want to show it to the user