### PR TITLE
chore(core): we shouldn't have to nullify the grid object

### DIFF
--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -229,7 +229,6 @@ export class SlickDraggableGrouping {
     this.pubSubService.unsubscribeAll(this._subscriptions);
     this._bindEventService.unbindAll();
     emptyElement(document.querySelector(`.${this.gridUid} .slick-preheader-panel`));
-    this._grid = undefined as any;
   }
 
   clearDroppedGroups() {

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -166,7 +166,6 @@ export class DateFilter implements Filter {
     this.filterContainerElm?.remove();
     this._selectOperatorElm?.remove();
     this._filterElm?.remove();
-    this.grid = null as any;
   }
 
   hide() {

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -130,7 +130,6 @@ export class FilterService {
     }
     this.disposeColumnFilters();
     this._onSearchChange = null;
-    this._grid = null as any;
   }
 
   /**


### PR DESCRIPTION
- the only place we should nullify the grid object should be in the lib itself (vanilla-grid-bundle, or other frameworks)