### PR TITLE
chore: add codecov token to avoid failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,5 +80,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: .Build/log/coverage
+          directory: test/jest-coverage
           verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,4 +77,8 @@ jobs:
 
       - name: Upload Jest coverage to Codecov
         if: "!contains(github.event.head_commit.message, 'chore(release)')"
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: .Build/log/coverage
+          verbose: true


### PR DESCRIPTION
- codecov seems to fail more and more when we're not providing a token