### PR TITLE
feat(filters): add "target" prop to `onBeforeSearchChange`

### DIFF
--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -372,7 +372,8 @@ describe('FilterService', () => {
           operator: 'EQ',
           searchTerms: ['John'],
           parsedSearchTerms: ['John'],
-          grid: gridStub
+          grid: gridStub,
+          target: null,
         }, expect.anything());
         expect(spyEmit).toHaveBeenCalledWith('local');
         done();
@@ -402,7 +403,8 @@ describe('FilterService', () => {
         operator: 'EQ',
         searchTerms: ['John'],
         parsedSearchTerms: ['John'],
-        grid: gridStub
+        grid: gridStub,
+        target: { value: 'John', },
       }, expect.anything());
     });
 
@@ -436,7 +438,8 @@ describe('FilterService', () => {
         operator: 'EQ',
         searchTerms: [''],
         parsedSearchTerms: [''],
-        grid: gridStub
+        grid: gridStub,
+        target: null,
       }, expect.anything());
       expect(service.getCurrentLocalFilters()).toEqual([{ columnId: 'firstName', operator: 'EQ', searchTerms: [''] }]);
     });

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -50,6 +50,7 @@ interface OnSearchChangeEventArgs {
   parsedSearchTerms?: SearchTerm | SearchTerm[] | undefined;
   searchTerms: SearchTerm[] | undefined;
   grid: SlickGrid;
+  target?: HTMLElement;
 }
 
 export class FilterService {
@@ -1160,7 +1161,8 @@ export class FilterService {
           operator: operator || mapOperatorByFieldType(fieldType),
           searchTerms,
           parsedSearchTerms,
-          grid: this._grid
+          grid: this._grid,
+          target: event?.target
         } as OnSearchChangeEventArgs;
 
         const onBeforeDispatchResult = this.pubSubService.publish('onBeforeSearchChange', eventArgs);


### PR DESCRIPTION
- add event target to the `onBeforeSearchChange` event so that we know if the filter was changed from the filter input or from the operator select dropdown