### PR TITLE
fix(styling): add pointer cursor on ms-filter, avoid Bootstrap override

### DIFF
--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -596,8 +596,13 @@ li.hidden {
     font-size: var(--slick-header-font-size, $slick-header-font-size);
   }
 }
-.ms-filter.search-filter {
-  width: 100% !important;
+.ms-filter {
+  &.search-filter {
+    width: 100% !important;
+  }
+  .placeholder {
+    cursor: pointer;
+  }
 }
 .ms-drop {
   max-width: var(--slick-multiselect-dropdown-max-width, $slick-multiselect-dropdown-max-width);


### PR DESCRIPTION
- fixes wrong cursor shown on multiple-select filter when empty, original issue found in Angular-Slickgrid issue [#877](https://github.com/ghiscoding/Angular-Slickgrid/issues/877)