### PR TITLE
fix(composite): selected row count always 0 on mass-selected

### DIFF
--- a/packages/common/src/services/__tests__/container.service.spec.ts
+++ b/packages/common/src/services/__tests__/container.service.spec.ts
@@ -5,6 +5,10 @@ describe('Container Service', () => {
     expect(() => ContainerService.prototype.get!('MyService')).toThrow('ContainerService "get" method must be implemented');
   });
 
+  it('should display a not implemented when calling "dispose" method', () => {
+    expect(() => ContainerService.prototype.dispose!()).toThrow('ContainerService "dispose" method must be implemented');
+  });
+
   it('should display a not implemented when calling "registerInstance" method', () => {
     expect(() => ContainerService.prototype.registerInstance('MyService', {})).toThrow('ContainerService "registerInstance" method must be implemented');
   });

--- a/packages/common/src/services/container.service.ts
+++ b/packages/common/src/services/container.service.ts
@@ -9,6 +9,10 @@ export class ContainerService {
     throw new Error('ContainerService "get" method must be implemented');
   }
 
+  dispose() {
+    throw new Error('ContainerService "dispose" method must be implemented');
+  }
+
   registerInstance(_key: any, _instance: any) {
     throw new Error('ContainerService "registerInstance" method must be implemented');
   }

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -412,6 +412,7 @@ export class SlickVanillaGridBundle {
     this.resizerService?.dispose();
     this.sortService?.dispose();
     this.treeDataService?.dispose();
+    this.universalContainerService?.dispose();
 
     // dispose all registered external resources
     if (Array.isArray(this._registeredResources)) {

--- a/packages/vanilla-bundle/src/services/universalContainer.service.ts
+++ b/packages/vanilla-bundle/src/services/universalContainer.service.ts
@@ -11,6 +11,10 @@ export class UniversalContainerService implements ContainerService {
     return null;
   }
 
+  dispose() {
+    this.dependencies = [];
+  }
+
   registerInstance(key: string, instance: any) {
     const dependency = this.dependencies.some(dep => dep.key === key);
     if (!dependency) {


### PR DESCRIPTION
- add dispose method to container service to start with a blank array whenever we route to another page, this is to avoid reusing already disposed services that might still be in the container service
- the issue was found in Angular-Slickgrid and did not seem to show up as a problem in Slickgrid-Universal itself but better play safe and apply the same here