### PR TITLE
fix(plugin): Copy command from Context Menu should work with numbers

### DIFF
--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -762,6 +762,31 @@ describe('ContextMenu Plugin', () => {
         expect(execSpy).toHaveBeenCalledWith('copy', false, 'JOHN');
       });
 
+      it('should call "copyToClipboard", with a number when the command triggered is "copy" and expect it to be copied without transformation', () => {
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExcelExport: false, enableTextExport: false, exportOptions: { exportWithFormatter: true } } as GridOption;
+        const columnMock = { id: 'age', name: 'Age', field: 'age' } as Column;
+        const dataContextMock = { id: 123, firstName: 'John', lastName: 'Doe', age: 50 };
+        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        const execSpy = jest.spyOn(window.document, 'execCommand');
+        plugin.dispose();
+        plugin.init({ commandItems: [] });
+        plugin.init({ commandItems: [] });
+
+        const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'copy') as MenuCommandItem;
+        menuItemCommand.action!(new CustomEvent('change'), {
+          command: 'copy',
+          cell: 2,
+          row: 5,
+          grid: gridStub,
+          column: columnMock,
+          dataContext: dataContextMock,
+          item: menuItemCommand,
+          value: 50
+        });
+
+        expect(execSpy).toHaveBeenCalledWith('copy', false, 50);
+      });
+
       it('should call "copyToClipboard" and get the value even when there is a "queryFieldNameGetterFn" callback defined when the command triggered is "copy"', () => {
         const firstNameColIdx = 0;
         const copyGridOptionsMock = { ...gridOptionsMock, enableExcelExport: false, enableTextExport: false, contextMenu: { hideCopyCellValueCommand: false } } as GridOption;

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -388,13 +388,18 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
         const grid = this.sharedService?.slickGrid;
         const exportOptions = gridOptions && ((gridOptions.excelExportOptions || { ...gridOptions.exportOptions, ...gridOptions.textExportOptions }));
         let textToCopy = exportWithFormatterWhenDefined(row, cell, columnDef, dataContext, grid, exportOptions);
-
         if (typeof columnDef.queryFieldNameGetterFn === 'function') {
           textToCopy = getCellValueFromQueryFieldGetter(columnDef, dataContext, '');
         }
+        let finalTextToCopy = textToCopy;
 
-        // remove any unwanted Tree Data/Grouping symbols from the beginning of the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
-        const finalTextToCopy = textToCopy.replace(/^([·|⮞|⮟]\s*)|([·|⮞|⮟])\s*/gi, '').replace(/[\u00b7|\u034f]/gi, '').trim();
+        // when it's a string, we'll remove any unwanted Tree Data/Grouping symbols from the beginning (if exist) from the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
+        if (typeof textToCopy === 'string') {
+          finalTextToCopy = textToCopy
+            .replace(/^([·|⮞|⮟]\s*)|([·|⮞|⮟])\s*/gi, '')
+            .replace(/[\u00b7|\u034f]/gi, '')
+            .trim();
+        }
 
         // create fake <textarea> (positioned outside of the screen) to copy into clipboard & delete it from the DOM once we're done
         const tmpElem = document.createElement('textarea');


### PR DESCRIPTION
- when trying the feature on a number, I found out that the numbers weren't copied because previous code was calling string methods on every call but we shouldn't on types number/null/undefined