### PR TITLE
fix(editor): comparing select editor value against `['']` isn't valid

### DIFF
--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -496,7 +496,7 @@ export class SelectEditor implements Editor {
 
         // clear select when it's newly disabled and not yet empty
         const currentValues: string | number | Array<string | number> = this.getValue();
-        const isValueBlank = this.isMultipleSelect ? currentValues === [''] as Array<string | number> : currentValues === '';
+        const isValueBlank = Array.isArray(currentValues) && this.isMultipleSelect ? currentValues?.[0] === '' : currentValues === '';
         if (prevIsDisabled !== isDisabled && this.isCompositeEditor && !isValueBlank) {
           this.reset('', true, true);
         }

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -37,6 +37,7 @@
     "bundle": "npm-run-all bundle:commonjs bundle:esm webpack:prod",
     "bundle:commonjs": "tsc --project tsconfig.bundle.json --outDir dist/commonjs --module commonjs",
     "bundle:esm": "tsc --project tsconfig.bundle.json --outDir dist/esm --module esnext --target es2018",
+    "bundle:web": "esbuild src/index.ts --bundle --minify --format=iife --sourcemap --target=es2018 --main-fields=module,main --external:jquery --global-name=Slicker --outfile=dist/bundle/slickgrid-vanilla-bundle.js",
     "prebundle:zip": "pnpm run delete:zip",
     "bundle:zip": "pnpm run zip:dist",
     "delete:zip": "cross-env rimraf --maxBusyTries=10 dist-bundle-zip",


### PR DESCRIPTION
- the error came from ESbuild when trying to bundle the lib, the warning is the following
```sh
 [WARNING] Comparison using the "===" operator here is always false [equals-new-object]
 ```