### PR TITLE
Fix for page being cleared when using copy and paste with selectEditor

### DIFF
--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -136,7 +136,7 @@ export class SlickCellExternalCopyManager {
       // if a custom setter is not defined, we call applyValue of the editor to unserialize
       if (columnDef.editor) {
         const editor = new (columnDef as any).editor({
-          container: document.body,  // a dummy container
+          container: document.createElement('div'),  // a dummy container
           column: columnDef,
           position: { top: 0, left: 0 },  // a dummy position required by some editors
           grid: this._grid


### PR DESCRIPTION
I encountered an issue using copy and paste with the selectEditor control. When data is pasted into a column that uses selectEditor, the page will be cleared. This is because the main branch is using document.body as the container for the element when setting the value for the column.

Here is the line of code that creates the editor with document.body as the container:
https://github.com/ghiscoding/slickgrid-universal/blob/76e97195e36d1d901bbe922c54f35702f2714ac8/packages/common/src/extensions/slickCellExternalCopyManager.ts#L139

We can see the line that clears the container in selectEditor.ts:
https://github.com/ghiscoding/slickgrid-universal/blob/76e97195e36d1d901bbe922c54f35702f2714ac8/packages/common/src/editors/selectEditor.ts#L738

I was able to fix this by using a new div as the container instead. 