### PR TITLE
chore: use only available TS Types and `baseUrl` only

### DIFF
--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'cypress';
 import fs from 'fs';
 
 export default defineConfig({
-  baseExampleUrl: 'http://localhost:8888/#',
   video: false,
   projectId: 'p5zxx6',
   viewportWidth: 1000,
@@ -22,7 +21,7 @@ export default defineConfig({
     // setupNodeEvents(on, config) {
     //   return require('./cypress/plugins/index.js')(on, config);
     // },
-    baseUrl: 'http://localhost:8888',
+    baseUrl: 'http://localhost:8888/#',
     specPattern: 'test/cypress/e2e/**/*.{js,ts}',
     supportFile: 'test/cypress/support/index.js',
     setupNodeEvents(on, config) {

--- a/test/cypress/e2e/example01.cy.js
+++ b/test/cypress/e2e/example01.cy.js
@@ -14,7 +14,7 @@ describe('Example 01 - Basic Grids', { retries: 1 }, () => {
   })
 
   it('should display Example title', () => {
-    cy.visit(Cypress.config('baseExampleUrl'), { timeout: 200000 });
+    cy.visit(Cypress.config('baseUrl'), { timeout: 200000 });
     cy.get('h3').should('contain', 'Example 01 - Basic Grids');
     cy.get('h3 span.subtitle').should('contain', '(with Salesforce Theme)');
     cy.getCookie('serve-mode').its('value').should('eq', 'cypress')

--- a/test/cypress/e2e/example02.cy.js
+++ b/test/cypress/e2e/example02.cy.js
@@ -10,7 +10,7 @@ describe('Example 02 - Grouping & Aggregators', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 45;
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example02`);
+    cy.visit(`${Cypress.config('baseUrl')}/example02`);
     cy.get('h3').should('contain', 'Example 02 - Grouping & Aggregators');
     cy.get('h3 span.subtitle').should('contain', '(with Material Theme)');
   });

--- a/test/cypress/e2e/example03.cy.js
+++ b/test/cypress/e2e/example03.cy.js
@@ -5,7 +5,7 @@ describe('Example 03 - Draggable Grouping', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 33;
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example03`);
+    cy.visit(`${Cypress.config('baseUrl')}/example03`);
     cy.get('h3').should('contain', 'Example 03 - Draggable Grouping');
     cy.get('h3 span.subtitle').should('contain', '(with Salesforce Theme)');
   });

--- a/test/cypress/e2e/example04.cy.js
+++ b/test/cypress/e2e/example04.cy.js
@@ -7,7 +7,7 @@ describe('Example 04 - Frozen Grid', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 45;
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example04`);
+    cy.visit(`${Cypress.config('baseUrl')}/example04`);
     cy.get('h3').should('contain', 'Example 04 - Pinned (frozen) Columns/Rows');
   });
 

--- a/test/cypress/e2e/example05.cy.js
+++ b/test/cypress/e2e/example05.cy.js
@@ -5,7 +5,7 @@ describe('Example 05 - Tree Data (from a flat dataset with parentId references)'
   const titles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example05`);
+    cy.visit(`${Cypress.config('baseUrl')}/example05`);
     cy.get('h3').should('contain', 'Example 05 - Tree Data');
     cy.get('h3 span.subtitle').should('contain', '(from a flat dataset with parentId references)');
   });

--- a/test/cypress/e2e/example06.cy.js
+++ b/test/cypress/e2e/example06.cy.js
@@ -12,7 +12,7 @@ describe('Example 06 - Tree Data (from a Hierarchical Dataset)', { retries: 1 },
   const popMusicWith3ExtraSongs = ['music', 'mp3', 'pop', 'pop-125.mp3', 'pop-126.mp3', 'pop-127.mp3', 'song.mp3', 'theme.mp3',];
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example06`);
+    cy.visit(`${Cypress.config('baseUrl')}/example06`);
     cy.get('h3').should('contain', 'Example 06 - Tree Data');
     cy.get('h3 span.subtitle').should('contain', '(from a Hierarchical Dataset)');
   });

--- a/test/cypress/e2e/example07.cy.js
+++ b/test/cypress/e2e/example07.cy.js
@@ -9,7 +9,7 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', { retries
   const fullTitles = ['', '', 'Title', 'Action', 'Duration', '% Complete', 'Start', 'Finish', 'Completed', 'Prerequisites'];
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example07`);
+    cy.visit(`${Cypress.config('baseUrl')}/example07`);
     cy.get('h3').should('contain', 'Example 07 - Row Move & Row Selections');
   });
 

--- a/test/cypress/e2e/example08.cy.js
+++ b/test/cypress/e2e/example08.cy.js
@@ -11,7 +11,7 @@ describe('Example 08 - Column Span & Header Grouping', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 33;
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example08`);
+    cy.visit(`${Cypress.config('baseUrl')}/example08`);
     cy.get('h3').should('contain', 'Example 08 - Column Span & Header Grouping');
   });
 

--- a/test/cypress/e2e/example09.cy.js
+++ b/test/cypress/e2e/example09.cy.js
@@ -11,7 +11,7 @@ describe('Example 09 - OData Grid', { retries: 1 }, () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example09`);
+    cy.visit(`${Cypress.config('baseUrl')}/example09`);
     cy.get('h3').should('contain', 'Example 09 - Grid with OData Backend Service');
   });
 

