### PR TITLE
fix(styling): new Slider not flexed correctly

### DIFF
--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -1147,7 +1147,8 @@ input.flatpickr.form-control {
 
 .slider-input-container {
   position: relative;
-  width: 100%;
+  flex: 1 1 auto;
+  width: 1%;
   background-color: var(--slick-slider-filter-input-bgcolor, $slick-slider-filter-input-bgcolor);
 
   &.slider-values {


### PR DESCRIPTION
- the new refactored code that added Slider Range no longer uses `form-control` CSS class and that created styling issues for some UI framework like Bootstrap in Angular-Slickgrid