### PR TITLE
fix(filters): changing Slider value should update tooltip value

### DIFF
--- a/packages/common/src/filters/compoundSliderFilter.ts
+++ b/packages/common/src/filters/compoundSliderFilter.ts
@@ -10,6 +10,7 @@ import {
   GridOption,
   OperatorDetail,
   SlickGrid,
+  SlickNamespace,
 } from '../interfaces/index';
 import { Constants } from '../constants';
 import { OperatorString, OperatorType, SearchTerm } from '../enums/index';
@@ -18,6 +19,8 @@ import { createDomElement, emptyElement } from '../services/domUtilities';
 import { mapOperatorToShorthandDesignation, } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { TranslaterService } from '../services/translater.service';
+
+declare const Slick: SlickNamespace;
 
 export class CompoundSliderFilter implements Filter {
   protected _bindEventService: BindingEventService;
@@ -286,7 +289,11 @@ export class CompoundSliderFilter implements Filter {
     this._clearFilterTriggered = false;
     this._shouldTriggerQuery = true;
 
-    // trigger leave event to avoid having previous value still being displayed with custom tooltip feat
-    this.grid?.onHeaderMouseLeave.notify({ column: this.columnDef, grid: this.grid });
+    // trigger mouse enter event on the filter for optionally hooked SlickCustomTooltip
+    // the minimum requirements for tooltip to work are the columnDef and targetElement
+    setTimeout(() => this.grid.onHeaderRowMouseEnter.notify(
+      { column: this.columnDef, grid: this.grid },
+      { ...new Slick.EventData(), target: this.filterContainerElm }
+    ));
   }
 }

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -10,9 +10,12 @@ import {
   FilterArguments,
   FilterCallback,
   SlickGrid,
+  SlickNamespace,
 } from '../interfaces/index';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { createDomElement, emptyElement, } from '../services/domUtilities';
+
+declare const Slick: SlickNamespace;
 
 export class SliderFilter implements Filter {
   protected _bindEventService: BindingEventService;
@@ -246,7 +249,11 @@ export class SliderFilter implements Filter {
     this._clearFilterTriggered = false;
     this._shouldTriggerQuery = true;
 
-    // trigger leave event to avoid having previous value still being displayed with custom tooltip feat
-    this.grid?.onHeaderMouseLeave.notify({ column: this.columnDef, grid: this.grid });
+    // trigger mouse enter event on the filter for optionally hooked SlickCustomTooltip
+    // the minimum requirements for tooltip to work are the columnDef and targetElement
+    setTimeout(() => this.grid.onHeaderRowMouseEnter.notify(
+      { column: this.columnDef, grid: this.grid },
+      { ...new Slick.EventData(), target: this.filterContainerElm }
+    ));
   }
 }

--- a/packages/common/src/filters/sliderRangeFilter.ts
+++ b/packages/common/src/filters/sliderRangeFilter.ts
@@ -333,7 +333,7 @@ export class SliderRangeFilter implements Filter {
     setTimeout(() => this.grid.onHeaderRowMouseEnter.notify(
       { column: this.columnDef, grid: this.grid },
       { ...new Slick.EventData(), target: this._argFilterContainerElm }
-    ), 20);
+    ));
   }
 
   protected changeBothSliderFocuses(isAddingFocus: boolean) {


### PR DESCRIPTION
- when using SlickCustomTooltip addon and changing slider value, it should update the tooltip value without having to leave the cell and rehovering to see the updated value, it turns out that calling `onHeaderRowMouseEnter` will have that effect as long as we add a small `setTimeout` delay

![brave_uxWANvpJSe](https://user-images.githubusercontent.com/643976/199625791-f93b36d0-9c98-4dcd-ac3f-da2db229bbd9.gif)
