### PR TITLE
fix(utilities): check if the normalize function exists

### DIFF
--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -917,7 +917,7 @@ export function parseUtcDate(inputDateString: any, useUtc?: boolean): string {
  * @returns
  */
 export function removeAccentFromText(text: string, shouldLowerCase = false) {
-  const normalizedText = text?.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const normalizedText = (typeof text.normalize === 'function') ? text.normalize('NFD').replace(/[\u0300-\u036f]/g, '') : text;
   return shouldLowerCase ? normalizedText.toLowerCase() : normalizedText;
 }
 


### PR DESCRIPTION
dear @ghiscoding ,

I verified that after the compilation of the "slickgrid-vanilla-bundle.js" version, the line of code responsible for checking the existence of the "normalize" function is generated with wrong logic causing an error:
![2022-02-14 08_49_47-DevTools - ingty sharepoint com_sites_pwa_dev_Project%20Detail%20Pages_DashProj](https://user-images.githubusercontent.com/44271732/154095679-22c090cb-c422-46bf-b9b4-738b44e58424.png)

Original Code:
![image](https://user-images.githubusercontent.com/44271732/154096064-45237b80-5be3-4988-9c9f-98893c048608.png)

Generated code:
![image](https://user-images.githubusercontent.com/44271732/154096540-e82581bd-ea46-49d0-9017-762a12f68212.png)

Code generated after correction:
![image](https://user-images.githubusercontent.com/44271732/154118318-f24d8305-8822-4fa9-b0b0-761ca4ef1898.png)
