### PR TITLE
chore(build): replace `npm-run-all` with `npm-run-all2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     ]
   },
   "devDependencies": {
+    "@lerna-lite/cli": "^1.0.5",
+    "@lerna-lite/run": "^1.0.5",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
-    "@lerna-lite/cli": "^1.0.5",
-    "@lerna-lite/run": "^1.0.5",
     "cypress": "^9.5.3",
     "eslint": "^8.12.0",
     "eslint-plugin-import": "^2.25.4",
@@ -70,7 +70,7 @@
     "jest-extended": "^2.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "^3.0.2",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rxjs": "^7.5.5",
     "serve": "^13.0.2",
     "ts-jest": "^27.1.4",

--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -90,7 +90,7 @@
     "cross-env": "^7.0.3",
     "mini-css-extract-plugin": "^2.6.0",
     "nodemon": "^2.0.15",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "postcss": "^8.4.12",
     "postcss-cli": "^9.1.0",
     "rimraf": "^3.0.2",

--- a/packages/composite-editor-component/package.json
+++ b/packages/composite-editor-component/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/custom-footer-component/package.json
+++ b/packages/custom-footer-component/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/custom-tooltip-plugin/package.json
+++ b/packages/custom-tooltip-plugin/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/empty-warning-component/package.json
+++ b/packages/empty-warning-component/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/event-pub-sub/package.json
+++ b/packages/event-pub-sub/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/excel-export/package.json
+++ b/packages/excel-export/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   },
   "funding": {

--- a/packages/pagination-component/package.json
+++ b/packages/pagination-component/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/row-detail-view-plugin/package.json
+++ b/packages/row-detail-view-plugin/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/rxjs-observable/package.json
+++ b/packages/rxjs-observable/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/text-export/package.json
+++ b/packages/text-export/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/text-encoding-utf-8": "^1.0.2",
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   },
   "funding": {

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2"
   },
   "funding": {

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -71,7 +71,7 @@
     "archiver": "^5.3.0",
     "cross-env": "^7.0.3",
     "html-loader": "^3.1.0",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^5.0.2",
     "rimraf": "^3.0.2",
     "webpack": "^5.70.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,7 +2798,7 @@ chalk@2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.0.0, chalk@^2.4.1:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3354,7 +3354,7 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -3983,28 +3983,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-es-abstract@^1.18.0-next.2:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4"
-  integrity sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
-  dependencies:
-    call-bind "^1.0.2"
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    get-intrinsic "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.2"
-    is-callable "^1.2.3"
-    is-negative-zero "^2.0.1"
-    is-regex "^1.1.2"
-    is-string "^1.0.5"
-    object-inspect "^1.9.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    string.prototype.trimend "^1.0.4"
-    string.prototype.trimstart "^1.0.4"
-    unbox-primitive "^1.0.0"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1:
   version "1.19.1"
@@ -5169,7 +5147,7 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
-has-bigints@^1.0.0, has-bigints@^1.0.1:
+has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
@@ -5184,7 +5162,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2:
+has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
@@ -5677,7 +5655,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.0"
 
-is-callable@^1.1.4, is-callable@^1.2.3:
+is-callable@^1.1.4:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
@@ -5865,7 +5843,7 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-regex@^1.0.4, is-regex@^1.1.2:
+is-regex@^1.0.4:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
   integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
@@ -7725,20 +7703,18 @@ npm-registry-fetch@^13.0.1, npm-registry-fetch@^13.1.0:
     npm-package-arg "^9.0.1"
     proc-log "^2.0.0"
 
-npm-run-all@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
-  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+npm-run-all2@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-all2/-/npm-run-all2-5.0.2.tgz#7dae8e11ba90be9edd05379414a01407416b336c"
+  integrity sha512-S2G6FWZ3pNWAAKm2PFSOtEAG/N+XO/kz3+9l6V91IY+Y3XFSt7Lp7DV92KCgEboEW0hRTu0vFaMe4zXDZYaOyA==
   dependencies:
-    ansi-styles "^3.2.1"
-    chalk "^2.4.1"
-    cross-spawn "^6.0.5"
+    ansi-styles "^5.0.0"
+    cross-spawn "^7.0.3"
     memorystream "^0.3.1"
     minimatch "^3.0.4"
-    pidtree "^0.3.0"
-    read-pkg "^3.0.0"
+    pidtree "^0.5.0"
+    read-pkg "^5.2.0"
     shell-quote "^1.6.1"
-    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -8263,10 +8239,10 @@ picomatch@^2.2.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-pidtree@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
-  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
+pidtree@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.5.0.tgz#ad5fbc1de78b8a5f99d6fbdd4f6e4eee21d1aca1"
+  integrity sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -9542,15 +9518,6 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.padend@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz#6858ca4f35c5268ebd5e8615e1327d55f59ee311"
-  integrity sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.2"
-
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -10125,16 +10092,6 @@ un-flatten-tree@^2.0.12:
   resolved "https://registry.yarnpkg.com/un-flatten-tree/-/un-flatten-tree-2.0.12.tgz#8d92ec454a1b7e1aead948ed029907e1cb9a9ed8"
   integrity sha1-jZLsRUobfhrq2UjtApkH4cuantg=
 
-unbox-primitive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.0.tgz#eeacbc4affa28e9b3d36b5eaeccc50b3251b1d3f"
-  integrity sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==
-  dependencies:
-    function-bind "^1.1.1"
-    has-bigints "^1.0.0"
-    has-symbols "^1.0.0"
-    which-boxed-primitive "^1.0.1"
-
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -10629,7 +10586,7 @@ whatwg-url@^8.0.0, whatwg-url@^8.5.0:
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
 
-which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
+which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
   integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==


### PR DESCRIPTION
- original package does not seem to be updated anymore and `npm-run-all2` was created for that reason to be up to date