### PR TITLE
fix(styling): do not remove ul>li bullet on html root, fixes #868

### DIFF
--- a/packages/common/src/styles/slick-bootstrap.scss
+++ b/packages/common/src/styles/slick-bootstrap.scss
@@ -21,10 +21,6 @@
   to { background: none; }
 }
 
-ul {
-  list-style-type: none;
-}
-
 .slickgrid-container {
   border-top: var(--slick-container-border-top, $slick-container-border-top);
   border-bottom: var(--slick-container-border-bottom, $slick-container-border-bottom);


### PR DESCRIPTION
- we shouldn't change any styling that are not explicitely under CSS classes related to Slickgrid since these overrides user's styling which is unexpected and it is also hard for the user to override