### PR TITLE
fix(common): changing Slider value(s) should update Tooltip instantly

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example16.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example16.ts
@@ -8,6 +8,7 @@ import {
   GridOption,
   OperatorType,
   SliderOption,
+  SliderRangeOption,
 } from '@slickgrid-universal/common';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
@@ -154,8 +155,8 @@ export class Example16 {
         exportWithFormatter: false,
         formatter: Formatters.percentCompleteBar,
         sortable: true, filterable: true,
-        filter: { model: Filters.sliderRange, operator: '>=' },
-        customTooltip: { useRegularTooltip: true, position: 'center' },
+        filter: { model: Filters.sliderRange, operator: '>=', filterOptions: { hideSliderNumbers: true } as SliderRangeOption },
+        customTooltip: { position: 'center', formatter: (row, cell, value) => `${value}%`, headerFormatter: null, headerRowFormatter: null },
       },
       {
         id: 'start', name: 'Start', field: 'start', sortable: true,

--- a/packages/common/src/editors/__tests__/sliderEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/sliderEditor.spec.ts
@@ -30,6 +30,7 @@ const gridStub = {
   getOptions: () => gridOptionMock,
   render: jest.fn(),
   onBeforeEditCell: new Slick.Event(),
+  onMouseEnter: new Slick.Event(),
   onCompositeEditorChange: new Slick.Event(),
 } as unknown as SlickGrid;
 
@@ -215,6 +216,7 @@ describe('SliderEditor', () => {
     });
 
     it('should update slider number every time a change event happens on the input slider', () => {
+      const cellMouseEnterSpy = jest.spyOn(gridStub.onMouseEnter, 'notify');
       (mockColumn.internalColumnEditor as ColumnEditor).params = { hideSliderNumber: false };
       mockItemData = { id: 1, price: 32, isActive: true };
       editor = new SliderEditor(editorArguments);
@@ -229,6 +231,7 @@ describe('SliderEditor', () => {
 
       expect(editor.isValueChanged()).toBe(true);
       expect(editorNumberElm.textContent).toBe('13');
+      expect(cellMouseEnterSpy).toHaveBeenCalledWith({ grid: gridStub }, expect.anything());
     });
 
     describe('isValueChanged method', () => {

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -33,6 +33,7 @@ export class SliderEditor implements Editor {
   protected _defaultValue = 0;
   protected _isValueTouched = false;
   protected _originalValue?: number | string;
+  protected _cellContainerElm!: HTMLDivElement;
   protected _editorElm!: HTMLDivElement;
   protected _inputElm!: HTMLInputElement;
   protected _sliderOptions!: CurrentSliderOption;
@@ -98,9 +99,9 @@ export class SliderEditor implements Editor {
   }
 
   init(): void {
-    const container = this.args && this.args.container;
+    this._cellContainerElm = this.args?.container;
 
-    if (container && this.columnDef) {
+    if (this._cellContainerElm && this.columnDef) {
       // define the input & slider number IDs
       const compositeEditorOptions = this.args.compositeEditorOptions;
 
@@ -113,7 +114,7 @@ export class SliderEditor implements Editor {
       }
 
       // watch on change event
-      container.appendChild(this._editorElm);
+      this._cellContainerElm.appendChild(this._editorElm);
       this._bindEventService.bind(this._sliderTrackElm, ['click', 'mouseup'], this.sliderTrackClicked.bind(this) as EventListener);
       this._bindEventService.bind(this._editorElm, ['change', 'mouseup', 'touchend'], this.handleChangeEvent.bind(this) as EventListener);
 
@@ -313,7 +314,7 @@ export class SliderEditor implements Editor {
    */
   protected buildDomElement(): HTMLDivElement {
     const columnId = this.columnDef?.id ?? '';
-    const title = this.columnEditor && this.columnEditor.title || '';
+    const title = this.columnEditor?.title ?? '';
     const minValue = +(this.columnEditor?.minValue ?? Constants.SLIDER_DEFAULT_MIN_VALUE);
     const maxValue = +(this.columnEditor?.maxValue ?? Constants.SLIDER_DEFAULT_MAX_VALUE);
     const step = +(this.columnEditor?.valueStep ?? Constants.SLIDER_DEFAULT_STEP);
@@ -377,6 +378,12 @@ export class SliderEditor implements Editor {
         this._sliderNumberElm.textContent = value;
       }
       this._inputElm.title = value;
+
+      // trigger mouse enter event on the editor for optionally hooked SlickCustomTooltip
+      this.grid.onMouseEnter.notify(
+        { grid: this.grid },
+        { ...new Slick.EventData(), target: event?.target }
+      );
     }
     this.updateTrackFilledColorWhenEnabled();
   }

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -380,10 +380,12 @@ export class SliderEditor implements Editor {
       this._inputElm.title = value;
 
       // trigger mouse enter event on the editor for optionally hooked SlickCustomTooltip
-      this.grid.onMouseEnter.notify(
-        { grid: this.grid },
-        { ...new Slick.EventData(), target: event?.target }
-      );
+      if (!this.args?.compositeEditorOptions) {
+        this.grid.onMouseEnter.notify(
+          { grid: this.grid },
+          { ...new Slick.EventData(), target: event?.target }
+        );
+      }
     }
     this.updateTrackFilledColorWhenEnabled();
   }

--- a/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
@@ -89,9 +89,21 @@ describe('CompoundSliderFilter', () => {
     const filterElm = divContainer.querySelector('.input-group.search-filter.filter-duration input') as HTMLInputElement;
     filterElm.dispatchEvent(new Event('change'));
 
-    jest.runAllTimers(); // fast-forward timer
-
     expect(callbackSpy).toHaveBeenLastCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>', searchTerms: [2], shouldTriggerQuery: true });
+    expect(rowMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
+  });
+
+  it('should trigger an slider input change event and expect slider value to be updated and also "onHeaderRowMouseEnter" to be notified', () => {
+    const rowMouseEnterSpy = jest.spyOn(gridStub.onHeaderRowMouseEnter, 'notify');
+    const filterArgs = { ...filterArguments, operator: '>', grid: gridStub } as FilterArguments;
+
+    filter.init(filterArgs);
+    filter.setValues(['2']);
+    const filterNumberElm = divContainer.querySelector('.input-group-text') as HTMLInputElement;
+    const filterElm = divContainer.querySelector('.input-group.search-filter.filter-duration input') as HTMLInputElement;
+    filterElm.dispatchEvent(new Event('input'));
+
+    expect(filterNumberElm.textContent).toBe('2');
     expect(rowMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
   });
 

--- a/packages/common/src/filters/__tests__/singleSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/singleSliderFilter.spec.ts
@@ -83,9 +83,20 @@ describe('SingleSliderFilter', () => {
     const filterElm = divContainer.querySelector('.search-filter.slider-container.filter-duration input') as HTMLInputElement;
     filterElm.dispatchEvent(new Event('change'));
 
-    jest.runAllTimers(); // fast-forward timer
-
     expect(callbackSpy).toHaveBeenLastCalledWith(new Event('change'), { columnDef: mockColumn, operator: 'GE', searchTerms: [2], shouldTriggerQuery: true });
+    expect(rowMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
+  });
+
+  it('should trigger an slider input change event and expect slider value to be updated and also "onHeaderRowMouseEnter" to be notified', () => {
+    const rowMouseEnterSpy = jest.spyOn(gridStub.onHeaderRowMouseEnter, 'notify');
+
+    filter.init(filterArgs);
+    filter.setValues(['2']);
+    const filterNumberElm = divContainer.querySelector('.input-group-text') as HTMLInputElement;
+    const filterElm = divContainer.querySelector('.input-group.search-filter.filter-duration input') as HTMLInputElement;
+    filterElm.dispatchEvent(new Event('input'));
+
+    expect(filterNumberElm.textContent).toBe('2');
     expect(rowMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
   });
 

--- a/packages/common/src/filters/__tests__/sliderRangeFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/sliderRangeFilter.spec.ts
@@ -102,9 +102,23 @@ describe('SliderRangeFilter', () => {
     const filterElms = divContainer.querySelectorAll<HTMLInputElement>('.search-filter.slider-container.filter-duration input');
     filterElms[0].dispatchEvent(new CustomEvent('change'));
 
-    jest.runAllTimers(); // fast-forward timer
-
     expect(callbackSpy).toHaveBeenLastCalledWith(expect.anything(), { columnDef: mockColumn, operator: 'RangeInclusive', searchTerms: [2, 80], shouldTriggerQuery: true });
+    expect(rowMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
+  });
+
+  it('should trigger an slider input change event and expect slider value to be updated and also "onHeaderRowMouseEnter" to be notified', () => {
+    const rowMouseEnterSpy = jest.spyOn(gridStub.onHeaderRowMouseEnter, 'notify');
+
+    filter.init(filterArguments);
+    filter.setValues([2, 80]);
+    const filterElms = divContainer.querySelectorAll<HTMLInputElement>('.search-filter.slider-container.filter-duration input');
+    filterElms[0].dispatchEvent(new CustomEvent('input'));
+
+    const filterLowestElm = divContainer.querySelector('.lowest-range-duration') as HTMLInputElement;
+    const filterHighestElm = divContainer.querySelector('.highest-range-duration') as HTMLInputElement;
+
+    expect(filterLowestElm.textContent).toBe('2');
+    expect(filterHighestElm.textContent).toBe('80');
     expect(rowMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
   });
 

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -418,10 +418,10 @@ export class SliderFilter implements Filter {
 
     // trigger mouse enter event on the filter for optionally hooked SlickCustomTooltip
     // the minimum requirements for tooltip to work are the columnDef and targetElement
-    setTimeout(() => this.grid.onHeaderRowMouseEnter.notify(
+    this.grid.onHeaderRowMouseEnter.notify(
       { column: this.columnDef, grid: this.grid },
       { ...new Slick.EventData(), target: this._argFilterContainerElm }
-    ));
+    );
   }
 
   protected changeBothSliderFocuses(isAddingFocus: boolean) {
@@ -438,8 +438,6 @@ export class SliderFilter implements Filter {
       this._sliderLeftElm.value = String(sliderLeftVal - getFilterOptionByName<SliderRangeOption, 'stopGapBetweenSliderHandles'>(this.columnFilter, 'stopGapBetweenSliderHandles', GAP_BETWEEN_SLIDER_HANDLES)!);
     }
 
-    this._sliderRangeContainElm.title = this.sliderType === 'double' ? `${sliderLeftVal} - ${sliderRightVal}` : `${sliderRightVal}`;
-
     // change which handle has higher z-index to make them still usable,
     // ie when left handle reaches the end, it has to have higher z-index or else it will be stuck below
     // and we cannot move right because it cannot go below min value
@@ -453,12 +451,7 @@ export class SliderFilter implements Filter {
       }
     }
 
-    this.updateTrackFilledColorWhenEnabled();
-    this.changeBothSliderFocuses(true);
-    const hideSliderNumbers = getFilterOptionByName<SliderOption, 'hideSliderNumber'>(this.columnFilter, 'hideSliderNumber') ?? getFilterOptionByName<SliderRangeOption, 'hideSliderNumbers'>(this.columnFilter, 'hideSliderNumbers');
-    if (!hideSliderNumbers && this._leftSliderNumberElm?.textContent) {
-      this._leftSliderNumberElm.textContent = this._sliderLeftElm?.value ?? '';
-    }
+    this.sliderLeftOrRightChanged(sliderLeftVal, sliderRightVal);
   }
 
   protected slideRightInputChanged() {
@@ -469,6 +462,10 @@ export class SliderFilter implements Filter {
       this._sliderRightElm.value = String(sliderLeftVal + getFilterOptionByName<SliderRangeOption, 'stopGapBetweenSliderHandles'>(this.columnFilter, 'stopGapBetweenSliderHandles', GAP_BETWEEN_SLIDER_HANDLES)!);
     }
 
+    this.sliderLeftOrRightChanged(sliderLeftVal, sliderRightVal);
+  }
+
+  protected sliderLeftOrRightChanged(sliderLeftVal: number, sliderRightVal: number) {
     this.updateTrackFilledColorWhenEnabled();
     this.changeBothSliderFocuses(true);
     this._sliderRangeContainElm.title = this.sliderType === 'double' ? `${sliderLeftVal} - ${sliderRightVal}` : `${sliderRightVal}`;
@@ -477,6 +474,12 @@ export class SliderFilter implements Filter {
     if (!hideSliderNumbers && this._rightSliderNumberElm?.textContent) {
       this._rightSliderNumberElm.textContent = this._sliderRightElm?.value ?? '';
     }
+
+    // also trigger mouse enter event on the filter in case a SlickCustomTooltip is attached
+    this.grid.onHeaderRowMouseEnter.notify(
+      { column: this.columnDef, grid: this.grid },
+      { ...new Slick.EventData(), target: this._argFilterContainerElm }
+    );
   }
 
   protected sliderTrackClicked(e: MouseEvent) {

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -104,7 +104,7 @@ $slick-header-filter-row-border-bottom:                     0 none !default;
 $slick-header-filter-row-border-left:                       0 none !default;
 $slick-header-font-size:                                    $slick-font-size-base !default;
 $slick-header-font-weight:                                  bold !default;
-$slick-header-input-height:                                 27px !default;                        // height of the filter form element (input, textarea, select)
+$slick-header-input-height:                                 100% !default;                        // height of the filter form element (input, textarea, select)
 $slick-header-input-padding:                                0 6px !default;                       // padding of the filter form element (input, textarea, select)
 $slick-header-padding-top:                                  4px !default;
 $slick-header-padding-right:                                4px !default;
@@ -455,7 +455,7 @@ $slick-text-editor-padding-top:                             0 !default;
 $slick-text-editor-focus-border-color:                      $slick-editor-focus-border-color !default;
 $slick-text-editor-focus-box-shadow:                        $slick-editor-focus-box-shadow !default;
 $slick-text-editor-readonly-color:                          #f0f0f0 !default;
-$slick-slider-editor-height:                                $slick-editor-input-height !default;
+$slick-slider-editor-height:                                100% !default;
 $slick-slider-editor-runnable-track-padding:                0 6px !default;
 $slick-slider-editor-number-padding:                        4px 6px !default;
 $slick-slider-editor-focus-border-color:                    $slick-editor-focus-border-color !default;
@@ -564,7 +564,7 @@ $slick-editor-modal-large-editor-count-color:               $slick-large-editor-
 $slick-editor-modal-large-editor-count-font-size:           10px !default;
 $slick-editor-modal-large-editor-count-margin:              0 !default;
 $slick-editor-modal-multiselect-editor-height:              $slick-editor-modal-input-editor-height !default;
-$slick-editor-modal-slider-editor-value-height:             $slick-editor-modal-input-editor-height !default;
+$slick-editor-modal-slider-editor-value-height:             100% !default;
 $slick-editor-modal-slider-editor-value-min-height:         100% !default;
 $slick-editor-modal-title-font-color:                       #333333 !default;
 $slick-editor-modal-title-font-size:                        20px !default;

--- a/packages/common/src/styles/slick-editors.scss
+++ b/packages/common/src/styles/slick-editors.scss
@@ -383,6 +383,7 @@
         }
       }
       .input-group {
+        display: flex;
         position: relative;
         height: var(--slick-editor-modal-input-editor-height, $slick-editor-modal-input-editor-height);
         input {

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -971,6 +971,7 @@ input.flatpickr.form-control {
 
 .slider-container {
   display: flex;
+  height: 100%;
 
   input[type=range] {
     /*removes default webkit styles*/
@@ -1131,6 +1132,10 @@ input.flatpickr.form-control {
     border-bottom-left-radius: var(--slick-slider-filter-border-radius, $slick-slider-filter-border-radius);
     border-top-left-radius: var(--slick-slider-filter-border-radius, $slick-slider-filter-border-radius);
   }
+  .input-group-addon:last-child .input-group-text {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+  }
 }
 
 .slider-editor {
@@ -1146,6 +1151,7 @@ input.flatpickr.form-control {
 }
 
 .slider-input-container {
+  height: 100%;
   position: relative;
   flex: 1 1 auto;
   width: 1%;

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -84,13 +84,15 @@ describe('SlickCustomTooltip plugin', () => {
   });
 
   it('should return without creating a tooltip when column definition has "disableTooltip: true" when "onMouseEnter" event is triggered', () => {
+    const cellNode = document.createElement('div');
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', disableTooltip: true }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
     jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
 
     plugin.init(gridStub, container);
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     expect(document.body.querySelector('.slick-custom-tooltip')).toBeFalsy();
   });
@@ -120,6 +122,8 @@ describe('SlickCustomTooltip plugin', () => {
   });
 
   it('should return without creating a tooltip when "usabilityOverride" returns False', () => {
+    const cellNode = document.createElement('div');
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
@@ -127,14 +131,14 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ usabilityOverride: () => false });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     expect(document.body.querySelector('.slick-custom-tooltip')).toBeFalsy();
   });
 
   it('should NOT create a tooltip when tooltip option has "useRegularTooltip" set BUT [title] attribute is not set or is empty', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.setAttribute('title', '');
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
@@ -144,7 +148,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     expect(document.body.querySelector('.slick-custom-tooltip')).toBeFalsy();
   });

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -153,7 +153,7 @@ describe('SlickCustomTooltip plugin', () => {
     jest.spyOn(getEditorLockMock, 'isActive').mockReturnValue(true);
     const cellNode = document.createElement('div');
     const editInput = document.createElement('input');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     editInput.setAttribute('title', 'editing input tooltip text');
     cellNode.appendChild(editInput);
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
@@ -164,7 +164,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -177,7 +177,7 @@ describe('SlickCustomTooltip plugin', () => {
     jest.spyOn(getEditorLockMock, 'isActive').mockReturnValue(true);
     const cellNode = document.createElement('div');
     const editInput = document.createElement('input');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     editInput.setAttribute('title', 'editing input tooltip text 20');
     cellNode.appendChild(editInput);
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
@@ -188,7 +188,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: false, formatter: () => 'EDITING FORMATTER' });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -199,7 +199,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a tooltip, with default positioning (down & leftAlign), when tooltip option has "useRegularTooltip" enabled', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.setAttribute('title', 'tooltip text');
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
@@ -209,7 +209,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -220,7 +220,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a tooltip align on the right, when position is set to "right-align"', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.setAttribute('title', 'tooltip text');
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
@@ -230,7 +230,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, position: 'right-align' });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -243,7 +243,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a centered tooltip, when position is set to "center"', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.setAttribute('title', 'tooltip text');
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
@@ -253,7 +253,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, position: 'center' });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -266,7 +266,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a tooltip with truncated text when tooltip option has "useRegularTooltip" enabled and the tooltipt text is longer than that of "tooltipTextMaxLength"', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.setAttribute('title', 'some very extra long tooltip text sentence');
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
@@ -276,7 +276,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, tooltipTextMaxLength: 23 });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -287,7 +287,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a tooltip as regular tooltip with coming from text content when it is filled & also expect "hideTooltip" to be called after leaving the cell when "onHeaderMouseLeave" event is triggered', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.textContent = 'some text content';
     cellNode.setAttribute('title', 'tooltip text');
     Object.defineProperty(cellNode, 'scrollWidth', { writable: true, configurable: true, value: 400 });
@@ -300,7 +300,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, maxWidth: 85 });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -317,7 +317,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a tooltip as regular tooltip with truncated text when tooltip option has "useRegularTooltip" enabled and the tooltipt text is longer than that of "tooltipTextMaxLength"', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.textContent = 'some very extra long tooltip text sentence';
     cellNode.setAttribute('title', 'tooltip text');
     Object.defineProperty(cellNode, 'scrollWidth', { writable: true, configurable: true, value: 400 });
@@ -330,7 +330,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, tooltipTextMaxLength: 23 });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -341,7 +341,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a tooltip with only the tooltip formatter output when tooltip option has "useRegularTooltip" & "useRegularTooltipFromFormatterOnly" enabled and column definition has a regular formatter with a "title" attribute filled', () => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     cellNode.setAttribute('title', 'tooltip text');
     const mockColumns = [{ id: 'firstName', field: 'firstName', formatter: () => `<span title="formatter tooltip text">Hello World</span>` }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
@@ -351,7 +351,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, useRegularTooltipFromFormatterOnly: true, maxHeight: 100 });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -364,7 +364,7 @@ describe('SlickCustomTooltip plugin', () => {
   it('should throw an error when trying to create an async tooltip without "asyncPostFormatter" defined', () => {
     const consoleSpy = jest.spyOn(global.console, 'error').mockReturnValue();
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
@@ -379,14 +379,14 @@ describe('SlickCustomTooltip plugin', () => {
       formatter: () => 'loading...',
       asyncPostFormatter: undefined
     });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     expect(consoleSpy).toHaveBeenCalledWith(`[Slickgrid-Universal] when using "asyncProcess" with Custom Tooltip, you must also provide an "asyncPostFormatter" formatter.`);
   });
 
   it('should create an Observable async tooltip', (done) => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
@@ -400,7 +400,7 @@ describe('SlickCustomTooltip plugin', () => {
       formatter: () => 'loading...',
       asyncPostFormatter: (row, cell, val, column, dataContext) => `async post text with ratio: ${dataContext.__params.ratio || ''}`,
     });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     let tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -416,7 +416,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create an Observable async tooltip and throw an error when the Observable is throwing', (done) => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
@@ -431,7 +431,7 @@ describe('SlickCustomTooltip plugin', () => {
       formatter: () => 'loading...',
       asyncPostFormatter: (row, cell, val, column, dataContext) => `async post text with ratio: ${dataContext.__params.ratio || ''}`,
     });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     let tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -445,7 +445,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a Promise async tooltip with position (up & right align) when space is not available on the right of the tooltip', (done) => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
@@ -461,7 +461,7 @@ describe('SlickCustomTooltip plugin', () => {
       asyncProcess: () => Promise.resolve({ ratio: 1.2 }),
       asyncPostFormatter: (row, cell, val, column, dataContext) => `async post text with ratio: ${dataContext.__params.ratio || ''}`,
     });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     let tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     jest.spyOn(tooltipElm, 'getBoundingClientRect').mockReturnValue({ top: 22, left: 11, height: 100, width: 250 } as any);
@@ -484,7 +484,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a Promise async tooltip even on regular tooltip with "asyncProcess" and "useRegularTooltip" flags', (done) => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
@@ -499,7 +499,7 @@ describe('SlickCustomTooltip plugin', () => {
       asyncProcess: () => Promise.resolve({ ratio: 1.2 }),
       asyncPostFormatter: (row, cell, val, column, dataContext) => `<span title="tooltip title text with ratio: ${dataContext.__params.ratio || ''}">cell value</span>`,
     });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
 
     let tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
 
@@ -516,7 +516,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should create a Promise async tooltip and throw an error when the Promise is not completing (rejected)', (done) => {
     const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell';
+    cellNode.className = 'slick-cell l2 r2';
     const mockColumns = [{ id: 'firstName', field: 'firstName', }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
@@ -529,7 +529,7 @@ describe('SlickCustomTooltip plugin', () => {
       formatter: () => 'loading...',
       asyncPostFormatter: (row, cell, val, column, dataContext) => `async post text with ratio: ${dataContext.__params.ratio || ''}`,
     });
-    gridStub.onMouseEnter.notify({ grid: gridStub });
+    gridStub.onMouseEnter.notify({ grid: gridStub }, { ...new Slick.EventData(), target: cellNode });
     const cancellablePromise = plugin.cancellablePromise;
     let tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -220,7 +220,10 @@ export class SlickCustomTooltip {
     this.hideTooltip();
 
     if (event && this._grid) {
-      const cell = this._grid.getCellFromEvent(event);
+      // get cell only when it's possible (ie, Composite Editor will not be able to get cell and so it will never show any tooltip)
+      const targetClassName = (event?.target as HTMLDivElement)?.closest('.slick-cell')?.className;
+      const cell = (targetClassName && /l\d+/.exec(targetClassName || '')) ? this._grid.getCellFromEvent(event) : null;
+
       if (cell) {
         const item = this.dataView ? this.dataView.getItem(cell.row) : this._grid.getDataItem(cell.row);
         const columnDef = this._grid.getColumns()[cell.cell];

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -235,13 +235,16 @@ export class SlickCustomTooltip {
 
           const value = item.hasOwnProperty(columnDef.field) ? item[columnDef.field] : null;
 
+          // when cell is currently lock for editing, we'll force a tooltip title search
+          const cellValue = this._grid.getEditorLock().isActive() ? null : value;
+
           // when there aren't any formatter OR when user specifically want to use a regular tooltip (via "title" attribute)
           if ((this._cellAddonOptions.useRegularTooltip && !this._cellAddonOptions?.asyncProcess) || !this._cellAddonOptions?.formatter) {
-            this.renderRegularTooltip(columnDef.formatter, cell, value, columnDef, item);
+            this.renderRegularTooltip(columnDef.formatter, cell, cellValue, columnDef, item);
           } else {
             // when we aren't using regular tooltip and we do have a tooltip formatter, let's render it
             if (typeof this._cellAddonOptions?.formatter === 'function') {
-              this.renderTooltipFormatter(this._cellAddonOptions.formatter, cell, value, columnDef, item);
+              this.renderTooltipFormatter(this._cellAddonOptions.formatter, cell, cellValue, columnDef, item);
             }
 
             // when tooltip is an Async (delayed, e.g. with a backend API call)
@@ -342,6 +345,14 @@ export class SlickCustomTooltip {
     this._tooltipElm.classList.add(this.gridUid);
     this._tooltipElm.classList.add('l' + cell.cell);
     this._tooltipElm.classList.add('r' + cell.cell);
+
+    // when cell is currently lock for editing, we'll force a tooltip title search
+    // that can happen when user has a formatter but is currently editing and in that case we want the new value
+    // ie: when user is currently editing and uses the Slider, when dragging its value is changing, so we wish to use the editing value instead of the previous cell value.
+    if (value === null || value === undefined) {
+      const tmpTitleElm = this._cellNodeElm?.querySelector<HTMLDivElement>('[title], [data-slick-tooltip]');
+      value = findFirstElementAttribute(tmpTitleElm, ['title', 'data-slick-tooltip']) || value;
+    }
 
     let outputText = tooltipText || this.parseFormatterAndSanitize(formatter, cell, value, columnDef, item) || '';
     outputText = (this._cellAddonOptions?.tooltipTextMaxLength && outputText.length > this._cellAddonOptions.tooltipTextMaxLength) ? outputText.substring(0, this._cellAddonOptions.tooltipTextMaxLength - 3) + '...' : outputText;


### PR DESCRIPTION
- when dragging slider to a new value, it should update the tooltip (when using SlickCustomTooltip plugin) on the fly while dragging, that is whenever the Slider value changes it should reflect the new value instantly on the tooltip as well

![brave_iw9CZAmJPx](https://user-images.githubusercontent.com/643976/200748159-a2c256a4-aa52-4d07-aeda-bfefd75b5bf6.gif)
