### PR TITLE
fix(core): grid service `resetGrid` method wasn't always resetting

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "lerna run build --stream",
     "prebundle": "pnpm lint",
     "bundle": "lerna run bundle --stream",
+    "bundle:common": "pnpm -r --stream --filter=./packages/common run bundle",
     "prebundle:zip": "pnpm bundle",
     "bundle:zip": "pnpm -r --stream --filter=./packages/** run bundle:zip",
     "build:demo": "pnpm -r --stream build:demo",

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -1728,24 +1728,32 @@ describe('Grid Service', () => {
       service.resetGrid();
 
       expect(allColumnSpy).toHaveBeenCalled();
-      expect(setColSpy).toHaveBeenCalled();
+      expect(setColSpy).toHaveBeenCalledTimes(1);
       expect(autosizeSpy).toHaveBeenCalled();
       expect(gridStateSpy).toHaveBeenCalled();
       expect(filterSpy).toHaveBeenCalled();
       expect(sortSpy).toHaveBeenCalled();
-      expect(clearPinningSpy).toHaveBeenCalled();
+      expect(clearPinningSpy).toHaveBeenCalledWith(false);
     });
 
     it('should call a reset and expect the grid "resetColumns" method to be called with the column definitions provided to the method', () => {
       const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
       jest.spyOn(gridStub, 'getOptions').mockReturnValue({ enableAutoResize: true, enableAutoSizeColumns: true } as GridOption);
       const allColumnSpy = jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(mockColumns);
+      const setColSpy = jest.spyOn(gridStub, 'setColumns');
       const gridStateSpy = jest.spyOn(gridStateServiceStub, 'resetColumns');
+      const clearPinningSpy = jest.spyOn(service, 'clearPinning');
+      const filterSpy = jest.spyOn(filterServiceStub, 'clearFilters');
+      const sortSpy = jest.spyOn(sortServiceStub, 'clearSorting');
 
       service.resetGrid(mockColumns);
 
+      expect(setColSpy).toHaveBeenCalledTimes(1);
       expect(allColumnSpy).toHaveBeenCalled();
       expect(gridStateSpy).toHaveBeenCalledWith(mockColumns);
+      expect(clearPinningSpy).toHaveBeenCalledWith(false);
+      expect(filterSpy).toHaveBeenCalled();
+      expect(sortSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -73,13 +73,13 @@ export class GridService {
   }
 
   /** Clear all the pinning (frozen) options */
-  clearPinning() {
+  clearPinning(resetColumns = true) {
     const visibleColumns = [...this.sharedService.visibleColumns];
     this.sharedService.slickGrid.setOptions({ frozenColumn: -1, frozenRow: -1, frozenBottom: false, enableMouseWheelScrollHandler: false });
 
     // SlickGrid seems to be somehow resetting the columns to their original positions,
     // so let's re-fix them to the position we kept as reference
-    if (Array.isArray(visibleColumns)) {
+    if (resetColumns && Array.isArray(visibleColumns)) {
       this.sharedService.slickGrid.setColumns(visibleColumns);
     }
   }
@@ -363,6 +363,10 @@ export class GridService {
    * The reset will clear the Filters & Sort, then will reset the Columns to their original state
    */
   resetGrid(columnDefinitions?: Column[]) {
+    // clear any Pinning/Frozen columns/rows
+    // do it prior to setting the Columns back on the next few lines
+    this.clearPinning(false);
+
     // reset columns to original states & refresh the grid
     if (this._grid) {
       const originalColumns = this.sharedService.allColumns || [];
@@ -377,13 +381,10 @@ export class GridService {
       }
     }
 
-    // clear any Pinning/Frozen columns/rows
-    this.clearPinning();
-
-    if (this.filterService && this.filterService.clearFilters) {
+    if (typeof this.filterService?.clearFilters === 'function') {
       this.filterService.clearFilters();
     }
-    if (this.sortService && this.sortService.clearSorting) {
+    if (typeof this.sortService?.clearSorting === 'function') {
       this.sortService.clearSorting();
     }
   }


### PR DESCRIPTION
- the previous code called `clearPinning()` which also called a 2nd `setColumns` but with a different set of columns which was conflicting with the first set