### PR TITLE
fix(bundle): fetch API isn't always an instance of Response

### DIFF
--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1176,7 +1176,7 @@ export class SlickVanillaGridBundle {
       collectionAsync.then((response: any | any[]) => {
         if (Array.isArray(response)) {
           this.updateEditorCollection(column, response); // from Promise
-        } else if (response instanceof Response && typeof response.json === 'function') {
+        } else if (response?.status >= 200 && response.status < 300 && typeof response.json === 'function') {
           if (response.bodyUsed) {
             console.warn(`[SlickGrid-Universal] The response body passed to collectionAsync was already read.`
               + `Either pass the dataset from the Response or clone the response first using response.clone()`);
@@ -1184,7 +1184,7 @@ export class SlickVanillaGridBundle {
             // from Fetch
             (response as Response).json().then(data => this.updateEditorCollection(column, data));
           }
-        } else if (response && response['content']) {
+        } else if (response?.content) {
           this.updateEditorCollection(column, response['content']); // from http-client
         }
       });


### PR DESCRIPTION
- the output of the Fetch API Promise isn't always an `instanceof Response`, the better way of validating the Fetch resolved output is to check its status to be between 200-300 and also make sure that it has the `.json()` type to be a function