### PR TITLE
chore(exports): remove recent unnecessary exportWithExcelFormat flag

### DIFF
--- a/examples/webpack-demo-vanilla-bundle/src/examples/example02.html
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example02.html
@@ -58,6 +58,7 @@
             onclick.delegate="groupByDurationEffortDrivenPercent()">
       Group by Duration then Effort-Driven then Percent.
     </button>
+    <span class.bind="loadingClass"></span>
   </div>
 </section>
 

--- a/examples/webpack-demo-vanilla-bundle/src/examples/example02.ts
+++ b/examples/webpack-demo-vanilla-bundle/src/examples/example02.ts
@@ -30,6 +30,7 @@ export class Example2 {
   commandQueue = [];
   sgb: SlickVanillaGridBundle;
   excelExportService: ExcelExportService;
+  loadingClass = '';
 
   constructor() {
     this.excelExportService = new ExcelExportService();
@@ -41,8 +42,8 @@ export class Example2 {
     this.dataset = this.loadData(NB_ITEMS);
     const gridContainerElm = document.querySelector<HTMLDivElement>(`.grid2`);
 
-    this._bindingEventService.bind(gridContainerElm, 'onbeforeexporttoexcel', () => console.log('onBeforeExportToExcel'));
-    this._bindingEventService.bind(gridContainerElm, 'onafterexporttoexcel', () => console.log('onAfterExportToExcel'));
+    this._bindingEventService.bind(gridContainerElm, 'onbeforeexporttoexcel', () => this.loadingClass = 'mdi mdi-load mdi-spin-1s mdi-22px');
+    this._bindingEventService.bind(gridContainerElm, 'onafterexporttoexcel', () => this.loadingClass = '');
     this.sgb = new Slicker.GridBundle(gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, this.dataset);
 
     // you could group by duration on page load (must be AFTER the DataView is created, so after GridBundle)
@@ -189,7 +190,6 @@ export class Example2 {
       excelExportOptions: {
         filename: 'my-export',
         sanitizeDataExport: true,
-        exportWithExcelFormat: true,
         columnHeaderStyle: {
           font: { color: 'FFFFFFFF' },
           fill: { type: 'pattern', patternType: 'solid', fgColor: 'FF4a6c91' }

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -146,7 +146,6 @@ export const GlobalGridOptions: GridOption = {
   excelExportOptions: {
     addGroupIndentation: true,
     exportWithFormatter: false,
-    exportWithExcelFormat: true,
     filename: 'export',
     format: FileType.xlsx,
     groupingColumnHeaderTitle: 'Group By',

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -81,7 +81,7 @@ export interface Column<T = any> {
   /** Any inline editor function that implements Editor for the cell value or ColumnEditor */
   editor?: ColumnEditor;
 
-  /** Excel export custom options for cell formatting & width, this option only works when `exportWithExcelFormat` is enabled */
+  /** Excel export custom options for cell formatting & width */
   excelExportOptions?: ColumnExcelExportOption;
 
   /** Default to false, which leads to exclude the column title from the Column Picker. */
@@ -119,13 +119,6 @@ export interface Column<T = any> {
    * Most often used with dates that are stored as UTC but displayed as Date ISO (or any other format) with a Formatter.
    */
   exportWithFormatter?: boolean;
-
-  /**
-   * Defaults to true, which leads to ExcelExportService that will try to detect the best possible Excel format for each cell.
-   * The difference with the other flag is that "exportWithFormatter" will always export as a string, while this option here will try to detect the best Excel format and cell type.
-   * NOTE: Date will be exported as string (not as Excel Date), the numbers are the ones making the best out of this option.
-   */
-  exportWithExcelFormat?: boolean;
 
   /**
    * Do we want to force the cell value to be a string?
@@ -168,7 +161,7 @@ export interface Column<T = any> {
   /** Grouping option used by a Draggable Grouping Column */
   grouping?: Grouping;
 
-  /** Excel export custom options for cell formatting & width, this option only works when `exportWithExcelFormat` is enabled */
+  /** Excel export custom options for cell formatting & width */
   groupTotalsExcelExportOptions?: GroupTotalExportOption;
 
   /** Group Totals Formatter function that can be used to add grouping totals in the grid */

--- a/packages/common/src/interfaces/excelExportOption.interface.ts
+++ b/packages/common/src/interfaces/excelExportOption.interface.ts
@@ -16,13 +16,6 @@ export interface ExcelExportOption {
   /** Defaults to false, which leads to all Formatters of the grid being evaluated on export. You can also override a column by changing the propery on the column itself */
   exportWithFormatter?: boolean;
 
-  /**
-   * Defaults to true, which leads to ExcelExportService that will try to detect the best possible Excel format for each cell.
-   * The difference with the other flag is that "exportWithFormatter" will always export as a string, while this option here will try to detect the best Excel format and cell type.
-   * NOTE: Date will be exported as string (not as Excel Date), the numbers are the ones making the best out of this option.
-   */
-  exportWithExcelFormat?: boolean;
-
   /** filename (without extension) */
   filename?: string;
 

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -536,12 +536,12 @@ describe('ExcelExportService', () => {
       let mockCollection: any[];
 
       beforeEach(() => {
-        mockGridOptions.excelExportOptions = { sanitizeDataExport: true, exportWithExcelFormat: true, };
+        mockGridOptions.excelExportOptions = { sanitizeDataExport: true, };
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100 },
-          { id: 'firstName', field: 'firstName', width: 100, formatter: myBoldHtmlFormatter, exportWithExcelFormat: false },
-          { id: 'lastName', field: 'lastName', width: 100, sanitizeDataExport: true, exportWithFormatter: true, exportWithExcelFormat: false },
+          { id: 'firstName', field: 'firstName', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', width: 100, sanitizeDataExport: true, exportWithFormatter: true },
           {
             id: 'position', field: 'position', width: 100,
             excelExportOptions: { style: { font: { outline: true, italic: true }, format: '€0.00##;[Red](€0.00##)' }, width: 18 }
@@ -603,7 +603,7 @@ describe('ExcelExportService', () => {
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'firstName', field: 'user.firstName', name: 'First Name', width: 100, formatter: Formatters.complexObject, exportWithFormatter: true },
           { id: 'lastName', field: 'user.lastName', name: 'Last Name', width: 100, formatter: Formatters.complexObject, exportWithFormatter: true },
-          { id: 'position', field: 'position', width: 100, type: FieldType.number, exportWithExcelFormat: true },
+          { id: 'position', field: 'position', width: 100, type: FieldType.number },
         ] as Column[];
 
         jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
@@ -825,7 +825,7 @@ describe('ExcelExportService', () => {
       beforeEach(() => {
         mockGridOptions.enableGrouping = true;
         mockGridOptions.enableTranslate = false;
-        mockGridOptions.excelExportOptions = { sanitizeDataExport: true, addGroupIndentation: true, exportWithExcelFormat: true };
+        mockGridOptions.excelExportOptions = { sanitizeDataExport: true, addGroupIndentation: true };
 
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
@@ -1033,7 +1033,7 @@ describe('ExcelExportService', () => {
       beforeEach(() => {
         mockGridOptions.enableGrouping = true;
         mockGridOptions.enableTranslate = true;
-        mockGridOptions.excelExportOptions = { sanitizeDataExport: true, addGroupIndentation: true, exportWithFormatter: true, exportWithExcelFormat: true };
+        mockGridOptions.excelExportOptions = { sanitizeDataExport: true, addGroupIndentation: true, exportWithFormatter: true };
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100 },

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -712,7 +712,7 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Position', },
               { metadata: { style: 1, }, value: 'Order', },
             ],
-            ['1E06', 'John', 'X', 'Sales Rep.', '10'],
+            ['1E06', 'John', 'X', { metadata: { style: 3 }, value: 'Sales Rep.' }, '10'],
           ]
         });
       });
@@ -805,9 +805,9 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Order', },
             ],
             ['⮟ Order: 20 (2 items)'],
-            ['', '1E06', 'John', 'X', 'SALES_REP', '10'],
-            ['', '2B02', 'Jane', 'DOE', 'FINANCE_MANAGER', '10'],
-            ['', '', '', '', '', 'Custom: 20'],
+            ['', '1E06', 'John', 'X', 'SALES_REP', { metadata: { style: 3, type: 'number' }, value: 10 }],
+            ['', '2B02', 'Jane', 'DOE', 'FINANCE_MANAGER', { metadata: { style: 3, type: 'number' }, value: 10 }],
+            ['', '', '', '', '', { metadata: { style: 4, type: 'number' }, value: 20 }],
           ]
         });
       });
@@ -1011,9 +1011,9 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Order', },
             ],
             ['⮟ Order: 20 (2 items)'],
-            ['', '1E06', 'John', 'X', 'Sales Rep.', '10'],
-            ['', '2B02', 'Jane', 'DOE', 'Finance Manager', '10'],
-            ['', '', '', '', '', '20'],
+            ['', '1E06', 'John', 'X', { metadata: { style: 3 }, value: 'Sales Rep.' }, { metadata: { style: 3, type: 'number' }, value: 10 }],
+            ['', '2B02', 'Jane', 'DOE', { metadata: { style: 3 }, value: 'Finance Manager' }, { metadata: { style: 3, type: 'number' }, value: 10 }],
+            ['', '', '', '', '', { metadata: { style: 4, type: 'number', }, value: 20, }],
           ]
         });
       });

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -129,17 +129,16 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
     if (!this._grid || !this._dataView || !this._pubSubService) {
       throw new Error('[Slickgrid-Universal] it seems that the SlickGrid & DataView objects and/or PubSubService are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
     }
+    this._pubSubService?.publish(`onBeforeExportToExcel`, true);
+    this._excelExportOptions = deepCopy({ ...DEFAULT_EXPORT_OPTIONS, ...this._gridOptions.excelExportOptions, ...options });
+    this._fileFormat = this._excelExportOptions.format || FileType.xlsx;
+
+    // reset references of detected Excel formats
+    this._regularCellExcelFormats = {};
+    this._groupTotalExcelFormats = {};
 
     // wrap in a Promise so that we can add loading spinner
     return new Promise(resolve => {
-      this._pubSubService?.publish(`onBeforeExportToExcel`, true);
-      this._excelExportOptions = deepCopy({ ...DEFAULT_EXPORT_OPTIONS, ...this._gridOptions.excelExportOptions, ...options });
-      this._fileFormat = this._excelExportOptions.format || FileType.xlsx;
-
-      // reset references of detected Excel formats
-      this._regularCellExcelFormats = {};
-      this._groupTotalExcelFormats = {};
-
       // prepare the Excel Workbook & Sheet
       // we can use ExcelBuilder constructor with WebPack but we need to use function calls with RequireJS/SystemJS
       const worksheetOptions = { name: this._excelExportOptions.sheetName || 'Sheet1' };
@@ -562,21 +561,19 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
         // auto-detect best possible Excel format, unless the user provide his own formatting,
         // we only do this check once per column (everything after that will be pull from temp ref)
-        if (this.isExportingWithExcelFormat(columnDef)) {
-          if (!this._regularCellExcelFormats.hasOwnProperty(columnDef.id)) {
-            const cellStyleFormat = useCellFormatByFieldType(this._stylesheet, this._stylesheetFormats, columnDef, this._grid);
-            // user could also override style and/or valueParserCallback
-            if (columnDef.excelExportOptions?.style) {
-              cellStyleFormat.stylesheetFormatterId = this._stylesheet.createFormat(columnDef.excelExportOptions.style).id;
-            }
-            if (columnDef.excelExportOptions?.valueParserCallback) {
-              cellStyleFormat.getDataValueParser = columnDef.excelExportOptions.valueParserCallback;
-            }
-            this._regularCellExcelFormats[columnDef.id] = cellStyleFormat;
+        if (!this._regularCellExcelFormats.hasOwnProperty(columnDef.id)) {
+          const cellStyleFormat = useCellFormatByFieldType(this._stylesheet, this._stylesheetFormats, columnDef, this._grid);
+          // user could also override style and/or valueParserCallback
+          if (columnDef.excelExportOptions?.style) {
+            cellStyleFormat.stylesheetFormatterId = this._stylesheet.createFormat(columnDef.excelExportOptions.style).id;
           }
-          const { stylesheetFormatterId, getDataValueParser: getDataValueParser } = this._regularCellExcelFormats[columnDef.id];
-          itemData = getDataValueParser(itemData, columnDef, stylesheetFormatterId, this._stylesheet);
+          if (columnDef.excelExportOptions?.valueParserCallback) {
+            cellStyleFormat.getDataValueParser = columnDef.excelExportOptions.valueParserCallback;
+          }
+          this._regularCellExcelFormats[columnDef.id] = cellStyleFormat;
         }
+        const { stylesheetFormatterId, getDataValueParser: getDataValueParser } = this._regularCellExcelFormats[columnDef.id];
+        itemData = getDataValueParser(itemData, columnDef, stylesheetFormatterId, this._stylesheet);
 
         // does the user want to sanitize the output data (remove HTML tags)?
         if (typeof itemData === 'string' && (columnDef.sanitizeDataExport || this._excelExportOptions.sanitizeDataExport)) {
@@ -589,20 +586,6 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
     }
 
     return rowOutputStrings as string[];
-  }
-
-  protected isExportingWithExcelFormat(columnDef: Column) {
-    let isExportWithExcelFormatEnabled = false;
-
-    // first check if there are any export options provided (as Grid Options)
-    if (this._excelExportOptions?.hasOwnProperty('exportWithExcelFormat')) {
-      isExportWithExcelFormatEnabled = !!this._excelExportOptions.exportWithExcelFormat;
-    }
-    // second check if "exportWithExcelFormat" is provided in the column definition, if so it will have precendence over the Grid Options exportOptions
-    if (columnDef?.hasOwnProperty('exportWithExcelFormat')) {
-      isExportWithExcelFormatEnabled = !!columnDef.exportWithExcelFormat;
-    }
-    return isExportWithExcelFormatEnabled;
   }
 
   /**
@@ -637,7 +620,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
       // auto-detect best possible Excel format for Group Totals, unless the user provide his own formatting,
       // we only do this check once per column (everything after that will be pull from temp ref)
-      if (this.isExportingWithExcelFormat(columnDef) && fieldType === FieldType.number) {
+      if (fieldType === FieldType.number) {
         let groupCellFormat = this._groupTotalExcelFormats[columnDef.id];
         if (!groupCellFormat?.groupType) {
           groupCellFormat = getExcelFormatFromGridFormatter(this._stylesheet, this._stylesheetFormats, columnDef, this._grid, 'group');

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -618,6 +618,11 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
       const fieldType = columnDef.outputType || columnDef.type || FieldType.string;
       const skippedField = columnDef.excludeFromExport || false;
 
+      // if there's a exportCustomGroupTotalsFormatter or groupTotalsFormatter, we will re-run it to get the exact same output as what is shown in UI
+      if (columnDef.exportCustomGroupTotalsFormatter) {
+        itemData = columnDef.exportCustomGroupTotalsFormatter(itemObj, columnDef, this._grid);
+      }
+
       // auto-detect best possible Excel format for Group Totals, unless the user provide his own formatting,
       // we only do this check once per column (everything after that will be pull from temp ref)
       if (fieldType === FieldType.number) {
@@ -637,15 +642,8 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
             metadata: { style: groupCellFormat.stylesheetFormatter?.id }
           };
         }
-      } else {
-        // if there's a exportCustomGroupTotalsFormatter or groupTotalsFormatter, we will re-run it to get the exact same output as what is shown in UI
-        if (columnDef.exportCustomGroupTotalsFormatter) {
-          itemData = columnDef.exportCustomGroupTotalsFormatter(itemObj, columnDef, this._grid);
-        } else {
-          if (columnDef.groupTotalsFormatter) {
-            itemData = columnDef.groupTotalsFormatter(itemObj, columnDef, this._grid);
-          }
-        }
+      } else if (columnDef.groupTotalsFormatter) {
+        itemData = columnDef.groupTotalsFormatter(itemObj, columnDef, this._grid);
       }
 
       // does the user want to sanitize the output data (remove HTML tags)?


### PR DESCRIPTION
I added this flag when I started the work on the auto-detection of Excel format but I realize that it should probably be enabled at all time, so no need for a flag