### PR TITLE
chore: add import type for all interface imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -122,7 +122,7 @@
     "no-console": "off",
     "no-debugger": "error",
     "no-duplicate-case": "error",
-    "no-duplicate-imports": "error",
+    "no-duplicate-imports": "off",
     "no-empty": 1,
     "no-eval": "error",
     "no-extra-bind": "error",

--- a/packages/binding/src/binding.service.ts
+++ b/packages/binding/src/binding.service.ts
@@ -1,4 +1,4 @@
-import { Binding, BoundedEventWithListener, ElementBinding, ElementBindingWithListener } from './interfaces';
+import type { Binding, BoundedEventWithListener, ElementBinding, ElementBindingWithListener } from './interfaces';
 
 /**
  * Create 2 way Bindings for any variable that are primitive or object types, when it's an object type it will watch for property changes

--- a/packages/common/src/aggregators/avgAggregator.ts
+++ b/packages/common/src/aggregators/avgAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class AvgAggregator implements Aggregator {
   private _nonNullCount = 0;

--- a/packages/common/src/aggregators/cloneAggregator.ts
+++ b/packages/common/src/aggregators/cloneAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class CloneAggregator implements Aggregator {
   private _field: number | string;

--- a/packages/common/src/aggregators/countAggregator.ts
+++ b/packages/common/src/aggregators/countAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class CountAggregator implements Aggregator {
   private _field: number | string;

--- a/packages/common/src/aggregators/distinctAggregator.ts
+++ b/packages/common/src/aggregators/distinctAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class DistinctAggregator implements Aggregator {
   private _field: number | string;

--- a/packages/common/src/aggregators/maxAggregator.ts
+++ b/packages/common/src/aggregators/maxAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class MaxAggregator implements Aggregator {
   private _max: number | null = null;

--- a/packages/common/src/aggregators/minAggregator.ts
+++ b/packages/common/src/aggregators/minAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class MinAggregator implements Aggregator {
   private _min: number | null = null;

--- a/packages/common/src/aggregators/sumAggregator.ts
+++ b/packages/common/src/aggregators/sumAggregator.ts
@@ -1,4 +1,4 @@
-import { Aggregator } from './../interfaces/aggregator.interface';
+import type { Aggregator } from './../interfaces/aggregator.interface';
 
 export class SumAggregator implements Aggregator {
   private _sum = 0;

--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -1,6 +1,6 @@
 import { AutocompleteItem } from 'autocompleter';
 
-import { AutocompleterOption } from '../interfaces/index';
+import type { AutocompleterOption } from '../interfaces/index';
 
 /**
  * add loading class ".slick-autocomplete-loading" to the Kraaden Autocomplete input element

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,4 +1,4 @@
-import { Locale } from './interfaces/locale.interface';
+import type { Locale } from './interfaces/locale.interface';
 
 export class Constants {
   static readonly locales: Locale = {

--- a/packages/common/src/editorValidators/floatValidator.ts
+++ b/packages/common/src/editorValidators/floatValidator.ts
@@ -1,6 +1,6 @@
 import { Constants } from '../constants';
-import { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
-import { EditorValidator } from '../interfaces/editorValidator.interface';
+import type { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
+import type { EditorValidator } from '../interfaces/editorValidator.interface';
 
 interface FloatValidatorOptions {
   editorArgs: any;

--- a/packages/common/src/editorValidators/integerValidator.ts
+++ b/packages/common/src/editorValidators/integerValidator.ts
@@ -1,6 +1,6 @@
 import { Constants } from '../constants';
-import { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
-import { EditorValidator } from '../interfaces/editorValidator.interface';
+import type { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
+import type { EditorValidator } from '../interfaces/editorValidator.interface';
 
 interface IntegerValidatorOptions {
   editorArgs: any;

--- a/packages/common/src/editorValidators/sliderValidator.ts
+++ b/packages/common/src/editorValidators/sliderValidator.ts
@@ -1,6 +1,6 @@
 import { Constants } from '../constants';
-import { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
-import { EditorValidator } from '../interfaces/editorValidator.interface';
+import type { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
+import type { EditorValidator } from '../interfaces/editorValidator.interface';
 
 interface SliderValidatorOptions {
   editorArgs: any;

--- a/packages/common/src/editorValidators/textValidator.ts
+++ b/packages/common/src/editorValidators/textValidator.ts
@@ -1,6 +1,6 @@
 import { Constants } from '../constants';
-import { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
-import { EditorValidator } from '../interfaces/editorValidator.interface';
+import type { EditorValidationResult } from '../interfaces/editorValidationResult.interface';
+import type { EditorValidator } from '../interfaces/editorValidator.interface';
 
 interface TextValidatorOptions {
   editorArgs: any;

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -1,12 +1,12 @@
 import * as autocompleter_ from 'autocompleter';
 const autocomplete = (autocompleter_ && autocompleter_['default'] || autocompleter_) as <T extends AutocompleteItem>(settings: AutocompleteSettings<T>) => AutocompleteResult; // patch for rollup
 
-import { AutocompleteItem, AutocompleteResult, AutocompleteSettings } from 'autocompleter';
+import type { AutocompleteItem, AutocompleteResult, AutocompleteSettings } from 'autocompleter';
 import { isObject, isPrimmitive, setDeepValue, toKebabCase } from '@slickgrid-universal/utils';
 
 import { Constants } from './../constants';
 import { FieldType, KeyCode, } from '../enums/index';
-import {
+import type {
   AutocompleterOption,
   AutocompleteSearchItem,
   CollectionCustomStructure,
@@ -29,7 +29,7 @@ import { getEditorOptionByName } from './editorUtilities';
 import { createDomElement, sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
 import { findOrDefault, getDescendantProperty, } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 
 // minimum length of chars to type before starting to start querying
 const MIN_LENGTH = 3;

--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -1,7 +1,7 @@
 import { setDeepValue, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { Constants } from './../constants';
-import { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace } from './../interfaces/index';
+import type { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace } from './../interfaces/index';
 import { createDomElement } from '../services/domUtilities';
 import { getDescendantProperty, } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -1,14 +1,14 @@
 import { setDeepValue } from '@slickgrid-universal/utils';
 import * as flatpickr_ from 'flatpickr';
 import * as moment_ from 'moment-mini';
-import { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
-import { Instance as FlatpickrInstance, FlatpickrFn } from 'flatpickr/dist/types/instance';
+import type { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
+import type { Instance as FlatpickrInstance, FlatpickrFn } from 'flatpickr/dist/types/instance';
 const flatpickr: FlatpickrFn = (flatpickr_ && flatpickr_['default'] || flatpickr_) as any; // patch for rollup
 const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import { Constants } from './../constants';
 import { FieldType } from '../enums/index';
-import {
+import type {
   Column,
   ColumnEditor,
   CompositeEditorOption,
@@ -25,7 +25,7 @@ import { getEditorOptionByName } from './editorUtilities';
 import { createDomElement, destroyObjectDomElementProps, emptyElement, } from '../services/domUtilities';
 import { getDescendantProperty, mapFlatpickrDateFormatWithFieldType, mapMomentDateFormatWithFieldType, } from './../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 
 // using external non-typed js libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -1,7 +1,7 @@
 import { setDeepValue, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { KeyCode } from '../enums/keyCode.enum';
-import {
+import type {
   DOMEvent,
   Column,
   ColumnEditor,

--- a/packages/common/src/editors/editorUtilities.ts
+++ b/packages/common/src/editors/editorUtilities.ts
@@ -1,5 +1,5 @@
 // import { InferObjectPropTypeByName } from '../enums/inferObjectPropTypeByName.type';
-import { ColumnEditor } from '../interfaces/index';
+import type { ColumnEditor } from '../interfaces/index';
 
 /**
  * Get option from editor.params PR editor.editorOptions

--- a/packages/common/src/editors/floatEditor.ts
+++ b/packages/common/src/editors/floatEditor.ts
@@ -1,7 +1,7 @@
 import { toSentenceCase } from '@slickgrid-universal/utils';
 
 import { KeyCode } from '../enums/index';
-import { EditorArguments, EditorValidationResult } from '../interfaces/index';
+import type { EditorArguments, EditorValidationResult } from '../interfaces/index';
 import { floatValidator } from '../editorValidators/floatValidator';
 import { InputEditor } from './inputEditor';
 import { createDomElement } from '../services/domUtilities';

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -1,7 +1,18 @@
 import { setDeepValue, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { KeyCode } from '../enums/keyCode.enum';
-import { Column, ColumnEditor, CompositeEditorOption, Editor, EditorArguments, EditorValidator, EditorValidationResult, GridOption, SlickGrid, SlickNamespace, } from '../interfaces/index';
+import type {
+  Column,
+  ColumnEditor,
+  CompositeEditorOption,
+  Editor,
+  EditorArguments,
+  EditorValidator,
+  EditorValidationResult,
+  GridOption,
+  SlickGrid,
+  SlickNamespace,
+} from '../interfaces/index';
 import { getDescendantProperty } from '../services/utilities';
 import { textValidator } from '../editorValidators/textValidator';
 import { BindingEventService } from '../services/bindingEvent.service';

--- a/packages/common/src/editors/inputPasswordEditor.ts
+++ b/packages/common/src/editors/inputPasswordEditor.ts
@@ -1,4 +1,4 @@
-import { EditorArguments } from '../interfaces/editorArguments.interface';
+import type { EditorArguments } from '../interfaces/editorArguments.interface';
 import { InputEditor } from './inputEditor';
 
 export class InputPasswordEditor extends InputEditor {

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -1,7 +1,7 @@
 import { toSentenceCase } from '@slickgrid-universal/utils';
 
 import { KeyCode } from '../enums/index';
-import { EditorArguments, EditorValidationResult } from '../interfaces/index';
+import type { EditorArguments, EditorValidationResult } from '../interfaces/index';
 import { integerValidator } from '../editorValidators/integerValidator';
 import { InputEditor } from './inputEditor';
 import { createDomElement } from '../services/domUtilities';

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -2,7 +2,7 @@ import { setDeepValue, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { Constants } from './../constants';
 import { KeyCode } from '../enums/keyCode.enum';
-import {
+import type {
   Column,
   ColumnEditor,
   CompositeEditorOption,
@@ -21,7 +21,7 @@ import {
 import { createDomElement, getHtmlElementOffset, } from '../services/domUtilities';
 import { getDescendantProperty, getTranslationPrefix, } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 import { textValidator } from '../editorValidators/textValidator';
 
 // using external non-typed js libraries

--- a/packages/common/src/editors/multipleSelectEditor.ts
+++ b/packages/common/src/editors/multipleSelectEditor.ts
@@ -1,4 +1,4 @@
-import { EditorArguments } from '../interfaces/editorArguments.interface';
+import type { EditorArguments } from '../interfaces/editorArguments.interface';
 import { SelectEditor } from './selectEditor';
 
 export class MultipleSelectEditor extends SelectEditor {

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -3,7 +3,7 @@ import { dequal } from 'dequal/lite';
 
 import { Constants } from '../constants';
 import { FieldType } from './../enums/index';
-import {
+import type {
   CollectionCustomStructure,
   CollectionOption,
   CollectionOverrideArgs,
@@ -21,7 +21,7 @@ import {
   SlickGrid,
   SlickNamespace,
 } from './../interfaces/index';
-import { buildSelectEditorOrFilterDomElement, CollectionService, findOrDefault, TranslaterService } from '../services/index';
+import { CollectionService, findOrDefault, type TranslaterService } from '../services/index';
 import { getDescendantProperty, getTranslationPrefix, } from '../services/utilities';
 
 // using external non-typed js libraries

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -21,7 +21,7 @@ import type {
   SlickGrid,
   SlickNamespace,
 } from './../interfaces/index';
-import { CollectionService, findOrDefault, type TranslaterService } from '../services/index';
+import { buildSelectEditorOrFilterDomElement, CollectionService, findOrDefault, type TranslaterService } from '../services/index';
 import { getDescendantProperty, getTranslationPrefix, } from '../services/utilities';
 
 // using external non-typed js libraries

--- a/packages/common/src/editors/singleSelectEditor.ts
+++ b/packages/common/src/editors/singleSelectEditor.ts
@@ -1,4 +1,4 @@
-import { EditorArguments } from '../interfaces/editorArguments.interface';
+import type { EditorArguments } from '../interfaces/editorArguments.interface';
 import { SelectEditor } from './selectEditor';
 
 export class SingleSelectEditor extends SelectEditor {

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -1,10 +1,11 @@
 import { setDeepValue, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { Constants } from '../constants';
-import {
+import type {
   Column,
   ColumnEditor,
   CompositeEditorOption,
+  CurrentSliderOption,
   Editor,
   EditorArguments,
   EditorValidator,
@@ -13,7 +14,6 @@ import {
   SlickGrid,
   SlickNamespace,
   SliderOption,
-  CurrentSliderOption
 } from '../interfaces/index';
 import { getEditorOptionByName } from './editorUtilities';
 import { getDescendantProperty } from '../services/utilities';

--- a/packages/common/src/enums/columnReorderFunction.type.ts
+++ b/packages/common/src/enums/columnReorderFunction.type.ts
@@ -1,3 +1,3 @@
-import { Column, SlickEvent, SlickGrid } from '../interfaces/index';
+import type { Column, SlickEvent, SlickGrid } from '../interfaces/index';
 
 export type ColumnReorderFunction = (grid: SlickGrid, headers: any, headerColumnWidthDiff: any, setColumns: (cols: Column[]) => void, setupColumnResize: () => void, columns: Column[], getColumnIndex: (columnId: string) => number, uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) => void;

--- a/packages/common/src/enums/extensionList.type.ts
+++ b/packages/common/src/enums/extensionList.type.ts
@@ -1,4 +1,4 @@
-import { ExtensionName, SlickControlList, SlickPluginList } from './index';
-import { ExtensionModel } from '../interfaces/index';
+import type { ExtensionName, SlickControlList, SlickPluginList } from './index';
+import type { ExtensionModel } from '../interfaces/index';
 
 export type ExtensionList<P extends (SlickControlList | SlickPluginList)> = Record<ExtensionName, ExtensionModel<P>>;

--- a/packages/common/src/enums/positionMethod.type.ts
+++ b/packages/common/src/enums/positionMethod.type.ts
@@ -1,3 +1,3 @@
-import { ElementPosition } from '../interfaces/elementPosition.interface';
+import type { ElementPosition } from '../interfaces/elementPosition.interface';
 
 export type PositionMethod = () => ElementPosition;

--- a/packages/common/src/enums/slickControlList.enum.ts
+++ b/packages/common/src/enums/slickControlList.enum.ts
@@ -1,3 +1,3 @@
-import { SlickColumnPicker, SlickGridMenu } from '../extensions/index';
+import type { SlickColumnPicker, SlickGridMenu } from '../extensions/index';
 
 export type SlickControlList = SlickColumnPicker | SlickGridMenu;

--- a/packages/common/src/enums/slickPluginList.enum.ts
+++ b/packages/common/src/enums/slickPluginList.enum.ts
@@ -1,6 +1,6 @@
-import { ExtensionName } from '../enums/index';
-import { SlickEditorLock, SlickRowDetailView } from '../interfaces/index';
-import {
+import type { ExtensionName } from '../enums/index';
+import type { SlickEditorLock, SlickRowDetailView } from '../interfaces/index';
+import type {
   SlickAutoTooltip,
   SlickCellExcelCopyManager,
   SlickCellExternalCopyManager,

--- a/packages/common/src/enums/usabilityOverrideFn.type.ts
+++ b/packages/common/src/enums/usabilityOverrideFn.type.ts
@@ -1,3 +1,3 @@
-import { SlickGrid } from '../interfaces/slickGrid.interface';
+import type { SlickGrid } from '../interfaces/slickGrid.interface';
 
 export type UsabilityOverrideFn = (row: number, dataContext: any, grid: SlickGrid) => boolean;

--- a/packages/common/src/extensions/extensionCommonUtils.ts
+++ b/packages/common/src/extensions/extensionCommonUtils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 import { titleCase } from '@slickgrid-universal/utils';
 
-import { Column, ColumnPickerOption, DOMEvent, GridMenuOption } from '../interfaces/index';
+import type { Column, ColumnPickerOption, DOMEvent, GridMenuOption } from '../interfaces/index';
 import { createDomElement, sanitizeTextByAvailableSanitizer } from '../services/domUtilities';
 import { SlickColumnPicker } from './slickColumnPicker';
 import { SlickGridMenu } from './slickGridMenu';

--- a/packages/common/src/extensions/extensionUtility.ts
+++ b/packages/common/src/extensions/extensionUtility.ts
@@ -1,8 +1,8 @@
 import { Constants } from '../constants';
-import { Column, GridMenuItem, GridOption, Locale, MenuCommandItem, MenuOptionItem, } from '../interfaces/index';
-import { BackendUtilityService } from '../services/backendUtility.service';
-import { SharedService } from '../services/shared.service';
-import { TranslaterService } from '../services/translater.service';
+import type { Column, GridMenuItem, GridOption, Locale, MenuCommandItem, MenuOptionItem, } from '../interfaces/index';
+import type { BackendUtilityService } from '../services/backendUtility.service';
+import type { SharedService } from '../services/shared.service';
+import type { TranslaterService } from '../services/translater.service';
 import { getTranslationPrefix } from '../services/utilities';
 
 export class ExtensionUtility {

--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { hasData } from '@slickgrid-universal/utils';
 
-import {
+import type {
   CellMenu,
   Column,
   ContextMenu,
@@ -18,8 +18,8 @@ import {
   SlickNamespace,
 } from '../interfaces/index';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { ExtensionUtility } from '../extensions/extensionUtility';
-import { SharedService } from '../services/shared.service';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
+import type { SharedService } from '../services/shared.service';
 import { createDomElement, emptyElement } from '../services/domUtilities';
 
 // using external SlickGrid JS libraries

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { titleCase } from '@slickgrid-universal/utils';
 
-import {
+import type {
   CellMenu,
   ContextMenu,
   DOMMouseOrTouchEvent,
@@ -12,10 +12,10 @@ import {
   MenuOptionItem,
   MenuOptionItemCallbackArgs,
 } from '../interfaces/index';
-import { ExtensionUtility } from '../extensions/extensionUtility';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
 import { calculateAvailableSpace, createDomElement, findWidthOrDefault, getHtmlElementOffset, } from '../services/domUtilities';
-import { ExtendableItemTypes, ExtractMenuType, MenuBaseClass, MenuType } from './menuBaseClass';
-import { SharedService } from '../services/shared.service';
+import { type ExtendableItemTypes, type ExtractMenuType, MenuBaseClass, type MenuType } from './menuBaseClass';
+import type { SharedService } from '../services/shared.service';
 
 export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends MenuBaseClass<M> {
   protected _currentCell = -1;

--- a/packages/common/src/extensions/slickAutoTooltip.ts
+++ b/packages/common/src/extensions/slickAutoTooltip.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AutoTooltipOption,
   Column,
   SlickEventHandler,

--- a/packages/common/src/extensions/slickCellExcelCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExcelCopyManager.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Column,
   EditCommand,
   EditUndoRedoBuffer,

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -1,5 +1,5 @@
 import { KeyCode } from '../enums/index';
-import {
+import type {
   CellRange,
   Column,
   ExcelCopyBufferOption,

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -1,6 +1,6 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   CellMenu,
   CellMenuOption,
   Column,
@@ -9,8 +9,8 @@ import {
   MenuCommandItemCallbackArgs,
   MenuOptionItem,
 } from '../interfaces/index';
-import { ExtensionUtility } from '../extensions/extensionUtility';
-import { SharedService } from '../services/shared.service';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
+import type { SharedService } from '../services/shared.service';
 import { MenuFromCellBaseClass } from './menuFromCellBaseClass';
 
 /**

--- a/packages/common/src/extensions/slickCellRangeDecorator.ts
+++ b/packages/common/src/extensions/slickCellRangeDecorator.ts
@@ -1,6 +1,6 @@
 import { deepMerge } from '@slickgrid-universal/utils';
 
-import { CellRange, CellRangeDecoratorOption, CSSStyleDeclarationWritable, SlickGrid } from '../interfaces/index';
+import { CellRange, CellRangeDecoratorOption, type CSSStyleDeclarationWritable, type SlickGrid } from '../interfaces/index';
 import { createDomElement } from '../services/domUtilities';
 
 /**

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -1,6 +1,6 @@
 import { deepMerge } from '@slickgrid-universal/utils';
 
-import {
+import type {
   CellRange,
   CellRangeSelectorOption,
   DOMMouseOrTouchEvent,

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -1,5 +1,5 @@
 import { KeyCode } from '../enums/index';
-import { CellRange, OnActiveCellChangedEventArgs, SlickEventHandler, SlickGrid, SlickNamespace, SlickRange, } from '../interfaces/index';
+import type { CellRange, OnActiveCellChangedEventArgs, SlickEventHandler, SlickGrid, SlickNamespace, SlickRange, } from '../interfaces/index';
 import { SlickCellRangeSelector } from './index';
 
 // using external SlickGrid JS libraries

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
 import { KeyCode } from '../enums/keyCode.enum';
-import { CheckboxSelectorOption, Column, DOMMouseOrTouchEvent, GridOption, SelectableOverrideCallback, SlickDataView, SlickEventData, SlickEventHandler, SlickGrid, SlickNamespace } from '../interfaces/index';
+import type { CheckboxSelectorOption, Column, DOMMouseOrTouchEvent, GridOption, SelectableOverrideCallback, SlickDataView, SlickEventData, SlickEventHandler, SlickGrid, SlickNamespace } from '../interfaces/index';
 import { SlickRowSelectionModel } from './slickRowSelectionModel';
 import { createDomElement, emptyElement } from '../services/domUtilities';
 import { BindingEventService } from '../services/bindingEvent.service';

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -1,6 +1,6 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   Column,
   ColumnPickerOption,
   DOMMouseOrTouchEvent,
@@ -9,9 +9,9 @@ import {
   SlickGrid,
   SlickNamespace,
 } from '../interfaces/index';
-import { ExtensionUtility } from '../extensions/extensionUtility';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { SharedService } from '../services/shared.service';
+import type { SharedService } from '../services/shared.service';
 import { createDomElement, emptyElement, findWidthOrDefault } from '../services/domUtilities';
 import { addColumnTitleElementWhenDefined, addCloseButtomElement, handleColumnPickerItemClick, populateColumnPicker, updateColumnPickerOrder } from '../extensions/extensionCommonUtils';
 

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -1,5 +1,5 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import {
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type {
   ContextMenu,
   ContextMenuOption,
   Column,
@@ -10,11 +10,11 @@ import {
   MenuOptionItem,
 } from '../interfaces/index';
 import { DelimiterType, FileType } from '../enums/index';
-import { ExcelExportService, getCellValueFromQueryFieldGetter, getTranslationPrefix, TextExportService } from '../services/index';
+import { type ExcelExportService, getCellValueFromQueryFieldGetter, getTranslationPrefix, type TextExportService } from '../services/index';
 import { exportWithFormatterWhenDefined } from '../formatters/formatterUtilities';
-import { ExtensionUtility } from '../extensions/extensionUtility';
-import { SharedService } from '../services/shared.service';
-import { TreeDataService } from '../services/treeData.service';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
+import type { SharedService } from '../services/shared.service';
+import type { TreeDataService } from '../services/treeData.service';
 import { MenuFromCellBaseClass } from './menuFromCellBaseClass';
 
 

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -1,12 +1,12 @@
-import { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { isEmptyObject } from '@slickgrid-universal/utils';
-import SortableInstance, { Options as SortableOptions, SortableEvent } from 'sortablejs';
+import SortableInstance, { type Options as SortableOptions, type SortableEvent } from 'sortablejs';
 import * as Sortable_ from 'sortablejs';
 const Sortable = ((Sortable_ as any)?.['default'] ?? Sortable_); // patch for rollup
 
-import { ExtensionUtility } from '../extensions/extensionUtility';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
 import { SortDirectionNumber } from '../enums';
-import {
+import type {
   Column,
   DOMMouseOrTouchEvent,
   DraggableGrouping,
@@ -21,7 +21,7 @@ import {
   SlickNamespace,
 } from '../interfaces/index';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { SharedService } from '../services/shared.service';
+import type { SharedService } from '../services/shared.service';
 import { createDomElement, emptyElement } from '../services/domUtilities';
 import { sortByFieldType } from '../sortComparers';
 

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -1,6 +1,6 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   Column,
   DOMEvent,
   GridMenu,
@@ -13,15 +13,15 @@ import {
   SlickNamespace,
 } from '../interfaces/index';
 import { DelimiterType, FileType } from '../enums/index';
-import { ExtensionUtility } from '../extensions/extensionUtility';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
 import { createDomElement, emptyElement, findWidthOrDefault, getHtmlElementOffset, getTranslationPrefix, } from '../services/index';
-import { ExcelExportService } from '../services/excelExport.service';
-import { FilterService } from '../services/filter.service';
-import { SharedService } from '../services/shared.service';
-import { SortService } from '../services/sort.service';
-import { TextExportService } from '../services/textExport.service';
+import type { ExcelExportService } from '../services/excelExport.service';
+import type { FilterService } from '../services/filter.service';
+import type { SharedService } from '../services/shared.service';
+import type { SortService } from '../services/sort.service';
+import type { TextExportService } from '../services/textExport.service';
 import { addColumnTitleElementWhenDefined, addCloseButtomElement, handleColumnPickerItemClick, populateColumnPicker, updateColumnPickerOrder } from '../extensions/extensionCommonUtils';
-import { ExtendableItemTypes, ExtractMenuType, MenuBaseClass, MenuType } from '../extensions/menuBaseClass';
+import { type ExtendableItemTypes, type ExtractMenuType, MenuBaseClass, type MenuType } from '../extensions/menuBaseClass';
 
 // using external SlickGrid JS libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -1,5 +1,5 @@
 import { KeyCode } from '../enums/keyCode.enum';
-import {
+import type {
   Column,
   DOMEvent,
   GroupingFormatterItem,

--- a/packages/common/src/extensions/slickHeaderButtons.ts
+++ b/packages/common/src/extensions/slickHeaderButtons.ts
@@ -1,6 +1,6 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   Column,
   DOMEvent,
   HeaderButton,
@@ -13,9 +13,9 @@ import {
   SlickNamespace,
 } from '../interfaces/index';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { ExtensionUtility } from '../extensions/extensionUtility';
-import { SharedService } from '../services/shared.service';
-import { ExtendableItemTypes, ExtractMenuType, MenuBaseClass, MenuType } from './menuBaseClass';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
+import type { SharedService } from '../services/shared.service';
+import { type ExtendableItemTypes, type ExtractMenuType, MenuBaseClass, type MenuType } from './menuBaseClass';
 
 // using external SlickGrid JS libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -1,8 +1,8 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { arrayRemoveItemByIndex } from '@slickgrid-universal/utils';
 
 import { EmitterType } from '../enums/index';
-import {
+import type {
   Column,
   CurrentSorter,
   DOMEvent,
@@ -17,11 +17,11 @@ import {
   OnHeaderCellRenderedEventArgs,
 } from '../interfaces/index';
 import { createDomElement, emptyElement, getElementOffsetRelativeToParent, getTranslationPrefix } from '../services/index';
-import { ExtensionUtility } from '../extensions/extensionUtility';
-import { FilterService } from '../services/filter.service';
-import { SharedService } from '../services/shared.service';
-import { SortService } from '../services/sort.service';
-import { ExtendableItemTypes, ExtractMenuType, MenuBaseClass, MenuType } from './menuBaseClass';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
+import type { FilterService } from '../services/filter.service';
+import type { SharedService } from '../services/shared.service';
+import type { SortService } from '../services/sort.service';
+import { type ExtendableItemTypes, type ExtractMenuType, MenuBaseClass, type MenuType } from './menuBaseClass';
 
 /**
  * A plugin to add drop-down menus to column headers.
@@ -460,7 +460,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
       this._menuElm as HTMLDivElement,
       menu.items,
       args,
-      this.handleMenuItemCommandClick ,
+      this.handleMenuItemCommandClick,
     );
 
     this.repositionMenu(e);

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
-import {
+import type { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
+import type {
   Column,
   DragRowMove,
   FormatterResultObject,

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -1,5 +1,5 @@
 import { KeyCode } from '../enums/index';
-import {
+import type {
   CellRange,
   GridOption,
   OnActiveCellChangedEventArgs,

--- a/packages/common/src/filter-conditions/booleanFilterCondition.ts
+++ b/packages/common/src/filter-conditions/booleanFilterCondition.ts
@@ -1,7 +1,7 @@
 import { parseBoolean } from '@slickgrid-universal/utils';
 
-import { SearchTerm } from '../enums/index';
-import { FilterCondition, FilterConditionOption } from './../interfaces/index';
+import type { SearchTerm } from '../enums/index';
+import type { FilterCondition, FilterConditionOption } from './../interfaces/index';
 
 /** Execute filter condition check on each cell */
 export const executeBooleanFilterCondition: FilterCondition = ((options: FilterConditionOption, parsedSearchValue: boolean | undefined) => {

--- a/packages/common/src/filter-conditions/collectionSearchFilterCondition.ts
+++ b/packages/common/src/filter-conditions/collectionSearchFilterCondition.ts
@@ -1,4 +1,4 @@
-import { FilterCondition, FilterConditionOption } from '../interfaces/index';
+import type { FilterCondition, FilterConditionOption } from '../interfaces/index';
 import { testFilterCondition } from './filterUtilities';
 
 /**

--- a/packages/common/src/filter-conditions/dateFilterCondition.ts
+++ b/packages/common/src/filter-conditions/dateFilterCondition.ts
@@ -1,8 +1,8 @@
 import * as moment_ from 'moment-mini';
 const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
-import { FieldType, OperatorType, SearchTerm } from '../enums/index';
-import { FilterConditionOption } from '../interfaces/index';
+import { FieldType, OperatorType, type SearchTerm } from '../enums/index';
+import type { FilterConditionOption } from '../interfaces/index';
 import { mapMomentDateFormatWithFieldType } from '../services/utilities';
 import { testFilterCondition } from './filterUtilities';
 

--- a/packages/common/src/filter-conditions/filterConditionProcesses.ts
+++ b/packages/common/src/filter-conditions/filterConditionProcesses.ts
@@ -1,5 +1,5 @@
-import { FieldType, SearchTerm } from '../enums/index';
-import { FilterCondition, FilterConditionOption } from '../interfaces/index';
+import { FieldType, type SearchTerm } from '../enums/index';
+import type { FilterCondition, FilterConditionOption } from '../interfaces/index';
 import { executeBooleanFilterCondition, getFilterParsedBoolean } from './booleanFilterCondition';
 import { executeCollectionSearchFilterCondition } from './collectionSearchFilterCondition';
 import { getFilterParsedNumbers, executeNumberFilterCondition } from './numberFilterCondition';

--- a/packages/common/src/filter-conditions/filterUtilities.ts
+++ b/packages/common/src/filter-conditions/filterUtilities.ts
@@ -1,4 +1,4 @@
-import { OperatorString } from '../enums/index';
+import type { OperatorString } from '../enums/index';
 
 /**
  * Compare 2 objects,

--- a/packages/common/src/filter-conditions/numberFilterCondition.ts
+++ b/packages/common/src/filter-conditions/numberFilterCondition.ts
@@ -1,7 +1,7 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { OperatorType, SearchTerm } from '../enums/index';
-import { FilterCondition, FilterConditionOption } from '../interfaces/index';
+import { OperatorType, type SearchTerm } from '../enums/index';
+import type { FilterCondition, FilterConditionOption } from '../interfaces/index';
 import { testFilterCondition } from './filterUtilities';
 
 /** Execute filter condition check on each cell */

--- a/packages/common/src/filter-conditions/objectFilterCondition.ts
+++ b/packages/common/src/filter-conditions/objectFilterCondition.ts
@@ -1,5 +1,5 @@
-import { SearchTerm } from '../enums/searchTerm.type';
-import { FilterCondition, FilterConditionOption } from '../interfaces/index';
+import type { SearchTerm } from '../enums/searchTerm.type';
+import type { FilterCondition, FilterConditionOption } from '../interfaces/index';
 import { compareObjects } from './filterUtilities';
 
 /** Execute filter condition check on each cell */

--- a/packages/common/src/filter-conditions/stringFilterCondition.ts
+++ b/packages/common/src/filter-conditions/stringFilterCondition.ts
@@ -1,7 +1,7 @@
 import { removeAccentFromText } from '@slickgrid-universal/utils';
 
-import { OperatorString, OperatorType, SearchTerm } from '../enums/index';
-import { FilterCondition, FilterConditionOption } from '../interfaces/index';
+import { type OperatorString, OperatorType, type SearchTerm } from '../enums/index';
+import type { FilterCondition, FilterConditionOption } from '../interfaces/index';
 import { testFilterCondition } from './filterUtilities';
 
 /** Execute filter condition check on each cell */

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -1,16 +1,16 @@
 import * as autocompleter_ from 'autocompleter';
 const autocomplete = (autocompleter_ && autocompleter_['default'] || autocompleter_) as <T extends AutocompleteItem>(settings: AutocompleteSettings<T>) => AutocompleteResult; // patch for rollup
 
-import { AutocompleteItem, AutocompleteResult, AutocompleteSettings } from 'autocompleter';
+import type { AutocompleteItem, AutocompleteResult, AutocompleteSettings } from 'autocompleter';
 import { isPrimmitive, toKebabCase, toSentenceCase } from '@slickgrid-universal/utils';
 
 import {
   FieldType,
   OperatorType,
-  OperatorString,
-  SearchTerm,
+  type OperatorString,
+  type SearchTerm,
 } from '../enums/index';
-import {
+import type {
   AutocompleterOption,
   AutocompleteSearchItem,
   CollectionCustomStructure,
@@ -29,13 +29,13 @@ import {
 import { addAutocompleteLoadingByOverridingFetch } from '../commonEditorFilter';
 import { createDomElement, emptyElement, } from '../services';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { CollectionService } from '../services/collection.service';
+import type { CollectionService } from '../services/collection.service';
 import { collectionObserver, propertyObserver } from '../services/observers';
 import { sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
 import { getDescendantProperty, unsubscribeAll } from '../services/utilities';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 import { renderCollectionOptionsAsync } from './filterUtilities';
-import { RxJsFacade, Subscription } from '../services/rxjsFacade';
+import type { RxJsFacade, Subscription } from '../services/rxjsFacade';
 import { Constants } from '../constants';
 
 export class AutocompleterFilter<T extends AutocompleteItem = any> implements Filter {

--- a/packages/common/src/filters/compoundDateFilter.ts
+++ b/packages/common/src/filters/compoundDateFilter.ts
@@ -1,4 +1,4 @@
-import { TranslaterService } from '../services';
+import type { TranslaterService } from '../services';
 import { DateFilter } from './dateFilter';
 
 export class CompoundDateFilter extends DateFilter {

--- a/packages/common/src/filters/compoundInputFilter.ts
+++ b/packages/common/src/filters/compoundInputFilter.ts
@@ -1,5 +1,5 @@
 import { InputFilter } from './inputFilter';
-import { TranslaterService } from '../services';
+import type { TranslaterService } from '../services';
 
 export class CompoundInputFilter extends InputFilter {
   /**

--- a/packages/common/src/filters/compoundInputNumberFilter.ts
+++ b/packages/common/src/filters/compoundInputNumberFilter.ts
@@ -1,5 +1,5 @@
 import { InputFilter } from './inputFilter';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 
 export class CompoundInputNumberFilter extends InputFilter {
   /** Initialize the Filter */

--- a/packages/common/src/filters/compoundInputPasswordFilter.ts
+++ b/packages/common/src/filters/compoundInputPasswordFilter.ts
@@ -1,5 +1,5 @@
 import { InputFilter } from './inputFilter';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 
 export class CompoundInputPasswordFilter extends InputFilter {
   /** Initialize the Filter */

--- a/packages/common/src/filters/compoundSliderFilter.ts
+++ b/packages/common/src/filters/compoundSliderFilter.ts
@@ -1,5 +1,5 @@
-import { TranslaterService } from '../services';
 import { SliderFilter } from './sliderFilter';
+import type { TranslaterService } from '../services';
 
 export class CompoundSliderFilter extends SliderFilter {
   /**

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -1,17 +1,17 @@
 import * as flatpickr_ from 'flatpickr';
 import * as moment_ from 'moment-mini';
-import { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
-import { Instance as FlatpickrInstance, FlatpickrFn } from 'flatpickr/dist/types/instance';
+import type { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
+import type { Instance as FlatpickrInstance, FlatpickrFn } from 'flatpickr/dist/types/instance';
 const flatpickr: FlatpickrFn = (flatpickr_?.['default'] ?? flatpickr_) as any; // patch for rollup
 const moment = (moment_ as any)?.['default'] ?? moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import {
   FieldType,
-  OperatorString,
   OperatorType,
-  SearchTerm,
+  type OperatorString,
+  type SearchTerm,
 } from '../enums/index';
-import {
+import type {
   Column,
   ColumnFilter,
   Filter,
@@ -26,7 +26,7 @@ import { buildSelectOperator, compoundOperatorNumeric } from './filterUtilities'
 import { createDomElement, destroyObjectDomElementProps, emptyElement, } from '../services/domUtilities';
 import { mapFlatpickrDateFormatWithFieldType, mapMomentDateFormatWithFieldType, mapOperatorToShorthandDesignation } from '../services/utilities';
 import { BindingEventService } from '../services/bindingEvent.service';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 
 export class DateFilter implements Filter {
   protected _bindEventService: BindingEventService;

--- a/packages/common/src/filters/dateRangeFilter.ts
+++ b/packages/common/src/filters/dateRangeFilter.ts
@@ -1,5 +1,5 @@
-import { TranslaterService } from '../services';
 import { DateFilter } from './dateFilter';
+import type { TranslaterService } from '../services';
 
 export class DateRangeFilter extends DateFilter {
   /** Initialize the Filter */

--- a/packages/common/src/filters/filterFactory.ts
+++ b/packages/common/src/filters/filterFactory.ts
@@ -1,8 +1,8 @@
-import { ColumnFilter, Filter } from '../interfaces/index';
-import { SlickgridConfig } from '../slickgrid-config';
-import { CollectionService } from '../services/collection.service';
-import { TranslaterService } from '../services/translater.service';
-import { RxJsFacade } from '../services/rxjsFacade';
+import type { ColumnFilter, Filter } from '../interfaces/index';
+import type { SlickgridConfig } from '../slickgrid-config';
+import type { CollectionService } from '../services/collection.service';
+import type { TranslaterService } from '../services/translater.service';
+import type { RxJsFacade } from '../services/rxjsFacade';
 
 export class FilterFactory {
   /** The options from the SlickgridConfig */

--- a/packages/common/src/filters/filterUtilities.ts
+++ b/packages/common/src/filters/filterUtilities.ts
@@ -1,10 +1,10 @@
 import { Constants } from '../constants';
-import { OperatorString } from '../enums/index';
-import { Column, ColumnFilter, GridOption, Locale } from '../interfaces/index';
-import { Observable, RxJsFacade, Subject, Subscription } from '../services/rxjsFacade';
+import type { OperatorString } from '../enums/index';
+import type { Column, ColumnFilter, GridOption, Locale } from '../interfaces/index';
+import type { Observable, RxJsFacade, Subject, Subscription } from '../services/rxjsFacade';
 import { createDomElement, htmlEncodedStringWithPadding, sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
 import { castObservableToPromise, getDescendantProperty, getTranslationPrefix, } from '../services/utilities';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 
 /**
  * Create and return a select dropdown HTML element with a list of Operators with descriptions

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -1,6 +1,6 @@
 import { toSentenceCase } from '@slickgrid-universal/utils';
 
-import {
+import type {
   Column,
   ColumnFilter,
   Filter,
@@ -10,10 +10,10 @@ import {
   OperatorDetail,
   SlickGrid,
 } from '../interfaces/index';
-import { FieldType, OperatorType, OperatorString, SearchTerm } from '../enums/index';
+import { FieldType, OperatorType, type OperatorString, type SearchTerm } from '../enums/index';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { buildSelectOperator, compoundOperatorNumeric, compoundOperatorString } from './filterUtilities';
-import { createDomElement, emptyElement, mapOperatorToShorthandDesignation, TranslaterService, } from '../services';
+import { createDomElement, emptyElement, mapOperatorToShorthandDesignation, type TranslaterService, } from '../services';
 
 export class InputFilter implements Filter {
   protected _bindEventService: BindingEventService;

--- a/packages/common/src/filters/inputMaskFilter.ts
+++ b/packages/common/src/filters/inputMaskFilter.ts
@@ -1,6 +1,6 @@
 import { InputFilter } from './inputFilter';
-import { FilterArguments } from '../interfaces/filterArguments.interface';
-import { TranslaterService } from '../services/translater.service';
+import type { FilterArguments } from '../interfaces/filterArguments.interface';
+import type { TranslaterService } from '../services/translater.service';
 
 export class InputMaskFilter extends InputFilter {
   protected _inputMask = '';

--- a/packages/common/src/filters/inputNumberFilter.ts
+++ b/packages/common/src/filters/inputNumberFilter.ts
@@ -1,5 +1,5 @@
-import { TranslaterService } from '../services/translater.service';
 import { InputFilter } from './inputFilter';
+import type { TranslaterService } from '../services/translater.service';
 
 export class InputNumberFilter extends InputFilter {
   /** Initialize the Filter */

--- a/packages/common/src/filters/inputPasswordFilter.ts
+++ b/packages/common/src/filters/inputPasswordFilter.ts
@@ -1,5 +1,5 @@
-import { TranslaterService } from '../services/translater.service';
 import { InputFilter } from './inputFilter';
+import type { TranslaterService } from '../services/translater.service';
 
 export class InputPasswordFilter extends InputFilter {
   /** Initialize the Filter */

--- a/packages/common/src/filters/multipleSelectFilter.ts
+++ b/packages/common/src/filters/multipleSelectFilter.ts
@@ -1,7 +1,7 @@
 import { SelectFilter } from './selectFilter';
-import { CollectionService } from './../services/collection.service';
-import { TranslaterService } from '../services/translater.service';
-import { RxJsFacade } from '../services/rxjsFacade';
+import type { CollectionService } from './../services/collection.service';
+import type { TranslaterService } from '../services/translater.service';
+import type { RxJsFacade } from '../services/rxjsFacade';
 
 export class MultipleSelectFilter extends SelectFilter {
   /**

--- a/packages/common/src/filters/nativeSelectFilter.ts
+++ b/packages/common/src/filters/nativeSelectFilter.ts
@@ -1,6 +1,6 @@
 import { toSentenceCase } from '@slickgrid-universal/utils';
 
-import {
+import type {
   Column,
   ColumnFilter,
   Filter,
@@ -9,9 +9,9 @@ import {
   GridOption,
   SlickGrid,
 } from '../interfaces/index';
-import { OperatorType, OperatorString, SearchTerm } from '../enums/index';
+import { OperatorType, type OperatorString, type SearchTerm } from '../enums/index';
 import { createDomElement, emptyElement, } from '../services/domUtilities';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 import { BindingEventService } from '../services/bindingEvent.service';
 
 export class NativeSelectFilter implements Filter {

--- a/packages/common/src/filters/selectFilter.ts
+++ b/packages/common/src/filters/selectFilter.ts
@@ -1,6 +1,6 @@
 import { Constants } from '../constants';
-import { OperatorString, OperatorType, SearchTerm, } from '../enums/index';
-import {
+import { type OperatorString, OperatorType, type SearchTerm, } from '../enums/index';
+import type {
   CollectionCustomStructure,
   CollectionOption,
   Column,
@@ -13,10 +13,10 @@ import {
   MultipleSelectOption,
   SlickGrid,
 } from './../interfaces/index';
-import { CollectionService } from '../services/collection.service';
+import type { CollectionService } from '../services/collection.service';
 import { collectionObserver, propertyObserver } from '../services/observers';
 import { getDescendantProperty, getTranslationPrefix, unsubscribeAll } from '../services/utilities';
-import { buildSelectEditorOrFilterDomElement, RxJsFacade, Subscription, TranslaterService } from '../services/index';
+import { buildSelectEditorOrFilterDomElement, type RxJsFacade, type Subscription, type TranslaterService } from '../services/index';
 import { renderCollectionOptionsAsync } from './filterUtilities';
 
 export class SelectFilter implements Filter {

--- a/packages/common/src/filters/singleSelectFilter.ts
+++ b/packages/common/src/filters/singleSelectFilter.ts
@@ -1,7 +1,7 @@
 import { SelectFilter } from './selectFilter';
-import { CollectionService } from './../services/collection.service';
-import { TranslaterService } from '../services/translater.service';
-import { RxJsFacade } from '../services/rxjsFacade';
+import type { CollectionService } from './../services/collection.service';
+import type { TranslaterService } from '../services/translater.service';
+import type { RxJsFacade } from '../services/rxjsFacade';
 
 export class SingleSelectFilter extends SelectFilter {
   /**

--- a/packages/common/src/filters/singleSliderFilter.ts
+++ b/packages/common/src/filters/singleSliderFilter.ts
@@ -1,5 +1,5 @@
-import { TranslaterService } from '../services';
 import { SliderFilter } from './sliderFilter';
+import  type { TranslaterService } from '../services';
 
 export class SingleSliderFilter extends SliderFilter {
   /**

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -1,8 +1,8 @@
 import { hasData, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { Constants } from '../constants';
-import { OperatorString, OperatorType, SearchTerm, } from '../enums/index';
-import {
+import { type OperatorString, OperatorType, type SearchTerm, } from '../enums/index';
+import type {
   Column,
   ColumnFilter,
   CurrentSliderOption,
@@ -19,7 +19,7 @@ import {
 } from '../interfaces/index';
 import { BindingEventService } from '../services/bindingEvent.service';
 import { createDomElement, emptyElement } from '../services/domUtilities';
-import { TranslaterService } from '../services/translater.service';
+import type { TranslaterService } from '../services/translater.service';
 import { mapOperatorToShorthandDesignation } from '../services/utilities';
 import { buildSelectOperator, compoundOperatorNumeric, getFilterOptionByName } from './filterUtilities';
 

--- a/packages/common/src/filters/sliderRangeFilter.ts
+++ b/packages/common/src/filters/sliderRangeFilter.ts
@@ -1,5 +1,5 @@
-import { TranslaterService } from '../services';
 import { SliderFilter } from './sliderFilter';
+import type { TranslaterService } from '../services';
 
 export class SliderRangeFilter extends SliderFilter {
   /**

--- a/packages/common/src/formatters/alignRightFormatter.ts
+++ b/packages/common/src/formatters/alignRightFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /** Align cell value to the right */
 export const alignRightFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/arrayObjectToCsvFormatter.ts
+++ b/packages/common/src/formatters/arrayObjectToCsvFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /**
  * Takes an array of complex objects converts it to a comma delimited string.

--- a/packages/common/src/formatters/arrayToCsvFormatter.ts
+++ b/packages/common/src/formatters/arrayToCsvFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /** Takes an array of string and converts it to a comma delimited string */
 export const arrayToCsvFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/boldFormatter.ts
+++ b/packages/common/src/formatters/boldFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /** show value in bold font weight */
 export const boldFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/centerFormatter.ts
+++ b/packages/common/src/formatters/centerFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /** Align cell value to the center (alias to Formatters.center) */
 export const centerFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/checkboxFormatter.ts
+++ b/packages/common/src/formatters/checkboxFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /** When value is filled (true), it will display a checkbox Unicode icon */
 export const checkboxFormatter: Formatter = (_row, _cell, value) =>

--- a/packages/common/src/formatters/checkmarkFormatter.ts
+++ b/packages/common/src/formatters/checkmarkFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /**
  * When value is filled, or if the value is a number and is bigger than 0, it will display a Font-Awesome icon (fa-check).

--- a/packages/common/src/formatters/checkmarkMaterialFormatter.ts
+++ b/packages/common/src/formatters/checkmarkMaterialFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /**
  * When value is filled, or if the value is a number and is bigger than 0, it will display a Material Design check icon (mdi-check).

--- a/packages/common/src/formatters/collectionEditorFormatter.ts
+++ b/packages/common/src/formatters/collectionEditorFormatter.ts
@@ -1,5 +1,5 @@
 import { arrayToCsvFormatter } from './arrayToCsvFormatter';
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 import { findOrDefault } from '../services/index';
 
 /**

--- a/packages/common/src/formatters/collectionFormatter.ts
+++ b/packages/common/src/formatters/collectionFormatter.ts
@@ -1,5 +1,5 @@
 import { arrayToCsvFormatter } from './arrayToCsvFormatter';
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 import { findOrDefault } from '../services/index';
 
 /**

--- a/packages/common/src/formatters/complexObjectFormatter.ts
+++ b/packages/common/src/formatters/complexObjectFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 
 /**
  * Takes a complex data object and return the data under that property (for example: "user.firstName" will return the first name "John")

--- a/packages/common/src/formatters/currencyFormatter.ts
+++ b/packages/common/src/formatters/currencyFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from '../interfaces/index';
+import type { Formatter } from '../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/decimalFormatter.ts
+++ b/packages/common/src/formatters/decimalFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import type { Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/deleteIconFormatter.ts
+++ b/packages/common/src/formatters/deleteIconFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Displays a Font-Awesome delete icon (fa-trash) */
 export const deleteIconFormatter: Formatter = () =>

--- a/packages/common/src/formatters/dollarColoredBoldFormatter.ts
+++ b/packages/common/src/formatters/dollarColoredBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/dollarColoredFormatter.ts
+++ b/packages/common/src/formatters/dollarColoredFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/dollarFormatter.ts
+++ b/packages/common/src/formatters/dollarFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/editIconFormatter.ts
+++ b/packages/common/src/formatters/editIconFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Displays a Font-Awesome edit icon (fa-pencil) */
 export const editIconFormatter: Formatter = () =>

--- a/packages/common/src/formatters/fakeHyperlinkFormatter.ts
+++ b/packages/common/src/formatters/fakeHyperlinkFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes any text value and display it as a fake a hyperlink (only styled as an hyperlink), this can be used in combo with "onCellClick" event */
 export const fakeHyperlinkFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -1,5 +1,5 @@
 import { FieldType } from '../enums/fieldType.enum';
-import { Column, ExcelExportOption, Formatter, GridOption, SlickGrid, TextExportOption } from '../interfaces/index';
+import type { Column, ExcelExportOption, Formatter, GridOption, SlickGrid, TextExportOption } from '../interfaces/index';
 import { sanitizeHtmlToText } from '../services/domUtilities';
 import { mapMomentDateFormatWithFieldType } from '../services/utilities';
 import { multipleFormatter } from './multipleFormatter';

--- a/packages/common/src/formatters/hyperlinkFormatter.ts
+++ b/packages/common/src/formatters/hyperlinkFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
 
 /**

--- a/packages/common/src/formatters/iconFormatter.ts
+++ b/packages/common/src/formatters/iconFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type  Formatter } from './../interfaces/index';
 
 /** Display whichever icon you want (library agnostic, it could be Font-Awesome or any other) */
 export const iconFormatter: Formatter = (_row, _cell, _value, columnDef) => {

--- a/packages/common/src/formatters/infoIconFormatter.ts
+++ b/packages/common/src/formatters/infoIconFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import {  type Formatter } from './../interfaces/index';
 
 /** Displays a Font-Awesome edit icon (fa-info-circle) */
 export const infoIconFormatter: Formatter = () =>

--- a/packages/common/src/formatters/italicFormatter.ts
+++ b/packages/common/src/formatters/italicFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** show input text value as italic text */
 export const italicFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/lowercaseFormatter.ts
+++ b/packages/common/src/formatters/lowercaseFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a value and displays it all lowercase */
 export const lowercaseFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/maskFormatter.ts
+++ b/packages/common/src/formatters/maskFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /**
  * Takes a value display it according to a mask provided

--- a/packages/common/src/formatters/multipleFormatter.ts
+++ b/packages/common/src/formatters/multipleFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /**
  * You can pipe multiple formatters (executed in sequence), use params to pass the list of formatters.

--- a/packages/common/src/formatters/percentCompleteBarFormatter.ts
+++ b/packages/common/src/formatters/percentCompleteBarFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a cell value number (between 0-100) and displays a SlickGrid custom "percent-complete-bar" a red (<30), silver (>30 & <70) or green (>=70) bar */
 export const percentCompleteBarFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/percentCompleteBarWithTextFormatter.ts
+++ b/packages/common/src/formatters/percentCompleteBarWithTextFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a cell value number (between 0-100) and displays SlickGrid custom "percent-complete-bar" with Text a red (<30), silver (>30 & <70) or green (>=70) bar */
 export const percentCompleteBarWithTextFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/percentCompleteFormatter.ts
+++ b/packages/common/src/formatters/percentCompleteFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/percentFormatter.ts
+++ b/packages/common/src/formatters/percentFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/percentSymbolFormatter.ts
+++ b/packages/common/src/formatters/percentSymbolFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from './formatterUtilities';
 

--- a/packages/common/src/formatters/progressBarFormatter.ts
+++ b/packages/common/src/formatters/progressBarFormatter.ts
@@ -1,6 +1,6 @@
 import { isNumber } from '@slickgrid-universal/utils';
 
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a cell value number (between 0-100) and displays Bootstrap "progress-bar" a red (<30), silver (>30 & <70) or green (>=70) bar */
 export const progressBarFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/translateBooleanFormatter.ts
+++ b/packages/common/src/formatters/translateBooleanFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a boolean value, cast it to upperCase string and finally translates it (i18n). */
 export const translateBooleanFormatter: Formatter = (_row, _cell, value, columnDef, _dataContext, grid) => {

--- a/packages/common/src/formatters/translateFormatter.ts
+++ b/packages/common/src/formatters/translateFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a cell value and translates it (translater). Requires an instance of the Translate Service:: `translater: this.translate */
 export const translateFormatter: Formatter = (_row, _cell, value, columnDef, _dataContext, grid) => {

--- a/packages/common/src/formatters/treeExportFormatter.ts
+++ b/packages/common/src/formatters/treeExportFormatter.ts
@@ -1,7 +1,7 @@
 import { addWhiteSpaces } from '@slickgrid-universal/utils';
 
 import { Constants } from '../constants';
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { sanitizeHtmlToText, } from '../services/domUtilities';
 import { getCellValueFromQueryFieldGetter, } from '../services/utilities';
 import { parseFormatterWhenExist } from './formatterUtilities';

--- a/packages/common/src/formatters/treeFormatter.ts
+++ b/packages/common/src/formatters/treeFormatter.ts
@@ -1,5 +1,5 @@
 import { Constants } from '../constants';
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 import { parseFormatterWhenExist } from './formatterUtilities';
 import { sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
 import { getCellValueFromQueryFieldGetter, } from '../services/utilities';

--- a/packages/common/src/formatters/uppercaseFormatter.ts
+++ b/packages/common/src/formatters/uppercaseFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a value and displays it all uppercase */
 export const uppercaseFormatter: Formatter = (_row, _cell, value) => {

--- a/packages/common/src/formatters/yesNoFormatter.ts
+++ b/packages/common/src/formatters/yesNoFormatter.ts
@@ -1,4 +1,4 @@
-import { Formatter } from './../interfaces/index';
+import { type Formatter } from './../interfaces/index';
 
 /** Takes a boolean value and display a string 'Yes' or 'No' */
 export const yesNoFormatter: Formatter = (_row, _cell, value) =>

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -1,7 +1,7 @@
 import { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
 
 import { DelimiterType, FileType, GridAutosizeColsMode, OperatorType } from './enums/index';
-import { Column, EmptyWarning, GridOption, TreeDataOption } from './interfaces/index';
+import type { Column, EmptyWarning, GridOption, TreeDataOption } from './interfaces/index';
 import { Filters } from './filters';
 
 /** Global Grid Options Defaults */

--- a/packages/common/src/grouping-formatters/avgTotalsCurrencyFormatter.ts
+++ b/packages/common/src/grouping-formatters/avgTotalsCurrencyFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from '../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from '../interfaces/index';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 import { formatNumber } from '../services/utilities';
 

--- a/packages/common/src/grouping-formatters/avgTotalsDollarFormatter.ts
+++ b/packages/common/src/grouping-formatters/avgTotalsDollarFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 import { formatNumber } from './../services/utilities';
 

--- a/packages/common/src/grouping-formatters/avgTotalsFormatter.ts
+++ b/packages/common/src/grouping-formatters/avgTotalsFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { decimalFormatted, thousandSeparatorFormatted } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/avgTotalsPercentageFormatter.ts
+++ b/packages/common/src/grouping-formatters/avgTotalsPercentageFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { decimalFormatted, thousandSeparatorFormatted } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/maxTotalsFormatter.ts
+++ b/packages/common/src/grouping-formatters/maxTotalsFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/minTotalsFormatter.ts
+++ b/packages/common/src/grouping-formatters/minTotalsFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsBoldFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsBoldFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsColoredFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsColoredFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsCurrencyColoredFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsCurrencyColoredFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from '../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from '../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsCurrencyFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsCurrencyFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from '../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from '../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsDollarBoldFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsDollarBoldFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsDollarColoredBoldFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsDollarColoredBoldFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsDollarColoredFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsDollarColoredFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsDollarFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsDollarFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from './../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/grouping-formatters/sumTotalsFormatter.ts
+++ b/packages/common/src/grouping-formatters/sumTotalsFormatter.ts
@@ -1,4 +1,4 @@
-import { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
+import type { Column, GroupTotalsFormatter, SlickGrid } from './../interfaces/index';
 import { formatNumber } from '../services/utilities';
 import { retrieveFormatterOptions } from '../formatters/formatterUtilities';
 

--- a/packages/common/src/interfaces/autoResizeOption.interface.ts
+++ b/packages/common/src/interfaces/autoResizeOption.interface.ts
@@ -1,4 +1,4 @@
-import { ResizerOption } from './resizerOption.interface';
+import type { ResizerOption } from './resizerOption.interface';
 
 export interface AutoResizeOption extends ResizerOption {
   /** defaults to 10ms, delay before triggering the auto-resize (only on 1st page load) */

--- a/packages/common/src/interfaces/autocompleterOption.interface.ts
+++ b/packages/common/src/interfaces/autocompleterOption.interface.ts
@@ -1,5 +1,5 @@
-import { AutocompleteItem, AutocompleteSettings } from 'autocompleter';
-import { Column } from './column.interface';
+import type { AutocompleteItem, AutocompleteSettings } from 'autocompleter';
+import type { Column } from './column.interface';
 
 export interface AutoCompleterRenderItemDefinition {
   /** which custom Layout to use? We created 2 custom styled layouts "twoRows" and "fourCorners", both layouts also support an optional icon on the left. */

--- a/packages/common/src/interfaces/backendService.interface.ts
+++ b/packages/common/src/interfaces/backendService.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BackendServiceOption,
   ColumnFilters,
   CurrentFilter,

--- a/packages/common/src/interfaces/backendServiceApi.interface.ts
+++ b/packages/common/src/interfaces/backendServiceApi.interface.ts
@@ -1,5 +1,5 @@
-import { Observable } from '../services/rxjsFacade';
-import { BackendService } from './backendService.interface';
+import type { Observable } from '../services/rxjsFacade';
+import type { BackendService } from './backendService.interface';
 
 export interface BackendServiceApi {
   /** How long to wait until we start querying backend to avoid sending too many requests to backend server. Default to 500ms */

--- a/packages/common/src/interfaces/cellArgs.interface.ts
+++ b/packages/common/src/interfaces/cellArgs.interface.ts
@@ -1,4 +1,4 @@
-import { SlickGrid } from './slickGrid.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface CellArgs {
   row: number;

--- a/packages/common/src/interfaces/cellMenu.interface.ts
+++ b/packages/common/src/interfaces/cellMenu.interface.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   CellMenuOption,
   MenuCommandItemCallbackArgs,
   MenuFromCellCallbackArgs,
   MenuOptionItemCallbackArgs,
 } from './index';
-import { SlickCellMenu } from '../extensions/slickCellMenu';
+import type { SlickCellMenu } from '../extensions/slickCellMenu';
 
 export interface CellMenu extends CellMenuOption {
 

--- a/packages/common/src/interfaces/cellMenuOption.interface.ts
+++ b/packages/common/src/interfaces/cellMenuOption.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   MenuCallbackArgs,
   MenuCommandItem,
   MenuOptionItem,

--- a/packages/common/src/interfaces/cellRange.interface.ts
+++ b/packages/common/src/interfaces/cellRange.interface.ts
@@ -1,4 +1,4 @@
-import { SlickCellRangeDecorator } from '../extensions/slickCellRangeDecorator';
+import type { SlickCellRangeDecorator } from '../extensions/slickCellRangeDecorator';
 
 export interface CellRange {
   /** Selection start from which cell? */

--- a/packages/common/src/interfaces/checkboxSelectorOption.interface.ts
+++ b/packages/common/src/interfaces/checkboxSelectorOption.interface.ts
@@ -1,4 +1,4 @@
-import { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
+import type { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
 
 export interface CheckboxSelectorOption {
   /**

--- a/packages/common/src/interfaces/collectionFilterBy.interface.ts
+++ b/packages/common/src/interfaces/collectionFilterBy.interface.ts
@@ -1,4 +1,4 @@
-import { OperatorType } from '../enums/operatorType.enum';
+import type { OperatorType } from '../enums/operatorType.enum';
 
 export interface CollectionFilterBy {
   /** Object Property name when the collection is an array of objects */

--- a/packages/common/src/interfaces/collectionOption.interface.ts
+++ b/packages/common/src/interfaces/collectionOption.interface.ts
@@ -1,5 +1,5 @@
-import { FilterMultiplePassType } from '../enums/filterMultiplePassType.enum';
-import { FilterMultiplePassTypeString } from '../enums/filterMultiplePassTypeString.type';
+import type { FilterMultiplePassType } from '../enums/filterMultiplePassType.enum';
+import type { FilterMultiplePassTypeString } from '../enums/filterMultiplePassTypeString.type';
 
 export interface CollectionOption {
   /**

--- a/packages/common/src/interfaces/collectionOverrideArgs.interface.ts
+++ b/packages/common/src/interfaces/collectionOverrideArgs.interface.ts
@@ -1,5 +1,5 @@
-import { CompositeEditorOption } from './compositeEditorOption.interface';
-import { Column, SlickGrid } from './index';
+import type { CompositeEditorOption } from './compositeEditorOption.interface';
+import type { Column, SlickGrid } from './index';
 
 export interface CollectionOverrideArgs {
   /** Column Definition */

--- a/packages/common/src/interfaces/collectionSortBy.interface.ts
+++ b/packages/common/src/interfaces/collectionSortBy.interface.ts
@@ -1,4 +1,4 @@
-import { FieldType } from '../enums/index';
+import type { FieldType } from '../enums/index';
 
 export interface CollectionSortBy {
   /** Object Property name when the collection is an array of objects */

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/indent */
-import {
+import type {
   CellMenu,
   ColumnEditor,
   ColumnExcelExportOption,
@@ -15,7 +15,7 @@ import {
   SlickEventData,
   SortComparer,
 } from './index';
-import { FieldType } from '../enums/fieldType.enum';
+import type { FieldType } from '../enums/fieldType.enum';
 
 type PathsToStringProps<T> = T extends string | number | boolean | Date ? [] : {
   [K in Extract<keyof T, string>]: [K, ...PathsToStringProps<T[K]>]

--- a/packages/common/src/interfaces/columnEditor.interface.ts
+++ b/packages/common/src/interfaces/columnEditor.interface.ts
@@ -1,6 +1,6 @@
-import { FieldType } from '../enums/index';
-import { Observable } from '../services/rxjsFacade';
-import {
+import type { FieldType } from '../enums/index';
+import type { Observable } from '../services/rxjsFacade';
+import type {
   CollectionCustomStructure,
   CollectionFilterBy,
   CollectionOption,

--- a/packages/common/src/interfaces/columnEditorDualInput.interface.ts
+++ b/packages/common/src/interfaces/columnEditorDualInput.interface.ts
@@ -1,4 +1,4 @@
-import { ColumnEditor } from './columnEditor.interface';
+import type { ColumnEditor } from './columnEditor.interface';
 
 export interface EditorDualInput extends Partial<ColumnEditor> {
   /** Associated Item Field */

--- a/packages/common/src/interfaces/columnExcelExportOption.interface.ts
+++ b/packages/common/src/interfaces/columnExcelExportOption.interface.ts
@@ -1,6 +1,6 @@
-import { Column } from './column.interface';
-import { ExcelCellFormat } from './excelCellFormat.interface';
-import { GridOption } from './gridOption.interface';
+import type { Column } from './column.interface';
+import type { ExcelCellFormat } from './excelCellFormat.interface';
+import type { GridOption } from './gridOption.interface';
 
 /** Excel custom export options (formatting & width) that can be applied to a column */
 export interface ColumnExcelExportOption {

--- a/packages/common/src/interfaces/columnFilter.interface.ts
+++ b/packages/common/src/interfaces/columnFilter.interface.ts
@@ -1,5 +1,5 @@
-import { FieldType, OperatorString, OperatorType, SearchTerm, } from '../enums/index';
-import {
+import type { FieldType, OperatorString, OperatorType, SearchTerm, } from '../enums/index';
+import type {
   CollectionCustomStructure,
   CollectionFilterBy,
   CollectionOption,
@@ -8,7 +8,7 @@ import {
   Filter,
   OperatorDetail,
 } from './index';
-import { Observable, Subject } from '../services/rxjsFacade';
+import type { Observable, Subject } from '../services/rxjsFacade';
 
 export interface ColumnFilter {
   /** Optionally provide an aria-label for assistive scren reader, defaults to "{inputName} Search Filter" */

--- a/packages/common/src/interfaces/columnFilters.interface.ts
+++ b/packages/common/src/interfaces/columnFilters.interface.ts
@@ -1,4 +1,4 @@
-import { SearchColumnFilter } from './searchColumnFilter.interface';
+import type { SearchColumnFilter } from './searchColumnFilter.interface';
 
 export interface ColumnFilters {
   [key: string]: SearchColumnFilter;

--- a/packages/common/src/interfaces/columnPicker.interface.ts
+++ b/packages/common/src/interfaces/columnPicker.interface.ts
@@ -1,5 +1,5 @@
-import { Column, GridOption, SlickGrid } from './index';
-import { SlickColumnPicker } from '../extensions/slickColumnPicker';
+import type { Column, GridOption, SlickGrid } from './index';
+import type { SlickColumnPicker } from '../extensions/slickColumnPicker';
 
 export interface ColumnPicker extends ColumnPickerOption {
 

--- a/packages/common/src/interfaces/columnSort.interface.ts
+++ b/packages/common/src/interfaces/columnSort.interface.ts
@@ -1,4 +1,4 @@
-import { Column } from './column.interface';
+import type { Column } from './column.interface';
 
 export interface ColumnSort {
   /** Column Id to be sorted */

--- a/packages/common/src/interfaces/compositeEditorError.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorError.interface.ts
@@ -1,4 +1,4 @@
-import { Editor } from './editor.interface';
+import type { Editor } from './editor.interface';
 
 export interface CompositeEditorError {
   /** Editor DOM element container */

--- a/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
@@ -1,6 +1,6 @@
-import { CompositeEditorModalType } from '../enums/compositeEditorModalType.type';
-import { CompositeEditorLabel } from './compositeEditorLabel.interface';
-import { GridServiceInsertOption } from './gridServiceInsertOption.interface';
+import type { CompositeEditorModalType } from '../enums/compositeEditorModalType.type';
+import type { CompositeEditorLabel } from './compositeEditorLabel.interface';
+import type { GridServiceInsertOption } from './gridServiceInsertOption.interface';
 
 export type OnErrorOption = {
   /** Error code (typically an uppercase error code key like: "NO_RECORD_FOUND") */

--- a/packages/common/src/interfaces/compositeEditorOption.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorOption.interface.ts
@@ -1,5 +1,5 @@
-import { Editor } from './editor.interface';
-import { CompositeEditorModalType } from '../enums/compositeEditorModalType.type';
+import type { Editor } from './editor.interface';
+import type { CompositeEditorModalType } from '../enums/compositeEditorModalType.type';
 
 export interface CompositeEditorOption {
   /** Defaults to "edit", what is the type of Composite Editor Modal is used? */

--- a/packages/common/src/interfaces/contextMenu.interface.ts
+++ b/packages/common/src/interfaces/contextMenu.interface.ts
@@ -1,5 +1,5 @@
-import { SlickContextMenu } from '../extensions/slickContextMenu';
-import {
+import type { SlickContextMenu } from '../extensions/slickContextMenu';
+import type {
   ContextMenuOption,
   MenuCommandItemCallbackArgs,
   MenuFromCellCallbackArgs,

--- a/packages/common/src/interfaces/contextMenuOption.interface.ts
+++ b/packages/common/src/interfaces/contextMenuOption.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   MenuCallbackArgs,
   MenuCommandItem,
   MenuOptionItem,

--- a/packages/common/src/interfaces/currentFilter.interface.ts
+++ b/packages/common/src/interfaces/currentFilter.interface.ts
@@ -1,5 +1,5 @@
-import { OperatorString, OperatorType } from '../enums/index';
-import { SearchTerm } from '../enums/searchTerm.type';
+import type { OperatorString, OperatorType } from '../enums/index';
+import type { SearchTerm } from '../enums/searchTerm.type';
 
 export interface CurrentFilter {
   /**

--- a/packages/common/src/interfaces/currentSorter.interface.ts
+++ b/packages/common/src/interfaces/currentSorter.interface.ts
@@ -1,4 +1,4 @@
-import { SortDirection, SortDirectionString } from '../enums/index';
+import type { SortDirection, SortDirectionString } from '../enums/index';
 
 export interface CurrentSorter {
   /**

--- a/packages/common/src/interfaces/customFooterOption.interface.ts
+++ b/packages/common/src/interfaces/customFooterOption.interface.ts
@@ -1,4 +1,4 @@
-import { MetricTexts } from './metricTexts.interface';
+import type { MetricTexts } from './metricTexts.interface';
 
 export interface CustomFooterOption {
   /** Optionally provide some text to be displayed on the left side of the footer (in the "left-footer" css class) */

--- a/packages/common/src/interfaces/customTooltipOption.interface.ts
+++ b/packages/common/src/interfaces/customTooltipOption.interface.ts
@@ -1,5 +1,5 @@
-import { Observable, Subject } from '../services/rxjsFacade';
-import { Column, Formatter, SlickGrid } from './index';
+import type { Observable, Subject } from '../services/rxjsFacade';
+import type { Column, Formatter, SlickGrid } from './index';
 
 type PostProcessOutput<P> = P & { [asyncParamsPropName: string]: any; };
 export type asyncProcess<T = any> = (row: number, cell: number, value: any, columnDef: Column<T>, dataContext: T, grid?: SlickGrid) => Promise<PostProcessOutput<T>> | Observable<PostProcessOutput<T>> | Subject<PostProcessOutput<T>>;

--- a/packages/common/src/interfaces/dataViewOption.interface.ts
+++ b/packages/common/src/interfaces/dataViewOption.interface.ts
@@ -1,4 +1,4 @@
-import { SlickGroupItemMetadataProvider } from '../extensions/slickGroupItemMetadataProvider';
+import type { SlickGroupItemMetadataProvider } from '../extensions/slickGroupItemMetadataProvider';
 
 export interface DataViewOption {
   /** Defaults to false, use with great care as this will break built-in filters */

--- a/packages/common/src/interfaces/drag.interface.ts
+++ b/packages/common/src/interfaces/drag.interface.ts
@@ -1,4 +1,4 @@
-import { SlickGrid } from './index';
+import type { SlickGrid } from './index';
 
 export interface DragPosition {
   startX: number;

--- a/packages/common/src/interfaces/draggableGrouping.interface.ts
+++ b/packages/common/src/interfaces/draggableGrouping.interface.ts
@@ -1,6 +1,6 @@
-import { Grouping, SlickEventData } from './index';
-import { DraggableGroupingOption } from './draggableGroupingOption.interface';
-import { SlickDraggableGrouping } from '../extensions/slickDraggableGrouping';
+import type { Grouping, SlickEventData } from './index';
+import type { DraggableGroupingOption } from './draggableGroupingOption.interface';
+import type { SlickDraggableGrouping } from '../extensions/slickDraggableGrouping';
 
 export interface DraggableGrouping extends DraggableGroupingOption {
   //

--- a/packages/common/src/interfaces/draggableGroupingOption.interface.ts
+++ b/packages/common/src/interfaces/draggableGroupingOption.interface.ts
@@ -1,5 +1,5 @@
-import { ColumnReorderFunction } from '../enums/columnReorderFunction.type';
-import { GroupingGetterFunction } from './grouping.interface';
+import type { ColumnReorderFunction } from '../enums/columnReorderFunction.type';
+import type { GroupingGetterFunction } from './grouping.interface';
 
 export interface DraggableGroupingOption {
   /** an extra CSS class to add to the delete button (default undefined), if deleteIconCssClass is undefined then slick-groupby-remove-icon class will be added */

--- a/packages/common/src/interfaces/editCommand.interface.ts
+++ b/packages/common/src/interfaces/editCommand.interface.ts
@@ -1,4 +1,4 @@
-import { Editor } from './editor.interface';
+import type { Editor } from './editor.interface';
 
 export interface EditCommand {
   /** The row of the cell being edited */

--- a/packages/common/src/interfaces/editUndoRedoBuffer.interface.ts
+++ b/packages/common/src/interfaces/editUndoRedoBuffer.interface.ts
@@ -1,4 +1,4 @@
-import { EditCommand } from './editCommand.interface';
+import type { EditCommand } from './editCommand.interface';
 
 export interface EditUndoRedoBuffer {
   /** Send the Edit Command to the Queue and Execute it after doing so */

--- a/packages/common/src/interfaces/editor.interface.ts
+++ b/packages/common/src/interfaces/editor.interface.ts
@@ -1,5 +1,5 @@
-import { EditorArguments } from './editorArguments.interface';
-import { EditorValidationResult } from './editorValidationResult.interface';
+import type { EditorArguments } from './editorArguments.interface';
+import type { EditorValidationResult } from './editorValidationResult.interface';
 
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo

--- a/packages/common/src/interfaces/editorArguments.interface.ts
+++ b/packages/common/src/interfaces/editorArguments.interface.ts
@@ -1,5 +1,5 @@
-import { Column, CompositeEditorOption, ElementPosition, SlickDataView, SlickGrid } from './index';
-import { PositionMethod } from '../enums/positionMethod.type';
+import type { Column, CompositeEditorOption, ElementPosition, SlickDataView, SlickGrid } from './index';
+import type { PositionMethod } from '../enums/positionMethod.type';
 
 export interface EditorArguments {
   /** Column Definition */

--- a/packages/common/src/interfaces/editorValidationResult.interface.ts
+++ b/packages/common/src/interfaces/editorValidationResult.interface.ts
@@ -1,4 +1,4 @@
-import { CompositeEditorError } from './compositeEditorError.interface';
+import type { CompositeEditorError } from './compositeEditorError.interface';
 
 export interface EditorValidationResult {
   /** Did the validation pass? */

--- a/packages/common/src/interfaces/editorValidator.interface.ts
+++ b/packages/common/src/interfaces/editorValidator.interface.ts
@@ -1,3 +1,3 @@
-import { EditorArguments, EditorValidationResult } from './index';
+import type { EditorArguments, EditorValidationResult } from './index';
 
 export type EditorValidator = (value: any, args?: EditorArguments) => EditorValidationResult;

--- a/packages/common/src/interfaces/excelCellFormat.interface.ts
+++ b/packages/common/src/interfaces/excelCellFormat.interface.ts
@@ -1,4 +1,4 @@
-import { ExcelMetadata } from './excelMetadata.interface';
+import type { ExcelMetadata } from './excelMetadata.interface';
 
 export interface ExcelCellFormat {
   value: any;

--- a/packages/common/src/interfaces/excelCopyBufferOption.interface.ts
+++ b/packages/common/src/interfaces/excelCopyBufferOption.interface.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   Column,
   CellRange,
   FormatterResultObject,
   SlickEventData,
 } from './index';
-import { SlickCellExcelCopyManager, } from '../extensions/slickCellExcelCopyManager';
+import type { SlickCellExcelCopyManager, } from '../extensions/slickCellExcelCopyManager';
 
 export interface ExcelCopyBufferOption<T = any> {
   /** defaults to 2000(ms), delay in ms to wait before clearing the selection after a paste action */

--- a/packages/common/src/interfaces/excelExportOption.interface.ts
+++ b/packages/common/src/interfaces/excelExportOption.interface.ts
@@ -1,7 +1,7 @@
-import { ExcelCustomStyling } from './columnExcelExportOption.interface';
-import { ExcelWorksheet } from './excelWorksheet.interface';
-import { ExcelWorkbook } from './excelWorkbook.interface';
-import { FileType } from '../enums/fileType.enum';
+import type { ExcelCustomStyling } from './columnExcelExportOption.interface';
+import type { ExcelWorksheet } from './excelWorksheet.interface';
+import type { ExcelWorkbook } from './excelWorkbook.interface';
+import type { FileType } from '../enums/fileType.enum';
 
 export interface ExcelExportOption {
   /** Defaults to true, when grid is using Grouping, it will show indentation of the text with collapsed/expanded symbol as well */

--- a/packages/common/src/interfaces/excelWorkbook.interface.ts
+++ b/packages/common/src/interfaces/excelWorkbook.interface.ts
@@ -1,5 +1,5 @@
-import { ExcelWorksheet } from './excelWorksheet.interface';
-import { ExcelStylesheet } from './excelStylesheet.interface';
+import type { ExcelWorksheet } from './excelWorksheet.interface';
+import type { ExcelStylesheet } from './excelStylesheet.interface';
 
 export interface ExcelWorkbook {
   addDrawings: (drawings: any) => any;

--- a/packages/common/src/interfaces/extensionModel.interface.ts
+++ b/packages/common/src/interfaces/extensionModel.interface.ts
@@ -1,4 +1,4 @@
-import { ExtensionName, SlickControlList, SlickPluginList } from '../enums/index';
+import type { ExtensionName, SlickControlList, SlickPluginList } from '../enums/index';
 
 export interface ExtensionModel<P extends (SlickControlList | SlickPluginList)> {
   /** Name of the Slickgrid-Universal Extension */

--- a/packages/common/src/interfaces/externalCopyClipCommand.interface.ts
+++ b/packages/common/src/interfaces/externalCopyClipCommand.interface.ts
@@ -1,5 +1,5 @@
-import { SlickCellExternalCopyManager } from '../extensions/slickCellExternalCopyManager';
-import { CellRange, Column, ExcelCopyBufferOption } from './index';
+import type { SlickCellExternalCopyManager } from '../extensions/slickCellExternalCopyManager';
+import type { CellRange, Column, ExcelCopyBufferOption } from './index';
 
 export interface ExternalCopyClipCommand {
   activeCell: number;

--- a/packages/common/src/interfaces/externalResource.interface.ts
+++ b/packages/common/src/interfaces/externalResource.interface.ts
@@ -1,5 +1,5 @@
-import { SlickGrid } from './slickGrid.interface';
-import { ContainerService } from '../services/index';
+import type { SlickGrid } from './slickGrid.interface';
+import type { ContainerService } from '../services/index';
 
 export interface ExternalResource {
   /** optionally provide the Service class name of the resource to make it easier to find even with minified code */

--- a/packages/common/src/interfaces/filter.interface.ts
+++ b/packages/common/src/interfaces/filter.interface.ts
@@ -1,5 +1,5 @@
-import { Column, FilterArguments, FilterCallback, SlickGrid } from './index';
-import { OperatorType, OperatorString, SearchTerm, } from '../enums/index';
+import type { Column, FilterArguments, FilterCallback, SlickGrid } from './index';
+import type { OperatorType, OperatorString, SearchTerm, } from '../enums/index';
 
 // export type Filter = (searchTerms: string | number | string[] | number[], columnDef: Column, params?: any) => string;
 export interface Filter {

--- a/packages/common/src/interfaces/filterArguments.interface.ts
+++ b/packages/common/src/interfaces/filterArguments.interface.ts
@@ -1,5 +1,5 @@
-import { Column, FilterCallback, SlickGrid } from './index';
-import { OperatorString, OperatorType, SearchTerm } from '../enums/index';
+import type { Column, FilterCallback, SlickGrid } from './index';
+import type { OperatorString, OperatorType, SearchTerm } from '../enums/index';
 
 export interface FilterArguments {
   grid: SlickGrid;

--- a/packages/common/src/interfaces/filterCallback.interface.ts
+++ b/packages/common/src/interfaces/filterCallback.interface.ts
@@ -1,5 +1,5 @@
-import { Column, SlickEventData } from './index';
-import { OperatorString, OperatorType, SearchTerm } from '../enums/index';
+import type { Column, SlickEventData } from './index';
+import type { OperatorString, OperatorType, SearchTerm } from '../enums/index';
 
 export interface FilterCallbackArg {
   /** Was the last event a Clear Filter that was triggered? */

--- a/packages/common/src/interfaces/filterChangedArgs.interface.ts
+++ b/packages/common/src/interfaces/filterChangedArgs.interface.ts
@@ -1,9 +1,9 @@
-import { Column } from './column.interface';
-import { ColumnFilters } from './columnFilters.interface';
-import { OperatorType } from '../enums/operatorType.enum';
-import { OperatorString } from '../enums/operatorString.type';
-import { SearchTerm } from '../enums/searchTerm.type';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { ColumnFilters } from './columnFilters.interface';
+import type { OperatorType } from '../enums/operatorType.enum';
+import type { OperatorString } from '../enums/operatorString.type';
+import type { SearchTerm } from '../enums/searchTerm.type';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface FilterChangedArgs {
   clearFilterTriggered?: boolean;

--- a/packages/common/src/interfaces/filterCondition.interface.ts
+++ b/packages/common/src/interfaces/filterCondition.interface.ts
@@ -1,5 +1,5 @@
-import { SearchTerm } from '../enums/searchTerm.type';
-import { FilterConditionOption } from './filterConditionOption.interface';
+import type { SearchTerm } from '../enums/searchTerm.type';
+import type { FilterConditionOption } from './filterConditionOption.interface';
 
 
 export type FilterCondition = (options: FilterConditionOption, parsedSearchTerms?: SearchTerm | SearchTerm[]) => boolean;

--- a/packages/common/src/interfaces/filterConditionOption.interface.ts
+++ b/packages/common/src/interfaces/filterConditionOption.interface.ts
@@ -1,4 +1,4 @@
-import { FieldType, OperatorString, OperatorType, SearchTerm } from '../enums/index';
+import type { FieldType, OperatorString, OperatorType, SearchTerm } from '../enums/index';
 
 export interface FilterConditionOption {
   /** optional object data key */

--- a/packages/common/src/interfaces/flatpickrOption.interface.ts
+++ b/packages/common/src/interfaces/flatpickrOption.interface.ts
@@ -1,5 +1,5 @@
-import { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';
-import { Locale } from 'flatpickr/dist/types/locale';
+import type { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';
+import type { Locale } from 'flatpickr/dist/types/locale';
 
 export interface FlatpickrOption {
   /** defaults to "F j, Y",	exactly the same as date format, but for the altInput field */

--- a/packages/common/src/interfaces/formatter.interface.ts
+++ b/packages/common/src/interfaces/formatter.interface.ts
@@ -1,5 +1,5 @@
-import { Column } from './column.interface';
-import { FormatterResultObject } from './formatterResultObject.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { FormatterResultObject } from './formatterResultObject.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export declare type Formatter<T = any> = (row: number, cell: number, value: any, columnDef: Column<T>, dataContext: T, grid: SlickGrid) => string | FormatterResultObject;

--- a/packages/common/src/interfaces/gridMenu.interface.ts
+++ b/packages/common/src/interfaces/gridMenu.interface.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   Column,
   GridMenuOption,
   GridMenuCommandItemCallbackArgs,
   SlickGrid,
 } from './index';
-import { SlickGridMenu } from '../extensions/slickGridMenu';
+import type { SlickGridMenu } from '../extensions/slickGridMenu';
 
 export interface GridMenu extends GridMenuOption {
   // --

--- a/packages/common/src/interfaces/gridMenuCommandItemCallbackArgs.interface.ts
+++ b/packages/common/src/interfaces/gridMenuCommandItemCallbackArgs.interface.ts
@@ -1,5 +1,5 @@
-import { Column, SlickGrid } from '.';
-import { MenuCommandItem } from './menuCommandItem.interface';
+import type { Column, SlickGrid } from '.';
+import type { MenuCommandItem } from './menuCommandItem.interface';
 
 export interface GridMenuCallbackArgs {
   grid: SlickGrid;

--- a/packages/common/src/interfaces/gridMenuItem.interface.ts
+++ b/packages/common/src/interfaces/gridMenuItem.interface.ts
@@ -1,5 +1,5 @@
-import { GridMenuCallbackArgs, GridMenuCommandItemCallbackArgs } from './gridMenuCommandItemCallbackArgs.interface';
-import { MenuCommandItem } from './menuCommandItem.interface';
+import type { GridMenuCallbackArgs, GridMenuCommandItemCallbackArgs } from './gridMenuCommandItemCallbackArgs.interface';
+import type { MenuCommandItem } from './menuCommandItem.interface';
 
 export interface GridMenuItem extends MenuCommandItem<GridMenuCommandItemCallbackArgs, GridMenuCallbackArgs> {
   // --

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -1,4 +1,4 @@
-import { Column, GridMenuCallbackArgs, GridMenuCommandItemCallbackArgs, GridMenuLabel, GridOption, MenuCallbackArgs, MenuCommandItem, } from './index';
+import type { Column, GridMenuCallbackArgs, GridMenuCommandItemCallbackArgs, GridMenuLabel, GridOption, MenuCallbackArgs, MenuCommandItem, } from './index';
 
 export interface GridMenuOption {
   /**

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -1,6 +1,6 @@
-import { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
+import type { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   AutoResizeOption,
   AutoTooltipOption,
   BackendServiceApi,
@@ -36,8 +36,8 @@ import {
   TextExportOption,
   TreeDataOption,
 } from './index';
-import { ColumnReorderFunction, GridAutosizeColsMode, OperatorType, OperatorString, } from '../enums/index';
-import { TranslaterService } from '../services/translater.service';
+import type { ColumnReorderFunction, GridAutosizeColsMode, OperatorType, OperatorString, } from '../enums/index';
+import type { TranslaterService } from '../services/translater.service';
 
 export interface GridOption {
   /** CSS class name used on newly added row */

--- a/packages/common/src/interfaces/gridState.interface.ts
+++ b/packages/common/src/interfaces/gridState.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CurrentColumn,
   CurrentFilter,
   CurrentPagination,

--- a/packages/common/src/interfaces/gridStateChange.interface.ts
+++ b/packages/common/src/interfaces/gridStateChange.interface.ts
@@ -1,5 +1,5 @@
-import { GridStateType } from '../enums/index';
-import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentPinning, CurrentRowSelection, CurrentSorter, GridState, TreeToggleStateChange } from './index';
+import type { GridStateType } from '../enums/index';
+import type { CurrentColumn, CurrentFilter, CurrentPagination, CurrentPinning, CurrentRowSelection, CurrentSorter, GridState, TreeToggleStateChange } from './index';
 
 export interface GridStateChange {
   /** Last Grid State Change that was triggered (only 1 type of change at a time) */

--- a/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
+++ b/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
@@ -1,5 +1,5 @@
-import { Formatter } from './formatter.interface';
-import { SlickCheckboxSelectColumn } from '../extensions/slickCheckboxSelectColumn';
+import type { Formatter } from './formatter.interface';
+import type { SlickCheckboxSelectColumn } from '../extensions/slickCheckboxSelectColumn';
 
 export interface GroupItemMetadataProviderOption {
   /** Whether or not we want to use group select checkbox. */

--- a/packages/common/src/interfaces/groupTotalsFormatter.interface.ts
+++ b/packages/common/src/interfaces/groupTotalsFormatter.interface.ts
@@ -1,4 +1,4 @@
-import { Column } from './column.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export type GroupTotalsFormatter = (totals: any, columnDef: Column, grid: SlickGrid) => string;

--- a/packages/common/src/interfaces/grouping.interface.ts
+++ b/packages/common/src/interfaces/grouping.interface.ts
@@ -1,7 +1,7 @@
-import { Aggregator } from './aggregator.interface';
-import { GroupingComparerItem } from './groupingComparerItem.interface';
-import { GroupingFormatterItem } from './groupingFormatterItem.interface';
-import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
+import type { Aggregator } from './aggregator.interface';
+import type { GroupingComparerItem } from './groupingComparerItem.interface';
+import type { GroupingFormatterItem } from './groupingFormatterItem.interface';
+import type { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
 export type GroupingGetterFunction<T = any> = (value: T) => string;
 

--- a/packages/common/src/interfaces/headerButton.interface.ts
+++ b/packages/common/src/interfaces/headerButton.interface.ts
@@ -1,6 +1,6 @@
-import { SlickHeaderButtons } from '../extensions/slickHeaderButtons';
-import { HeaderButtonOnCommandArgs } from './headerButtonOnCommandArgs.interface';
-import { SlickEventData } from './slickEventData.interface';
+import type { SlickHeaderButtons } from '../extensions/slickHeaderButtons';
+import type { HeaderButtonOnCommandArgs } from './headerButtonOnCommandArgs.interface';
+import type { SlickEventData } from './slickEventData.interface';
 
 export interface HeaderButton extends HeaderButtonOption {
   // --

--- a/packages/common/src/interfaces/headerButtonItem.interface.ts
+++ b/packages/common/src/interfaces/headerButtonItem.interface.ts
@@ -1,5 +1,5 @@
-import { Column } from './column.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface HeaderButtonItem {
   /** A command identifier to be passed to the onCommand event handlers. */

--- a/packages/common/src/interfaces/headerButtonOnCommandArgs.interface.ts
+++ b/packages/common/src/interfaces/headerButtonOnCommandArgs.interface.ts
@@ -1,6 +1,6 @@
-import { Column } from './column.interface';
-import { HeaderButtonItem } from './headerButtonItem.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { HeaderButtonItem } from './headerButtonItem.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface HeaderButtonOnCommandArgs {
   grid: SlickGrid;

--- a/packages/common/src/interfaces/headerButtonsOrMenu.interface.ts
+++ b/packages/common/src/interfaces/headerButtonsOrMenu.interface.ts
@@ -1,5 +1,5 @@
-import { HeaderButtonItem } from './headerButtonItem.interface';
-import { HeaderMenuItems } from './headerMenuItems.interface';
+import type { HeaderButtonItem } from './headerButtonItem.interface';
+import type { HeaderMenuItems } from './headerMenuItems.interface';
 
 export interface HeaderButtonsOrMenu {
   /** list of Buttons to show in the header */

--- a/packages/common/src/interfaces/headerMenu.interface.ts
+++ b/packages/common/src/interfaces/headerMenu.interface.ts
@@ -1,6 +1,6 @@
-import { MenuCommandItem } from '../index';
-import { SlickHeaderMenu } from '../extensions/slickHeaderMenu';
-import {
+import type { MenuCommandItem } from '../index';
+import type { SlickHeaderMenu } from '../extensions/slickHeaderMenu';
+import type {
   Column,
   HeaderMenuOption,
   MenuCommandItemCallbackArgs,

--- a/packages/common/src/interfaces/headerMenuItems.interface.ts
+++ b/packages/common/src/interfaces/headerMenuItems.interface.ts
@@ -1,4 +1,4 @@
-import { MenuCommandItem } from './menuCommandItem.interface';
+import type { MenuCommandItem } from './menuCommandItem.interface';
 
 export interface HeaderMenuItems {
   items: Array<MenuCommandItem | 'divider'>;

--- a/packages/common/src/interfaces/headerMenuOption.interface.ts
+++ b/packages/common/src/interfaces/headerMenuOption.interface.ts
@@ -1,4 +1,4 @@
-import { Column, SlickGrid } from './index';
+import type { Column, SlickGrid } from './index';
 
 export interface HeaderMenuOption {
   /** Auto-align drop menu to the left when not enough viewport space to show on the right */

--- a/packages/common/src/interfaces/itemMetadata.interface.ts
+++ b/packages/common/src/interfaces/itemMetadata.interface.ts
@@ -1,4 +1,4 @@
-import { Editor, Formatter, GroupTotalsFormatter } from './index';
+import type { Editor, Formatter, GroupTotalsFormatter } from './index';
 
 /**
  * Provides a powerful way of specifying additional information about a data item that let the grid customize the appearance

--- a/packages/common/src/interfaces/menuCallbackArgs.interface.ts
+++ b/packages/common/src/interfaces/menuCallbackArgs.interface.ts
@@ -1,5 +1,5 @@
-import { Column } from './column.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface MenuCallbackArgs<T = any> {
   /** Cell or column index */

--- a/packages/common/src/interfaces/menuCommandItem.interface.ts
+++ b/packages/common/src/interfaces/menuCommandItem.interface.ts
@@ -1,7 +1,7 @@
-import { MenuItem } from './menuItem.interface';
-import { MenuCommandItemCallbackArgs } from './menuCommandItemCallbackArgs.interface';
-import { SlickEventData } from './slickEventData.interface';
-import { MenuCallbackArgs } from './menuCallbackArgs.interface';
+import type { MenuItem } from './menuItem.interface';
+import type { MenuCommandItemCallbackArgs } from './menuCommandItemCallbackArgs.interface';
+import type { SlickEventData } from './slickEventData.interface';
+import type { MenuCallbackArgs } from './menuCallbackArgs.interface';
 
 export interface MenuCommandItem<A = MenuCommandItemCallbackArgs, R = MenuCallbackArgs> extends MenuItem<R> {
   /** A command identifier to be passed to the onCommand event callback handler (when using "commandItems"). */

--- a/packages/common/src/interfaces/menuCommandItemCallbackArgs.interface.ts
+++ b/packages/common/src/interfaces/menuCommandItemCallbackArgs.interface.ts
@@ -1,5 +1,5 @@
-import { MenuCallbackArgs } from './menuCallbackArgs.interface';
-import { MenuCommandItem } from './menuCommandItem.interface';
+import type { MenuCallbackArgs } from './menuCallbackArgs.interface';
+import type { MenuCommandItem } from './menuCommandItem.interface';
 
 export interface MenuCommandItemCallbackArgs extends MenuCallbackArgs {
   /** A command identifier returned by the onCommand (or action) event callback handler. */

--- a/packages/common/src/interfaces/menuFromCellCallbackArgs.interface.ts
+++ b/packages/common/src/interfaces/menuFromCellCallbackArgs.interface.ts
@@ -1,5 +1,5 @@
-import { Column } from './column.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface MenuFromCellCallbackArgs {
   /** Grid cell/column index */

--- a/packages/common/src/interfaces/menuItem.interface.ts
+++ b/packages/common/src/interfaces/menuItem.interface.ts
@@ -1,4 +1,4 @@
-import { MenuCallbackArgs } from './menuCallbackArgs.interface';
+import type { MenuCallbackArgs } from './menuCallbackArgs.interface';
 
 export interface MenuItem<O = MenuCallbackArgs> {
   /** A CSS class to be added to the menu item container. */

--- a/packages/common/src/interfaces/menuOptionItem.interface.ts
+++ b/packages/common/src/interfaces/menuOptionItem.interface.ts
@@ -1,5 +1,5 @@
-import { MenuItem } from './menuItem.interface';
-import { MenuOptionItemCallbackArgs } from './menuOptionItemCallbackArgs.interface';
+import type { MenuItem } from './menuItem.interface';
+import type { MenuOptionItemCallbackArgs } from './menuOptionItemCallbackArgs.interface';
 
 export interface MenuOptionItem extends MenuItem {
   /** An option returned by the onOptionSelected (or action) event callback handler. */

--- a/packages/common/src/interfaces/menuOptionItemCallbackArgs.interface.ts
+++ b/packages/common/src/interfaces/menuOptionItemCallbackArgs.interface.ts
@@ -1,5 +1,5 @@
-import { MenuOptionItem } from './menuOptionItem.interface';
-import { MenuCallbackArgs } from './menuCallbackArgs.interface';
+import type { MenuOptionItem } from './menuOptionItem.interface';
+import type { MenuCallbackArgs } from './menuCallbackArgs.interface';
 
 export interface MenuOptionItemCallbackArgs extends MenuCallbackArgs {
   /** A command identifier to be passed to the onCommand event callback handler (when using "commandItems"). */

--- a/packages/common/src/interfaces/mouseOffsetViewport.interface.ts
+++ b/packages/common/src/interfaces/mouseOffsetViewport.interface.ts
@@ -1,4 +1,4 @@
-import { DragPosition } from './drag.interface';
+import type { DragPosition } from './drag.interface';
 
 export interface MouseOffsetViewport {
   e: any,

--- a/packages/common/src/interfaces/multiColumnSort.interface.ts
+++ b/packages/common/src/interfaces/multiColumnSort.interface.ts
@@ -1,5 +1,5 @@
-import { ColumnSort } from './columnSort.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { ColumnSort } from './columnSort.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface MultiColumnSort {
   /** SlickGrid grid object */

--- a/packages/common/src/interfaces/onEventArgs.interface.ts
+++ b/packages/common/src/interfaces/onEventArgs.interface.ts
@@ -1,6 +1,6 @@
-import { Column } from './column.interface';
-import { SlickDataView } from './slickDataView.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { Column } from './column.interface';
+import type { SlickDataView } from './slickDataView.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface OnEventArgs {
   row: number;

--- a/packages/common/src/interfaces/onValidationErrorResult.interface.ts
+++ b/packages/common/src/interfaces/onValidationErrorResult.interface.ts
@@ -1,4 +1,4 @@
-import { EditorValidationResult } from './editorValidationResult.interface';
+import type { EditorValidationResult } from './editorValidationResult.interface';
 
 export interface OnValidationErrorResult {
   validationResults: EditorValidationResult;

--- a/packages/common/src/interfaces/operatorDetail.interface.ts
+++ b/packages/common/src/interfaces/operatorDetail.interface.ts
@@ -1,4 +1,4 @@
-import { OperatorString, OperatorType } from '../enums/index';
+import type { OperatorString, OperatorType } from '../enums/index';
 
 /** Operator with its Description */
 export interface OperatorDetail {

--- a/packages/common/src/interfaces/pagingInfo.interface.ts
+++ b/packages/common/src/interfaces/pagingInfo.interface.ts
@@ -1,4 +1,4 @@
-import { SlickDataView } from './slickDataView.interface';
+import type { SlickDataView } from './slickDataView.interface';
 
 export interface PagingInfo {
   /** Page size number */

--- a/packages/common/src/interfaces/resizer.interface.ts
+++ b/packages/common/src/interfaces/resizer.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   GridSize,
   ResizerOption,
   SlickEventData,

--- a/packages/common/src/interfaces/rowDetailView.interface.ts
+++ b/packages/common/src/interfaces/rowDetailView.interface.ts
@@ -1,4 +1,4 @@
-import { RowDetailViewOption, SlickEventData, SlickGrid, SlickRowDetailView } from './index';
+import type { RowDetailViewOption, SlickEventData, SlickGrid, SlickRowDetailView } from './index';
 
 export interface RowDetailView extends RowDetailViewOption {
   // --

--- a/packages/common/src/interfaces/rowDetailViewOption.interface.ts
+++ b/packages/common/src/interfaces/rowDetailViewOption.interface.ts
@@ -1,5 +1,5 @@
-import { UsabilityOverrideFn } from '../index';
-import { Observable, Subject } from '../services/rxjsFacade';
+import type { UsabilityOverrideFn } from '../index';
+import type { Observable, Subject } from '../services/rxjsFacade';
 
 export interface RowDetailViewOption {
   /** Defaults to True, do we always render/reRender the column */

--- a/packages/common/src/interfaces/rowMoveManager.interface.ts
+++ b/packages/common/src/interfaces/rowMoveManager.interface.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   RowMoveManagerOption,
   SlickEventData,
   SlickGrid,
 } from './index';
-import { SlickRowMoveManager } from '../extensions/slickRowMoveManager';
+import type { SlickRowMoveManager } from '../extensions/slickRowMoveManager';
 
 export interface RowMoveManager extends RowMoveManagerOption {
   //

--- a/packages/common/src/interfaces/rowMoveManagerOption.interface.ts
+++ b/packages/common/src/interfaces/rowMoveManagerOption.interface.ts
@@ -1,5 +1,5 @@
-import { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
-import { SlickCellRangeSelector } from '../extensions/slickCellRangeSelector';
+import type { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
+import type { SlickCellRangeSelector } from '../extensions/slickCellRangeSelector';
 
 export interface RowMoveManagerOption {
   /**

--- a/packages/common/src/interfaces/rowSelectionModelOption.interface.ts
+++ b/packages/common/src/interfaces/rowSelectionModelOption.interface.ts
@@ -1,4 +1,4 @@
-import { SlickCellRangeSelector } from '../extensions/slickCellRangeSelector';
+import type { SlickCellRangeSelector } from '../extensions/slickCellRangeSelector';
 
 export type RowSelectionModelOption = {
   /** Defaults to True, should we auto-scroll when dragging a row */

--- a/packages/common/src/interfaces/searchColumnFilter.interface.ts
+++ b/packages/common/src/interfaces/searchColumnFilter.interface.ts
@@ -1,6 +1,6 @@
-import { FieldType, OperatorString, OperatorType, } from '../enums/index';
-import { Column, } from './index';
-import { SearchTerm } from '../enums/searchTerm.type';
+import type { FieldType, OperatorString, OperatorType, } from '../enums/index';
+import type { Column, } from './index';
+import type { SearchTerm } from '../enums/searchTerm.type';
 
 export interface SearchColumnFilter {
   /** Column definition Id */

--- a/packages/common/src/interfaces/selectableOverrideCallback.interface.ts
+++ b/packages/common/src/interfaces/selectableOverrideCallback.interface.ts
@@ -1,4 +1,4 @@
-import { SlickGrid } from './slickGrid.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 /** Method that user can pass to override the default behavior or making every row a selectable row. */
 export type SelectableOverrideCallback<T> = (

--- a/packages/common/src/interfaces/servicePagination.interface.ts
+++ b/packages/common/src/interfaces/servicePagination.interface.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './pagination.interface';
+import type { Pagination } from './pagination.interface';
 
 export interface ServicePagination extends Pagination {
   /** How many pages do we have in total to display the entire dataset? */

--- a/packages/common/src/interfaces/singleColumnSort.interface.ts
+++ b/packages/common/src/interfaces/singleColumnSort.interface.ts
@@ -1,5 +1,5 @@
-import { ColumnSort } from './columnSort.interface';
-import { SlickGrid } from './slickGrid.interface';
+import type { ColumnSort } from './columnSort.interface';
+import type { SlickGrid } from './slickGrid.interface';
 
 export interface SingleColumnSort extends ColumnSort {
   /** SlickGrid grid object */

--- a/packages/common/src/interfaces/slickCompositeEditor.interface.ts
+++ b/packages/common/src/interfaces/slickCompositeEditor.interface.ts
@@ -1,4 +1,4 @@
-import { Column, CompositeEditorOption, Editor, ElementPosition, } from './index';
+import type { Column, CompositeEditorOption, Editor, ElementPosition, } from './index';
 
 /** A composite SlickGrid editor factory. */
 export interface SlickCompositeEditor {

--- a/packages/common/src/interfaces/slickDataView.interface.ts
+++ b/packages/common/src/interfaces/slickDataView.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Grouping,
   ItemMetadata,
   PagingInfo,

--- a/packages/common/src/interfaces/slickEditorLock.interface.ts
+++ b/packages/common/src/interfaces/slickEditorLock.interface.ts
@@ -1,4 +1,4 @@
-import { Editor } from './editor.interface';
+import type { Editor } from './editor.interface';
 
 /**
  * A locking helper to track the active edit controller and ensure that only a single controller

--- a/packages/common/src/interfaces/slickEvent.interface.ts
+++ b/packages/common/src/interfaces/slickEvent.interface.ts
@@ -1,4 +1,4 @@
-import { SlickEventData } from './slickEventData.interface';
+import type { SlickEventData } from './slickEventData.interface';
 
 export interface SlickEvent<T = any> {
   /**

--- a/packages/common/src/interfaces/slickEventHandler.interface.ts
+++ b/packages/common/src/interfaces/slickEventHandler.interface.ts
@@ -1,4 +1,4 @@
-import { SlickEvent, SlickEventData } from './index';
+import type { SlickEvent, SlickEventData } from './index';
 
 export type Handler<H> = (e: SlickEventData, data: H) => void;
 

--- a/packages/common/src/interfaces/slickGrid.interface.ts
+++ b/packages/common/src/interfaces/slickGrid.interface.ts
@@ -1,6 +1,6 @@
-import { SlickPluginList } from '../enums/index';
-import { CompositeEditorOption } from './compositeEditorOption.interface';
-import {
+import type { SlickPluginList } from '../enums/index';
+import type { CompositeEditorOption } from './compositeEditorOption.interface';
+import type {
   Column,
   ColumnSort,
   DragRowMove,
@@ -17,7 +17,7 @@ import {
   SlickEditorLock,
   SlickEvent,
 } from './index';
-import {
+import type {
   SlickCellSelectionModel,
   SlickRowSelectionModel,
 } from '../extensions/index';

--- a/packages/common/src/interfaces/slickNamespace.interface.ts
+++ b/packages/common/src/interfaces/slickNamespace.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AutoTooltipOption,
   CellMenuOption,
   CheckboxSelectorOption,
@@ -29,7 +29,7 @@ import {
   SlickResizer,
   SlickRowDetailView,
 } from './index';
-import {
+import type {
   SlickAutoTooltip,
   SlickCellExternalCopyManager,
   SlickCellMenu,

--- a/packages/common/src/interfaces/slickRange.interface.ts
+++ b/packages/common/src/interfaces/slickRange.interface.ts
@@ -1,4 +1,4 @@
-import { CellRange } from './cellRange.interface';
+import type { CellRange } from './cellRange.interface';
 
 export interface SlickRange extends CellRange {
   /**

--- a/packages/common/src/interfaces/slickRemoteModel.interface.ts
+++ b/packages/common/src/interfaces/slickRemoteModel.interface.ts
@@ -1,5 +1,5 @@
-import { Column } from './column.interface';
-import { SlickEvent } from './index';
+import type { Column } from './column.interface';
+import type { SlickEvent } from './index';
 
 /**
  * A sample AJAX remote data store implementation.

--- a/packages/common/src/interfaces/slickResizer.interface.ts
+++ b/packages/common/src/interfaces/slickResizer.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   GridSize,
   ResizerOption,
   SlickEvent,

--- a/packages/common/src/interfaces/slickRowDetailView.interface.ts
+++ b/packages/common/src/interfaces/slickRowDetailView.interface.ts
@@ -1,6 +1,6 @@
-import { Column, GridOption, RowDetailViewOption, SlickEvent, SlickGrid, } from './index';
-import { ContainerService } from '../services/container.service';
-import { UsabilityOverrideFn } from '../enums';
+import type { Column, GridOption, RowDetailViewOption, SlickEvent, SlickGrid, } from './index';
+import type { ContainerService } from '../services/container.service';
+import type { UsabilityOverrideFn } from '../enums';
 
 /** A plugin to add row detail panel. */
 export interface SlickRowDetailView {

--- a/packages/common/src/interfaces/sorter.interface.ts
+++ b/packages/common/src/interfaces/sorter.interface.ts
@@ -1,5 +1,5 @@
-import { Column } from './column.interface';
-import { GridOption } from './gridOption.interface';
-import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
+import type { Column } from './column.interface';
+import type { GridOption } from './gridOption.interface';
+import type { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
 export type SortComparer = (value1: any, value2: any, sortDirection: SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => number;

--- a/packages/common/src/interfaces/textExportOption.interface.ts
+++ b/packages/common/src/interfaces/textExportOption.interface.ts
@@ -1,5 +1,5 @@
-import { DelimiterType } from '../enums/delimiterType.enum';
-import { FileType } from '../enums/fileType.enum';
+import type { DelimiterType } from '../enums/delimiterType.enum';
+import type { FileType } from '../enums/fileType.enum';
 
 export interface TextExportOption {
   /** export delimiter, can be (comma, tab, ... or even custom string). */

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -1,6 +1,6 @@
 // import { Aggregator } from './aggregator.interface';
-import { SortDirection, SortDirectionString } from '../enums/index';
-import { Formatter } from './formatter.interface';
+import type { SortDirection, SortDirectionString } from '../enums/index';
+import type { Formatter } from './formatter.interface';
 
 export interface TreeDataOption {
   /** Column Id of which column in the column definitions has the Tree Data, there can only be one with a Tree Data. */

--- a/packages/common/src/interfaces/treeToggleStateChange.interface.ts
+++ b/packages/common/src/interfaces/treeToggleStateChange.interface.ts
@@ -1,5 +1,5 @@
-import { ToggleStateChangeType, ToggleStateChangeTypeString } from '../enums/toggleStateChangeType';
-import { TreeToggledItem } from './treeToggledItem.interface';
+import type { ToggleStateChangeType, ToggleStateChangeTypeString } from '../enums/toggleStateChangeType';
+import type { TreeToggledItem } from './treeToggledItem.interface';
 
 export interface TreeToggleStateChange {
   /** Optional, what was the item Id that triggered the toggle? Only available when a parent item got toggled within the grid */

--- a/packages/common/src/services/backendUtility.service.ts
+++ b/packages/common/src/services/backendUtility.service.ts
@@ -1,6 +1,6 @@
 import { EmitterType } from '../enums/emitterType.enum';
-import { BackendServiceApi, GridOption } from '../interfaces/index';
-import { Observable, RxJsFacade, Subject } from './rxjsFacade';
+import type { BackendServiceApi, GridOption } from '../interfaces/index';
+import type { Observable, RxJsFacade, Subject } from './rxjsFacade';
 
 export interface BackendCallbacks {
   emitActionChangedCallback?: (type: EmitterType) => void;

--- a/packages/common/src/services/bindingEvent.service.ts
+++ b/packages/common/src/services/bindingEvent.service.ts
@@ -1,4 +1,4 @@
-import { ElementEventListener } from '../interfaces/elementEventListener.interface';
+import type { ElementEventListener } from '../interfaces/elementEventListener.interface';
 
 export class BindingEventService {
   protected _boundedEvents: ElementEventListener[] = [];

--- a/packages/common/src/services/collection.service.ts
+++ b/packages/common/src/services/collection.service.ts
@@ -2,14 +2,14 @@ import { uniqueArray } from '@slickgrid-universal/utils';
 
 import {
   FilterMultiplePassType,
-  FilterMultiplePassTypeString,
+  type FilterMultiplePassTypeString,
   FieldType,
   OperatorType,
   SortDirectionNumber,
 } from './../enums/index';
-import { CollectionFilterBy, CollectionSortBy, Column } from './../interfaces/index';
+import type { CollectionFilterBy, CollectionSortBy, Column } from './../interfaces/index';
 import { sortByFieldType } from '../sortComparers/sortUtilities';
-import { TranslaterService } from './translater.service';
+import type { TranslaterService } from './translater.service';
 
 export class CollectionService<T = any> {
   constructor(protected readonly translaterService?: TranslaterService) { }

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -2,9 +2,9 @@ import { deepMerge } from '@slickgrid-universal/utils';
 import * as DOMPurify_ from 'dompurify';
 const DOMPurify = ((DOMPurify_ as any)?.['default'] ?? DOMPurify_); // patch for rollup
 
-import { InferDOMType, SearchTerm } from '../enums/index';
-import { Column, GridOption, HtmlElementPosition, SelectOption, SlickGrid, } from '../interfaces/index';
-import { TranslaterService } from './translater.service';
+import type { InferDOMType, SearchTerm } from '../enums/index';
+import type { Column, GridOption, HtmlElementPosition, SelectOption, SlickGrid, } from '../interfaces/index';
+import type { TranslaterService } from './translater.service';
 
 /**
  * Create the HTML DOM Element for a Select Editor or Filter, this is specific to these 2 types only and the unit tests are directly under them

--- a/packages/common/src/services/excelExport.service.ts
+++ b/packages/common/src/services/excelExport.service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ExcelExportOption, ExternalResource, SlickGrid } from '../interfaces/index';
-import { ContainerService } from '../services/container.service';
+import type { ExcelExportOption, ExternalResource, SlickGrid } from '../interfaces/index';
+import type { ContainerService } from '../services/container.service';
 
 export abstract class ExcelExportService implements ExternalResource {
   /** ExcelExportService class name which is use to find service instance in the external registered services */

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -1,9 +1,9 @@
 import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import { Column, ExtensionModel, GridOption, SlickRowDetailView, } from '../interfaces/index';
-import { ColumnReorderFunction, ExtensionList, ExtensionName, InferExtensionByName, SlickControlList, SlickPluginList } from '../enums/index';
-import { SharedService } from './shared.service';
-import { TranslaterService } from './translater.service';
+import type { Column, ExtensionModel, GridOption, SlickRowDetailView, } from '../interfaces/index';
+import { type ColumnReorderFunction, type ExtensionList, ExtensionName, type InferExtensionByName, type SlickControlList, type SlickPluginList } from '../enums/index';
+import type { SharedService } from './shared.service';
+import type { TranslaterService } from './translater.service';
 import {
   ExtensionUtility,
   SlickAutoTooltip,
@@ -20,9 +20,9 @@ import {
   SlickRowMoveManager,
   SlickRowSelectionModel
 } from '../extensions/index';
-import { FilterService } from './filter.service';
-import { SortService } from './sort.service';
-import { TreeDataService } from './treeData.service';
+import type { FilterService } from './filter.service';
+import type { SortService } from './sort.service';
+import type { TreeDataService } from './treeData.service';
 
 interface ExtensionWithColumnIndexPosition {
   name: ExtensionName;

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -3,16 +3,16 @@ import { deepCopy } from '@slickgrid-universal/utils';
 import { dequal } from 'dequal/lite';
 
 import { FilterConditions, getParsedSearchTermsByFieldType } from './../filter-conditions/index';
-import { FilterFactory } from './../filters/filterFactory';
+import { type FilterFactory } from './../filters/filterFactory';
 import {
   EmitterType,
   FieldType,
   KeyCode,
   OperatorType,
-  OperatorString,
-  SearchTerm,
+  type OperatorString,
+  type SearchTerm,
 } from '../enums/index';
-import {
+import type {
   Column,
   ColumnFilters,
   CurrentFilter,
@@ -30,11 +30,11 @@ import {
   SlickGrid,
   SlickNamespace,
 } from './../interfaces/index';
-import { BackendUtilityService } from './backendUtility.service';
+import type { BackendUtilityService } from './backendUtility.service';
 import { getSelectorStringFromElement, sanitizeHtmlToText, } from '../services/domUtilities';
 import { getDescendantProperty, mapOperatorByFieldType, } from './utilities';
-import { SharedService } from './shared.service';
-import { RxJsFacade, Subject } from './rxjsFacade';
+import type { SharedService } from './shared.service';
+import type { RxJsFacade, Subject } from './rxjsFacade';
 import { Constants } from '../constants';
 
 // using external non-typed js libraries

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { arrayRemoveItemByIndex, isObjectEmpty } from '@slickgrid-universal/utils';
 
-import {
+import type {
   CellArgs,
   Column,
   CurrentPinning,
@@ -14,12 +14,12 @@ import {
   OnEventArgs,
   SlickGrid,
 } from '../interfaces/index';
-import { FilterService } from './filter.service';
-import { GridStateService } from './gridState.service';
-import { PaginationService } from '../services/pagination.service';
-import { SharedService } from './shared.service';
-import { SortService } from './sort.service';
-import { TreeDataService } from './treeData.service';
+import type { FilterService } from './filter.service';
+import type { GridStateService } from './gridState.service';
+import type { PaginationService } from '../services/pagination.service';
+import type { SharedService } from './shared.service';
+import type { SortService } from './sort.service';
+import type { TreeDataService } from './treeData.service';
 import { SlickRowSelectionModel } from '../extensions/slickRowSelectionModel';
 
 let highlightTimerEnd: any;

--- a/packages/common/src/services/gridEvent.service.ts
+++ b/packages/common/src/services/gridEvent.service.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Column,
   OnEventArgs,
   SlickDataView,

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -1,11 +1,8 @@
-import { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { dequal } from 'dequal/lite';
 
-import {
-  ExtensionName,
-  GridStateType,
-} from '../enums/index';
-import {
+import { ExtensionName, GridStateType, } from '../enums/index';
+import type {
   Column,
   CurrentColumn,
   CurrentFilter,
@@ -19,11 +16,11 @@ import {
   SlickNamespace,
   TreeToggleStateChange,
 } from '../interfaces/index';
-import { ExtensionService } from './extension.service';
-import { FilterService } from './filter.service';
-import { SharedService } from './shared.service';
-import { SortService } from './sort.service';
-import { TreeDataService } from './treeData.service';
+import type { ExtensionService } from './extension.service';
+import type { FilterService } from './filter.service';
+import type { SharedService } from './shared.service';
+import type { SortService } from './sort.service';
+import type { TreeDataService } from './treeData.service';
 
 // using external non-typed js libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -1,6 +1,6 @@
-import { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   Column,
   GridOption,
   SlickDataView,
@@ -9,7 +9,7 @@ import {
   SlickNamespace,
   SlickResizer,
 } from './../interfaces/index';
-import { ExtensionUtility } from '../extensions/extensionUtility';
+import type { ExtensionUtility } from '../extensions/extensionUtility';
 import { createDomElement, emptyElement } from './domUtilities';
 
 // using external non-typed js libraries

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { dequal } from 'dequal/lite';
 
-import {
+import type {
   BackendServiceApi,
   CurrentPagination,
   Pagination,
@@ -10,9 +10,9 @@ import {
   SlickGrid,
   SlickNamespace,
 } from '../interfaces/index';
-import { BackendUtilityService } from './backendUtility.service';
-import { SharedService } from './shared.service';
-import { Observable, RxJsFacade } from './rxjsFacade';
+import type { BackendUtilityService } from './backendUtility.service';
+import type { SharedService } from './shared.service';
+import type { Observable, RxJsFacade } from './rxjsFacade';
 
 // using external non-typed js libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -1,7 +1,7 @@
-import { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 
 import { FieldType, } from '../enums/index';
-import {
+import type {
   AutoResizeOption,
   Column,
   GridOption,

--- a/packages/common/src/services/shared.service.ts
+++ b/packages/common/src/services/shared.service.ts
@@ -1,5 +1,5 @@
-import { Column, CurrentPagination, GridOption, SlickDataView, SlickGrid, } from '../interfaces/index';
-import { SlickGroupItemMetadataProvider } from '../extensions/slickGroupItemMetadataProvider';
+import type { Column, CurrentPagination, GridOption, SlickDataView, SlickGrid, } from '../interfaces/index';
+import type { SlickGroupItemMetadataProvider } from '../extensions/slickGroupItemMetadataProvider';
 
 export class SharedService {
   protected _allColumns!: Column[];

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -1,6 +1,6 @@
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import {
+import type {
   Column,
   ColumnSort,
   SlickDataView,
@@ -19,13 +19,13 @@ import {
   FieldType,
   SortDirection,
   SortDirectionNumber,
-  SortDirectionString,
+  type SortDirectionString,
 } from '../enums/index';
-import { BackendUtilityService } from './backendUtility.service';
+import type { BackendUtilityService } from './backendUtility.service';
 import { getDescendantProperty, flattenToParentChildArray } from './utilities';
 import { sortByFieldType } from '../sortComparers/sortUtilities';
-import { SharedService } from './shared.service';
-import { RxJsFacade, Subject } from './rxjsFacade';
+import type { SharedService } from './shared.service';
+import type { RxJsFacade, Subject } from './rxjsFacade';
 
 // using external non-typed js libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/services/textExport.service.ts
+++ b/packages/common/src/services/textExport.service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ExternalResource, SlickGrid, TextExportOption } from '../interfaces/index';
-import { ContainerService } from '../services/container.service';
+import type { ExternalResource, SlickGrid, TextExportOption } from '../interfaces/index';
+import type { ContainerService } from '../services/container.service';
 
 export abstract class TextExportService implements ExternalResource {
   /** ExcelExportService class name which is use to find service instance in the external registered services */

--- a/packages/common/src/services/translater.service.ts
+++ b/packages/common/src/services/translater.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
 export type TranslateServiceEventName = 'onLanguageChanged';
 

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -1,8 +1,8 @@
-import { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 
 import { Constants } from '../constants';
-import { ToggleStateChangeType, ToggleStateChangeTypeString } from '../enums/index';
-import {
+import { ToggleStateChangeType, type ToggleStateChangeTypeString } from '../enums/index';
+import type {
   Column,
   ColumnSort,
   GridOption,
@@ -17,8 +17,8 @@ import {
   TreeToggleStateChange,
 } from '../interfaces/index';
 import { findItemInTreeStructure, unflattenParentChildArrayToTree } from './utilities';
-import { SharedService } from './shared.service';
-import { SortService } from './sort.service';
+import type { SharedService } from './shared.service';
+import type { SortService } from './sort.service';
 
 // using external non-typed js libraries
 declare const Slick: SlickNamespace;

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -1,12 +1,12 @@
-import { EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { flatten } from 'un-flatten-tree';
 import * as moment_ from 'moment-mini';
 const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
 import { Constants } from '../constants';
-import { FieldType, OperatorString, OperatorType } from '../enums/index';
-import { CancellablePromiseWrapper, Column, GridOption, } from '../interfaces/index';
-import { Observable, RxJsFacade, Subject, Subscription } from './rxjsFacade';
+import { FieldType, type OperatorString, OperatorType } from '../enums/index';
+import type { CancellablePromiseWrapper, Column, GridOption, } from '../interfaces/index';
+import type { Observable, RxJsFacade, Subject, Subscription } from './rxjsFacade';
 
 /** Cancelled Extension that can be only be thrown by the `cancellablePromise()` function */
 export class CancelledException extends Error {

--- a/packages/common/src/slickgrid-config.ts
+++ b/packages/common/src/slickgrid-config.ts
@@ -1,4 +1,4 @@
-import { GridOption } from './interfaces/gridOption.interface';
+import type { GridOption } from './interfaces/gridOption.interface';
 import { GlobalGridOptions } from './global-grid-options';
 
 export class SlickgridConfig {

--- a/packages/common/src/sortComparers/booleanSortComparer.ts
+++ b/packages/common/src/sortComparers/booleanSortComparer.ts
@@ -1,4 +1,4 @@
-import { SortComparer } from '../interfaces/index';
+import type { SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
 export const booleanSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber) => {

--- a/packages/common/src/sortComparers/dateUtilities.ts
+++ b/packages/common/src/sortComparers/dateUtilities.ts
@@ -1,5 +1,5 @@
 import { FieldType } from '../enums/fieldType.enum';
-import { SortComparer } from '../interfaces/index';
+import type { SortComparer } from '../interfaces/index';
 import { mapMomentDateFormatWithFieldType } from '../services/utilities';
 import * as moment_ from 'moment-mini';
 const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670

--- a/packages/common/src/sortComparers/numericSortComparer.ts
+++ b/packages/common/src/sortComparers/numericSortComparer.ts
@@ -1,4 +1,4 @@
-import { Column, GridOption, SortComparer } from '../interfaces/index';
+import type { Column, GridOption, SortComparer } from '../interfaces/index';
 
 export const numericSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number, sortColumn?: Column, gridOptions?: GridOption) => {
   const checkForUndefinedValues = sortColumn?.valueCouldBeUndefined ?? gridOptions?.cellValueCouldBeUndefined ?? false;

--- a/packages/common/src/sortComparers/objectStringSortComparer.ts
+++ b/packages/common/src/sortComparers/objectStringSortComparer.ts
@@ -1,4 +1,4 @@
-import { Column, GridOption, SortComparer } from '../interfaces/index';
+import type { Column, GridOption, SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
 export const objectStringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => {

--- a/packages/common/src/sortComparers/sortUtilities.ts
+++ b/packages/common/src/sortComparers/sortUtilities.ts
@@ -1,5 +1,5 @@
-import { FieldType, SortDirectionNumber } from '../enums/index';
-import { Column, GridOption } from '../interfaces/index';
+import { FieldType, type SortDirectionNumber } from '../enums/index';
+import type { Column, GridOption } from '../interfaces/index';
 import { SortComparers } from './index';
 import { getAssociatedDateSortComparer } from './dateUtilities';
 

--- a/packages/common/src/sortComparers/stringSortComparer.ts
+++ b/packages/common/src/sortComparers/stringSortComparer.ts
@@ -1,6 +1,6 @@
 import { removeAccentFromText } from '@slickgrid-universal/utils';
 
-import { Column, GridOption, SortComparer } from '../interfaces/index';
+import type { Column, GridOption, SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
 export const stringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => {

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -1,14 +1,16 @@
-import {
+import type {
   Column,
   CompositeEditorOption,
   Editor,
   EditorArguments,
   EditorValidationResult,
   ElementPosition,
-  emptyElement,
-  getHtmlElementOffset,
   HtmlElementPosition,
   SlickNamespace
+} from '@slickgrid-universal/common';
+import {
+  emptyElement,
+  getHtmlElementOffset,
 } from '@slickgrid-universal/common';
 
 // using external non-typed js libraries

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -1,34 +1,36 @@
 import { deepCopy, deepMerge, emptyObject, setDeepValue } from '@slickgrid-universal/utils';
-import {
-  BindingEventService,
+import type {
   Column,
   CompositeEditorLabel,
   CompositeEditorModalType,
   CompositeEditorOpenDetailOption,
   CompositeEditorOption,
-  Constants,
   ContainerService,
-  createDomElement,
   DOMEvent,
   Editor,
   EditorValidationResult,
   ExternalResource,
-  getDescendantProperty,
   GridOption,
   GridService,
   Locale,
-  numericSortComparer,
   OnErrorOption,
   OnCompositeEditorChangeEventArgs,
   PlainFunc,
-  sanitizeTextByAvailableSanitizer,
   SlickCompositeEditor,
   SlickDataView,
   SlickEventHandler,
   SlickGrid,
   SlickNamespace,
-  SortDirectionNumber,
   TranslaterService,
+} from '@slickgrid-universal/common';
+import {
+  BindingEventService,
+  Constants,
+  createDomElement,
+  getDescendantProperty,
+  numericSortComparer,
+  sanitizeTextByAvailableSanitizer,
+  SortDirectionNumber,
 } from '@slickgrid-universal/common';
 import { CompositeEditor } from './compositeEditor.factory';
 

--- a/packages/custom-footer-component/src/slick-footer.component.ts
+++ b/packages/custom-footer-component/src/slick-footer.component.ts
@@ -1,21 +1,19 @@
 import * as moment_ from 'moment-mini';
 const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
-import {
-  Constants,
-  createDomElement,
+import type {
   CustomFooterOption,
   GridOption,
   Locale,
   Metrics,
   MetricTexts,
-  sanitizeTextByAvailableSanitizer,
   SlickEventHandler,
   SlickGrid,
   SlickNamespace,
   Subscription,
   TranslaterService,
 } from '@slickgrid-universal/common';
+import { Constants, createDomElement, sanitizeTextByAvailableSanitizer, } from '@slickgrid-universal/common';
 import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { BindingHelper } from '@slickgrid-universal/binding';
 

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -1,19 +1,12 @@
-import {
-  calculateAvailableSpace,
+import type {
   CancellablePromiseWrapper,
-  cancellablePromise,
-  CancelledException,
   Column,
   ContainerService,
-  createDomElement,
   CustomTooltipOption,
-  findFirstElementAttribute,
   Formatter,
-  getHtmlElementOffset,
   GridOption,
   Observable,
   RxJsFacade,
-  sanitizeTextByAvailableSanitizer,
   SharedService,
   SlickDataView,
   SlickEventData,
@@ -21,6 +14,15 @@ import {
   SlickGrid,
   SlickNamespace,
   Subscription,
+} from '@slickgrid-universal/common';
+import {
+  calculateAvailableSpace,
+  CancelledException,
+  cancellablePromise,
+  createDomElement,
+  findFirstElementAttribute,
+  getHtmlElementOffset,
+  sanitizeTextByAvailableSanitizer,
 } from '@slickgrid-universal/common';
 
 // using external SlickGrid JS libraries

--- a/packages/empty-warning-component/src/slick-empty-warning.component.ts
+++ b/packages/empty-warning-component/src/slick-empty-warning.component.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   ContainerService,
   EmptyWarning,
   ExternalResource,
   GridOption,
-  sanitizeTextByAvailableSanitizer,
   SlickGrid,
   TranslaterService
 } from '@slickgrid-universal/common';
+import { sanitizeTextByAvailableSanitizer } from '@slickgrid-universal/common';
 
 export class SlickEmptyWarningComponent implements ExternalResource {
   protected _warningLeftElement: HTMLDivElement | null = null;

--- a/packages/event-pub-sub/src/basePubSub.service.ts
+++ b/packages/event-pub-sub/src/basePubSub.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { EventSubscription } from './types';
+import type { EventSubscription } from './types';
 
 export abstract class BasePubSubService {
   /**

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -1,6 +1,6 @@
 import { titleCase, toKebabCase } from '@slickgrid-universal/utils';
-import { BasePubSubService } from './basePubSub.service';
-import { EventNamingStyle, EventSubscription, Subscription, } from './types';
+import type { BasePubSubService } from './basePubSub.service';
+import { EventNamingStyle, type EventSubscription, type Subscription, } from './types';
 
 export interface PubSubEvent<T = any> {
   name: string;

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -1,34 +1,35 @@
 import * as ExcelBuilder_ from 'excel-builder-webpacker';
 const ExcelBuilder = (ExcelBuilder_ as any)['default'] || ExcelBuilder_; // patch to fix rollup "ExcelBuilder has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
-import {
-  // utility functions
-  exportWithFormatterWhenDefined,
-  getTranslationPrefix,
-  sanitizeHtmlToText,
-
-  // interfaces
+import type {
   Column,
-  Constants,
   ContainerService,
   ExcelExportService as BaseExcelExportService,
   ExcelExportOption,
   ExternalResource,
   ExcelWorkbook,
   ExcelWorksheet,
-  FieldType,
-  FileType,
-  getColumnFieldType,
+
   GetDataValueCallback,
   GetGroupTotalValueCallback,
   GridOption,
-  isColumnDateType,
   KeyTitlePair,
   Locale,
   PubSubService,
   SlickDataView,
   SlickGrid,
   TranslaterService,
+} from '@slickgrid-universal/common';
+import {
+  Constants,
+  FieldType,
+  FileType,
+  // utility functions
+  exportWithFormatterWhenDefined,
+  getColumnFieldType,
+  getTranslationPrefix,
+  isColumnDateType,
+  sanitizeHtmlToText,
 } from '@slickgrid-universal/common';
 import { addWhiteSpaces, deepCopy, titleCase } from '@slickgrid-universal/utils';
 

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -1,19 +1,21 @@
-import {
+import type {
   Column,
-  Constants,
   ExcelStylesheet,
-  FieldType,
   Formatter,
-  Formatters,
   FormatterType,
-  getColumnFieldType,
   GetDataValueCallback,
-  getValueFromParamsOrFormatterOptions,
   GridOption,
+  SlickGrid,
+} from '@slickgrid-universal/common';
+import {
+  Constants,
+  FieldType,
+  Formatters,
+  getColumnFieldType,
+  getValueFromParamsOrFormatterOptions,
   GroupTotalFormatters,
   retrieveFormatterOptions,
   sanitizeHtmlToText,
-  SlickGrid,
 } from '@slickgrid-universal/common';
 
 export type ExcelFormatter = object & { id: number; };

--- a/packages/graphql/src/interfaces/graphqlDatasetFilter.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlDatasetFilter.interface.ts
@@ -1,5 +1,5 @@
-import { GraphqlFilteringOption } from './graphqlFilteringOption.interface';
-import { GraphqlSortingOption } from './graphqlSortingOption.interface';
+import type { GraphqlFilteringOption } from './graphqlFilteringOption.interface';
+import type { GraphqlSortingOption } from './graphqlSortingOption.interface';
 
 export interface GraphqlDatasetFilter {
   first?: number;

--- a/packages/graphql/src/interfaces/graphqlFilteringOption.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlFilteringOption.interface.ts
@@ -1,4 +1,4 @@
-import { OperatorString, OperatorType } from '@slickgrid-universal/common';
+import type { OperatorString, OperatorType } from '@slickgrid-universal/common';
 
 export interface GraphqlFilteringOption {
   /** Field name to use when filtering */

--- a/packages/graphql/src/interfaces/graphqlPaginatedResult.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlPaginatedResult.interface.ts
@@ -1,4 +1,4 @@
-import { Metrics } from '@slickgrid-universal/common';
+import type { Metrics } from '@slickgrid-universal/common';
 
 export interface GraphqlPaginatedResult {
   data: {

--- a/packages/graphql/src/interfaces/graphqlResult.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlResult.interface.ts
@@ -1,4 +1,4 @@
-import { Metrics } from '@slickgrid-universal/common';
+import type { Metrics } from '@slickgrid-universal/common';
 
 export interface GraphqlResult<T = any> {
   data: {

--- a/packages/graphql/src/interfaces/graphqlServiceApi.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlServiceApi.interface.ts
@@ -1,9 +1,9 @@
-import { BackendServiceApi, Observable } from '@slickgrid-universal/common';
+import type { BackendServiceApi, Observable } from '@slickgrid-universal/common';
 
-import { GraphqlResult } from './graphqlResult.interface';
-import { GraphqlPaginatedResult } from './graphqlPaginatedResult.interface';
-import { GraphqlServiceOption } from './graphqlServiceOption.interface';
-import { GraphqlService } from '../services/index';
+import type { GraphqlResult } from './graphqlResult.interface';
+import type { GraphqlPaginatedResult } from './graphqlPaginatedResult.interface';
+import type { GraphqlServiceOption } from './graphqlServiceOption.interface';
+import type { GraphqlService } from '../services/index';
 
 export interface GraphqlServiceApi extends BackendServiceApi {
   /** Backend Service Options */

--- a/packages/graphql/src/interfaces/graphqlServiceOption.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlServiceOption.interface.ts
@@ -1,10 +1,10 @@
-import { BackendServiceOption } from '@slickgrid-universal/common';
+import type { BackendServiceOption } from '@slickgrid-universal/common';
 
-import { GraphqlFilteringOption } from './graphqlFilteringOption.interface';
-import { GraphqlSortingOption } from './graphqlSortingOption.interface';
-import { GraphqlCursorPaginationOption } from './graphqlCursorPaginationOption.interface';
-import { GraphqlPaginationOption } from './graphqlPaginationOption.interface';
-import { QueryArgument } from './queryArgument.interface';
+import type { GraphqlFilteringOption } from './graphqlFilteringOption.interface';
+import type { GraphqlSortingOption } from './graphqlSortingOption.interface';
+import type { GraphqlCursorPaginationOption } from './graphqlCursorPaginationOption.interface';
+import type { GraphqlPaginationOption } from './graphqlPaginationOption.interface';
+import type { QueryArgument } from './queryArgument.interface';
 
 export interface GraphqlServiceOption extends BackendServiceOption {
   /**

--- a/packages/graphql/src/interfaces/graphqlSortingOption.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlSortingOption.interface.ts
@@ -1,4 +1,4 @@
-import { SortDirection, SortDirectionString } from '@slickgrid-universal/common';
+import type { SortDirection, SortDirectionString } from '@slickgrid-universal/common';
 
 export interface GraphqlSortingOption {
   field: string;

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -1,9 +1,4 @@
-import {
-  // utilities
-  mapOperatorType,
-  mapOperatorByFieldType,
-
-  // enums/interfaces
+import type {
   BackendService,
   Column,
   ColumnFilter,
@@ -12,19 +7,24 @@ import {
   CurrentFilter,
   CurrentPagination,
   CurrentSorter,
-  FieldType,
   FilterChangedArgs,
   GridOption,
   MultiColumnSort,
   OperatorString,
-  OperatorType,
   Pagination,
   PaginationChangedArgs,
   SharedService,
   SingleColumnSort,
   SlickGrid,
-  SortDirection,
   SortDirectionString,
+} from '@slickgrid-universal/common';
+import {
+  FieldType,
+  // utilities
+  mapOperatorType,
+  mapOperatorByFieldType,
+  OperatorType,
+  SortDirection,
 } from '@slickgrid-universal/common';
 import {
   GraphqlCursorPaginationOption,
@@ -413,7 +413,7 @@ export class GraphqlService implements BackendService {
           ? fieldSearchValue.match(/^([<>!=\*]{0,2})(.*[^<>!=\*])([\*]?)$/) // group 1: Operator, 2: searchValue, 3: last char is '*' (meaning starts with, ex.: abc*)
           : [fieldSearchValue, '', fieldSearchValue, '']; // when parsing is disabled, we'll only keep the search value in the index 2 to make it easy for code reuse
 
-        let operator: OperatorString = columnFilter.operator ||  matches?.[1] || '';
+        let operator: OperatorString = columnFilter.operator || matches?.[1] || '';
         searchValue = matches?.[2] || '';
         const lastValueChar = matches?.[3] || (operator === '*z' ? '*' : '');
 

--- a/packages/odata/src/interfaces/odataOption.interface.ts
+++ b/packages/odata/src/interfaces/odataOption.interface.ts
@@ -1,4 +1,4 @@
-import { BackendServiceOption, CaseType } from '@slickgrid-universal/common';
+import type { BackendServiceOption, CaseType } from '@slickgrid-universal/common';
 
 export interface OdataOption extends BackendServiceOption {
   /** What is the casing type to use? Typically that would be 1 of the following 2: camelCase or PascalCase */

--- a/packages/odata/src/interfaces/odataServiceApi.interface.ts
+++ b/packages/odata/src/interfaces/odataServiceApi.interface.ts
@@ -1,6 +1,6 @@
-import { BackendServiceApi } from '@slickgrid-universal/common';
-import { OdataOption } from './odataOption.interface';
-import { GridOdataService } from '../services/index';
+import type { BackendServiceApi } from '@slickgrid-universal/common';
+import type { OdataOption } from './odataOption.interface';
+import type { GridOdataService } from '../services/index';
 
 export interface OdataServiceApi extends BackendServiceApi {
   /** Backend Service Options */

--- a/packages/odata/src/interfaces/odataSortingOption.interface.ts
+++ b/packages/odata/src/interfaces/odataSortingOption.interface.ts
@@ -1,4 +1,4 @@
-import { SortDirection, SortDirectionString } from '@slickgrid-universal/common';
+import type { SortDirection, SortDirectionString } from '@slickgrid-universal/common';
 
 export interface OdataSortingOption {
   field: string;

--- a/packages/odata/src/services/grid-odata.service.ts
+++ b/packages/odata/src/services/grid-odata.service.ts
@@ -1,11 +1,6 @@
-import {
-  // utilities
-  parseUtcDate,
-  mapOperatorByFieldType,
-
+import type {
   // enums/interfaces
   BackendService,
-  CaseType,
   Column,
   ColumnFilter,
   ColumnFilters,
@@ -14,19 +9,24 @@ import {
   CurrentPagination,
   CurrentSorter,
   FilterChangedArgs,
-  FieldType,
   GridOption,
   MultiColumnSort,
   Pagination,
   PaginationChangedArgs,
-  SortDirection,
   SortDirectionString,
-  OperatorType,
   OperatorString,
   SearchTerm,
   SharedService,
   SingleColumnSort,
   SlickGrid,
+} from '@slickgrid-universal/common';
+import {
+  CaseType,
+  FieldType,
+  mapOperatorByFieldType,
+  OperatorType,
+  parseUtcDate,
+  SortDirection,
 } from '@slickgrid-universal/common';
 import { titleCase } from '@slickgrid-universal/utils';
 import { OdataQueryBuilderService } from './odataQueryBuilder.service';

--- a/packages/odata/src/services/odataQueryBuilder.service.ts
+++ b/packages/odata/src/services/odataQueryBuilder.service.ts
@@ -1,6 +1,6 @@
-import { CaseType, Column } from '@slickgrid-universal/common';
+import { CaseType, type Column } from '@slickgrid-universal/common';
 import { titleCase } from '@slickgrid-universal/utils';
-import { OdataOption } from '../interfaces/odataOption.interface';
+import type { OdataOption } from '../interfaces/odataOption.interface';
 
 export class OdataQueryBuilderService {
   _columnFilters: any;

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -1,16 +1,18 @@
-import {
-  Constants,
-  createDomElement,
-  getTranslationPrefix,
+import type {
   GridOption,
   Locale,
   PaginationService,
   PubSubService,
   ServicePagination,
   SharedService,
-  SlickGrid,
   Subscription,
   TranslaterService,
+} from '@slickgrid-universal/common';
+import {
+  Constants,
+  createDomElement,
+  getTranslationPrefix,
+  SlickGrid,
 } from '@slickgrid-universal/common';
 import { BindingHelper } from '@slickgrid-universal/binding';
 

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Column,
   DOMMouseOrTouchEvent,
   ExternalResource,

--- a/packages/rxjs-observable/src/rxjs.resource.ts
+++ b/packages/rxjs-observable/src/rxjs.resource.ts
@@ -1,4 +1,4 @@
-import { RxJsFacade } from '@slickgrid-universal/common';
+import type { RxJsFacade } from '@slickgrid-universal/common';
 import { EMPTY, iif, isObservable, firstValueFrom, Observable, ObservableInput, of, OperatorFunction, ObservedValueOf, Subject, switchMap, } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 

--- a/packages/text-export/src/textExport.service.ts
+++ b/packages/text-export/src/textExport.service.ts
@@ -1,18 +1,8 @@
 import { TextEncoder } from 'text-encoding-utf-8';
-import {
-  // utility functions
-  exportWithFormatterWhenDefined,
-  getTranslationPrefix,
-  htmlEntityDecode,
-  sanitizeHtmlToText,
-
-  // interfaces
+import type {
   Column,
-  Constants,
   ContainerService,
-  DelimiterType,
   ExternalResource,
-  FileType,
   GridOption,
   KeyTitlePair,
   Locale,
@@ -22,6 +12,16 @@ import {
   TextExportOption,
   TextExportService as BaseTextExportService,
   TranslaterService,
+} from '@slickgrid-universal/common';
+import {
+  Constants,
+  DelimiterType,
+  FileType,
+  // utility functions
+  exportWithFormatterWhenDefined,
+  getTranslationPrefix,
+  htmlEntityDecode,
+  sanitizeHtmlToText,
 } from '@slickgrid-universal/common';
 import { addWhiteSpaces, deepCopy, titleCase } from '@slickgrid-universal/utils';
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -8,9 +8,7 @@ import 'slickgrid/slick.dataview';
 import SortableInstance, * as Sortable_ from 'sortablejs';
 const Sortable = ((Sortable_ as any)?.['default'] ?? Sortable_); // patch for rollup
 
-import {
-  autoAddEditorFormatterToColumnsWithEditor,
-  AutocompleterEditor,
+import type {
   BackendServiceApi,
   BackendServiceOption,
   Column,
@@ -18,9 +16,7 @@ import {
   DataViewOption,
   ExtensionList,
   ExternalResource,
-  GlobalGridOptions,
   GridOption,
-  GridStateType,
   Metrics,
   Pagination,
   SelectEditor,
@@ -28,9 +24,18 @@ import {
   SlickDataView,
   SlickEventHandler,
   SlickGrid,
-  SlickGroupItemMetadataProvider,
   SlickNamespace,
   Subscription,
+  RxJsFacade,
+} from '@slickgrid-universal/common';
+
+import {
+  autoAddEditorFormatterToColumnsWithEditor,
+  AutocompleterEditor,
+  GlobalGridOptions,
+  GridStateType,
+  SlickGroupItemMetadataProvider,
+
   // services
   BackendUtilityService,
   CollectionService,
@@ -45,7 +50,6 @@ import {
   Observable,
   PaginationService,
   ResizerService,
-  RxJsFacade,
   SharedService,
   SortService,
   SlickgridConfig,

--- a/packages/vanilla-bundle/src/interfaces/slickerGridInstance.interface.ts
+++ b/packages/vanilla-bundle/src/interfaces/slickerGridInstance.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BackendService,
   ExtensionService,
   ExtensionUtility,

--- a/packages/vanilla-bundle/src/services/universalContainer.service.ts
+++ b/packages/vanilla-bundle/src/services/universalContainer.service.ts
@@ -1,4 +1,4 @@
-import { ContainerInstance, ContainerService } from '@slickgrid-universal/common';
+import type { ContainerInstance, ContainerService } from '@slickgrid-universal/common';
 
 export class UniversalContainerService implements ContainerService {
   dependencies: ContainerInstance[] = [];

--- a/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
+++ b/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
@@ -1,4 +1,4 @@
-import { GridOption } from '@slickgrid-universal/common';
+import type { GridOption } from '@slickgrid-universal/common';
 import { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
 
 /** Global Grid Options Defaults for Salesforce */


### PR DESCRIPTION
add `type` only imports when possible