### PR TITLE
fix(addons): onGroupChanged callback should be executed with Draggable

### DIFF
--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -56,7 +56,7 @@ declare const Slick: SlickNamespace;
  *   }];
  */
 export class SlickDraggableGrouping {
-  protected _addonOptions!: DraggableGroupingOption;
+  protected _addonOptions!: DraggableGrouping;
   protected _bindEventService: BindingEventService;
   protected _droppableInstance?: SortableInstance;
   protected _dropzoneElm!: HTMLDivElement;
@@ -615,13 +615,21 @@ export class SlickDraggableGrouping {
     if (this.columnsGroupBy.length === 0) {
       this.dataView.setGrouping([]);
       this._dropzonePlaceholderElm.style.display = 'inline-block';
-      this.onGroupChanged.notify({ caller: originator, groupColumns: [] });
+      this.triggerOnGroupChangedEvent({ caller: originator, groupColumns: [] });
       return;
     }
     const groupingArray: Grouping<any>[] = [];
     this.columnsGroupBy.forEach(element => groupingArray.push(element.grouping!));
     this.dataView.setGrouping(groupingArray);
     this._dropzonePlaceholderElm.style.display = 'none';
-    this.onGroupChanged.notify({ caller: originator, groupColumns: groupingArray });
+    this.triggerOnGroupChangedEvent({ caller: originator, groupColumns: groupingArray });
+  }
+
+  /** call notify on slickgrid event and execute onGroupChanged callback when defined as a function by the user */
+  protected triggerOnGroupChangedEvent(args: { caller?: string; groupColumns: Grouping[] }) {
+    if (this._addonOptions && typeof this._addonOptions.onGroupChanged === 'function') {
+      this._addonOptions.onGroupChanged(new Slick.EventData(), args);
+    }
+    this.onGroupChanged.notify(args);
   }
 }

--- a/packages/common/src/interfaces/draggableGrouping.interface.ts
+++ b/packages/common/src/interfaces/draggableGrouping.interface.ts
@@ -7,7 +7,7 @@ export interface DraggableGrouping extends DraggableGroupingOption {
   // Events
   // ---------
   /** Fired when grouped columns changed */
-  onGroupChanged?: (e: SlickEventData, args: { caller?: string; groupColumns: Grouping[] }) => void;
+  onGroupChanged?: (e: SlickEventData | null, args: { caller?: string; groupColumns: Grouping[] }) => void;
 
   /** Fired after extension (plugin) is registered by SlickGrid */
   onExtensionRegistered?: (plugin: SlickDraggableGrouping) => void;


### PR DESCRIPTION
- after rewriting all SlickGrid plugins into standalone  Slickgrid-Universal extensions (in commit  8e6eb488), it seems that the `onGroupChanged` function callback was forgotten and the new code was never executing it when it was defined as a function callback by the user, this PR fixes that. Note that the `onGroupChanged` can be both a function callback (defined by the user in its grid option) and a Slick Event that has notify/subscribe