### PR TITLE
fix(plugin): do not show drag group sort when column is not sortable

### DIFF
--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -468,9 +468,10 @@ export class SlickDraggableGrouping {
               groupRemoveIconElm.classList.add('slick-groupby-remove-icon');
             }
 
-            // sorting icons
+            // sorting icons when enabled
             let groupSortContainerElm: HTMLDivElement | undefined;
-            if (this._addonOptions?.hideGroupSortIcons !== true) {
+            console.log('col id:', col.id, 'sortable:', col.sortable);
+            if (this._addonOptions?.hideGroupSortIcons !== true && col.sortable) {
               if (col.grouping?.sortAsc === undefined) {
                 col.grouping.sortAsc = true;
               }


### PR DESCRIPTION
- recent feature to add sort icon in SlickDraggableGrouping did not look at the possibility that the column itself might not be `sortable`, however it has to be considered

for example, below we can see that the "Market" column is not sortable and should not have the sort icon in the preheader group 
![image](https://user-images.githubusercontent.com/643976/202540846-e6a5f9f4-1227-4081-b876-bc3b416962ed.png)
