### PR TITLE
fix(plugins): rollback PR #781 to fix regression with Grid Presets

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example07.ts
@@ -541,12 +541,11 @@ export class Example7 {
     this.sgb.columnDefinitions.pop();
     this.sgb.columnDefinitions = this.sgb.columnDefinitions.slice();
 
-    // NOTE if you use an Extensions (Row Move, Row Detail, Row Selections) that modifies the column definitions in any way
-    // it will update the column definitions but only on the sgb instance, so you can use "this.sgb.columnDefinitions" to get full list.
-    // However please note that this will ALWAYS return all columns in their original positions,
-    // in other words, if you change column reordering, that unfortunately won't be reflected.
+    // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
+    // you MUST use the code below, first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
+    // in other words, SlickGrid is not using the same as Slickgrid-Universal uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
-    const allOriginalColumns = this.sgb.columnDefinitions(); // or: this.slickerGridInstance.gridService.getAllColumnDefinitions();
+    const allOriginalColumns = this.slickerGridInstance.gridService.getAllColumnDefinitions();
     const allOriginalColumns = allOriginalColumns.map((column) => {
       column.editor = column.internalColumnEditor;
       return column;

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -520,13 +520,14 @@ export class SlickVanillaGridBundle {
     this.sharedService.allColumns = this._columnDefinitions;
     this.sharedService.visibleColumns = this._columnDefinitions;
 
+    // TODO: revisit later, this is conflicting with Grid State & Presets
     // before certain extentions/plugins potentially adds extra columns not created by the user itself (RowMove, RowDetail, RowSelections)
     // we'll subscribe to the event and push back the change to the user so they always use full column defs array including extra cols
-    this.subscriptions.push(
-      this._eventPubSubService.subscribe<{ columns: Column[]; pluginName: string }>('onPluginColumnsChanged', data => {
-        this._columnDefinitions = this.columnDefinitions = data.columns;
-      })
-    );
+    // this.subscriptions.push(
+    //   this._eventPubSubService.subscribe<{ columns: Column[]; pluginName: string }>('onPluginColumnsChanged', data => {
+    //     this._columnDefinitions = this.columnDefinitions = data.columns;
+    //   })
+    // );
 
     // after subscribing to potential columns changed, we are ready to create these optional extensions
     // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)


### PR DESCRIPTION
- synching column definitions after plugin (like Row Move col) is causing issue when used with Grid State & Presets since the presets seem out of sync with the ones pushed by the plugin changed event