### PR TITLE
chore(common): use input autocomplete "none" instead of "presentation"

### DIFF
--- a/packages/common/src/editors/autoCompleteEditor.ts
+++ b/packages/common/src/editors/autoCompleteEditor.ts
@@ -524,7 +524,7 @@ export class AutoCompleteEditor implements Editor {
     const placeholder = this.columnEditor?.placeholder ?? '';
     const title = this.columnEditor?.title ?? '';
 
-    this._$input = $(`<input type="text" role="presentation" autocomplete="off" class="autocomplete form-control editor-text editor-${columnId}" placeholder="${placeholder}" title="${title}" />`)
+    this._$input = $(`<input type="text" autocomplete="none" class="autocomplete form-control editor-text editor-${columnId}" placeholder="${placeholder}" title="${title}" />`)
       .appendTo(this.args.container)
       .on('keydown.nav', (event: JQuery.Event) => {
         this._lastInputKeyEvent = event;

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -194,11 +194,10 @@ export class DualInputEditor implements Editor {
       type: fieldType || 'text',
       id: `item-${itemId}-${position}`,
       className: `dual-editor-text editor-${columnId} ${position.replace(/input/gi, '')}`,
-      autocomplete: 'off',
+      autocomplete: 'none',
       placeholder: editorSideParams.placeholder || '',
       title: editorSideParams.title || '',
     });
-    input.setAttribute('role', 'presentation');
     input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`);
 
     if (fieldType === 'readonly') {

--- a/packages/common/src/editors/floatEditor.ts
+++ b/packages/common/src/editors/floatEditor.ts
@@ -21,13 +21,12 @@ export class FloatEditor extends InputEditor {
       const compositeEditorOptions = this.args.compositeEditorOptions;
 
       this._input = createDomElement('input', {
-        type: 'number', autocomplete: 'off',
+        type: 'number', autocomplete: 'none',
         className: `editor-text editor-${columnId}`,
         placeholder: this.columnEditor?.placeholder ?? '',
         title: this.columnEditor?.title ?? '',
         step: `${(this.columnEditor.valueStep !== undefined) ? this.columnEditor.valueStep : this.getInputDecimalSteps()}`,
       });
-      this._input.setAttribute('role', 'presentation');
       this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Number Editor`);
       const cellContainer = this.args.container;
       if (cellContainer && typeof cellContainer.appendChild === 'function') {

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -88,12 +88,11 @@ export class InputEditor implements Editor {
 
     this._input = createDomElement('input', {
       type: this._inputType || 'text',
-      autocomplete: 'off',
+      autocomplete: 'none',
       placeholder: this.columnEditor?.placeholder ?? '',
       title: this.columnEditor?.title ?? '',
       className: `editor-text editor-${columnId}`,
     });
-    this._input.setAttribute('role', 'presentation');
     this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`);
     const cellContainer = this.args.container;
     if (cellContainer && typeof cellContainer.appendChild === 'function') {

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -19,13 +19,12 @@ export class IntegerEditor extends InputEditor {
       const compositeEditorOptions = this.args.compositeEditorOptions;
 
       this._input = createDomElement('input', {
-        type: 'number', autocomplete: 'off',
+        type: 'number', autocomplete: 'none',
         placeholder: this.columnEditor?.placeholder ?? '',
         title: this.columnEditor?.title ?? '',
         step: `${(this.columnEditor.valueStep !== undefined) ? this.columnEditor.valueStep : '1'}`,
         className: `editor-text editor-${columnId}`,
       });
-      this._input.setAttribute('role', 'presentation');
       this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`);
       const cellContainer = this.args.container;
       if (cellContainer && typeof cellContainer.appendChild === 'function') {

--- a/packages/common/src/filters/autoCompleteFilter.ts
+++ b/packages/common/src/filters/autoCompleteFilter.ts
@@ -348,7 +348,7 @@ export class AutoCompleteFilter implements Filter {
     if (this.columnFilter?.placeholder) {
       placeholder = this.columnFilter.placeholder;
     }
-    return `<input type="text" role="presentation" autocomplete="off" class="form-control search-filter filter-${columnId}" placeholder="${placeholder}">`;
+    return `<input type="text" autocomplete="none" class="form-control search-filter filter-${columnId}" placeholder="${placeholder}">`;
   }
 
   /**

--- a/packages/common/src/filters/compoundInputFilter.ts
+++ b/packages/common/src/filters/compoundInputFilter.ts
@@ -183,10 +183,9 @@ export class CompoundInputFilter implements Filter {
 
     const inputElm = createDomElement('input', {
       type: this._inputType || 'text',
-      autocomplete: 'off', placeholder,
+      autocomplete: 'none', placeholder,
       className: `form-control compound-input filter-${columnId}`,
     });
-    inputElm.setAttribute('role', 'presentation');
     inputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
 
     return inputElm;

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -200,13 +200,12 @@ export class InputFilter implements Filter {
 
     const inputElm = createDomElement('input', {
       type: this._inputType || 'text',
-      autocomplete: 'off', placeholder,
+      autocomplete: 'none', placeholder,
       className: `form-control search-filter filter-${columnId}`,
       value: (searchTerm ?? '') as string,
       dataset: { columnid: `${columnId}` }
     });
     inputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
-    inputElm.setAttribute('role', 'presentation');
 
 
     // if there's a search term, we will add the "filled" class for styling purposes


### PR DESCRIPTION
- the use of `role="presentation"` has a downside of disabling Aria which is not ideal, however we can simply use `autocomplete="none"` (the most often used "off" doesn't work in chrome but "none" does)