### PR TITLE
feat(plugins): sync column definitions to user after plugin adds column

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
@@ -539,12 +539,16 @@ export class Example7 {
     this.sgb.columnDefinitions.pop();
     this.sgb.columnDefinitions = this.sgb.columnDefinitions.slice();
 
-    // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
-    // you MUST use the code below, first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
+    // NOTE if you use an Extensions (Row Move, Row Detail, Row Selections) that modifies the column definitions in any way
+    // it will update the column definitions but only on the sgb instance, so you can use "this.sgb.columnDefinitions" to get full list.
+    // However please note that this will ALWAYS return all columns in their original positions,
+    // in other words, if you change column reordering, that unfortunately won't be reflected.
+    // Another important thing is that SlickGrid does not have "editors: { model ...}" and you MUST use the code below to let SlickGrid have that info,
+    // first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
     // in other words, SlickGrid is not using the same as Slickgrid-Universal uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
-    const allColumns = this.slickerGridInstance.gridService.getAllColumnDefinitions();
-    const allOriginalColumns = allColumns.map((column) => {
+    const allOriginalColumns = this.sgb.columnDefinitions(); // or: this.slickerGridInstance.gridService.getAllColumnDefinitions();
+    const allOriginalColumns = allOriginalColumns.map((column) => {
       column.editor = column.internalColumnEditor;
       return column;
     });

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
@@ -543,9 +543,6 @@ export class Example7 {
     // it will update the column definitions but only on the sgb instance, so you can use "this.sgb.columnDefinitions" to get full list.
     // However please note that this will ALWAYS return all columns in their original positions,
     // in other words, if you change column reordering, that unfortunately won't be reflected.
-    // Another important thing is that SlickGrid does not have "editors: { model ...}" and you MUST use the code below to let SlickGrid have that info,
-    // first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
-    // in other words, SlickGrid is not using the same as Slickgrid-Universal uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
     const allOriginalColumns = this.sgb.columnDefinitions(); // or: this.slickerGridInstance.gridService.getAllColumnDefinitions();
     const allOriginalColumns = allOriginalColumns.map((column) => {

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example14.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example14.ts
@@ -2,6 +2,7 @@ import {
   AutocompleterOption,
   BindingEventService,
   Column,
+  EditCommand,
   Editors,
   EventNamingStyle,
   FieldType,
@@ -84,7 +85,7 @@ export class Example14 {
   isGridEditable = true;
   classDefaultResizeButton = 'button is-small';
   classNewResizeButton = 'button is-small is-selected is-primary';
-  editQueue = [];
+  editQueue: Array<{ item: any; columns: Column[]; editCommand: EditCommand }> = [];
   editedItems = {};
   sgb: SlickVanillaGridBundle;
   gridContainerElm: HTMLDivElement;

--- a/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
@@ -1,8 +1,9 @@
 import 'jest-extended';
+import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+
 import { SlickCheckboxSelectColumn } from '../slickCheckboxSelectColumn';
 import { Column, OnSelectedRowsChangedEventArgs, SlickGrid, SlickNamespace, } from '../../interfaces/index';
 import { SlickRowSelectionModel } from '../../extensions/slickRowSelectionModel';
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
 declare const Slick: SlickNamespace;
 
@@ -354,10 +355,8 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
   });
 
   it('should call the "create" method and expect plugin to be created with checkbox column to be created at position 0 when using default', () => {
-    plugin.create(mockColumns, { checkboxSelector: { columnId: 'chk-id' } });
-
-    expect(plugin).toBeTruthy();
-    expect(mockColumns[0]).toEqual({
+    const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
+    const checkboxColumnMock = {
       cssClass: null,
       excludeFromColumnPicker: true,
       excludeFromExport: true,
@@ -365,7 +364,6 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       excludeFromHeaderMenu: true,
       excludeFromQuery: true,
       field: 'sel',
-      formatter: expect.toBeFunction(),
       hideSelectAllCheckbox: false,
       id: 'chk-id',
       name: `<input id="header-selector${plugin.selectAllUid}" type="checkbox"><label for="header-selector${plugin.selectAllUid}"></label>`,
@@ -373,7 +371,13 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       sortable: false,
       toolTip: 'Select/Deselect All',
       width: 30,
-    });
+    };
+
+    plugin.create(mockColumns, { checkboxSelector: { columnId: 'chk-id' } });
+
+    expect(pubSubSpy).toHaveBeenCalledWith('onPluginColumnsChanged', { columns: expect.arrayContaining([{ ...checkboxColumnMock, formatter: expect.toBeFunction() }]), pluginName: 'CheckboxSelectColumn' });
+    expect(plugin).toBeTruthy();
+    expect(mockColumns[0]).toEqual(expect.objectContaining({ ...checkboxColumnMock, formatter: expect.toBeFunction() }));
   });
 
   it('should call the "create" method and expect plugin to be created at position 1 when defined', () => {

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -174,8 +174,8 @@ describe('HeaderMenu Plugin', () => {
 
     beforeEach(() => {
       jest.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
-      columnsMock[0].header.menu.items[1] = undefined;
-      columnsMock[0].header.menu.items[1] = {
+      columnsMock[0].header!.menu!.items[1] = undefined as any;
+      columnsMock[0].header!.menu!.items[1] = {
         cssClass: 'mdi mdi-lightbulb-on',
         command: 'show-negative-numbers',
         tooltip: 'Highlight negative numbers.',
@@ -195,7 +195,7 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu button with extra button css classes when header menu option "buttonCssClass" and cell is being rendered', () => {
       plugin.dispose();
       plugin.init({ buttonCssClass: 'mdi mdi-chevron-down' });
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => undefined;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => undefined as any;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
@@ -207,7 +207,7 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu button with extra tooltip title attribute when header menu option "tooltip" and cell is being rendered', () => {
       plugin.dispose();
       plugin.init({ tooltip: 'some tooltip text' });
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => undefined;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => undefined as any;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
@@ -219,7 +219,7 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu when cell is being rendered and a 2nd button item visibility callback returns undefined', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => undefined;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => undefined as any;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
@@ -235,7 +235,7 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu when cell is being rendered and a 2nd button item visibility callback returns false', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => false;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => false;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
@@ -248,8 +248,8 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu when cell is being rendered and a 2nd button item visibility & usability callbacks returns true', () => {
       plugin.dispose();
       plugin.init({ hideFreezeColumnsCommand: false, hideFilterCommand: false });
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemUsabilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemUsabilityOverride = () => true;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
@@ -258,7 +258,7 @@ describe('HeaderMenu Plugin', () => {
       // add Header Menu which is visible
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(`<div class="slick-header-menu-button"></div>`));
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -272,15 +272,15 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu and a 2nd button item usability callback returns false and expect button to be disabled', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemUsabilityOverride = () => false;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemUsabilityOverride = () => false;
       const publishSpy = jest.spyOn(pubSubServiceStub, 'publish');
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button:nth-child(1)') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-disabled');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-disabled') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -297,14 +297,14 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu and a 2nd button is "disabled" and expect button to be disabled', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = undefined;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).disabled = true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = undefined;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).disabled = true;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-disabled');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-disabled') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -318,13 +318,13 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu and expect button to be disabled when command property is disabled', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).hidden = true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).hidden = true;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-hidden');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-hidden') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -338,13 +338,13 @@ describe('HeaderMenu Plugin', () => {
     it('should populate a Header Menu and a 2nd button and property "tooltip" is filled and expect button to include a "title" attribute for the tooltip', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).tooltip = 'Some Tooltip';
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).tooltip = 'Some Tooltip';
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -360,13 +360,13 @@ describe('HeaderMenu Plugin', () => {
 
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).action = actionMock;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).action = actionMock;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -376,7 +376,7 @@ describe('HeaderMenu Plugin', () => {
           </li>`
       ));
 
-      gridContainerDiv.querySelector('.slick-menu-item.mdi-lightbulb-on').dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+      gridContainerDiv.querySelector('.slick-menu-item.mdi-lightbulb-on')!.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
       expect(actionMock).toHaveBeenCalled();
       expect(gridContainerDiv.innerHTML).toBe('');
     });
@@ -392,7 +392,7 @@ describe('HeaderMenu Plugin', () => {
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -402,7 +402,7 @@ describe('HeaderMenu Plugin', () => {
           </li>`
       ));
 
-      gridContainerDiv.querySelector('.slick-menu-item.mdi-lightbulb-on').dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+      gridContainerDiv.querySelector('.slick-menu-item.mdi-lightbulb-on')!.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
       expect(onCommandMock).toHaveBeenCalled();
       expect(gridContainerDiv.innerHTML).toBe('');
     });
@@ -412,16 +412,16 @@ describe('HeaderMenu Plugin', () => {
 
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemUsabilityOverride = () => true;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).disabled = true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemUsabilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).disabled = true;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onBeforeSetColumns.notify({ previousColumns: [], newColumns: columnsMock, grid: gridStub }, eventData, gridStub);
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -441,13 +441,13 @@ describe('HeaderMenu Plugin', () => {
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const buttonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       buttonElm.dispatchEvent(new Event('click'));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]') as HTMLDivElement;
       const menuElm = gridContainerDiv.querySelector('.slick-header-menu') as HTMLDivElement;
       const clickEvent = new MouseEvent('click');
       Object.defineProperty(buttonElm, 'clientWidth', { writable: true, configurable: true, value: 350 });
       Object.defineProperty(plugin.menuElement, 'clientWidth', { writable: true, configurable: true, value: 275 });
       Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: buttonElm });
-      plugin.showMenu(clickEvent, columnsMock[0], columnsMock[0].header.menu);
+      plugin.showMenu(clickEvent, columnsMock[0], columnsMock[0].header!.menu!);
 
       expect(menuElm).toBeTruthy();
       expect(menuElm.clientWidth).toBe(275);
@@ -464,14 +464,14 @@ describe('HeaderMenu Plugin', () => {
     it('should not populate a Header Menu when 2nd button item visibility callback returns false', () => {
       plugin.dispose();
       plugin.init();
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => false;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemUsabilityOverride = () => false;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => false;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemUsabilityOverride = () => false;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button:nth-child(1)') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-disabled');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item.slick-menu-item-disabled') as HTMLDivElement;
 
       expect(commandElm).toBeFalsy();
     });
@@ -481,9 +481,9 @@ describe('HeaderMenu Plugin', () => {
 
       plugin.dispose();
       plugin.init({ menuUsabilityOverride: () => false });
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).itemUsabilityOverride = () => true;
-      (columnsMock[0].header.menu.items[1] as MenuCommandItem).disabled = true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemVisibilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).itemUsabilityOverride = () => true;
+      (columnsMock[0].header!.menu!.items[1] as MenuCommandItem).disabled = true;
 
       const eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
       gridStub.onBeforeSetColumns.notify({ previousColumns: [], newColumns: columnsMock, grid: gridStub }, eventData, gridStub);
@@ -505,7 +505,7 @@ describe('HeaderMenu Plugin', () => {
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData, gridStub);
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]');
+      const commandElm = gridContainerDiv.querySelector('.slick-menu-item[data-command="show-negative-numbers"]') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
@@ -523,9 +523,9 @@ describe('HeaderMenu Plugin', () => {
     describe('hideColumn method', () => {
       beforeEach(() => {
         jest.clearAllMocks();
-        columnsMock[0].header.menu = undefined;
-        columnsMock[1].header.menu = undefined;
-        columnsMock[2].header.menu = undefined;
+        columnsMock[0].header!.menu = undefined;
+        columnsMock[1].header!.menu = undefined;
+        columnsMock[2].header!.menu = undefined;
         const mockColumn = { id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE', sortable: true, filterable: true } as any;
         jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue([mockColumn]);
         jest.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock);
@@ -583,8 +583,8 @@ describe('HeaderMenu Plugin', () => {
       let eventData: SlickEventData;
 
       beforeEach(() => {
-        columnsMock[1].header.menu = undefined;
-        columnsMock[2].header.menu = undefined;
+        columnsMock[1].header!.menu = undefined;
+        columnsMock[2].header!.menu = undefined;
         headerDiv = document.createElement('div');
         headerDiv.className = 'slick-header-column';
         eventData = { ...new Slick.EventData(), preventDefault: jest.fn() };
@@ -613,7 +613,7 @@ describe('HeaderMenu Plugin', () => {
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
 
         const commandDivElm = gridContainerDiv.querySelector('[data-command="freeze-columns"]') as HTMLDivElement;
-        expect((originalColumnDefinitions[1] as any).header.menu.items).toEqual([
+        expect((originalColumnDefinitions[1] as any).header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-thumb-tack', title: 'Freeze Columns', titleKey: 'FREEZE_COLUMNS', command: 'freeze-columns', positionOrder: 47 },
           { divider: true, command: '', positionOrder: 49 },
         ]);
@@ -639,7 +639,7 @@ describe('HeaderMenu Plugin', () => {
         const commandDivElm = gridContainerDiv.querySelector('[data-command="clear-filter"]') as HTMLDivElement;
         const commandIconElm = commandDivElm.querySelector('.slick-menu-icon') as HTMLDivElement;
         const commandLabelElm = commandDivElm.querySelector('.slick-menu-content') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual(headerMenuExpected);
+        expect(columnsMock[1].header!.menu!.items).toEqual(headerMenuExpected);
         expect(commandIconElm.classList.contains('fa-filter')).toBeTruthy();
         expect(commandLabelElm.textContent).toBe('Remove Filter');
 
@@ -678,7 +678,7 @@ describe('HeaderMenu Plugin', () => {
         const commandDivElm = gridContainerDiv.querySelector('[data-command="column-resize-by-content"]') as HTMLDivElement;
         const commandIconElm = commandDivElm.querySelector('.slick-menu-icon') as HTMLDivElement;
         const commandLabelElm = commandDivElm.querySelector('.slick-menu-content') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual(headerMenuExpected);
+        expect(columnsMock[1].header!.menu!.items).toEqual(headerMenuExpected);
         expect(commandIconElm.classList.contains('fa-arrows-h')).toBeTruthy();
         expect(commandLabelElm.textContent).toBe('Resize by Content');
 
@@ -712,7 +712,7 @@ describe('HeaderMenu Plugin', () => {
         const commandDivElm = gridContainerDiv.querySelector('[data-command="hide-column"]') as HTMLDivElement;
         const commandIconElm = commandDivElm.querySelector('.slick-menu-icon') as HTMLDivElement;
         const commandLabelElm = commandDivElm.querySelector('.slick-menu-content') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual(headerMenuExpected);
+        expect(columnsMock[1].header!.menu!.items).toEqual(headerMenuExpected);
         expect(commandIconElm.classList.contains('fa-times')).toBeTruthy();
         expect(commandLabelElm.textContent).toBe('Hide Column');
 
@@ -738,7 +738,7 @@ describe('HeaderMenu Plugin', () => {
         const commandDivElm = gridContainerDiv.querySelector('[data-command="clear-filter"]') as HTMLDivElement;
         const commandIconElm = commandDivElm.querySelector('.slick-menu-icon') as HTMLDivElement;
         const commandLabelElm = commandDivElm.querySelector('.slick-menu-content') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual(headerMenuExpected);
+        expect(columnsMock[1].header!.menu!.items).toEqual(headerMenuExpected);
         expect(commandIconElm.classList.contains('fa-filter')).toBeTruthy();
         expect(commandLabelElm.textContent).toBe('Remove Filter');
 
@@ -764,7 +764,7 @@ describe('HeaderMenu Plugin', () => {
         const commandDivElm = gridContainerDiv.querySelector('[data-command="clear-sort"]') as HTMLDivElement;
         const commandIconElm = commandDivElm.querySelector('.slick-menu-icon') as HTMLDivElement;
         const commandLabelElm = commandDivElm.querySelector('.slick-menu-content') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual([
+        expect(columnsMock[1].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-sort-asc', title: 'Sort Ascending', titleKey: 'SORT_ASCENDING', command: 'sort-asc', positionOrder: 50 },
           { iconCssClass: 'fa fa-sort-desc', title: 'Sort Descending', titleKey: 'SORT_DESCENDING', command: 'sort-desc', positionOrder: 51 },
           { divider: true, command: '', positionOrder: 52 },
@@ -775,7 +775,7 @@ describe('HeaderMenu Plugin', () => {
 
         translateService.use('fr');
         plugin.translateHeaderMenu();
-        expect(columnsMock[1].header.menu.items).toEqual([
+        expect(columnsMock[1].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-sort-asc', title: 'Trier par ordre croissant', titleKey: 'SORT_ASCENDING', command: 'sort-asc', positionOrder: 50 },
           { iconCssClass: 'fa fa-sort-desc', title: 'Trier par ordre décroissant', titleKey: 'SORT_DESCENDING', command: 'sort-desc', positionOrder: 51 },
           { divider: true, command: '', positionOrder: 52 },
@@ -805,7 +805,7 @@ describe('HeaderMenu Plugin', () => {
         const commandDivElm = gridContainerDiv.querySelector('[data-command="freeze-columns"]') as HTMLDivElement;
         const commandIconElm = commandDivElm.querySelector('.slick-menu-icon') as HTMLDivElement;
         const commandLabelElm = commandDivElm.querySelector('.slick-menu-content') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual([
+        expect(columnsMock[1].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-thumb-tack', title: 'Freeze Columns', titleKey: 'FREEZE_COLUMNS', command: 'freeze-columns', positionOrder: 47 },
           { divider: true, command: '', positionOrder: 49 },
         ]);
@@ -814,7 +814,7 @@ describe('HeaderMenu Plugin', () => {
 
         translateService.use('fr');
         plugin.translateHeaderMenu();
-        expect(columnsMock[1].header.menu.items).toEqual([
+        expect(columnsMock[1].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-thumb-tack', title: 'Geler les colonnes', titleKey: 'FREEZE_COLUMNS', command: 'freeze-columns', positionOrder: 47 },
           { divider: true, command: '', positionOrder: 49 },
         ]);
@@ -838,7 +838,7 @@ describe('HeaderMenu Plugin', () => {
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
 
         const commandDivElm = gridContainerDiv.querySelector('[data-command="freeze-columns"]') as HTMLDivElement;
-        expect(columnsMock[2].header.menu.items).toEqual([
+        expect(columnsMock[2].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-thumb-tack', title: 'Freeze Columns', titleKey: 'FREEZE_COLUMNS', command: 'freeze-columns', positionOrder: 47 },
           { divider: true, command: '', positionOrder: 49 },
         ]);
@@ -866,7 +866,7 @@ describe('HeaderMenu Plugin', () => {
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
 
         const commandDivElm = gridContainerDiv.querySelector('[data-command="freeze-columns"]') as HTMLDivElement;
-        expect((originalColumnDefinitions[1] as any).header.menu.items).toEqual([
+        expect((originalColumnDefinitions[1] as any).header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-thumb-tack', title: 'Freeze Columns', titleKey: 'FREEZE_COLUMNS', command: 'freeze-columns', positionOrder: 47 },
           { divider: true, command: '', positionOrder: 49 },
         ]);
@@ -893,7 +893,7 @@ describe('HeaderMenu Plugin', () => {
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
 
         const commandDivElm = gridContainerDiv.querySelector('[data-command="sort-asc"]') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual([
+        expect(columnsMock[1].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-sort-asc', title: 'Sort Ascending', titleKey: 'SORT_ASCENDING', command: 'sort-asc', positionOrder: 50 },
           { iconCssClass: 'fa fa-sort-desc', title: 'Sort Descending', titleKey: 'SORT_DESCENDING', command: 'sort-desc', positionOrder: 51 },
           { divider: true, command: '', positionOrder: 52 },
@@ -925,7 +925,7 @@ describe('HeaderMenu Plugin', () => {
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
 
         const commandDivElm = gridContainerDiv.querySelector('[data-command="sort-desc"]') as HTMLDivElement;
-        expect(columnsMock[1].header.menu.items).toEqual([
+        expect(columnsMock[1].header!.menu!.items).toEqual([
           { iconCssClass: 'fa fa-sort-asc', title: 'Sort Ascending', titleKey: 'SORT_ASCENDING', command: 'sort-asc', positionOrder: 50 },
           { iconCssClass: 'fa fa-sort-desc', title: 'Sort Descending', titleKey: 'SORT_DESCENDING', command: 'sort-desc', positionOrder: 51 },
           { divider: true, command: '', positionOrder: 52 },
@@ -956,7 +956,7 @@ describe('HeaderMenu Plugin', () => {
         gridStub.onHeaderCellRendered.notify({ column: columnsMock[1], node: headerDiv, grid: gridStub }, eventData, gridStub);
         const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-        gridContainerDiv.querySelector('[data-command="sort-desc"]').dispatchEvent(new Event('click'));
+        gridContainerDiv.querySelector('[data-command="sort-desc"]')!.dispatchEvent(new Event('click'));
         expect(previousSortSpy).toHaveBeenCalled();
         mockSortedOuput[1].sortCol = { ...columnsMock[1], ...mockSortedOuput[1].sortCol }; // merge with column header menu
         expect(previousSortSpy).toHaveBeenCalled();
@@ -980,7 +980,7 @@ describe('HeaderMenu Plugin', () => {
         gridStub.onHeaderCellRendered.notify({ column: columnsMock[1], node: headerDiv, grid: gridStub }, eventData, gridStub);
         const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
         headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-        gridContainerDiv.querySelector('[data-command="sort-desc"]').dispatchEvent(new Event('click'));
+        gridContainerDiv.querySelector('[data-command="sort-desc"]')!.dispatchEvent(new Event('click'));
         expect(previousSortSpy).toHaveBeenCalled();
         mockSortedOuput[1].sortCol = { ...columnsMock[1], ...mockSortedOuput[1].sortCol }; // merge with column header menu
         expect(previousSortSpy).toHaveBeenCalled();

--- a/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
@@ -137,10 +137,8 @@ describe('SlickRowMoveManager Plugin', () => {
   });
 
   it('should call the "create" method and expect plugin to be created with checkbox column to be created at position 0 when using default', () => {
-    plugin.create(mockColumns, { rowMoveManager: { columnId: 'move-id' } });
-
-    expect(plugin).toBeTruthy();
-    expect(mockColumns[0]).toEqual({
+    const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
+    const rowMoveColumnMock = {
       cssClass: 'slick-row-move-column',
       excludeFromColumnPicker: true,
       excludeFromExport: true,
@@ -155,7 +153,13 @@ describe('SlickRowMoveManager Plugin', () => {
       resizable: false,
       selectable: false,
       width: 40,
-    });
+    };
+
+    plugin.create(mockColumns, { rowMoveManager: { columnId: 'move-id' } });
+
+    expect(plugin).toBeTruthy();
+    expect(pubSubSpy).toHaveBeenCalledWith('onPluginColumnsChanged', { columns: expect.arrayContaining([{ ...rowMoveColumnMock, formatter: expect.toBeFunction() }]), pluginName: 'RowMoveManager' });
+    expect(mockColumns[0]).toEqual(rowMoveColumnMock);
   });
 
   it('should create the plugin and call "setOptions" and expect options changed', () => {

--- a/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
@@ -1,3 +1,4 @@
+import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import 'jest-extended';
 
 import { Column, DragRowMove, GridOption, OnDragEventArgs, SlickGrid, SlickNamespace, } from '../../interfaces/index';
@@ -57,6 +58,13 @@ const gridStub = {
   onDragStart: new Slick.Event(),
 } as unknown as SlickGrid;
 
+const pubSubServiceStub = {
+  publish: jest.fn(),
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn(),
+  unsubscribeAll: jest.fn(),
+} as BasePubSubService;
+
 describe('SlickRowMoveManager Plugin', () => {
   let plugin: SlickRowMoveManager;
   const mockColumns = [
@@ -90,7 +98,7 @@ describe('SlickRowMoveManager Plugin', () => {
   jest.spyOn(gridStub, 'getCanvasNode').mockReturnValue(canvasTL);
 
   beforeEach(() => {
-    plugin = new SlickRowMoveManager();
+    plugin = new SlickRowMoveManager(pubSubServiceStub);
   });
 
   afterEach(() => {
@@ -194,7 +202,7 @@ describe('SlickRowMoveManager Plugin', () => {
 
   it('should process the "checkboxSelectionFormatter" and expect necessary Formatter to return null when usabilityOverride is provided as plugin option and is returning False', () => {
     plugin.init(gridStub, { usabilityOverride: () => false });
-    const output = plugin.getColumnDefinition().formatter(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
+    const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
 
     expect(plugin).toBeTruthy();
     expect(output).toEqual('');
@@ -203,7 +211,7 @@ describe('SlickRowMoveManager Plugin', () => {
   it('should process the "checkboxSelectionFormatter" and expect necessary Formatter to return null when usabilityOverride is defined and returning False', () => {
     plugin.usabilityOverride(() => false);
     plugin.create(mockColumns, {});
-    const output = plugin.getColumnDefinition().formatter(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
+    const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
 
     expect(plugin).toBeTruthy();
     expect(output).toEqual('');
@@ -212,7 +220,7 @@ describe('SlickRowMoveManager Plugin', () => {
   it('should process the "checkboxSelectionFormatter" and expect necessary Formatter to return regular formatter when usabilityOverride is returning True', () => {
     plugin.init(gridStub);
     plugin.usabilityOverride(() => true);
-    const output = plugin.getColumnDefinition().formatter(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
+    const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
 
     expect(plugin).toBeTruthy();
     expect(output).toEqual({ addClasses: 'cell-reorder dnd', text: '' });
@@ -220,8 +228,8 @@ describe('SlickRowMoveManager Plugin', () => {
 
   it('should process the "checkboxSelectionFormatter" and expect necessary Formatter to return regular formatter when usabilityOverride is not a function', () => {
     plugin.init(gridStub);
-    plugin.usabilityOverride(null);
-    const output = plugin.getColumnDefinition().formatter(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
+    plugin.usabilityOverride(null as any);
+    const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
 
     expect(plugin).toBeTruthy();
     expect(output).toEqual({ addClasses: 'cell-reorder dnd', text: '' });

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -1,3 +1,5 @@
+import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+
 import { KeyCode } from '../enums/keyCode.enum';
 import { CheckboxSelectorOption, Column, DOMMouseOrTouchEvent, GridOption, SelectableOverrideCallback, SlickEventData, SlickEventHandler, SlickGrid, SlickNamespace } from '../interfaces/index';
 import { SlickRowSelectionModel } from './slickRowSelectionModel';
@@ -31,7 +33,7 @@ export class SlickCheckboxSelectColumn<T = any> {
   protected _selectAll_UID: number;
   protected _selectedRowsLookup: any = {};
 
-  constructor(options?: CheckboxSelectorOption) {
+  constructor(protected readonly pubSubService: BasePubSubService, options?: CheckboxSelectorOption) {
     this._selectAll_UID = this.createUID();
     this._bindEventService = new BindingEventService();
     this._eventHandler = new Slick.EventHandler();
@@ -111,6 +113,11 @@ export class SlickCheckboxSelectColumn<T = any> {
       } else {
         columnDefinitions.unshift(selectionColumn);
       }
+
+      this.pubSubService.publish(`onPluginColumnsChanged`, {
+        columns: columnDefinitions,
+        pluginName: this.pluginName
+      });
     }
     return this;
   }

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -1,3 +1,5 @@
+import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+
 import { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
 import {
   Column,
@@ -54,7 +56,7 @@ export class SlickRowMoveManager {
   pluginName: 'RowMoveManager' = 'RowMoveManager' as const;
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
-  constructor() {
+  constructor(protected readonly pubSubService: BasePubSubService) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -111,6 +113,11 @@ export class SlickRowMoveManager {
       } else {
         columnDefinitions.unshift(finalRowMoveColumn);
       }
+
+      this.pubSubService.publish(`onPluginColumnsChanged`, {
+        columns: columnDefinitions,
+        pluginName: this.pluginName
+      });
     }
     return this;
   }

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -198,7 +198,7 @@ export class ExtensionService {
 
       // Checkbox Selector Plugin
       if (this.gridOptions.enableCheckboxSelector) {
-        this._checkboxSelectColumn = this._checkboxSelectColumn || new SlickCheckboxSelectColumn(this.gridOptions.checkboxSelector);
+        this._checkboxSelectColumn = this._checkboxSelectColumn || new SlickCheckboxSelectColumn(this.pubSubService, this.gridOptions.checkboxSelector);
         this._checkboxSelectColumn.init(this.sharedService.slickGrid);
         const createdExtension = this.getCreatedExtensionByName(ExtensionName.checkboxSelector); // get the instance from when it was really created earlier
         const instance = createdExtension && createdExtension.instance;
@@ -274,7 +274,7 @@ export class ExtensionService {
 
       // Row Move Manager Plugin
       if (this.gridOptions.enableRowMoveManager) {
-        this._rowMoveManagerPlugin = this._rowMoveManagerPlugin || new SlickRowMoveManager();
+        this._rowMoveManagerPlugin = this._rowMoveManagerPlugin || new SlickRowMoveManager(this.pubSubService);
         this._rowMoveManagerPlugin.init(this.sharedService.slickGrid, this.gridOptions.rowMoveManager);
         const createdExtension = this.getCreatedExtensionByName(ExtensionName.rowMoveManager); // get the instance from when it was really created earlier
         const instance = createdExtension?.instance;
@@ -298,13 +298,13 @@ export class ExtensionService {
     // we push them into a array and we'll process them by their position (if provided, else use same order that they were inserted)
     if (gridOptions.enableCheckboxSelector) {
       if (!this.getCreatedExtensionByName(ExtensionName.checkboxSelector)) {
-        this._checkboxSelectColumn = new SlickCheckboxSelectColumn(this.sharedService.gridOptions.checkboxSelector);
+        this._checkboxSelectColumn = new SlickCheckboxSelectColumn(this.pubSubService, this.sharedService.gridOptions.checkboxSelector);
         featureWithColumnIndexPositions.push({ name: ExtensionName.checkboxSelector, extension: this._checkboxSelectColumn, columnIndexPosition: gridOptions?.checkboxSelector?.columnIndexPosition ?? featureWithColumnIndexPositions.length });
       }
     }
     if (gridOptions.enableRowMoveManager) {
       if (!this.getCreatedExtensionByName(ExtensionName.rowMoveManager)) {
-        this._rowMoveManagerPlugin = new SlickRowMoveManager();
+        this._rowMoveManagerPlugin = new SlickRowMoveManager(this.pubSubService);
         featureWithColumnIndexPositions.push({ name: ExtensionName.rowMoveManager, extension: this._rowMoveManagerPlugin, columnIndexPosition: gridOptions?.rowMoveManager?.columnIndexPosition ?? featureWithColumnIndexPositions.length });
       }
     }

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -37,7 +37,6 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   protected _keyPrefix = '';
   protected _lastRange: { bottom: number; top: number; } | null = null;
   protected _outsideRange = 5;
-  protected _pubSubService: PubSubService | null = null;
   protected _rowIdsOutOfViewport: Array<number | string> = [];
   protected _visibleRenderedCellCount = 0;
   protected _defaults = {
@@ -77,7 +76,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   onRowOutOfViewportRange = new Slick.Event();
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
-  constructor() {
+  constructor(protected readonly pubSubService: PubSubService) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -209,7 +208,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
         columnDefinitions.unshift(finalRowDetailViewColumn);
       }
 
-      this._pubSubService?.publish(`onPluginColumnsChanged`, {
+      this.pubSubService.publish(`onPluginColumnsChanged`, {
         columns: columnDefinitions,
         pluginName: this.pluginName
       });

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -208,6 +208,11 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
       } else {
         columnDefinitions.unshift(finalRowDetailViewColumn);
       }
+
+      this._pubSubService?.publish(`onPluginColumnsChanged`, {
+        columns: columnDefinitions,
+        pluginName: this.pluginName
+      });
     }
     return this as unknown as UniversalRowDetailView;
   }

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -58,6 +58,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
+    "@slickgrid-universal/graphql": "workspace:~",
     "@types/jquery": "^3.5.14",
     "@types/sortablejs": "^1.15.0",
     "cross-env": "^7.0.3",

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -40,6 +40,7 @@ import {
   SortService,
   TreeDataService,
   TranslaterService,
+  BackendServiceApi,
 } from '@slickgrid-universal/common';
 import { GraphqlService, GraphqlPaginatedResult, GraphqlServiceApi, GraphqlServiceOption } from '@slickgrid-universal/graphql';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
@@ -390,6 +391,21 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
     expect(pubSubSpy).toHaveBeenNthCalledWith(6, 'onAfterGridDestroyed', true);
   });
 
+  it('should update column definitions when onPluginColumnsChanged event is triggered with updated columns', () => {
+    const columnsMock = [
+      { id: 'firstName', field: 'firstName', editor: undefined, internalColumnEditor: {} },
+      { id: 'lastName', field: 'lastName', editor: undefined, internalColumnEditor: {} }
+    ]
+    eventPubSubService.publish('onPluginColumnsChanged', {
+      columns: columnsMock,
+      pluginName: 'RowMoveManager'
+    });
+
+    component.initialization(divContainer, slickEventHandler);
+
+    expect(component.columnDefinitions).toEqual(columnsMock);
+  });
+
   describe('initialization method', () => {
     const customEditableInputFormatter: Formatter = (_row, _cell, value, columnDef) => {
       const isEditableLine = !!columnDef.editor;
@@ -457,7 +473,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const autosizeSpy = jest.spyOn(mockGrid, 'autosizeColumns');
         const updateSpy = jest.spyOn(component, 'updateColumnDefinitionsList');
         const eventSpy = jest.spyOn(eventPubSubService, 'publish');
-        const addPubSubSpy = jest.spyOn(component.translaterService, 'addPubSubMessaging');
+        const addPubSubSpy = jest.spyOn(component.translaterService as TranslaterService, 'addPubSubMessaging');
         const mockColDefs = [{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }];
 
         component.columnDefinitions = mockColDefs;
@@ -478,7 +494,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const updateSpy = jest.spyOn(component, 'updateColumnDefinitionsList');
         const renderSpy = jest.spyOn(extensionServiceStub, 'renderColumnHeaders');
         const eventSpy = jest.spyOn(eventPubSubService, 'publish');
-        const addPubSubSpy = jest.spyOn(component.translaterService, 'addPubSubMessaging');
+        const addPubSubSpy = jest.spyOn(component.translaterService as TranslaterService, 'addPubSubMessaging');
         const autoAddFormatterSpy = jest.spyOn(formatterUtilities, 'autoAddEditorFormatterToColumnsWithEditor');
         const mockColDefs = [{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }];
 
@@ -593,12 +609,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       });
 
       it('should merge grid options with global options when slickgrid "getOptions" does not exist yet', () => {
-        mockGrid.getOptions = null;
+        mockGrid.getOptions = null as any;
         const setOptionSpy = jest.spyOn(mockGrid, 'setOptions');
         const sharedOptionSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'set');
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
 
-        component.gridOptions = { autoCommitEdit: false, autoResize: null };
+        component.gridOptions = { autoCommitEdit: false, autoResize: null as any };
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
@@ -609,12 +625,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       });
 
       it('should merge grid options with global options and expect bottom padding to be calculated', () => {
-        mockGrid.getOptions = null;
+        mockGrid.getOptions = null as any;
         const setOptionSpy = jest.spyOn(mockGrid, 'setOptions');
         const sharedOptionSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'set');
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
 
-        component.gridOptions = { autoCommitEdit: false, autoResize: null };
+        component.gridOptions = { autoCommitEdit: false, autoResize: null as any };
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
@@ -664,9 +680,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         setTimeout(() => {
           expect(component.columnDefinitions[0].editor).toBeTruthy();
-          expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
+          expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
           done();
         });
       });
@@ -689,9 +705,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         setTimeout(() => {
           expect(component.columnDefinitions[0].editor).toBeTruthy();
-          expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
+          expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
           expect(disableSpy).toHaveBeenCalledWith(false);
           expect(destroySpy).toHaveBeenCalled();
           expect(renderSpy).toHaveBeenCalledWith(mockCollection);
@@ -707,9 +723,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
+          expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
           done();
         });
       });
@@ -727,9 +743,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
+          expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
           done();
         });
       });
@@ -780,7 +796,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         component.gridOptions = { draggableGrouping: {} };
         component.initialization(divContainer, slickEventHandler);
-        const extensions = component.extensions;
+        const extensions = component.extensions as ExtensionList<any>;
 
         expect(Object.keys(extensions).length).toBe(1);
         expect(dataviewSpy).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() });
@@ -1013,9 +1029,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.dataset = mockData;
 
         setTimeout(() => {
-          expect(component.paginationOptions.pageSize).toBe(2);
-          expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
-          expect(component.paginationOptions.totalItems).toBe(expectedTotalItems);
+          expect(component.paginationOptions!.pageSize).toBe(2);
+          expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
+          expect(component.paginationOptions!.totalItems).toBe(expectedTotalItems);
           expect(refreshSpy).toHaveBeenCalledWith(mockData);
           done();
         });
@@ -1040,9 +1056,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         setTimeout(() => {
           expect(getPagingSpy).toHaveBeenCalled();
-          expect(component.paginationOptions.pageSize).toBe(10);
-          expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
-          expect(component.paginationOptions.totalItems).toBe(expectedTotalItems);
+          expect(component.paginationOptions!.pageSize).toBe(10);
+          expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
+          expect(component.paginationOptions!.totalItems).toBe(expectedTotalItems);
           expect(refreshSpy).toHaveBeenCalledWith(mockData);
           done();
         });
@@ -1072,55 +1088,55 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
 
         expect(spy).toHaveBeenCalled();
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback method that was created by "createBackendApiInternalPostProcessCallback" with Pagination', () => {
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const spy = jest.spyOn(component, 'refreshGridData');
 
         component.initialization(divContainer, slickEventHandler);
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { users: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { users: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
 
         expect(spy).toHaveBeenCalled();
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback and expect totalItems to be updated in the PaginationService when "refreshGridData" is called on the 2nd time', () => {
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const refreshSpy = jest.spyOn(component, 'refreshGridData');
         const paginationSpy = jest.spyOn(paginationServiceStub, 'totalItems', 'set');
         const mockDataset = [{ firstName: 'John' }, { firstName: 'Jane' }];
 
         component.initialization(divContainer, slickEventHandler);
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { users: { nodes: mockDataset, totalCount: mockDataset.length } } } as GraphqlPaginatedResult);
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { users: { nodes: mockDataset, totalCount: mockDataset.length } } } as GraphqlPaginatedResult);
         component.refreshGridData(mockDataset, 1);
         component.refreshGridData(mockDataset, 1);
 
         expect(refreshSpy).toHaveBeenCalledTimes(3);
         expect(paginationSpy).toHaveBeenCalledWith(2);
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback method that was created by "createBackendApiInternalPostProcessCallback" without Pagination (when disabled)', () => {
         component.gridOptions.enablePagination = false;
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const spy = jest.spyOn(component, 'refreshGridData');
 
         component.initialization(divContainer, slickEventHandler);
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { users: [{ firstName: 'John' }] } });
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { users: [{ firstName: 'John' }] } });
 
         expect(spy).toHaveBeenCalled();
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback method but return an empty dataset when dataset name does not match "getDatasetName"', () => {
         component.gridOptions.enablePagination = true;
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const spy = jest.spyOn(component, 'refreshGridData');
 
         component.initialization(divContainer, slickEventHandler);
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { notUsers: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { notUsers: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
 
         expect(spy).not.toHaveBeenCalled();
         expect(component.dataset).toEqual([]);
@@ -1201,8 +1217,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
-        expect(component.paginationOptions.pageSize).toBe(10);
-        expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
+        expect(component.paginationOptions!.pageSize).toBe(10);
+        expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
         expect(refreshSpy).toHaveBeenCalledWith(mockData);
       });
 
@@ -1214,17 +1230,17 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
         const promise = new Promise(resolve => setTimeout(() => resolve(processResult), 1));
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(promise);
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(promise);
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'buildQuery').mockReturnValue(query);
         const backendExecuteSpy = jest.spyOn(backendUtilityServiceStub, 'executeBackendProcessesCallback');
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 
         expect(processSpy).toHaveBeenCalled();
 
         setTimeout(() => {
-          expect(backendExecuteSpy).toHaveBeenCalledWith(expect.toBeDate(), processResult, component.gridOptions.backendServiceApi, 0);
+          expect(backendExecuteSpy).toHaveBeenCalledWith(expect.toBeDate(), processResult, component.gridOptions.backendServiceApi as BackendServiceApi, 0);
           done();
         }, 5);
       });
@@ -1237,18 +1253,18 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           data: { users: { nodes: [] }, pageInfo: { hasNextPage: true }, totalCount: 0 },
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
-        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(of(processResult));
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi as BackendServiceApi, 'process').mockReturnValue(of(processResult));
         jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
         const backendExecuteSpy = jest.spyOn(backendUtilityServiceStub, 'executeBackendProcessesCallback');
 
         component.gridOptions.registerExternalResources = [rxjsMock];
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 
         expect(processSpy).toHaveBeenCalled();
 
         setTimeout(() => {
-          expect(backendExecuteSpy).toHaveBeenCalledWith(expect.toBeDate(), processResult, component.gridOptions.backendServiceApi, 0);
+          expect(backendExecuteSpy).toHaveBeenCalledWith(expect.toBeDate(), processResult, component.gridOptions.backendServiceApi as BackendServiceApi, 0);
           done();
         }, 5);
       });
@@ -1261,17 +1277,17 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
         const promise = new Promise(resolve => setTimeout(() => resolve(processResult), 1));
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(promise);
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(promise);
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'buildQuery').mockReturnValue(query);
         const backendExecuteSpy = jest.spyOn(backendUtilityServiceStub, 'executeBackendProcessesCallback');
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 
         expect(processSpy).toHaveBeenCalled();
 
         setTimeout(() => {
-          expect(backendExecuteSpy).toHaveBeenCalledWith(expect.toBeDate(), processResult, component.gridOptions.backendServiceApi, 0);
+          expect(backendExecuteSpy).toHaveBeenCalledWith(expect.toBeDate(), processResult, component.gridOptions.backendServiceApi as BackendServiceApi, 0);
           done();
         }, 5);
       });
@@ -1280,10 +1296,10 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockError = { error: '404' };
         const query = `query { users (first:20,offset:0) { totalCount, nodes { id,name,gender,company } } }`;
         const promise = new Promise((_resolve, reject) => setTimeout(() => reject(mockError), 1));
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(promise);
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(promise);
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'buildQuery').mockReturnValue(query);
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 
         expect(processSpy).toHaveBeenCalled();
@@ -1298,12 +1314,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockError = { error: '404' };
         const rxjsMock = new RxJsResourceStub();
         const query = `query { users (first:20,offset:0) { totalCount, nodes { id,name,gender,company } } }`;
-        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(throwError(mockError));
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi as BackendServiceApi, 'process').mockReturnValue(throwError(mockError));
         jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
         const backendErrorSpy = jest.spyOn(backendUtilityServiceStub, 'onBackendError');
 
         component.gridOptions.registerExternalResources = [rxjsMock];
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 
         expect(processSpy).toHaveBeenCalled();
@@ -1685,7 +1701,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         component.gridOptions = mockGridOptions;
         component.initialization(divContainer, slickEventHandler);
-        const emptySpy = jest.spyOn(component.slickEmptyWarning, 'showEmptyDataMessage');
+        const emptySpy = jest.spyOn(component.slickEmptyWarning!, 'showEmptyDataMessage');
         component.columnDefinitions = mockColDefs;
         component.refreshGridData([]);
         mockDataView.onRowCountChanged.notify({ current: 0, previous: 0, dataView: mockDataView, itemCount: 0, callingOnRowsChanged: false });
@@ -1789,7 +1805,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         component.gridOptions = { enablePagination: false, showCustomFooter: true };
         component.initialization(divContainer, slickEventHandler);
-        const footerSpy = jest.spyOn(component.slickFooter, 'metrics', 'set');
+        const footerSpy = jest.spyOn(component.slickFooter!, 'metrics', 'set');
         mockDataView.onRowCountChanged.notify({ current: 2, previous: 0, dataView: mockDataView, itemCount: 0, callingOnRowsChanged: false });
 
         expect(invalidateSpy).toHaveBeenCalled();
@@ -1809,7 +1825,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
         component.gridOptions = { enablePagination: false, showCustomFooter: true };
         component.initialization(divContainer, slickEventHandler);
-        const footerSpy = jest.spyOn(component.slickFooter, 'metrics', 'set');
+        const footerSpy = jest.spyOn(component.slickFooter!, 'metrics', 'set');
         mockDataView.onSetItemsCalled.notify({ idProperty: 'id', itemCount: 0 });
 
         expect(invalidateSpy).toHaveBeenCalled();
@@ -1876,7 +1892,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.gridOptions = {
           enableRowSelection: true,
           enablePagination: true,
-          backendServiceApi: null,
+          backendServiceApi: null as any,
           presets: { rowSelection: { dataContextIds: selectedGridRows } }
         };
         component.dataset = mockData;
@@ -1899,11 +1915,11 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should change "showPagination" flag when "onPaginationVisibilityChanged" from the Pagination Service is triggered', () => {
         component.gridOptions.enablePagination = true;
-        component.gridOptions.backendServiceApi = null;
+        component.gridOptions.backendServiceApi = null as any;
 
         component.initialization(divContainer, slickEventHandler);
         component.refreshGridData([{ firstName: 'John', lastName: 'Doe' }]);
-        const disposeSpy = jest.spyOn(component.slickPagination, 'dispose');
+        const disposeSpy = jest.spyOn(component.slickPagination!, 'dispose');
         eventPubSubService.publish('onPaginationVisibilityChanged', { visible: false });
 
         expect(component.showPagination).toBeFalsy();
@@ -2072,7 +2088,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor with 
   let eventPubSubService: EventPubSubService;
   let translateService: TranslateServiceStub;
   let dataset = [];
-  let hierarchicalDataset = null;
+  let hierarchicalDataset: any = null;
   let hierarchicalSpy;
 
   beforeEach(() => {
@@ -2177,7 +2193,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor with 
       columnDefinitions,
       gridOptions,
       dataset,
-      null,
+      null as any,
       {
         backendUtilityService: backendUtilityServiceStub,
         collectionService: collectionServiceStub,

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1,6 +1,7 @@
 import 'jest-extended';
 import { of, throwError } from 'rxjs';
 import {
+  BackendServiceApi,
   BackendUtilityService,
   Column,
   CollectionService,
@@ -40,7 +41,6 @@ import {
   SortService,
   TreeDataService,
   TranslaterService,
-  BackendServiceApi,
 } from '@slickgrid-universal/common';
 import { GraphqlService, GraphqlPaginatedResult, GraphqlServiceApi, GraphqlServiceOption } from '@slickgrid-universal/graphql';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -519,6 +519,17 @@ export class SlickVanillaGridBundle {
     // save reference for all columns before they optionally become hidden/visible
     this.sharedService.allColumns = this._columnDefinitions;
     this.sharedService.visibleColumns = this._columnDefinitions;
+
+    // before certain extentions/plugins potentially adds extra columns not created by the user itself (RowMove, RowDetail, RowSelections)
+    // we'll subscribe to the event and push back the change to the user so they always use full column defs array including extra cols
+    this.subscriptions.push(
+      this._eventPubSubService.subscribe<{ columns: Column[]; pluginName: string }>('onPluginColumnsChanged', data => {
+        this._columnDefinitions = this.columnDefinitions = data.columns;
+      })
+    );
+
+    // after subscribing to potential columns changed, we are ready to create these optional extensions
+    // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)
     this.extensionService.createExtensionsBeforeGridCreation(this._columnDefinitions, this._gridOptions);
 
     // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,7 @@ importers:
       '@slickgrid-universal/custom-footer-component': workspace:~
       '@slickgrid-universal/empty-warning-component': workspace:~
       '@slickgrid-universal/event-pub-sub': workspace:~
+      '@slickgrid-universal/graphql': workspace:~
       '@slickgrid-universal/pagination-component': workspace:~
       '@slickgrid-universal/utils': workspace:~
       '@types/jquery': ^3.5.14
@@ -450,6 +451,7 @@ importers:
       sortablejs: 1.15.0
       whatwg-fetch: 3.6.2
     devDependencies:
+      '@slickgrid-universal/graphql': link:../graphql
       '@types/jquery': 3.5.14
       '@types/sortablejs': 1.15.0
       cross-env: 7.0.3


### PR DESCRIPTION
- for some extensions/plugins, that is RowDetail, RowMove, RowSelections, are adding extra columns dynamically when the grid is created and are not synced to the user, this PR will help with that but has to be implement differently in each lib wrappers (Angular, Aurelia, ...)
- this is related to this Angular-Slickgrid [issue](https://github.com/ghiscoding/Angular-Slickgrid/issues/1018)