### PR TITLE
fix(utils): setDeepValue should accept array properties

### DIFF
--- a/packages/utils/src/utils.spec.ts
+++ b/packages/utils/src/utils.spec.ts
@@ -353,24 +353,56 @@ describe('Service/Utilies', () => {
   });
 
   describe('setDeepValue method', () => {
-    let obj = {};
+    let obj: any = {};
     beforeEach(() => {
-      obj = { id: 1, user: { firstName: 'John', lastName: 'Doe', address: { number: 123, street: 'Broadway' } } };
+      obj = { id: 1, user: { firstName: 'John', lastName: 'Doe', age: null, address: { number: 123, street: 'Broadway' } } };
     });
 
     it('should be able to update an object at 2nd level deep property', () => {
       setDeepValue(obj, 'user.firstName', 'Jane');
-      expect(obj['user'].firstName).toBe('Jane');
+      expect(obj.user.firstName).toBe('Jane');
     });
 
     it('should be able to update an object at 3rd level deep property', () => {
       setDeepValue(obj, 'user.address.number', 78);
-      expect(obj['user']['address']['number']).toBe(78);
+      expect(obj.user.address.number).toBe(78);
     });
 
     it('should be able to update a property that is not a complex object', () => {
       setDeepValue(obj, 'id', 76);
-      expect(obj['id']).toBe(76);
+      expect(obj.id).toBe(76);
+    });
+
+    it('should be able to udpate a property even when its original value was undefined', () => {
+      setDeepValue(obj, 'user.age', 20);
+      expect(obj.user.age).toBe(20);
+    });
+
+    it('should be able to udpate a property even when its original value was null', () => {
+      obj.user.age = null;
+      setDeepValue(obj, 'user.age', 20);
+      expect(obj.user.age).toBe(20);
+    });
+
+    it('should be able to update a property that has some properties with array as value', () => {
+      obj = { id: 1, user: { firstName: 'John', lastName: 'Doe', addresses: [{ number: 123, street: 'Broadway' }, { number: 234, street: 'Beverly' }] } };
+      setDeepValue(obj, 'id', 76);
+      expect(obj.id).toBe(76);
+      expect(obj).toEqual({ id: 76, user: { firstName: 'John', lastName: 'Doe', addresses: [{ number: 123, street: 'Broadway' }, { number: 234, street: 'Beverly' }] } });
+    });
+
+    it('should be able to update a property of an array inside a complex object', () => {
+      obj = { id: 1, user: { firstName: 'John', lastName: 'Doe', addresses: [{ number: null, street: 'Broadway' }, { number: 234, street: 'Beverly' }] } };
+      setDeepValue(obj, 'user.addresses.0.number', 111);
+      expect(obj.user.addresses[0].number).toBe(111);
+      expect(obj).toEqual({ id: 1, user: { firstName: 'John', lastName: 'Doe', addresses: [{ number: 111, street: 'Broadway' }, { number: 234, street: 'Beverly' }] } });
+    });
+
+    it('should be able to update a property of an array inside a complex object', () => {
+      obj = { id: 1, user: { firstName: 'John', lastName: 'Doe', addresses: [{ doorNumber: 123, street: 'Broadway' }, { doorNumber: ['234-B'], street: 'Beverly' }] } };
+      setDeepValue(obj, 'user.addresses.1.doorNumber', ['234-AA', '234-B']);
+      expect(obj.user.addresses[1].doorNumber).toEqual(['234-AA', '234-B']);
+      expect(obj).toEqual({ id: 1, user: { firstName: 'John', lastName: 'Doe', addresses: [{ doorNumber: 123, street: 'Broadway' }, { doorNumber: ['234-AA', '234-B'], street: 'Beverly' }] } });
     });
   });
 

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -210,7 +210,7 @@ export function removeAccentFromText(text: string, shouldLowerCase = false) {
 }
 
 /** Set the object value of deeper node from a given dot (.) notation path (e.g.: "user.firstName") */
-export function setDeepValue<T = any>(obj: T, path: string | string[], value: any) {
+export function setDeepValue<T = unknown>(obj: T, path: string | string[], value: any) {
   if (typeof path === 'string') {
     path = path.split('.');
   }
@@ -219,13 +219,15 @@ export function setDeepValue<T = any>(obj: T, path: string | string[], value: an
     const e = path.shift();
     if (obj && e !== undefined) {
       setDeepValue(
-        (obj as any)[e] = Object.prototype.toString.call((obj as any)[e]) === '[object Object]' ? (obj as any)[e] : {},
+        (obj)[e as keyof T] = (Array.isArray(obj[e as keyof T]) || Object.prototype.toString.call((obj)[e as keyof T]) === '[object Object]')
+          ? (obj)[e as keyof T]
+          : {} as T[keyof T],
         path,
         value
       );
     }
   } else if (obj && path[0]) {
-    (obj as any)[path[0]] = value;
+    (obj)[path[0] as keyof T] = value;
   }
 }
 


### PR DESCRIPTION
- prior to the fix, an array value was being transformed into an object and the array was lost, issue identified in this [SO](https://stackoverflow.com/questions/62423893/in-slick-grid-inline-edit-i-cant-able-to-get-the-entire-object/73153946#73153946)