### PR TITLE
feat(services): add extra features to EventPubSub Service

### DIFF
--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -392,7 +392,7 @@ export class GridStateService {
   subscribeToAllGridChanges(grid: SlickGrid) {
     // Subscribe to Event Emitter of Filter changed
     this._subscriptions.push(
-      this.pubSubService.subscribe('onFilterChanged', (currentFilters: CurrentFilter[]) => {
+      this.pubSubService.subscribe<CurrentFilter[]>('onFilterChanged', currentFilters => {
         this.resetRowSelectionWhenRequired();
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: currentFilters, type: GridStateType.filter }, gridState: this.getCurrentGridState({ requestRefreshRowFilteredRow: !this.hasRowSelectionEnabled() }) });
 
@@ -412,7 +412,7 @@ export class GridStateService {
 
     // Subscribe to Event Emitter of Sort changed
     this._subscriptions.push(
-      this.pubSubService.subscribe('onSortChanged', (currentSorters: CurrentSorter[]) => {
+      this.pubSubService.subscribe<CurrentSorter[]>('onSortChanged', currentSorters => {
         this.resetRowSelectionWhenRequired();
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: currentSorters, type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
       })
@@ -441,7 +441,7 @@ export class GridStateService {
 
     // subscribe to HeaderMenu (hide column)
     this._subscriptions.push(
-      this.pubSubService.subscribe('onHeaderMenuHideColumns', (visibleColumns: Column[]) => {
+      this.pubSubService.subscribe<Column[]>('onHeaderMenuHideColumns', visibleColumns => {
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(visibleColumns);
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       })
@@ -449,14 +449,14 @@ export class GridStateService {
 
     // subscribe to Tree Data toggle items changes
     this._subscriptions.push(
-      this.pubSubService.subscribe('onTreeItemToggled', (toggleChange: TreeToggleStateChange) => {
+      this.pubSubService.subscribe<TreeToggleStateChange>('onTreeItemToggled', toggleChange => {
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: toggleChange, type: GridStateType.treeData }, gridState: this.getCurrentGridState() });
       })
     );
 
     // subscribe to Tree Data full tree toggle changes
     this._subscriptions.push(
-      this.pubSubService.subscribe('onTreeFullToggleEnd', (toggleChange: Omit<TreeToggleStateChange, 'fromItemId'>) => {
+      this.pubSubService.subscribe<Omit<TreeToggleStateChange, 'fromItemId'>>('onTreeFullToggleEnd', toggleChange => {
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: toggleChange, type: GridStateType.treeData }, gridState: this.getCurrentGridState() });
       })
     );

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -125,8 +125,8 @@ export class PaginationService {
     // Subscribe to any dataview row count changed so that when Adding/Deleting item(s) through the DataView
     // that would trigger a refresh of the pagination numbers
     if (this.dataView) {
-      this._subscriptions.push(this.pubSubService.subscribe(`onItemAdded`, (items: any | any[]) => this.processOnItemAddedOrRemoved(items, true)));
-      this._subscriptions.push(this.pubSubService.subscribe(`onItemDeleted`, (items: any | any[]) => this.processOnItemAddedOrRemoved(items, false)));
+      this._subscriptions.push(this.pubSubService.subscribe<any | any[]>(`onItemAdded`, items => this.processOnItemAddedOrRemoved(items, true)));
+      this._subscriptions.push(this.pubSubService.subscribe<any | any[]>(`onItemDeleted`, items => this.processOnItemAddedOrRemoved(items, false)));
     }
 
     this.refreshPagination(false, false, true);

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -53,7 +53,7 @@ export class SlickPaginationComponent {
     // Anytime the pagination is initialized or has changes,
     // we'll copy the data into a local object so that we can add binding to this local object
     this._subscriptions.push(
-      this.pubSubService.subscribe('onPaginationRefreshed', (paginationChanges: ServicePagination) => {
+      this.pubSubService.subscribe<ServicePagination>('onPaginationRefreshed', paginationChanges => {
         for (const key of Object.keys(paginationChanges)) {
           (this.currentPagination as any)[key] = (paginationChanges as any)[key];
         }

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1120,8 +1120,8 @@ export class SlickVanillaGridBundle {
       this.paginationService.totalItems = this.totalItems;
       this.paginationService.init(this.slickGrid, paginationOptions, this.backendServiceApi);
       this.subscriptions.push(
-        this._eventPubSubService.subscribe('onPaginationChanged', (paginationChanges: ServicePagination) => this.paginationChanged(paginationChanges)),
-        this._eventPubSubService.subscribe('onPaginationVisibilityChanged', (visibility: { visible: boolean }) => {
+        this._eventPubSubService.subscribe<ServicePagination>('onPaginationChanged', paginationChanges => this.paginationChanged(paginationChanges)),
+        this._eventPubSubService.subscribe<{ visible: boolean; }>('onPaginationVisibilityChanged', visibility => {
           this.showPagination = visibility?.visible ?? false;
           if (this.gridOptions?.backendServiceApi) {
             this.backendUtilityService?.refreshBackendDataset(this.gridOptions);


### PR DESCRIPTION
- `subscribe` now returns a Subscription that user can now optionally call `unsubscribe` directly instead of just `unsubscribeAll`
- `unsubscribe` and `unsubscribeAll` should decrease the `subscribedEvents` array (it wasn't before, but now it does decrease its length)
- add Generics to `subscribe<T>` for easier type inference on the `data` argument
- add optional GETTER/SETTER on the `elementSource`