--- a/test/cypress/e2e/example10.cy.js
+++ b/test/cypress/e2e/example10.cy.js
@@ -10,7 +10,7 @@ const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
 
 describe('Example 10 - GraphQL Grid', { retries: 1 }, () => {
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example10`);
+    cy.visit(`${Cypress.config('baseUrl')}/example10`);
     cy.get('h3').should('contain', 'Example 10 - Grid with GraphQL Backend Service');
   });
 

--- a/test/cypress/e2e/example11.cy.js
+++ b/test/cypress/e2e/example11.cy.js
@@ -18,7 +18,7 @@ describe('Example 11 - Batch Editing', { retries: 1 }, () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example11`);
+    cy.visit(`${Cypress.config('baseUrl')}/example11`);
     cy.get('h3').should('contain', 'Example 11 - Batch Editing');
   });
 

--- a/test/cypress/e2e/example12.cy.js
+++ b/test/cypress/e2e/example12.cy.js
@@ -16,7 +16,7 @@ describe('Example 12 - Composite Editor Modal', { retries: 1 }, () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example12`);
+    cy.visit(`${Cypress.config('baseUrl')}/example12`);
     cy.get('h3').should('contain', 'Example 12 - Composite Editor Modal');
   });
 

--- a/test/cypress/e2e/example13.cy.js
+++ b/test/cypress/e2e/example13.cy.js
@@ -12,7 +12,7 @@ describe('Example 13 - Header Button Plugin', { retries: 1 }, () => {
 
   describe('Grid 1', () => {
     it('should display Example title', () => {
-      cy.visit(`${Cypress.config('baseExampleUrl')}/example13`);
+      cy.visit(`${Cypress.config('baseUrl')}/example13`);
       cy.get('h3').should('contain', 'Example 13 - Header Button Plugin');
     });
 

--- a/test/cypress/e2e/example14.cy.js
+++ b/test/cypress/e2e/example14.cy.js
@@ -11,7 +11,7 @@ describe('Example 14 - Columns Resize by Content', { retries: 1 }, () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example14`);
+    cy.visit(`${Cypress.config('baseUrl')}/example14`);
     cy.get('h3').should('contain', 'Example 14 - Columns Resize by Content');
   });
 

--- a/test/cypress/e2e/example15.cy.js
+++ b/test/cypress/e2e/example15.cy.js
@@ -9,7 +9,7 @@ describe('Example 15 - OData Grid using RxJS', { retries: 1 }, () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example15`);
+    cy.visit(`${Cypress.config('baseUrl')}/example15`);
     cy.get('h3').should('contain', 'Example 15 - Grid with OData Backend Service using RxJS Observables');
   });
 

--- a/test/cypress/e2e/example16.cy.js
+++ b/test/cypress/e2e/example16.cy.js
@@ -5,7 +5,7 @@ describe('Example 16 - Regular & Custom Tooltips', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 33;
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example16`);
+    cy.visit(`${Cypress.config('baseUrl')}/example16`);
     cy.get('h3').should('contain', 'Example 16 - Regular & Custom Tooltips');
     cy.get('h3 span.subtitle').should('contain', '(with Salesforce Theme)');
   });

--- a/test/cypress/e2e/example17.cy.js
+++ b/test/cypress/e2e/example17.cy.js
@@ -12,7 +12,7 @@ describe('Example 17 - Auto-Scroll with Range Selector', { retries: 1 }, () => {
   }
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example17`);
+    cy.visit(`${Cypress.config('baseUrl')}/example17`);
     cy.get('h3').should('contain', 'Example 17 - Auto-Scroll with Range Selector');
     cy.get('h3 span.subtitle').should('contain', '(with Salesforce Theme)');
   });

--- a/test/cypress/e2e/example18.cy.js
+++ b/test/cypress/e2e/example18.cy.js
@@ -5,7 +5,7 @@ describe('Example 18 - Real-Time Trading Platform', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 40;
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseExampleUrl')}/example18`);
+    cy.visit(`${Cypress.config('baseUrl')}/example18`);
     cy.get('h3').should('contain', 'Example 18 - Real-Time Trading Platform');
   });
 


### PR DESCRIPTION
- in order to stick with Cypress TypeScript interfaces, we shouldn't add any extra properties to the default options object