### PR TITLE
fix(filters): fetch API isn't always an instance of Response

### DIFF
--- a/packages/common/src/filters/filterUtilities.ts
+++ b/packages/common/src/filters/filterUtilities.ts
@@ -65,7 +65,7 @@ export async function renderCollectionOptionsAsync(collectionAsync: Promise<any 
 
     if (Array.isArray(response)) {
       awaitedCollection = response; // from Promise
-    } else if (response instanceof Response && typeof response['json'] === 'function') {
+    } else if (response?.status >= 200 && response.status < 300 && typeof response.json === 'function') {
       awaitedCollection = await response['json'](); // from Fetch
     } else if (response && response['content']) {
       awaitedCollection = response['content']; // from http-client


### PR DESCRIPTION
- same as previous PR #744, this one was found after
- the output of the Fetch API Promise isn't always an `instanceof Response`, the better way of validating the Fetch resolved output is to check its status to be between 200-300 and also make sure that it has the `.json()` type to be a function