### PR TITLE
chore: move compound operator list to common area

### DIFF
--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -1,14 +1,11 @@
 import { setDeepValue, toSentenceCase } from '@slickgrid-universal/utils';
 
+import { Constants } from '../constants';
 import { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace } from '../interfaces/index';
 import { getDescendantProperty } from '../services/utilities';
 import { sliderValidator } from '../editorValidators/sliderValidator';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { createDomElement } from '../services/domUtilities';
-
-const DEFAULT_MIN_VALUE = 0;
-const DEFAULT_MAX_VALUE = 100;
-const DEFAULT_STEP = 1;
 
 // using external non-typed js libraries
 declare const Slick: SlickNamespace;
@@ -304,15 +301,15 @@ export class SliderEditor implements Editor {
   protected buildDomElement(): HTMLDivElement {
     const columnId = this.columnDef?.id ?? '';
     const title = this.columnEditor && this.columnEditor.title || '';
-    const minValue = this.columnEditor.hasOwnProperty('minValue') ? this.columnEditor.minValue : DEFAULT_MIN_VALUE;
-    const maxValue = this.columnEditor.hasOwnProperty('maxValue') ? this.columnEditor.maxValue : DEFAULT_MAX_VALUE;
-    const defaultValue = this.editorParams.hasOwnProperty('sliderStartValue') ? this.editorParams.sliderStartValue : minValue;
+    const minValue = this.columnEditor?.minValue ?? Constants.SLIDER_DEFAULT_MIN_VALUE;
+    const maxValue = this.columnEditor?.maxValue ?? Constants.SLIDER_DEFAULT_MAX_VALUE;
+    const defaultValue = this.editorParams?.sliderStartValue ?? minValue;
     this._defaultValue = defaultValue;
 
     const inputElm = createDomElement('input', {
       type: 'range', name: this._elementRangeInputId, title,
       defaultValue, value: defaultValue, min: `${minValue}`, max: `${maxValue}`,
-      step: `${this.columnEditor.hasOwnProperty('valueStep') ? this.columnEditor.valueStep : DEFAULT_STEP}`,
+      step: `${this.columnEditor?.valueStep ?? Constants.SLIDER_DEFAULT_STEP}`,
       className: `form-control slider-editor-input editor-${columnId} range ${this._elementRangeInputId}`,
     });
     inputElm.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`);

--- a/packages/common/src/filters/compoundDateFilter.ts
+++ b/packages/common/src/filters/compoundDateFilter.ts
@@ -11,15 +11,13 @@ import {
   FilterCallback,
   FlatpickrOption,
   GridOption,
-  Locale,
   OperatorDetail,
   SlickGrid,
 } from '../interfaces/index';
 import { FieldType, OperatorString, OperatorType, SearchTerm } from '../enums/index';
-import { Constants } from '../constants';
-import { buildSelectOperator } from './filterUtilities';
+import { buildSelectOperator, compoundOperatorNumeric } from './filterUtilities';
 import { createDomElement, destroyObjectDomElementProps, emptyElement, } from '../services/domUtilities';
-import { getTranslationPrefix, mapFlatpickrDateFormatWithFieldType, mapOperatorToShorthandDesignation } from '../services/utilities';
+import { mapFlatpickrDateFormatWithFieldType, mapOperatorToShorthandDesignation } from '../services/utilities';
 import { TranslaterService } from '../services/translater.service';
 import { BindingEventService } from '../services/bindingEvent.service';
 
@@ -68,11 +66,6 @@ export class CompoundDateFilter implements Filter {
   /** Getter for the Flatpickr Options */
   get flatpickrOptions(): FlatpickrOption {
     return this._flatpickrOptions || {};
-  }
-
-  /** Getter for the single Locale texts provided by the user in main file or else use default English locales via the Constants */
-  get locales(): Locale {
-    return this.gridOptions.locales || Constants.locales;
   }
 
   /** Getter for the Filter Operator */
@@ -269,25 +262,8 @@ export class CompoundDateFilter implements Filter {
     if (this.columnFilter?.compoundOperatorList) {
       return this.columnFilter.compoundOperatorList;
     } else {
-      return [
-        { operator: '', description: '' },
-        { operator: '=', description: this.getOutputText('EQUAL_TO', 'TEXT_EQUAL_TO', 'Equal to') },
-        { operator: '<', description: this.getOutputText('LESS_THAN', 'TEXT_LESS_THAN', 'Less than') },
-        { operator: '<=', description: this.getOutputText('LESS_THAN_OR_EQUAL_TO', 'TEXT_LESS_THAN_OR_EQUAL_TO', 'Less than or equal to') },
-        { operator: '>', description: this.getOutputText('GREATER_THAN', 'TEXT_GREATER_THAN', 'Greater than') },
-        { operator: '>=', description: this.getOutputText('GREATER_THAN_OR_EQUAL_TO', 'TEXT_GREATER_THAN_OR_EQUAL_TO', 'Greater than or equal to') },
-        { operator: '<>', description: this.getOutputText('NOT_EQUAL_TO', 'TEXT_NOT_EQUAL_TO', 'Not equal to') }
-      ];
+      return compoundOperatorNumeric(this.gridOptions, this.translaterService);
     }
-  }
-
-  /** Get Locale, Translated or a Default Text if first two aren't detected */
-  protected getOutputText(translationKey: string, localeText: string, defaultText: string): string {
-    if (this.gridOptions?.enableTranslate && this.translaterService?.translate) {
-      const translationPrefix = getTranslationPrefix(this.gridOptions);
-      return this.translaterService.translate(`${translationPrefix}${translationKey}`);
-    }
-    return this.locales?.[localeText as keyof Locale] ?? defaultText;
   }
 
   /**

--- a/packages/common/src/filters/filterUtilities.ts
+++ b/packages/common/src/filters/filterUtilities.ts
@@ -1,8 +1,10 @@
+import { Constants } from '../constants';
 import { OperatorString } from '../enums/operatorString.type';
-import { Column, GridOption } from '../interfaces/index';
+import { Column, GridOption, Locale } from '../interfaces/index';
 import { Observable, RxJsFacade, Subject, Subscription } from '../services/rxjsFacade';
 import { createDomElement, htmlEncodedStringWithPadding, sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
-import { castObservableToPromise, getDescendantProperty, } from '../services/utilities';
+import { castObservableToPromise, getDescendantProperty, getTranslationPrefix, } from '../services/utilities';
+import { TranslaterService } from '../services/translater.service';
 
 /**
  * Create and return a select dropdown HTML element with a list of Operators with descriptions
@@ -111,3 +113,37 @@ export function createCollectionAsyncSubject(columnDef: Column, renderDomElement
   }
 }
 
+/** Get Locale, Translated or a Default Text if first two aren't detected */
+function getOutputText(translationKey: string, localeText: string, defaultText: string, gridOptions: GridOption, translaterService?: TranslaterService): string {
+  if (gridOptions?.enableTranslate && translaterService?.translate) {
+    const translationPrefix = getTranslationPrefix(gridOptions);
+    return translaterService.translate(`${translationPrefix}${translationKey}`);
+  }
+  const locales = gridOptions.locales || Constants.locales;
+  return locales?.[localeText as keyof Locale] ?? defaultText;
+}
+
+/** returns common list of string related operators and their associated translation descriptions */
+export function compoundOperatorString(gridOptions: GridOption, translaterService?: TranslaterService) {
+  return [
+    { operator: '' as OperatorString, description: getOutputText('CONTAINS', 'TEXT_CONTAINS', 'Contains', gridOptions, translaterService) },
+    { operator: '<>' as OperatorString, description: getOutputText('NOT_CONTAINS', 'TEXT_NOT_CONTAINS', 'Not Contains', gridOptions, translaterService) },
+    { operator: '=' as OperatorString, description: getOutputText('EQUALS', 'TEXT_EQUALS', 'Equals', gridOptions, translaterService) },
+    { operator: '!=' as OperatorString, description: getOutputText('NOT_EQUAL_TO', 'TEXT_NOT_EQUAL_TO', 'Not equal to', gridOptions, translaterService) },
+    { operator: 'a*' as OperatorString, description: getOutputText('STARTS_WITH', 'TEXT_STARTS_WITH', 'Starts with', gridOptions, translaterService) },
+    { operator: '*z' as OperatorString, description: getOutputText('ENDS_WITH', 'TEXT_ENDS_WITH', 'Ends with', gridOptions, translaterService) },
+  ];
+}
+
+/** returns common list of numeric related operators and their associated translation descriptions */
+export function compoundOperatorNumeric(gridOptions: GridOption, translaterService?: TranslaterService) {
+  return [
+    { operator: '' as OperatorString, description: '' },
+    { operator: '=' as OperatorString, description: getOutputText('EQUAL_TO', 'TEXT_EQUAL_TO', 'Equal to', gridOptions, translaterService) },
+    { operator: '<' as OperatorString, description: getOutputText('LESS_THAN', 'TEXT_LESS_THAN', 'Less than', gridOptions, translaterService) },
+    { operator: '<=' as OperatorString, description: getOutputText('LESS_THAN_OR_EQUAL_TO', 'TEXT_LESS_THAN_OR_EQUAL_TO', 'Less than or equal to', gridOptions, translaterService) },
+    { operator: '>' as OperatorString, description: getOutputText('GREATER_THAN', 'TEXT_GREATER_THAN', 'Greater than', gridOptions, translaterService) },
+    { operator: '>=' as OperatorString, description: getOutputText('GREATER_THAN_OR_EQUAL_TO', 'TEXT_GREATER_THAN_OR_EQUAL_TO', 'Greater than or equal to', gridOptions, translaterService) },
+    { operator: '<>' as OperatorString, description: getOutputText('NOT_EQUAL_TO', 'TEXT_NOT_EQUAL_TO', 'Not equal to', gridOptions, translaterService) }
+  ];
+}


### PR DESCRIPTION
- instead of duplicating the same operator dropdown list into multiple compound filters, we can move the code into a common util