### PR TITLE
fix: SlickDraggableGrouping should hide group elms when dragging

### DIFF
--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -121,7 +121,6 @@ describe('Draggable Grouping Plugin', () => {
   let translateService: TranslateServiceStub;
   let headerDiv: HTMLDivElement;
   let preHeaderDiv: HTMLDivElement;
-  let dropzonePlaceholderElm: HTMLDivElement;
   let dropzoneElm: HTMLDivElement;
 
   beforeEach(() => {
@@ -130,12 +129,9 @@ describe('Draggable Grouping Plugin', () => {
     headerDiv = document.createElement('div');
     dropzoneElm = document.createElement('div');
     dropzoneElm.className = 'slick-dropzone';
-    dropzonePlaceholderElm = document.createElement('div');
-    dropzonePlaceholderElm.className = 'slick-placeholder';
     headerDiv.className = 'slick-header-column';
     preHeaderDiv = document.createElement('div');
     preHeaderDiv.className = 'slick-preheader-panel';
-    dropzoneElm.appendChild(dropzonePlaceholderElm);
     gridContainerDiv.appendChild(preHeaderDiv);
     preHeaderDiv.appendChild(dropzoneElm);
     document.body.appendChild(gridContainerDiv);
@@ -402,17 +398,18 @@ describe('Draggable Grouping Plugin', () => {
       fn.sortableLeftInstance!.options.onStart!({} as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
       fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+      const dropzonePlaceholderElm = dropzoneElm.querySelector('.slick-draggable-dropzone-placeholder');
 
       const dragoverEvent = new CustomEvent('dragover', { bubbles: true, detail: {} });
-      dropzonePlaceholderElm.dispatchEvent(dragoverEvent);
+      dropzonePlaceholderElm?.dispatchEvent(dragoverEvent);
 
       const dragenterEvent = new CustomEvent('dragenter', { bubbles: true, detail: {} });
-      dropzonePlaceholderElm.dispatchEvent(dragenterEvent);
-      expect(dropzoneElm.classList.contains('slick-dropzone-placeholder-hover')).toBeTruthy();
+      dropzonePlaceholderElm?.dispatchEvent(dragenterEvent);
+      expect(dropzoneElm.classList.contains('slick-dropzone-hover')).toBeTruthy();
 
       const dragleaveEvent = new CustomEvent('dragleave', { bubbles: true, detail: {} });
-      dropzonePlaceholderElm.dispatchEvent(dragleaveEvent);
-      expect(dropzoneElm.classList.contains('slick-dropzone-placeholder-hover')).toBeFalsy();
+      dropzonePlaceholderElm?.dispatchEvent(dragleaveEvent);
+      expect(dropzoneElm.classList.contains('slick-dropzone-hover')).toBeFalsy();
     });
 
     describe('setupColumnDropbox method', () => {
@@ -480,7 +477,6 @@ describe('Draggable Grouping Plugin', () => {
         it('should call "clearDroppedGroups" and expect the grouping to be cleared', () => {
           const preHeaderElm = document.querySelector('.slick-preheader-panel') as HTMLDivElement;
           let dropboxPlaceholderElm = preHeaderElm.querySelector('.slick-draggable-dropzone-placeholder') as HTMLDivElement;
-          expect(dropboxPlaceholderElm.style.display).toBe('none');
 
           plugin.clearDroppedGroups();
           dropboxPlaceholderElm = preHeaderElm.querySelector('.slick-draggable-dropzone-placeholder') as HTMLDivElement;

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -121,6 +121,7 @@ describe('Draggable Grouping Plugin', () => {
   let translateService: TranslateServiceStub;
   let headerDiv: HTMLDivElement;
   let preHeaderDiv: HTMLDivElement;
+  let dropzonePlaceholderElm: HTMLDivElement;
   let dropzoneElm: HTMLDivElement;
 
   beforeEach(() => {
@@ -129,9 +130,12 @@ describe('Draggable Grouping Plugin', () => {
     headerDiv = document.createElement('div');
     dropzoneElm = document.createElement('div');
     dropzoneElm.className = 'slick-dropzone';
+    dropzonePlaceholderElm = document.createElement('div');
+    dropzonePlaceholderElm.className = 'slick-placeholder';
     headerDiv.className = 'slick-header-column';
     preHeaderDiv = document.createElement('div');
     preHeaderDiv.className = 'slick-preheader-panel';
+    dropzoneElm.appendChild(dropzonePlaceholderElm);
     gridContainerDiv.appendChild(preHeaderDiv);
     preHeaderDiv.appendChild(dropzoneElm);
     document.body.appendChild(gridContainerDiv);
@@ -400,15 +404,15 @@ describe('Draggable Grouping Plugin', () => {
       fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
 
       const dragoverEvent = new CustomEvent('dragover', { bubbles: true, detail: {} });
-      dropzoneElm.dispatchEvent(dragoverEvent);
+      dropzonePlaceholderElm.dispatchEvent(dragoverEvent);
 
       const dragenterEvent = new CustomEvent('dragenter', { bubbles: true, detail: {} });
-      dropzoneElm.dispatchEvent(dragenterEvent);
-      expect(dropzoneElm.classList.contains('slick-dropzone-hover')).toBeTruthy();
+      dropzonePlaceholderElm.dispatchEvent(dragenterEvent);
+      expect(dropzoneElm.classList.contains('slick-dropzone-placeholder-hover')).toBeTruthy();
 
       const dragleaveEvent = new CustomEvent('dragleave', { bubbles: true, detail: {} });
-      dropzoneElm.dispatchEvent(dragleaveEvent);
-      expect(dropzoneElm.classList.contains('slick-dropzone-hover')).toBeFalsy();
+      dropzonePlaceholderElm.dispatchEvent(dragleaveEvent);
+      expect(dropzoneElm.classList.contains('slick-dropzone-placeholder-hover')).toBeFalsy();
     });
 
     describe('setupColumnDropbox method', () => {

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -302,7 +302,7 @@ export class SlickDraggableGrouping {
       // },
       onStart: () => {
         if (draggablePlaceholderElm) {
-          draggablePlaceholderElm.style.display = 'none';
+          draggablePlaceholderElm.style.display = 'inline-block';
         }
         const droppedGroupingElms = dropzoneElm.querySelectorAll<HTMLDivElement>('.slick-dropped-grouping');
         droppedGroupingElms.forEach(droppedGroupingElm => droppedGroupingElm.style.display = 'none');
@@ -324,8 +324,6 @@ export class SlickDraggableGrouping {
           if (groupTogglerElm) {
             groupTogglerElm.style.display = 'inline-block';
           }
-        } else if (draggablePlaceholderElm) {
-          draggablePlaceholderElm.style.display = 'inline-block';
         }
 
         if (!grid.getEditorLock().commitCurrentEdit()) {
@@ -538,12 +536,12 @@ export class SlickDraggableGrouping {
   }
 
   protected addDragOverDropzoneListeners() {
-    const draggablePlaceholderElm = this._dropzoneElm.querySelector('.slick-placeholder');
+    const draggablePlaceholderElm = this._dropzoneElm.querySelector('.slick-draggable-dropzone-placeholder');
 
-    if (draggablePlaceholderElm) {
+    if (draggablePlaceholderElm && this._dropzoneElm) {
       this._bindingEventService.bind(draggablePlaceholderElm, 'dragover', (e) => e.preventDefault);
-      this._bindingEventService.bind(draggablePlaceholderElm, 'dragenter', () => this._dropzoneElm.classList.add('slick-dropzone-placeholder-hover'));
-      this._bindingEventService.bind(draggablePlaceholderElm, 'dragleave', () => this._dropzoneElm.classList.remove('slick-dropzone-placeholder-hover'));
+      this._bindingEventService.bind(draggablePlaceholderElm, 'dragenter', () => this._dropzoneElm.classList.add('slick-dropzone-hover'));
+      this._bindingEventService.bind(draggablePlaceholderElm, 'dragleave', () => this._dropzoneElm.classList.remove('slick-dropzone-hover'));
     }
   }
 

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -57,7 +57,7 @@ declare const Slick: SlickNamespace;
  */
 export class SlickDraggableGrouping {
   protected _addonOptions!: DraggableGrouping;
-  protected _bindEventService: BindingEventService;
+  protected _bindingEventService: BindingEventService;
   protected _droppableInstance?: SortableInstance;
   protected _dropzoneElm!: HTMLDivElement;
   protected _dropzonePlaceholderElm!: HTMLDivElement;
@@ -87,7 +87,7 @@ export class SlickDraggableGrouping {
     protected readonly pubSubService: BasePubSubService,
     protected readonly sharedService: SharedService,
   ) {
-    this._bindEventService = new BindingEventService();
+    this._bindingEventService = new BindingEventService();
     this._eventHandler = new Slick.EventHandler();
     this.onGroupChanged = new Slick.Event();
   }
@@ -227,7 +227,7 @@ export class SlickDraggableGrouping {
     this.onGroupChanged.unsubscribe();
     this._eventHandler.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
-    this._bindEventService.unbindAll();
+    this._bindingEventService.unbindAll();
     emptyElement(document.querySelector(`.${this.gridUid} .slick-preheader-panel`));
   }
 
@@ -278,7 +278,7 @@ export class SlickDraggableGrouping {
    * @param uid - grid UID
    * @param trigger - callback to execute when triggering a column grouping
    */
-  setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, columns: Column[], getColumnIndex: (columnId: string) => number, uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) {
+  setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, _columns: Column[], getColumnIndex: (columnId: string) => number, _uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) {
     const dropzoneElm = grid.getPreHeaderPanel();
     const draggablePlaceholderElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-draggable-dropzone-placeholder');
     const groupTogglerElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-group-toggle-all');
@@ -304,10 +304,8 @@ export class SlickDraggableGrouping {
         if (draggablePlaceholderElm) {
           draggablePlaceholderElm.style.display = 'none';
         }
-        const droppedGroupingElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-dropped-grouping');
-        if (droppedGroupingElm) {
-          droppedGroupingElm.style.display = 'none';
-        }
+        const droppedGroupingElms = dropzoneElm.querySelectorAll<HTMLDivElement>('.slick-dropped-grouping');
+        droppedGroupingElms.forEach(droppedGroupingElm => droppedGroupingElm.style.display = 'none');
         if (groupTogglerElm) {
           groupTogglerElm.style.display = 'none';
         }
@@ -381,10 +379,10 @@ export class SlickDraggableGrouping {
   }
 
   protected addGroupByRemoveClickHandler(id: string | number, groupRemoveIconElm: HTMLDivElement, headerColumnElm: HTMLDivElement, entry: any) {
-    this._bindEventService.bind(groupRemoveIconElm, 'click', () => {
-      const boundedElms = this._bindEventService.boundedEvents.filter(boundedEvent => boundedEvent.element === groupRemoveIconElm);
+    this._bindingEventService.bind(groupRemoveIconElm, 'click', () => {
+      const boundedElms = this._bindingEventService.boundedEvents.filter(boundedEvent => boundedEvent.element === groupRemoveIconElm);
       for (const boundedEvent of boundedElms) {
-        this._bindEventService.unbind(boundedEvent.element, 'click', boundedEvent.listener);
+        this._bindingEventService.unbind(boundedEvent.element, 'click', boundedEvent.listener);
       }
       this.removeGroupBy(id, headerColumnElm, entry);
     });
@@ -392,7 +390,7 @@ export class SlickDraggableGrouping {
 
   protected addGroupSortClickHandler(col: Column, groupSortContainerElm: HTMLDivElement) {
     const { grouping, type } = col;
-    this._bindEventService.bind(groupSortContainerElm, 'click', () => {
+    this._bindingEventService.bind(groupSortContainerElm, 'click', () => {
       // group sorting requires all group to be opened, make sure that the Toggle All is also expanded
       this.toggleGroupAll(col, false);
 
@@ -541,10 +539,12 @@ export class SlickDraggableGrouping {
   }
 
   protected addDragOverDropzoneListeners() {
-    if (this._dropzoneElm) {
-      this._bindEventService.bind(this._dropzoneElm, 'dragover', (e: Event) => e.preventDefault);
-      this._bindEventService.bind(this._dropzoneElm, 'dragenter', () => this._dropzoneElm.classList.add('slick-dropzone-hover'));
-      this._bindEventService.bind(this._dropzoneElm, 'dragleave', () => this._dropzoneElm.classList.remove('slick-dropzone-hover'));
+    const draggablePlaceholderElm = this._dropzoneElm.querySelector('.slick-placeholder');
+
+    if (draggablePlaceholderElm) {
+      this._bindingEventService.bind(draggablePlaceholderElm, 'dragover', (e) => e.preventDefault);
+      this._bindingEventService.bind(draggablePlaceholderElm, 'dragenter', () => this._dropzoneElm.classList.add('slick-dropzone-placeholder-hover'));
+      this._bindingEventService.bind(draggablePlaceholderElm, 'dragleave', () => this._dropzoneElm.classList.remove('slick-dropzone-placeholder-hover'));
     }
   }
 
@@ -585,7 +585,7 @@ export class SlickDraggableGrouping {
     this.addDragOverDropzoneListeners();
 
     if (this._groupToggler) {
-      this._bindEventService.bind(this._groupToggler, 'click', ((event: DOMMouseOrTouchEvent<HTMLDivElement>) => {
+      this._bindingEventService.bind(this._groupToggler, 'click', ((event: DOMMouseOrTouchEvent<HTMLDivElement>) => {
         const target = event.target.classList.contains('slick-group-toggle-all-icon') ? event.target : event.currentTarget.querySelector('.slick-group-toggle-all-icon');
         this.toggleGroupToggler(target, target?.classList.contains('expanded'));
       }) as EventListener);

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -321,10 +321,6 @@ export class SlickDraggableGrouping {
           if (draggablePlaceholderElm) {
             draggablePlaceholderElm.style.display = 'none';
           }
-          const droppedGroupingElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-dropped-grouping');
-          if (droppedGroupingElm) {
-            droppedGroupingElm.style.display = 'flex';
-          }
           if (groupTogglerElm) {
             groupTogglerElm.style.display = 'inline-block';
           }

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -314,7 +314,10 @@ export class SlickDraggableGrouping {
         dropzoneElm?.classList.remove('slick-dropzone-hover');
         draggablePlaceholderElm?.parentElement?.classList.remove('slick-dropzone-placeholder-hover');
 
-        if (dropzoneElm.querySelectorAll('.slick-dropped-grouping').length) {
+        const droppedGroupingElms = dropzoneElm.querySelectorAll<HTMLDivElement>('.slick-dropped-grouping');
+        droppedGroupingElms.forEach(droppedGroupingElm => droppedGroupingElm.style.display = 'flex');
+
+        if (droppedGroupingElms.length) {
           if (draggablePlaceholderElm) {
             draggablePlaceholderElm.style.display = 'none';
           }

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -907,6 +907,7 @@ input.flatpickr.form-control {
     .slick-draggable-dropzone-placeholder {
       font-style: var(--slick-draggable-group-placeholder-font-style, $slick-draggable-group-placeholder-font-style);
       color: var(--slick-draggable-group-placeholder-color, $slick-draggable-group-placeholder-color);
+      width: 100%;
     }
 
     .slick-group-toggle-all {


### PR DESCRIPTION
- when dragging a column to a new group, it should hide all existing grouped elements
- also fixes an issue were the dropzone hovering wasn't working as it should