### PR TITLE
Update slickDraggableGrouping.ts

### DIFF
--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -279,7 +279,6 @@ export class SlickDraggableGrouping {
    * @param trigger - callback to execute when triggering a column grouping
    */
   setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, columns: Column[], getColumnIndex: (columnId: string) => number, uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) {
-    let reorderedColumns = grid.getColumns();
     const dropzoneElm = grid.getPreHeaderPanel();
     const draggablePlaceholderElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-draggable-dropzone-placeholder');
     const groupTogglerElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-group-toggle-all');
@@ -314,6 +313,7 @@ export class SlickDraggableGrouping {
         }
       },
       onEnd: (e: Event & { item: any; clone: HTMLElement; }) => {
+        const reorderedColumns = grid.getColumns();
         dropzoneElm?.classList.remove('slick-dropzone-hover');
         draggablePlaceholderElm?.parentElement?.classList.remove('slick-dropzone-placeholder-hover');
 


### PR DESCRIPTION
The reorderedColumns is now not getting lost on new columns instance