### PR TITLE
fix(filters): provide flag to disable special chars input filter parsing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,8 +33,8 @@
       ],
       "console": "internalConsole",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
       "windows": {
+        "name": "Jest",
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "test:watch": "cross-env TZ='America/New_York' jest --watch --config ./test/jest.config.js"
   },
   "comments": {
-    "new-version": "To create a new version with Lerna-Lite, simply run the following script (1) 'roll-new-release'."
+    "new-version": "To create a new version with Lerna-Lite, simply run the following script (1) 'roll-new-release'.",
+    "devDependencies": "The dev deps 'jQuery', 'slickgrid', 'sortablejs' and 'whatwg-fetch' are simply installed for Jest unit tests."
   },
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.3",
@@ -63,6 +64,7 @@
     "jest-cli": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "jest-extended": "^3.2.3",
+    "jquery": "^3.6.3",
     "jsdom": "^21.0.0",
     "jsdom-global": "^3.0.2",
     "moment-mini": "^2.29.4",
@@ -71,8 +73,11 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.7",
     "serve": "^14.1.2",
+    "slickgrid": "^3.0.2",
+    "sortablejs": "^1.15.0",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "whatwg-fetch": "^3.6.2"
   },
   "packageManager": "pnpm@7.25.1",
   "engines": {

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -13,6 +13,7 @@ export const GlobalGridOptions: GridOption = {
   autoFixResizeTimeout: 5 * 60 * 5, // interval is 200ms, so 4x is 1sec, so (5 * 60 * 5 = 5min)
   autoFixResizeRequiredGoodCount: 2,
   autoFixResizeWhenBrokenStyleDetected: false,
+  autoParseInputFilterOperator: true,
   autoResize: {
     applyResizeToContainer: true,
     calculateAvailableSizeBy: 'window',

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -37,6 +37,14 @@ export interface Column<T = any> {
   /** async background post-rendering formatter */
   asyncPostRender?: (domCellNode: any, row: number, dataContext: T, columnDef: Column) => void;
 
+  /**
+   * Defaults to true, when enabled it will parse the filter input string and extract filter operator (<, <=, >=, >, =, *) when found.
+   * When an operators is found in the input string, it will automatically be converted to a Filter Operators and will no longer be part of the search value itself.
+   * For example when the input value is "> 100", it will transform the search as to a Filter Operator of ">" and a search value of "100".
+   * The only time that the user would want to disable this flag is when the user's data has any of these special characters and the user really wants to filter them as part of the string (ie: >, <, ...)
+   */
+  autoParseInputFilterOperator?: boolean;
+
   /** optional Behavior of a column with action, for example it's used by the Row Move Manager Plugin */
   behavior?: string;
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -79,6 +79,14 @@ export interface GridOption {
   autoFitColumnsOnFirstLoad?: boolean;
 
   /**
+   * Defaults to true, when enabled it will parse the filter input string and extract filter operator (<, <=, >=, >, =, *) when found.
+   * When an operators is found in the input string, it will automatically be converted to a Filter Operators and will no longer be part of the search value itself.
+   * For example when the input value is "> 100", it will transform the search as to a Filter Operator of ">" and a search value of "100".
+   * The only time that the user would want to disable this flag is when the user's data has any of these special characters and the user really wants to filter them as part of the string (ie: >, <, ...)
+   */
+  autoParseInputFilterOperator?: boolean;
+
+  /**
    * Defaults to false, which leads to automatically adjust the width of each column by their cell value content and only on first page/component load.
    * If you wish this resize to also re-evaluate when resizing the browser, then you should also use `enableAutoResizeColumnsByCellContent`
    */

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -849,6 +849,21 @@ describe('FilterService', () => {
       expect(output).toBe(true);
     });
 
+    it('should return False when input value has special char "*" substring but "autoParseInputFilterOperator" is set to false so the text "Jo*" will not be found', () => {
+      const searchTerms = ['Jo*'];
+      const mockColumn1 = { id: 'firstName', field: 'firstName', filterable: true, autoParseInputFilterOperator: false } as Column;
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+
+      service.init(gridStub);
+      const columnFilter = { columnDef: mockColumn1, columnId: 'firstName', type: FieldType.string };
+      const filterCondition = service.parseFormInputFilterConditions(searchTerms, columnFilter);
+      const parsedSearchTerms = getParsedSearchTermsByFieldType(filterCondition.searchTerms, 'text');
+      const columnFilters = { firstName: { ...columnFilter, operator: filterCondition.operator, searchTerms: filterCondition.searchTerms, parsedSearchTerms } } as ColumnFilters;
+      const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+      expect(output).toBe(false);
+    });
+
     it('should return True when input value from datacontext is equal to endsWith substring', () => {
       const searchTerms = ['*hn'];
       const mockColumn1 = { id: 'firstName', field: 'firstName', filterable: true } as Column;
@@ -890,6 +905,36 @@ describe('FilterService', () => {
       const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
 
       expect(output).toBe(true);
+    });
+
+    it('should return True when input value from datacontext contains an operator ">=" and its value is greater than 10', () => {
+      const searchTerms = ['>=10'];
+      const mockColumn1 = { id: 'age', field: 'age', filterable: true, autoParseInputFilterOperator: false } as Column;
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+
+      service.init(gridStub);
+      const columnFilter = { columnDef: mockColumn1, columnId: 'age', type: FieldType.number };
+      const filterCondition = service.parseFormInputFilterConditions(searchTerms, columnFilter);
+      const parsedSearchTerms = getParsedSearchTermsByFieldType(filterCondition.searchTerms, 'number');
+      const columnFilters = { age: { ...columnFilter, operator: filterCondition.operator, searchTerms: filterCondition.searchTerms, parsedSearchTerms } } as ColumnFilters;
+      const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+      expect(output).toBe(true);
+    });
+
+    it('should return False when input value from datacontext contains an operator >= and its value is greater than 10 substring but "autoParseInputFilterOperator" is set to false', () => {
+      const searchTerms = ['>=10'];
+      const mockColumn1 = { id: 'age', field: 'age', filterable: true, autoParseInputFilterOperator: false } as Column;
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+
+      service.init(gridStub);
+      const columnFilter = { columnDef: mockColumn1, columnId: 'age', type: FieldType.string };
+      const filterCondition = service.parseFormInputFilterConditions(searchTerms, columnFilter);
+      const parsedSearchTerms = getParsedSearchTermsByFieldType(filterCondition.searchTerms, 'string');
+      const columnFilters = { age: { ...columnFilter, operator: filterCondition.operator, searchTerms: filterCondition.searchTerms, parsedSearchTerms } } as ColumnFilters;
+      const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+      expect(output).toBe(false);
     });
 
     it('should return True when input value is a complex object searchTerms value is found following the dot notation', () => {

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -396,7 +396,12 @@ export class FilterService {
     let matches = null;
     if (fieldType !== FieldType.object) {
       fieldSearchValue = (fieldSearchValue === undefined || fieldSearchValue === null) ? '' : `${fieldSearchValue}`; // make sure it's a string
-      matches = fieldSearchValue.match(/^([<>!=\*]{0,2})(.*[^<>!=\*])?([\*]?)$/); // group 1: Operator, 2: searchValue, 3: last char is '*' (meaning starts with, ex.: abc*)
+
+      // run regex to find possible filter operators unless the user disabled the feature
+      const autoParseInputFilterOperator = columnDef.autoParseInputFilterOperator ?? this._gridOptions.autoParseInputFilterOperator;
+      matches = autoParseInputFilterOperator !== false
+        ? fieldSearchValue.match(/^([<>!=\*]{0,2})(.*[^<>!=\*])?([\*]?)$/) // group 1: Operator, 2: searchValue, 3: last char is '*' (meaning starts with, ex.: abc*)
+        : [fieldSearchValue, '', fieldSearchValue, '']; // when parsing is disabled, we'll only keep the search value in the index 2 to make it easy for code reuse
     }
 
     let operator = matches?.[1] || columnFilter.operator;

--- a/packages/graphql/src/services/__tests__/graphql.service.spec.ts
+++ b/packages/graphql/src/services/__tests__/graphql.service.spec.ts
@@ -744,7 +744,7 @@ describe('GraphqlService', () => {
       expect(currentFilters).toEqual([{ columnId: 'gender', operator: 'EQ', searchTerms: ['female'] }]);
     });
 
-    it('should return a query with search having the operator StartsWith when search value has the * symbol as the last character', () => {
+    it('should return a query with search having the operator StartsWith when search value has the "*" symbol as the last character', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:StartsWith, value:"fem"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -758,7 +758,7 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should return a query with search having the operator EndsWith when search value has the * symbol as the first character', () => {
+    it('should return a query with search having the operator EndsWith when search value has the "*" symbol as the first character', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EndsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -772,7 +772,7 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should return a query with search having the operator EndsWith when the operator was provided as *z', () => {
+    it('should return a query with search having the operator EndsWith when the operator was provided as "*z"', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EndsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -786,7 +786,7 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should return a query with search having the operator StartsWith even when search value last char is * symbol but the operator provided is *z', () => {
+    it('should return a query with search having the operator StartsWith even when search value last char is "*" symbol but the operator provided is "*z"', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:StartsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -800,7 +800,7 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should return a query with search having the operator EndsWith when the Column Filter was provided as *z', () => {
+    it('should return a query with search having the operator EndsWith when the Column Filter was provided as "*z"', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EndsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender', filter: { operator: '*z' } } as Column;
       const mockColumnFilters = {
@@ -828,7 +828,7 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should return a query with search having the operator StartsWith when the operator was provided as a*', () => {
+    it('should return a query with search having the operator StartsWith when the operator was provided as "a*"', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:StartsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -847,6 +847,34 @@ describe('GraphqlService', () => {
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['le'], operator: 'StartsWith', type: FieldType.string, },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
+    it('should return a query with search having the operator Greater of Equal when the search value was provided as ">=10"', () => {
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:age, operator:GE, value:"10"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      const mockColumn = { id: 'age', field: 'age' } as Column;
+      const mockColumnFilters = {
+        age: { columnId: 'age', columnDef: mockColumn, searchTerms: ['>=10'], type: FieldType.string },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
+    it('should return a query with search NOT having the operator Greater of Equal when the search value was provided as ">=10" but "autoParseInputFilterOperator" is set to false', () => {
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:age, operator:Contains, value:">=10"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      const mockColumn = { id: 'age', field: 'age', autoParseInputFilterOperator: false } as Column;
+      const mockColumnFilters = {
+        age: { columnId: 'age', columnDef: mockColumn, searchTerms: ['>=10'], type: FieldType.string },
       } as ColumnFilters;
 
       service.init(serviceOptions, paginationOptions, gridStub);

--- a/packages/odata/src/services/__tests__/grid-odata.service.spec.ts
+++ b/packages/odata/src/services/__tests__/grid-odata.service.spec.ts
@@ -634,7 +634,7 @@ describe('GridOdataService', () => {
       expect(currentFilters).toEqual([{ columnId: 'gender', operator: 'EQ', searchTerms: ['female'] }]);
     });
 
-    it('should return a query with search having the operator StartsWith when search value has the * symbol as the last character', () => {
+    it('should return a query with search having the operator StartsWith when search value has the "*" symbol as the last character', () => {
       const expectation = `$top=10&$filter=(startswith(Gender, 'fem'))`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -648,7 +648,21 @@ describe('GridOdataService', () => {
       expect(query).toBe(expectation);
     });
 
-    it('should return a query with search having the operator EndsWith when search value has the * symbol as the first character', () => {
+    it('should return a query with search NOT having the operator StartsWith when search value has the "*" symbol as the last character but "autoParseInputFilterOperator" is set to false', () => {
+      const expectation = `$top=10&$filter=(substringof('fem*', Gender))`;
+      const mockColumn = { id: 'gender', field: 'gender', autoParseInputFilterOperator: false } as Column;
+      const mockColumnFilters = {
+        gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['fem*'], type: FieldType.string },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(query).toBe(expectation);
+    });
+
+    it('should return a query with search having the operator EndsWith when search value has the "*" symbol as the first character', () => {
       const expectation = `$top=10&$filter=(endswith(Gender, 'le'))`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -662,7 +676,7 @@ describe('GridOdataService', () => {
       expect(query).toBe(expectation);
     });
 
-    it('should return a query with search having the operator EndsWith when the operator was provided as *z', () => {
+    it('should return a query with search having the operator EndsWith when the operator was provided as "*z"', () => {
       const expectation = `$top=10&$filter=(endswith(Gender, 'le'))`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -676,7 +690,7 @@ describe('GridOdataService', () => {
       expect(query).toBe(expectation);
     });
 
-    it('should return a query with search having the operator StartsWith even when search value last char is * symbol but the operator provided is *z', () => {
+    it('should return a query with search having the operator StartsWith even when search value last char is "*" symbol but the operator provided is *z', () => {
       const expectation = `$top=10&$filter=(startswith(Gender, 'le'))`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
@@ -704,11 +718,39 @@ describe('GridOdataService', () => {
       expect(query).toBe(expectation);
     });
 
-    it('should return a query with search having the operator StartsWith when the operator was provided as a*', () => {
+    it('should return a query with search having the operator StartsWith when the operator was provided as "a*"', () => {
       const expectation = `$top=10&$filter=(startswith(Gender, 'le'))`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['le'], operator: 'a*', type: FieldType.string },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(query).toBe(expectation);
+    });
+
+    it('should return a query with search having the operator Greater of Equal when the search value was provided as ">=10"', () => {
+      const expectation = `$top=10&$filter=(Age ge '10')`;
+      const mockColumn = { id: 'age', field: 'age' } as Column;
+      const mockColumnFilters = {
+        age: { columnId: 'age', columnDef: mockColumn, searchTerms: ['>=10'], type: FieldType.string },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(query).toBe(expectation);
+    });
+
+    it('should return a query with search NOT having the operator Greater of Equal when the search value was provided as ">=10" but "autoParseInputFilterOperator" is set to false', () => {
+      const expectation = `$top=10&$filter=(substringof('%3E%3D10', Age))`;
+      const mockColumn = { id: 'age', field: 'age', autoParseInputFilterOperator: false } as Column;
+      const mockColumnFilters = {
+        age: { columnId: 'age', columnDef: mockColumn, searchTerms: ['>=10'], type: FieldType.string },
       } as ColumnFilters;
 
       service.init(serviceOptions, paginationOptions, gridStub);
@@ -732,7 +774,7 @@ describe('GridOdataService', () => {
       expect(query).toBe(expectation);
     });
 
-    it('should return a query with a CSV string when the filter operator is IN ', () => {
+    it('should return a query with a CSV string when the filter operator is IN', () => {
       const expectation = `$top=10&$filter=(Gender eq 'female' or Gender eq 'ma%2Fle')`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {

--- a/packages/odata/src/services/grid-odata.service.ts
+++ b/packages/odata/src/services/grid-odata.service.ts
@@ -331,10 +331,16 @@ export class GridOdataService implements BackendService {
         }
 
         fieldSearchValue = (fieldSearchValue === undefined || fieldSearchValue === null) ? '' : `${fieldSearchValue}`; // make sure it's a string
-        const matches = fieldSearchValue.match(/^([<>!=\*]{0,2})(.*[^<>!=\*])([\*]?)$/); // group 1: Operator, 2: searchValue, 3: last char is '*' (meaning starts with, ex.: abc*)
-        let operator = columnFilter.operator || ((matches) ? matches[1] : '');
-        let searchValue = (!!matches) ? matches[2] : '';
-        const lastValueChar = (!!matches) ? matches[3] : (operator === '*z' || operator === OperatorType.endsWith) ? '*' : '';
+
+        // run regex to find possible filter operators unless the user disabled the feature
+        const autoParseInputFilterOperator = columnDef.autoParseInputFilterOperator ?? this._gridOptions.autoParseInputFilterOperator;
+        const matches = autoParseInputFilterOperator !== false
+          ? fieldSearchValue.match(/^([<>!=\*]{0,2})(.*[^<>!=\*])([\*]?)$/) // group 1: Operator, 2: searchValue, 3: last char is '*' (meaning starts with, ex.: abc*)
+          : [fieldSearchValue, '', fieldSearchValue, '']; // when parsing is disabled, we'll only keep the search value in the index 2 to make it easy for code reuse
+
+        let operator = columnFilter.operator || matches?.[1];
+        let searchValue = matches?.[2] || '';
+        const lastValueChar = matches?.[3] || (operator === '*z' || operator === OperatorType.endsWith) ? '*' : '';
         const bypassOdataQuery = columnFilter.bypassBackendQuery || false;
 
         // no need to query if search value is empty

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ importers:
       jest-cli: ^29.3.1
       jest-environment-jsdom: ^29.3.1
       jest-extended: ^3.2.3
+      jquery: ^3.6.3
       jsdom: ^21.0.0
       jsdom-global: ^3.0.2
       moment-mini: ^2.29.4
@@ -30,8 +31,11 @@ importers:
       rimraf: ^3.0.2
       rxjs: ^7.5.7
       serve: ^14.1.2
+      slickgrid: ^3.0.2
+      sortablejs: ^1.15.0
       ts-jest: ^29.0.5
       typescript: ^4.9.4
+      whatwg-fetch: ^3.6.2
     devDependencies:
       '@4tw/cypress-drag-drop': 2.2.3_cypress@11.2.0
       '@jest/types': 29.3.1
@@ -51,6 +55,7 @@ importers:
       jest-cli: 29.3.1_@types+node@18.11.18
       jest-environment-jsdom: 29.3.1
       jest-extended: 3.2.3_jest@29.3.1
+      jquery: 3.6.3
       jsdom: 21.0.0
       jsdom-global: 3.0.2_jsdom@21.0.0
       moment-mini: 2.29.4
@@ -59,8 +64,11 @@ importers:
       rimraf: 3.0.2
       rxjs: 7.5.7
       serve: 14.1.2
+      slickgrid: 3.0.2
+      sortablejs: 1.15.0
       ts-jest: 29.0.5_a67wnu7kur6t3xg6vztzc6sc5i
       typescript: 4.9.4
+      whatwg-fetch: 3.6.2
 
   examples/webpack-demo-vanilla-bundle:
     specifiers:
@@ -6779,7 +6787,6 @@ packages:
 
   /jquery/3.6.3:
     resolution: {integrity: sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==}
-    dev: false
 
   /js-sdsl/4.1.4:
     resolution: {integrity: sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==}
@@ -9209,7 +9216,6 @@ packages:
     dependencies:
       jquery: 3.6.3
       sortablejs: 1.15.0
-    dev: false
 
   /smart-buffer/4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -9259,7 +9265,6 @@ packages:
 
   /sortablejs/1.15.0:
     resolution: {integrity: sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==}
-    dev: false
 
   /source-list-map/2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
@@ -10370,7 +10375,6 @@ packages:
 
   /whatwg-fetch/3.6.2:
     resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
-    dev: false
 
   /whatwg-mimetype/3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}


### PR DESCRIPTION
- Slickgrid-Universal is by default parsing some special characters (`<`, `>`, `=`, `*`) when found in filter input value but in some rare occasion the user might have data that includes these special chars and might want to disable the parsing, this PR provide a new flag `autoParseInputFilterOperator` that will disable parsing when set to `false` and search the value as it is
- this option is available from both the GridOption and the Column, the latter will always have precedence
- ref Stack Overflow [In angular slickgrid, the records with special characters "<" , "=" are not getting filtered](https://stackoverflow.com/questions/75155658/in-angular-slickgrid-the-records-with-special-characters-are-not-gett)