### PR TITLE
fix(collectionAsync): hidden column does not load edit field selection

### DIFF
--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -659,12 +659,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockCollection = ['male', 'female'];
         const promise = new Promise(resolve => resolve(mockCollection));
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
+        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
+          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor).toBeTruthy();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
@@ -682,7 +682,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           renderDomElement: jest.fn(),
         } as unknown as Editor;
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
+        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
         jest.spyOn(mockGrid, 'getCellEditor').mockReturnValue(mockEditor);
         const disableSpy = jest.spyOn(mockEditor, 'disable');
         const destroySpy = jest.spyOn(mockEditor, 'destroy');
@@ -691,7 +691,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
+          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor).toBeTruthy();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
@@ -707,12 +707,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockCollection = ['male', 'female'];
         const promise = new Promise(resolve => resolve({ content: mockCollection }));
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
+        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
+          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
@@ -729,12 +729,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         http.responseHeaders = { accept: 'json' };
         const collectionAsync = http.fetch('/api', { method: 'GET' });
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
+        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
+          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
@@ -745,7 +745,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       it('should be able to load async editors with an Observable', (done) => {
         const mockCollection = ['male', 'female'];
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: of(mockCollection) } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
+        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         const rxjsMock = new RxJsResourceStub();
         component.gridOptions = { registerExternalResources: [rxjsMock] } as unknown as GridOption;
@@ -753,7 +753,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
+          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
@@ -771,7 +771,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         http.responseHeaders = { accept: 'json' };
         const collectionAsync = http.fetch('invalid-url', { method: 'GET' });
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync } }] as Column[];
-        jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
+        //jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
         component.columnDefinitions = mockColDefs;
 
         component.initialization(divContainer, slickEventHandler);

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -659,12 +659,10 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockCollection = ['male', 'female'];
         const promise = new Promise(resolve => resolve(mockCollection));
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor).toBeTruthy();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
@@ -682,7 +680,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           renderDomElement: jest.fn(),
         } as unknown as Editor;
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
         jest.spyOn(mockGrid, 'getCellEditor').mockReturnValue(mockEditor);
         const disableSpy = jest.spyOn(mockEditor, 'disable');
         const destroySpy = jest.spyOn(mockEditor, 'destroy');
@@ -691,7 +688,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor).toBeTruthy();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
@@ -707,12 +703,10 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockCollection = ['male', 'female'];
         const promise = new Promise(resolve => resolve({ content: mockCollection }));
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
@@ -729,12 +723,10 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         http.responseHeaders = { accept: 'json' };
         const collectionAsync = http.fetch('/api', { method: 'GET' });
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync } }] as Column[];
-        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
@@ -745,7 +737,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       it('should be able to load async editors with an Observable', (done) => {
         const mockCollection = ['male', 'female'];
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: of(mockCollection) } }] as Column[];
-        //const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         const rxjsMock = new RxJsResourceStub();
         component.gridOptions = { registerExternalResources: [rxjsMock] } as unknown as GridOption;
@@ -753,7 +744,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          //expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
@@ -771,7 +761,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         http.responseHeaders = { accept: 'json' };
         const collectionAsync = http.fetch('invalid-url', { method: 'GET' });
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync } }] as Column[];
-        //jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
         component.columnDefinitions = mockColDefs;
 
         component.initialization(divContainer, slickEventHandler);

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1434,9 +1434,8 @@ export class SlickVanillaGridBundle {
 
     if (this.slickGrid) {
       // find the new column reference pointer & re-assign the new editor to the internalColumnEditor
-      const columns = this.columnDefinitions;
-      if (Array.isArray(columns)) {
-        const columnRef = columns.find((col: Column) => col.id === column.id);
+      if (Array.isArray(this.columnDefinitions)) {
+        const columnRef = this.columnDefinitions.find((col: Column) => col.id === column.id);
         if (columnRef) {
           columnRef.internalColumnEditor = column.editor as ColumnEditor;
         }

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1434,7 +1434,7 @@ export class SlickVanillaGridBundle {
 
     if (this.slickGrid) {
       // find the new column reference pointer & re-assign the new editor to the internalColumnEditor
-      const columns = this.slickGrid.getColumns();
+      const columns = this.columnDefinitions;
       if (Array.isArray(columns)) {
         const columnRef = columns.find((col: Column) => col.id === column.id);
         if (columnRef) {


### PR DESCRIPTION
Bug: Hidden column does not load edit field with selection options

The "this.slickGrid.getColumns()" method only returns the visible fields of the grid, so if the field that was configured to return a list of elements (collectionAsync) is hidden in the grid, it does not receive the list of elements.

note: Unfortunately after version 1.3.x I am no longer able to perform the "pnpm run build".
![image](https://user-images.githubusercontent.com/44271732/184175602-7f6934cb-8b5d-4c66-8a60-6b8a92369aa2.png)
