### PR TITLE
fix(common): calling Date Sorting multiple times was shuffling other lines

### DIFF
--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -120,7 +120,7 @@ export interface GridOption {
   /**
    * Defaults to false, can the cell value (dataContext) be undefined?
    * Typically undefined values are disregarded when sorting, when setting this flag it will adds extra logic to Sorting and also sort undefined value.
-   * This is an extra flag that user has to enable by themselve because Sorting undefined values has unwanted behavior in some use case
+   * This is an extra flag that user has to enable by themselve because Sorting undefined values has unintended behavior in some use case
    * (for example Row Detail has UI inconsistencies since undefined is used in the plugin's logic)
    */
   cellValueCouldBeUndefined?: boolean;

--- a/packages/common/src/sortComparers/dateUtilities.ts
+++ b/packages/common/src/sortComparers/dateUtilities.ts
@@ -1,21 +1,29 @@
 import { FieldType } from '../enums/fieldType.enum';
-import { Column, GridOption, SortComparer } from '../interfaces/index';
+import { SortComparer } from '../interfaces/index';
 import { mapMomentDateFormatWithFieldType } from '../services/utilities';
 import * as moment_ from 'moment-mini';
 const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
-export function compareDates(value1: any, value2: any, sortDirection: number, sortColumn: Column, gridOptions: GridOption, format: string | moment_.MomentBuiltinFormat, strict?: boolean) {
+export function compareDates(value1: any, value2: any, sortDirection: number, format: string | moment_.MomentBuiltinFormat, strict?: boolean) {
   let diff = 0;
-  const checkForUndefinedValues = sortColumn?.valueCouldBeUndefined ?? gridOptions?.cellValueCouldBeUndefined ?? false;
-  const date1 = moment(value1, format, strict);
-  const date2 = moment(value2, format, strict);
 
-  if (value1 === null || value1 === '' || (checkForUndefinedValues && value1 === undefined) || !date1.isValid()) {
-    diff = -1;
-  } else if (value2 === null || value2 === '' || (checkForUndefinedValues && value2 === undefined) || !date2.isValid()) {
-    diff = 1;
+  if (value1 === value2) {
+    diff = 0;
   } else {
-    diff = date1.valueOf() < date2.valueOf() ? -1 : 1;
+    // use moment to validate the date
+    let date1 = moment(value1, format, strict);
+    let date2 = moment(value2, format, strict);
+
+    // when moment date is invalid, we'll create a temporary old Date
+    if (!date1.isValid()) {
+      date1 = new Date(1001, 1, 1);
+    }
+    if (!date2.isValid()) {
+      date2 = new Date(1001, 1, 1);
+    }
+
+    // we can use valueOf on both moment & Date to sort
+    diff = date1.valueOf() - date2.valueOf();
   }
 
   return sortDirection * diff;
@@ -25,10 +33,10 @@ export function compareDates(value1: any, value2: any, sortDirection: number, so
 export function getAssociatedDateSortComparer(fieldType: typeof FieldType[keyof typeof FieldType]): SortComparer {
   const FORMAT = (fieldType === FieldType.date) ? moment.ISO_8601 : mapMomentDateFormatWithFieldType(fieldType);
 
-  return ((value1: any, value2: any, sortDirection: number, sortColumn: Column, gridOptions: GridOption) => {
+  return ((value1: any, value2: any, sortDirection: number) => {
     if (FORMAT === moment.ISO_8601) {
-      return compareDates(value1, value2, sortDirection, sortColumn, gridOptions, FORMAT, false) as number;
+      return compareDates(value1, value2, sortDirection, FORMAT, false) as number;
     }
-    return compareDates(value1, value2, sortDirection, sortColumn, gridOptions, FORMAT, true) as number;
+    return compareDates(value1, value2, sortDirection, FORMAT, true) as number;
   }) as SortComparer;
 }


### PR DESCRIPTION
- fixes bug mentioned in this Stack Overflow [question](https://stackoverflow.com/questions/74657131/slickgrid-header-menu-sorting-is-not-working-properly), opened an Angular-Slickgrid [issue](https://github.com/ghiscoding/Angular-Slickgrid/issues/1052) for this as well.
- for example if we had 10 lines with null values and 90 lines of valid dates, and we were sorting ascending multiple times, the dates were sorted correctly but the 10 null date lines were constantly being shuffled

#### Note
Note that the new code is taking slightly more time to execute because we now create a temp dates to sort nullish values, however it seems negligeable 1240ms vs 1125ms on first sort of 50k unsorted rows (so about 100-150ms longer).

![image](https://i.stack.imgur.com/tHwWu.gif)
