### PR TITLE
fix: Grid Menu filtering options should be removed when option disabled

### DIFF
--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -688,13 +688,11 @@ export class SlickVanillaGridBundle {
 
     // when we use Pagination on Local Grid, it doesn't seem to work without enableFiltering
     // so we'll enable the filtering but we'll keep the header row hidden
-    if (!options.enableFiltering && options.enablePagination && this._isLocalGrid) {
+    if (this.sharedService && !options.enableFiltering && options.enablePagination && this._isLocalGrid) {
       options.enableFiltering = true;
       options.showHeaderRow = false;
       this._hideHeaderRowAfterPageLoad = true;
-      if (this.sharedService) {
-        this.sharedService.hideHeaderRowAfterPageLoad = true;
-      }
+      this.sharedService.hideHeaderRowAfterPageLoad = true;
     }
 
     return options;


### PR DESCRIPTION
- when creating a grid without enabling the filtering and we use Pagination, the Grid Menu might show options related to filtering and the reason is because internally we have to enable filtering to create the Pagination and then disable back the filtering option and we do that only once, but in some cases it might do this check a little too early before the SharedService is available and that would cause the filtering option to remain half enabled, we should simply wait for SharedService to be available before doing this swap