### PR TITLE
fix(common): cell selection in Firefox not working

### DIFF
--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -344,6 +344,7 @@ export class SlickCellRangeSelector {
 
     // prevent the grid from cancelling drag'n'drop by default
     e.stopImmediatePropagation();
+    e.preventDefault();
   }
 
   protected handleDragStart(e: DOMMouseOrTouchEvent<HTMLDivElement>, dd: DragPosition) {


### PR DESCRIPTION
- fixes issue reported in SlickGrid [issue 714](https://github.com/6pac/SlickGrid/issues/714)

### BEFORE
![firefox_LsJ5K0CIKn](https://user-images.githubusercontent.com/643976/209415697-2883ef48-84f1-46d7-b328-5d2730099dcd.gif)


### AFTER with Fix
![firefox_fEf9DUBjXU](https://user-images.githubusercontent.com/643976/209415707-d8c979ef-fb75-4bdd-b2e5-de04f8895c19.gif)

