### PR TITLE
chore: lower build size by passing appendToParent to createDomElement fn

### DIFF
--- a/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
@@ -97,7 +97,7 @@ describe('CheckboxEditor', () => {
       editor = new CheckboxEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-checkbox') as HTMLInputElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Is Active Checkbox Editor');
+      expect(editorElm.ariaLabel).toBe('Is Active Checkbox Editor');
     });
 
     it('should initialize the editor even when user define his own editor options', () => {

--- a/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
@@ -115,7 +115,7 @@ describe('DualInputEditor', () => {
       editor = new DualInputEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.dual-editor-text.editor-range.left') as HTMLInputElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Range Input Editor');
+      expect(editorElm.ariaLabel).toBe('Range Input Editor');
     });
 
     it('should have a placeholder on the left input when defined in its column definition', () => {

--- a/packages/common/src/editors/__tests__/floatEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/floatEditor.spec.ts
@@ -103,7 +103,7 @@ describe('FloatEditor', () => {
       editor = new FloatEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Price Number Editor');
+      expect(editorElm.ariaLabel).toBe('Price Number Editor');
     });
 
     it('should initialize the editor and focus on the element after a small delay', () => {

--- a/packages/common/src/editors/__tests__/inputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputEditor.spec.ts
@@ -103,7 +103,7 @@ describe('InputEditor (TextEditor)', () => {
       editor = new InputEditor(editorArguments, 'text');
       const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Title Input Editor');
+      expect(editorElm.ariaLabel).toBe('Title Input Editor');
     });
 
     it('should initialize the editor and focus on the element after a small delay', () => {

--- a/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
@@ -103,7 +103,7 @@ describe('InputPasswordEditor', () => {
       editor = new InputPasswordEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Title Input Editor');
+      expect(editorElm.ariaLabel).toBe('Title Input Editor');
     });
 
     it('should initialize the editor and focus on the element after a small delay', () => {

--- a/packages/common/src/editors/__tests__/integerEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/integerEditor.spec.ts
@@ -103,7 +103,7 @@ describe('IntegerEditor', () => {
       editor = new IntegerEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Price Slider Editor');
+      expect(editorElm.ariaLabel).toBe('Price Slider Editor');
     });
 
     it('should initialize the editor and focus on the element after a small delay', () => {

--- a/packages/common/src/editors/__tests__/longTextEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/longTextEditor.spec.ts
@@ -134,7 +134,7 @@ describe('LongTextEditor', () => {
       editor = new LongTextEditor(editorArguments);
       const editorElm = document.body.querySelector('.slick-large-editor-text.editor-title textarea') as HTMLTextAreaElement;
 
-      expect(editorElm.getAttribute('aria-label')).toBe('Title Text Editor');
+      expect(editorElm.ariaLabel).toBe('Title Text Editor');
     });
 
     it('should initialize the editor with default constant text when translate service is not provided', () => {

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -500,9 +500,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
 
   protected renderRegularItem(item: T) {
     const itemLabel = (typeof item === 'string' ? item : item?.label ?? '') as string;
-    return createDomElement('div', {
-      textContent: itemLabel || ''
-    });
+    return createDomElement('div', { textContent: itemLabel || '' });
   }
 
   protected renderCustomItem(item: T) {
@@ -512,10 +510,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     // for the remaining allowed tags we'll permit all attributes
     const sanitizedTemplateText = sanitizeTextByAvailableSanitizer(this.gridOptions, templateString) || '';
 
-    return createDomElement('div', {
-      // dataset: { item },
-      innerHTML: sanitizedTemplateText
-    });
+    return createDomElement('div', { innerHTML: sanitizedTemplateText });
   }
 
   protected renderCollectionItem(item: any) { // CollectionCustomStructure
@@ -542,17 +537,19 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     this._editorInputGroupElm = createDomElement('div', { className: 'autocomplete-container input-group' });
     const closeButtonGroupElm = createDomElement('span', { className: 'input-group-btn input-group-append', dataset: { clear: '' } });
     this._clearButtonElm = createDomElement('button', { type: 'button', className: 'btn btn-default icon-clear' });
-    this._inputElm = createDomElement('input', {
-      type: 'text', placeholder, title,
-      autocomplete: 'none',
-      className: `autocomplete form-control editor-text input-group-editor editor-${columnId}`,
-      dataset: { input: '' }
-    });
-
-    this._editorInputGroupElm.appendChild(this._inputElm);
+    this._inputElm = createDomElement(
+      'input',
+      {
+        type: 'text', placeholder, title,
+        autocomplete: 'none',
+        className: `autocomplete form-control editor-text input-group-editor editor-${columnId}`,
+        dataset: { input: '' }
+      },
+      this._editorInputGroupElm
+    );
 
     // add an empty <span> in order to add loading spinner styling
-    this._editorInputGroupElm.appendChild(createDomElement('span'));
+    this._editorInputGroupElm.appendChild(document.createElement('span'));
 
     // show clear date button (unless user specifically doesn't want it)
     if (!getEditorOptionByName<AutocompleterOption, 'hideClearButton'>(this.columnEditor, 'hideClearButton')) {

--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -76,10 +76,10 @@ export class CheckboxEditor implements Editor {
 
     this._input = createDomElement('input', {
       type: 'checkbox', value: 'true',
+      ariaLabel: this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Checkbox Editor`,
       className: `editor-checkbox editor-${columnId}`,
       title: this.columnEditor?.title ?? '',
     });
-    this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Checkbox Editor`);
 
     const cellContainer = this.args?.container;
     if (cellContainer && typeof cellContainer.appendChild === 'function') {

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -153,14 +153,16 @@ export class DateEditor implements Editor {
       this._editorInputGroupElm = createDomElement('div', { className: 'flatpickr input-group' });
       const closeButtonGroupElm = createDomElement('span', { className: 'input-group-btn input-group-append', dataset: { clear: '' } });
       this._clearButtonElm = createDomElement('button', { type: 'button', className: 'btn btn-default icon-clear' });
-      this._inputElm = createDomElement('input', {
-        placeholder: this.columnEditor?.placeholder ?? '',
-        title: this.columnEditor && this.columnEditor.title || '',
-        className: inputCssClasses.replace(/\./g, ' '),
-        dataset: { input: '', defaultdate: this.defaultDate }
-      });
-
-      this._editorInputGroupElm.appendChild(this._inputElm);
+      this._inputElm = createDomElement(
+        'input',
+        {
+          placeholder: this.columnEditor?.placeholder ?? '',
+          title: this.columnEditor && this.columnEditor.title || '',
+          className: inputCssClasses.replace(/\./g, ' '),
+          dataset: { input: '', defaultdate: this.defaultDate }
+        },
+        this._editorInputGroupElm
+      );
 
       // show clear date button (unless user specifically doesn't want it)
       if (!getEditorOptionByName<FlatpickrOption, 'hideClearButton'>(this.columnEditor, 'hideClearButton')) {

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -193,12 +193,12 @@ export class DualInputEditor implements Editor {
     const input = createDomElement('input', {
       type: fieldType || 'text',
       id: `item-${itemId}-${position}`,
+      ariaLabel: this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`,
       className: `dual-editor-text editor-${columnId} ${position.replace(/input/gi, '')}`,
       autocomplete: 'none',
       placeholder: editorSideParams.placeholder || '',
       title: editorSideParams.title || '',
     });
-    input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`);
 
     if (fieldType === 'readonly') {
       // when the custom type is defined as readonly, we'll make a readonly text input

--- a/packages/common/src/editors/floatEditor.ts
+++ b/packages/common/src/editors/floatEditor.ts
@@ -22,12 +22,12 @@ export class FloatEditor extends InputEditor {
 
       this._input = createDomElement('input', {
         type: 'number', autocomplete: 'none',
+        ariaLabel: this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Number Editor`,
         className: `editor-text editor-${columnId}`,
         placeholder: this.columnEditor?.placeholder ?? '',
         title: this.columnEditor?.title ?? '',
         step: `${(this.columnEditor.valueStep !== undefined) ? this.columnEditor.valueStep : this.getInputDecimalSteps()}`,
       });
-      this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Number Editor`);
       const cellContainer = this.args.container;
       if (cellContainer && typeof cellContainer.appendChild === 'function') {
         cellContainer.appendChild(this._input);

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -100,11 +100,11 @@ export class InputEditor implements Editor {
     this._input = createDomElement('input', {
       type: this._inputType || 'text',
       autocomplete: 'none',
+      ariaLabel: this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`,
       placeholder: this.columnEditor?.placeholder ?? '',
       title: this.columnEditor?.title ?? '',
       className: `editor-text editor-${columnId}`,
     });
-    this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Input Editor`);
     const cellContainer = this.args.container;
     if (cellContainer && typeof cellContainer.appendChild === 'function') {
       cellContainer.appendChild(this._input);

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -20,12 +20,12 @@ export class IntegerEditor extends InputEditor {
 
       this._input = createDomElement('input', {
         type: 'number', autocomplete: 'none',
+        ariaLabel: this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`,
         placeholder: this.columnEditor?.placeholder ?? '',
         title: this.columnEditor?.title ?? '',
         step: `${(this.columnEditor.valueStep !== undefined) ? this.columnEditor.valueStep : '1'}`,
         className: `editor-text editor-${columnId}`,
       });
-      this._input.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`);
       const cellContainer = this.args.container;
       if (cellContainer && typeof cellContainer.appendChild === 'function') {
         cellContainer.appendChild(this._input);

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -132,14 +132,17 @@ export class LongTextEditor implements Editor {
     containerElm.appendChild(this._wrapperElm);
 
     // use textarea row if defined but don't go over 3 rows with composite editor modal
-    this._textareaElm = createDomElement('textarea', {
-      cols: this.editorOptions?.cols ?? 40,
-      rows: (compositeEditorOptions && textAreaRows > 3) ? 3 : textAreaRows,
-      placeholder: this.columnEditor?.placeholder ?? '',
-      title: this.columnEditor?.title ?? '',
-    });
-    this._textareaElm.setAttribute('aria-label', this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Text Editor`);
-    this._wrapperElm.appendChild(this._textareaElm);
+    this._textareaElm = createDomElement(
+      'textarea',
+      {
+        ariaLabel: this.columnEditor?.ariaLabel ?? `${toSentenceCase(columnId + '')} Text Editor`,
+        cols: this.editorOptions?.cols ?? 40,
+        rows: (compositeEditorOptions && textAreaRows > 3) ? 3 : textAreaRows,
+        placeholder: this.columnEditor?.placeholder ?? '',
+        title: this.columnEditor?.title ?? '',
+      },
+      this._wrapperElm
+    );
 
     const editorFooterElm = createDomElement('div', { className: 'editor-footer' });
     const countContainerElm = createDomElement('span', { className: 'counter' });
@@ -157,10 +160,8 @@ export class LongTextEditor implements Editor {
     editorFooterElm.appendChild(countContainerElm);
 
     if (!compositeEditorOptions) {
-      const cancelBtnElm = createDomElement('button', { className: 'btn btn-cancel btn-default btn-xs', textContent: cancelText });
-      const saveBtnElm = createDomElement('button', { className: 'btn btn-save btn-primary btn-xs', textContent: saveText });
-      editorFooterElm.appendChild(cancelBtnElm);
-      editorFooterElm.appendChild(saveBtnElm);
+      const cancelBtnElm = createDomElement('button', { className: 'btn btn-cancel btn-default btn-xs', textContent: cancelText }, editorFooterElm);
+      const saveBtnElm = createDomElement('button', { className: 'btn btn-save btn-primary btn-xs', textContent: saveText }, editorFooterElm);
       this._bindEventService.bind(cancelBtnElm, 'click', this.cancel.bind(this) as EventListener);
       this._bindEventService.bind(saveBtnElm, 'click', this.save.bind(this) as EventListener);
       this.position(this.args?.position as ElementPosition);

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -712,7 +712,7 @@ export class SelectEditor implements Editor {
 
     // step 2, create the DOM Element of the editor
     // we will later also subscribe to the onClose event to save the Editor whenever that event is triggered
-    this.createDomElement(selectBuildResult.selectElement);
+    this.createEditorElement(selectBuildResult.selectElement);
   }
 
   /** Create a blank entry that can be added to the collection. It will also reuse the same collection structure provided by the user */
@@ -734,7 +734,7 @@ export class SelectEditor implements Editor {
    * From the Select DOM Element created earlier, create a Multiple/Single Select Editor using the jQuery multiple-select.js lib
    * @param {Object} selectElement
    */
-  protected createDomElement(selectElement: HTMLSelectElement) {
+  protected createEditorElement(selectElement: HTMLSelectElement) {
     this.$editorElm = $(selectElement);
 
     if (this.$editorElm && typeof this.$editorElm.appendTo === 'function') {

--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -268,11 +268,12 @@ describe('CellMenu Plugin', () => {
         expect(cellMenuElm.classList.contains('dropdown'));
         expect(cellMenuElm.classList.contains('dropright'));
         expect(commandListElm.querySelectorAll('.slick-menu-item').length).toBe(5);
+        expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-cell-menu slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
             <div class="slick-menu-command-list">
               <div class="slick-command-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu" aria-label="Close">×</button>
+                <button class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
               <li class="slick-menu-item orange" data-command="command1">
                 <div class="slick-menu-icon">◦</div>
@@ -643,11 +644,12 @@ describe('CellMenu Plugin', () => {
         const optionListElm = cellMenuElm.querySelector('.slick-menu-option-list') as HTMLDivElement;
 
         expect(optionListElm.querySelectorAll('.slick-menu-item').length).toBe(5);
+        expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-cell-menu slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
             <div class="slick-menu-option-list">
               <div class="slick-option-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu" aria-label="Close">×</button>
+                <button class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
               <li class="slick-menu-item purple" data-option="option1">
                 <div class="slick-menu-icon">◦</div>

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -298,11 +298,12 @@ describe('ContextMenu Plugin', () => {
         expect(contextMenuElm.classList.contains('dropdown'));
         expect(contextMenuElm.classList.contains('dropright'));
         expect(commandListElm.querySelectorAll('.slick-menu-item').length).toBe(5);
+        expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-context-menu slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
             <div class="slick-menu-command-list">
               <div class="slick-command-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu" aria-label="Close">×</button>
+                <button class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
               <li class="slick-menu-item orange" data-command="command1">
                 <div class="slick-menu-icon">◦</div>
@@ -1247,11 +1248,12 @@ describe('ContextMenu Plugin', () => {
         const optionListElm = contextMenuElm.querySelector('.slick-menu-option-list') as HTMLDivElement;
 
         expect(optionListElm.querySelectorAll('.slick-menu-item').length).toBe(5);
+        expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-context-menu slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
             <div class="slick-menu-option-list">
               <div class="slick-option-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu" aria-label="Close">×</button>
+                <button class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
               <li class="slick-menu-item purple" data-option="option1">
                 <div class="slick-menu-icon">◦</div>

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -65,7 +65,7 @@ const dataViewStub = {
   collapseAllGroups: jest.fn(),
   expandAllGroups: jest.fn(),
   setGrouping: jest.fn(),
-}
+};
 
 const getEditorLockMock = {
   commitCurrentEdit: jest.fn(),
@@ -268,24 +268,20 @@ describe('Draggable Grouping Plugin', () => {
       dropEvent = new Event('mouseup');
       headerColumnDiv1 = createDomElement('div', {
         className: 'slick-header-column', id: `${GRID_UID}firstName`, dataset: { id: 'firstName' },
-      });
+      }, preHeaderDiv);
       headerColumnDiv2 = createDomElement('div', {
         className: 'slick-header-column', id: `${GRID_UID}lastName`, dataset: { id: 'lastName' },
-      });
+      }, preHeaderDiv);
       headerColumnDiv3 = createDomElement('div', {
         className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' },
-      });
+      }, preHeaderDiv);
       headerColumnDiv4 = createDomElement('div', {
         className: 'slick-header-column', id: `${GRID_UID}medals`, dataset: { id: 'medals' },
-      });
+      }, preHeaderDiv);
       headerColumnDiv1.appendChild(createDomElement('span', { className: 'slick-column-name', textContent: 'First Name' }));
       headerColumnDiv2.appendChild(createDomElement('span', { className: 'slick-column-name', textContent: 'Last Name' }));
       headerColumnDiv3.appendChild(createDomElement('span', { className: 'slick-column-name', textContent: 'Age' }));
       headerColumnDiv4.appendChild(createDomElement('span', { className: 'slick-column-name', textContent: 'Medals' }));
-      preHeaderDiv.appendChild(headerColumnDiv1);
-      preHeaderDiv.appendChild(headerColumnDiv2);
-      preHeaderDiv.appendChild(headerColumnDiv3);
-      preHeaderDiv.appendChild(headerColumnDiv4);
     });
 
     afterEach(() => {
@@ -578,7 +574,7 @@ describe('Draggable Grouping Plugin', () => {
           fn.sortableLeftInstance!.options.onStart!({} as any);
           plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
-          expect(plugin.addonOptions.hideGroupSortIcons).toBe(true)
+          expect(plugin.addonOptions.hideGroupSortIcons).toBe(true);
           let groupBySortElm = preHeaderDiv.querySelector('.slick-groupby-sort') as HTMLDivElement;
           let groupBySortAscIconElm = preHeaderDiv.querySelector('.slick-groupby-sort-asc-icon') as HTMLDivElement;
 
@@ -709,7 +705,7 @@ describe('Draggable Grouping Plugin', () => {
           .mockReturnValueOnce(1)
           .mockReturnValueOnce(2)
           .mockReturnValueOnce(3)
-          .mockReturnValueOnce(4)
+          .mockReturnValueOnce(4);
       });
 
       it('should execute the "onEnd" callback of Sortable and expect sortable to be cancelled', () => {

--- a/packages/common/src/extensions/extensionCommonUtils.ts
+++ b/packages/common/src/extensions/extensionCommonUtils.ts
@@ -11,10 +11,10 @@ export function addCloseButtomElement(this: SlickColumnPicker | SlickGridMenu, m
   const context: any = this;
   const closePickerButtonElm = createDomElement('button', {
     type: 'button', className: 'close',
+    ariaLabel: 'Close',
     innerHTML: '&times;',
     dataset: { dismiss: context instanceof SlickColumnPicker ? 'slick-column-picker' : 'slick-grid-menu' }
   });
-  closePickerButtonElm.setAttribute('aria-label', 'Close');
   menuElm.appendChild(closePickerButtonElm);
 }
 
@@ -22,8 +22,11 @@ export function addCloseButtomElement(this: SlickColumnPicker | SlickGridMenu, m
 export function addColumnTitleElementWhenDefined(this: SlickColumnPicker | SlickGridMenu, menuElm: HTMLDivElement) {
   const context: any = this;
   if (context.addonOptions?.columnTitle) {
-    context._columnTitleElm = createDomElement('div', { className: 'slick-menu-title', textContent: context.addonOptions?.columnTitle ?? context._defaults.columnTitle });
-    menuElm.appendChild(context._columnTitleElm);
+    context._columnTitleElm = createDomElement(
+      'div',
+      { className: 'slick-menu-title', textContent: context.addonOptions?.columnTitle ?? context._defaults.columnTitle },
+      menuElm
+    );
   }
 }
 

--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -215,11 +215,14 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
           iconElm.textContent = '◦';
         }
 
-        const textElm = createDomElement('span', {
-          className: `${this._menuCssPrefix}-content`,
-          textContent: typeof item === 'object' && (item as MenuCommandItem | MenuOptionItem).title || ''
-        });
-        commandLiElm.appendChild(textElm);
+        const textElm = createDomElement(
+          'span',
+          {
+            className: `${this._menuCssPrefix}-content`,
+            textContent: typeof item === 'object' && (item as MenuCommandItem | MenuOptionItem).title || ''
+          },
+          commandLiElm
+        );
 
         if ((item as MenuCommandItem | MenuOptionItem).textCssClass) {
           textElm.classList.add(...(item as MenuCommandItem | MenuOptionItem).textCssClass!.split(' '));

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -100,17 +100,15 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
         this._menuElm.style.width = findWidthOrDefault(this.addonOptions?.width);
       }
 
-      const closeButtonElm = createDomElement('button', { className: 'close', type: 'button', innerHTML: '&times;', dataset: { dismiss: this._menuCssPrefix } });
-      closeButtonElm.setAttribute('aria-label', 'Close');
+      const closeButtonElm = createDomElement('button', { ariaLabel: 'Close', className: 'close', type: 'button', innerHTML: '&times;', dataset: { dismiss: this._menuCssPrefix } });
 
       // -- Option List section
       if (!(this.addonOptions as CellMenu | ContextMenu).hideOptionSection && isColumnOptionAllowed && optionItems.length > 0) {
-        const optionMenuElm = createDomElement('div', { className: `${this._menuCssPrefix}-option-list`, role: 'menu' });
+        const optionMenuElm = createDomElement('div', { className: `${this._menuCssPrefix}-option-list`, role: 'menu' }, this._menuElm);
         this.populateCommandOrOptionTitle('option', this.addonOptions, optionMenuElm);
         if (!this.addonOptions.hideCloseButton) {
           this.populateCommandOrOptionCloseBtn('option', closeButtonElm, optionMenuElm);
         }
-        this._menuElm.appendChild(optionMenuElm);
         this.populateCommandOrOptionItems(
           'option',
           this.addonOptions,
@@ -123,12 +121,11 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
 
       // -- Command List section
       if (!(this.addonOptions as CellMenu | ContextMenu).hideCommandSection && isColumnCommandAllowed && commandItems.length > 0) {
-        const commandMenuElm = createDomElement('div', { className: `${this._menuCssPrefix}-command-list`, role: 'menu' });
+        const commandMenuElm = createDomElement('div', { className: `${this._menuCssPrefix}-command-list`, role: 'menu' }, this._menuElm);
         this.populateCommandOrOptionTitle('command', this.addonOptions, commandMenuElm);
         if (!this.addonOptions.hideCloseButton && (!isColumnOptionAllowed || optionItems.length === 0 || (this.addonOptions as CellMenu | ContextMenu).hideOptionSection)) {
           this.populateCommandOrOptionCloseBtn('command', closeButtonElm, commandMenuElm);
         }
-        this._menuElm.appendChild(commandMenuElm);
         this.populateCommandOrOptionItems(
           'command',
           this.addonOptions,

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -167,15 +167,13 @@ export class SlickCellExternalCopyManager {
   // ---------------------
 
   protected createTextBox(innerText: string) {
-    const textAreaElm = createDomElement('textarea', {
-      value: innerText,
-      style: {
-        position: 'absolute',
-        left: '-1000px',
-        top: `${document.body.scrollTop}px`,
-      }
-    });
-    this._bodyElement.appendChild(textAreaElm);
+    const textAreaElm = createDomElement(
+      'textarea',
+      {
+        value: innerText,
+        style: { position: 'absolute', left: '-1000px', top: `${document.body.scrollTop}px`, }
+      },
+      this._bodyElement);
     textAreaElm.select();
 
     return textAreaElm;

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -103,10 +103,10 @@ export class SlickColumnPicker {
     this._eventHandler.subscribe(this.grid.onColumnsReordered, updateColumnPickerOrder.bind(this) as EventListener);
 
     this._menuElm = createDomElement('div', {
+      ariaExpanded: 'false',
       className: `slick-column-picker ${this._gridUid}`, role: 'menu',
       style: { display: 'none' },
     });
-    this._menuElm.setAttribute('aria-expanded', 'false');
 
     // add Close button and optiona a Column list title
     addColumnTitleElementWhenDefined.call(this, this._menuElm);

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -151,8 +151,7 @@ export class SlickDraggableGrouping {
           title: this._addonOptions.toggleAllPlaceholderText ?? '',
           style: { display: 'none' },
         });
-        const groupTogglerIconElm = createDomElement('span', { className: 'slick-group-toggle-all-icon' });
-        this._groupToggler.appendChild(groupTogglerIconElm);
+        const groupTogglerIconElm = createDomElement('span', { className: 'slick-group-toggle-all-icon' }, this._groupToggler);
 
         if (this.gridOptions.enableTranslate && this._addonOptions.toggleAllButtonTextKey) {
           this._addonOptions.toggleAllButtonText = this.extensionUtility.translateWhenEnabledAndServiceExist(this._addonOptions.toggleAllButtonTextKey, 'TEXT_TOGGLE_ALL_GROUPS');
@@ -179,12 +178,11 @@ export class SlickDraggableGrouping {
         );
       }
 
-      this._dropzonePlaceholderElm = createDomElement('div', { className: 'slick-draggable-dropzone-placeholder' });
+      this._dropzonePlaceholderElm = createDomElement('div', { className: 'slick-draggable-dropzone-placeholder' }, this._dropzoneElm);
       if (this.gridOptions.enableTranslate && this._addonOptions?.dropPlaceHolderTextKey) {
         this._addonOptions.dropPlaceHolderText = this.extensionUtility.translateWhenEnabledAndServiceExist(this._addonOptions.dropPlaceHolderTextKey, 'TEXT_TOGGLE_ALL_GROUPS');
       }
       this._dropzonePlaceholderElm.textContent = this._addonOptions?.dropPlaceHolderText ?? this._defaults.dropPlaceHolderText ?? '';
-      this._dropzoneElm.appendChild(this._dropzonePlaceholderElm);
 
       this.setupColumnDropbox();
 
@@ -196,11 +194,10 @@ export class SlickDraggableGrouping {
 
           // also optionally add an icon beside each column title that can be dragged
           if (this._addonOptions.groupIconCssClass) {
-            const groupableIconElm = createDomElement('span', { className: 'slick-column-groupable' });
+            const groupableIconElm = createDomElement('span', { className: 'slick-column-groupable' }, node);
             if (this._addonOptions.groupIconCssClass) {
               groupableIconElm.classList.add(...this._addonOptions.groupIconCssClass.split(' '));
             }
-            node.appendChild(groupableIconElm);
           }
         }
       });
@@ -445,12 +442,11 @@ export class SlickDraggableGrouping {
               className: 'slick-dropped-grouping',
               dataset: { id: `${col.id}` }
             });
-            const groupTextElm = createDomElement('div', {
+            createDomElement('div', {
               className: 'slick-dropped-grouping-title',
               style: { display: 'inline-flex' },
               textContent: columnNameElm ? columnNameElm.textContent : headerColumnElm.textContent,
-            });
-            entryElm.appendChild(groupTextElm);
+            }, entryElm);
 
             // delete icon
             const groupRemoveIconElm = createDomElement('div', { className: 'slick-groupby-remove' });
@@ -467,9 +463,8 @@ export class SlickDraggableGrouping {
               if (col.grouping?.sortAsc === undefined) {
                 col.grouping.sortAsc = true;
               }
-              groupSortContainerElm = createDomElement('div', { className: 'slick-groupby-sort' });
+              groupSortContainerElm = createDomElement('div', { className: 'slick-groupby-sort' }, entryElm);
               this.getGroupBySortIcon(groupSortContainerElm, col.grouping.sortAsc);
-              entryElm.appendChild(groupSortContainerElm);
             }
 
             entryElm.appendChild(groupRemoveIconElm);
@@ -622,7 +617,7 @@ export class SlickDraggableGrouping {
   }
 
   /** call notify on slickgrid event and execute onGroupChanged callback when defined as a function by the user */
-  protected triggerOnGroupChangedEvent(args: { caller?: string; groupColumns: Grouping[] }) {
+  protected triggerOnGroupChangedEvent(args: { caller?: string; groupColumns: Grouping[]; }) {
     if (this._addonOptions && typeof this._addonOptions.onGroupChanged === 'function') {
       this._addonOptions.onGroupChanged(new Slick.EventData(), args);
     }

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -225,8 +225,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         style: { display: 'none' }
       });
 
-      this._commandMenuElm = createDomElement('div', { className: 'slick-menu-command-list', role: 'menu' });
-      this._menuElm.appendChild(this._commandMenuElm);
+      this._commandMenuElm = createDomElement('div', { className: 'slick-menu-command-list', role: 'menu' }, this._menuElm);
 
       this.recreateCommandList(this._gridMenuOptions, {
         grid: this.grid,

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -140,10 +140,10 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
 
     if (!this._menuElm) {
       this._menuElm = createDomElement('div', {
+        ariaExpanded: 'true',
         className: 'slick-header-menu', role: 'menu',
         style: { minWidth: `${this.addonOptions.minWidth}px` },
       });
-      this._menuElm.setAttribute('aria-expanded', 'true');
       this.grid.getContainerNode()?.appendChild(this._menuElm);
     }
 
@@ -178,7 +178,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
         return;
       }
 
-      const headerButtonDivElm = createDomElement('div', { className: 'slick-header-menu-button', ariaLabel: 'Header Menu' });
+      const headerButtonDivElm = createDomElement('div', { className: 'slick-header-menu-button', ariaLabel: 'Header Menu' }, args.node);
 
       if (this.addonOptions.buttonCssClass) {
         headerButtonDivElm.classList.add(...this.addonOptions.buttonCssClass.split(' '));
@@ -187,7 +187,6 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
       if (this.addonOptions.tooltip) {
         headerButtonDivElm.title = this.addonOptions.tooltip;
       }
-      args.node.appendChild(headerButtonDivElm);
 
       // show the header menu dropdown list of commands
       this._bindEventService.bind(headerButtonDivElm, 'click', ((e: MouseEvent) => this.showMenu(e, column, menu)) as EventListener);

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -294,8 +294,7 @@ export class SlickRowMoveManager {
           width: `${this._canvas.clientWidth}px`,
           height: `${rowHeight * selectedRows.length}px`,
         }
-      });
-      this._canvas.appendChild(dd.selectionProxy);
+      }, this._canvas);
 
       dd.guide = createDomElement('div', {
         className: 'slick-reorder-guide',
@@ -305,8 +304,7 @@ export class SlickRowMoveManager {
           width: `${this._canvas.clientWidth}px`,
           top: `-1000px`,
         }
-      });
-      this._canvas.appendChild(dd.guide);
+      }, this._canvas);
 
       dd.insertBefore = -1;
     }

--- a/packages/common/src/filters/__tests__/nativeSelectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/nativeSelectFilter.spec.ts
@@ -121,7 +121,7 @@ describe('NativeSelectFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('select.form-control.search-filter.filter-gender') as HTMLInputElement;
 
-    expect(filterInputElm.getAttribute('aria-label')).toBe('Gender Search Filter');
+    expect(filterInputElm.ariaLabel).toBe('Gender Search Filter');
   });
 
   it('should trigger select change event and expect the callback to be called with the search terms we select from dropdown list', () => {

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -387,16 +387,15 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
       placeholder = this.columnFilter.placeholder;
     }
 
-    const inputElm = createDomElement('input', {
+    this._filterElm = createDomElement('input', {
       type: 'text',
+      ariaLabel: this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`,
       autocomplete: 'none',
       placeholder,
       className: `form-control search-filter filter-${columnId} slick-autocomplete-container`,
       value: (searchTerm ?? '') as string,
       dataset: { columnid: `${columnId}` }
     });
-    inputElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
-    this._filterElm = inputElm;
 
     // create the DOM element & add an ID and filter class
     const searchTermInput = searchTerm as string;
@@ -471,25 +470,25 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
       } as AutocompleteSettings<any>);
     }
 
-    inputElm.value = searchTermInput ?? '';
+    this._filterElm.value = searchTermInput ?? '';
 
     // append the new DOM element to the header row
     const filterDivContainerElm = createDomElement('div', { className: 'autocomplete-filter-container' });
-    filterDivContainerElm.appendChild(inputElm);
+    filterDivContainerElm.appendChild(this._filterElm);
 
     // add an empty <span> in order to add loading spinner styling
     filterDivContainerElm.appendChild(createDomElement('span'));
 
     // if there's a search term, we will add the "filled" class for styling purposes
     if (searchTerm) {
-      inputElm.classList.add('filled');
+      this._filterElm.classList.add('filled');
     }
 
     // append the new DOM element to the header row & an empty span
     this.filterContainerElm.appendChild(filterDivContainerElm);
     this.filterContainerElm.appendChild(document.createElement('span'));
 
-    return inputElm;
+    return this._filterElm;
   }
 
   //

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -364,15 +364,11 @@ export class DateFilter implements Filter {
     } else {
       this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.gridOptions);
       const filterContainerElm = createDomElement('div', { className: `form-group search-filter filter-${columnId}` });
-      const containerInputGroupElm = createDomElement('div', { className: 'input-group flatpickr' });
-      const operatorInputGroupAddonElm = createDomElement('div', { className: 'input-group-addon input-group-prepend operator' });
+      const containerInputGroupElm = createDomElement('div', { className: 'input-group flatpickr' }, filterContainerElm);
+      const operatorInputGroupAddonElm = createDomElement('div', { className: 'input-group-addon input-group-prepend operator' }, containerInputGroupElm);
 
       operatorInputGroupAddonElm.appendChild(this._selectOperatorElm);
-      containerInputGroupElm.appendChild(operatorInputGroupAddonElm);
       containerInputGroupElm.appendChild(this._filterDivInputElm);
-
-      // create the DOM element & add an ID and filter class
-      filterContainerElm.appendChild(containerInputGroupElm);
 
       if (this.operator) {
         const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -284,17 +284,13 @@ export class InputFilter implements Filter {
       this._filterInputElm.classList.add('compound-input');
       this._selectOperatorElm = buildSelectOperator(this.getCompoundOperatorOptionValues(), this.gridOptions);
       this._filterContainerElm = createDomElement('div', { className: `form-group search-filter filter-${columnId}` });
-      const containerInputGroupElm = createDomElement('div', { className: 'input-group' });
-      const operatorInputGroupAddonElm = createDomElement('div', { className: 'input-group-addon input-group-prepend operator' });
+      const containerInputGroupElm = createDomElement('div', { className: 'input-group' }, this._filterContainerElm);
+      const operatorInputGroupAddonElm = createDomElement('div', { className: 'input-group-addon input-group-prepend operator' }, containerInputGroupElm);
 
       // append operator & input DOM element
       operatorInputGroupAddonElm.appendChild(this._selectOperatorElm);
-      containerInputGroupElm.appendChild(operatorInputGroupAddonElm);
       containerInputGroupElm.appendChild(this._filterInputElm);
       containerInputGroupElm.appendChild(createDomElement('span'));
-
-      // create the DOM element & add an ID and filter class
-      this._filterContainerElm.appendChild(containerInputGroupElm);
 
       if (this.operator) {
         this._selectOperatorElm.value = mapOperatorToShorthandDesignation(this.operator);

--- a/packages/common/src/filters/nativeSelectFilter.ts
+++ b/packages/common/src/filters/nativeSelectFilter.ts
@@ -85,7 +85,7 @@ export class NativeSelectFilter implements Filter {
     }
 
     // step 1, create the DOM Element of the filter & initialize it if searchTerm is filled
-    this.filterElm = this.createDomElement(searchTerm);
+    this.filterElm = this.createFilterElement(searchTerm);
 
     // step 2, subscribe to the change event and run the callback when that happens
     // also add/remove "filled" class for styling purposes
@@ -149,8 +149,10 @@ export class NativeSelectFilter implements Filter {
    */
   buildFilterSelectFromCollection(collection: any[]): HTMLSelectElement {
     const columnId = this.columnDef?.id ?? '';
-    const selectElm = createDomElement('select', { className: `form-control search-filter filter-${columnId}` });
-    selectElm.setAttribute('aria-label', this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`);
+    const selectElm = createDomElement('select', {
+      className: `form-control search-filter filter-${columnId}`,
+      ariaLabel: this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`
+    });
 
     const labelName = this.columnFilter.customStructure?.label ?? 'label';
     const valueName = this.columnFilter.customStructure?.value ?? 'value';
@@ -185,7 +187,7 @@ export class NativeSelectFilter implements Filter {
    * From the html template string, create a DOM element
    * @param filterTemplate
    */
-  protected createDomElement(searchTerm?: SearchTerm): HTMLSelectElement {
+  protected createFilterElement(searchTerm?: SearchTerm): HTMLSelectElement {
     const columnId = this.columnDef?.id ?? '';
     emptyElement(this.filterContainerElm);
 

--- a/packages/common/src/filters/selectFilter.ts
+++ b/packages/common/src/filters/selectFilter.ts
@@ -357,7 +357,7 @@ export class SelectFilter implements Filter {
 
     // step 2, create the DOM Element of the filter & pre-load search terms
     // we will later also subscribe to the onClose event to filter the data whenever that event is triggered
-    this.createDomElement(selectBuildResult.selectElement);
+    this.createFilterElement(selectBuildResult.selectElement);
     this._collectionLength = newCollection.length;
   }
 
@@ -380,7 +380,7 @@ export class SelectFilter implements Filter {
    * From the Select DOM Element created earlier, create a Multiple/Single Select Filter using the jQuery multiple-select.js lib
    * @param {Object} selectElement
    */
-  protected createDomElement(selectElement: HTMLSelectElement) {
+  protected createFilterElement(selectElement: HTMLSelectElement) {
     const columnId = this.columnDef?.id ?? '';
 
     // provide the name attribute to the DOM element which will be needed to auto-adjust drop position (dropup / dropdown)

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -268,14 +268,16 @@ export class SliderFilter implements Filter {
     const defaultStartValue = +((Array.isArray(searchTerms) && searchTerms?.[0]) ?? getFilterOptionByName<SliderRangeOption, 'sliderStartValue'>(this.columnFilter, 'sliderStartValue') ?? minValue);
     const defaultEndValue = +((Array.isArray(searchTerms) && searchTerms?.[1]) ?? getFilterOptionByName<SliderRangeOption, 'sliderEndValue'>(this.columnFilter, 'sliderEndValue') ?? maxValue);
 
-    this._sliderRangeContainElm = createDomElement('div', { className: `filter-input filter-${columnId} slider-input-container slider-values` });
-    this._sliderRangeContainElm.title = this.sliderType === 'double' ? `${defaultStartValue} - ${defaultEndValue}` : `${defaultStartValue}`;
+    this._sliderRangeContainElm = createDomElement('div', {
+      className: `filter-input filter-${columnId} slider-input-container slider-values`,
+      title: this.sliderType === 'double' ? `${defaultStartValue} - ${defaultEndValue}` : `${defaultStartValue}`
+    });
     this._sliderTrackElm = createDomElement('div', { className: 'slider-track' });
 
     // create Operator dropdown DOM element
     if (this.sliderType === 'compound') {
-      this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.gridOptions);
       const spanPrependElm = createDomElement('span', { className: 'input-group-addon input-group-prepend operator' });
+      this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.gridOptions);
       spanPrependElm.appendChild(this._selectOperatorElm);
     }
 
@@ -326,8 +328,7 @@ export class SliderFilter implements Filter {
       }
 
       const rightDivGroupElm = createDomElement('div', { className: `input-group-addon input-group-append slider-range-value` });
-      this._rightSliderNumberElm = createDomElement('span', { className: `input-group-text highest-range-${columnId}`, textContent: `${rightDefaultVal}` });
-      rightDivGroupElm.appendChild(this._rightSliderNumberElm);
+      this._rightSliderNumberElm = createDomElement('span', { className: `input-group-text highest-range-${columnId}`, textContent: `${rightDefaultVal}` }, rightDivGroupElm);
 
       if (leftDivGroupElm) {
         this._divContainerFilterElm.appendChild(leftDivGroupElm);

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -180,7 +180,7 @@ export function createDomElement<T extends keyof HTMLElementTagNameMap, K extend
       }
     });
   }
-  if (appendToParent && appendToParent.appendChild) {
+  if (appendToParent?.appendChild) {
     appendToParent.appendChild(elm);
   }
   return elm;

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -1,4 +1,3 @@
-import { deepMerge } from '@slickgrid-universal/utils';
 import * as DOMPurify_ from 'dompurify';
 const DOMPurify = ((DOMPurify_ as any)?.['default'] ?? DOMPurify_); // patch for rollup
 
@@ -154,19 +153,35 @@ export function calculateAvailableSpace(element: HTMLElement): { top: number; bo
   return { top, bottom, left, right };
 }
 
-/** Create a DOM Element with any optional attributes or properties */
-export function createDomElement<T extends keyof HTMLElementTagNameMap, K extends keyof HTMLElementTagNameMap[T]>(tagName: T, elementOptions?: { [P in K]: InferDOMType<HTMLElementTagNameMap[T][P]> }): HTMLElementTagNameMap[T] {
+/**
+ * Create a DOM Element with any optional attributes or properties.
+ * It will only accept valid DOM element properties that `createElement` would accept.
+ * For example: `createDomElement('div', { className: 'my-css-class' })`,
+ * for style or dataset you need to use nested object `{ style: { display: 'none' }}
+ * The last argument is to optionally append the created element to a parent container element.
+ * @param {String} tagName - html tag
+ * @param {Object} options - element properties
+ * @param {[Element]} appendToParent - parent element to append to
+ */
+export function createDomElement<T extends keyof HTMLElementTagNameMap, K extends keyof HTMLElementTagNameMap[T]>(
+  tagName: T,
+  elementOptions?: { [P in K]: InferDOMType<HTMLElementTagNameMap[T][P]> },
+  appendToParent?: Element
+): HTMLElementTagNameMap[T] {
   const elm = document.createElement<T>(tagName);
 
   if (elementOptions) {
     Object.keys(elementOptions).forEach((elmOptionKey) => {
       const elmValue = elementOptions[elmOptionKey as keyof typeof elementOptions];
       if (typeof elmValue === 'object') {
-        deepMerge(elm[elmOptionKey as K], elmValue);
+        Object.assign(elm[elmOptionKey as K] as object, elmValue);
       } else {
         elm[elmOptionKey as K] = (elementOptions as any)[elmOptionKey as keyof typeof elementOptions];
       }
     });
+  }
+  if (appendToParent && appendToParent.appendChild) {
+    appendToParent.appendChild(elm);
   }
   return elm;
 }

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -159,9 +159,8 @@ export class GroupingAndColspanService {
             style: { width: `${widthTotal - headerColumnWidthDiff}px` }
           });
 
-          const spanColumnNameElm = createDomElement('span', { className: 'slick-column-name', textContent: colDef.columnGroup || '' });
+          createDomElement('span', { className: 'slick-column-name', textContent: colDef.columnGroup || '' }, headerElm);
 
-          headerElm.appendChild(spanColumnNameElm);
           preHeaderPanel.appendChild(headerElm);
         }
         lastColumnGroup = colDef.columnGroup || '';

--- a/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
@@ -715,8 +715,8 @@ describe('CompositeEditorService', () => {
       expect(component.constructor).toBeDefined();
       expect(compositeContainerElm).toBeTruthy();
       expect(compositeFooterCancelBtnElm).toBeTruthy();
-      expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Cancel');
-      expect(compositeFooterCloseBtnElm.getAttribute('aria-label')).toBe('Close');
+      expect(compositeFooterCancelBtnElm.ariaLabel).toBe('Cancel');
+      expect(compositeFooterCloseBtnElm.ariaLabel).toBe('Close');
       expect(getEditSpy).toHaveBeenCalled();
       expect(cancelSpy).toHaveBeenCalled();
     });
@@ -811,8 +811,8 @@ describe('CompositeEditorService', () => {
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeHeaderElm).toBeTruthy();
         expect(compositeTitleElm).toBeTruthy();
-        expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Cancel');
-        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Clone');
+        expect(compositeFooterCancelBtnElm.ariaLabel).toBe('Cancel');
+        expect(compositeFooterSaveBtnElm.ariaLabel).toBe('Clone');
         expect(compositeTitleElm.textContent).toBe('Details');
         expect(productNameLabelElm.textContent).toBe('Product');
         expect(productNameDetailCellElm.classList.contains('modified')).toBe(true);
@@ -1078,7 +1078,7 @@ describe('CompositeEditorService', () => {
         expect(component).toBeTruthy();
         expect(input1ResetButtonElm).toBeTruthy();
         expect(input2ResetButtonElm).toBeTruthy();
-        expect(input1ResetButtonElm.getAttribute('aria-label')).toBe('Reset');
+        expect(input1ResetButtonElm.ariaLabel).toBe('Reset');
         expect(component.constructor).toBeDefined();
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeHeaderElm).toBeTruthy();
@@ -1527,7 +1527,7 @@ describe('CompositeEditorService', () => {
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeTitleElm.textContent).toBe('Mass Update');
         expect(compositeFooterSaveBtnElm.textContent).toBe('Mass Update');
-        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Mass Update');
+        expect(compositeFooterSaveBtnElm.ariaLabel).toBe('Mass Update');
       });
 
       it('should expect to have a header title & modal type representing "mass-selection" when using "auto-mass" type and having some row(s) selected', () => {
@@ -1548,7 +1548,7 @@ describe('CompositeEditorService', () => {
         expect(compositeContainerElm).toBeTruthy();
         expect(compositeTitleElm.textContent).toBe('Mass Selection');
         expect(compositeFooterSaveBtnElm.textContent).toBe('Update Selection');
-        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Update Selection');
+        expect(compositeFooterSaveBtnElm.ariaLabel).toBe('Update Selection');
       });
 
       it('should activate next available cell with an Editor when current active cell does not have an Editor', () => {
@@ -1958,8 +1958,8 @@ describe('CompositeEditorService', () => {
       expect(productNameLabelElm.textContent).toBe('Produit');
       expect(compositeFooterCancelBtnElm.textContent).toBe('Annuler');
       expect(compositeFooterSaveBtnElm.textContent).toBe('Sauvegarder');
-      expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Annuler');
-      expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Sauvegarder');
+      expect(compositeFooterCancelBtnElm.ariaLabel).toBe('Annuler');
+      expect(compositeFooterSaveBtnElm.ariaLabel).toBe('Sauvegarder');
     });
 
     it('should have translate text when opening Composite Editor when cloning an Item', () => {
@@ -1992,7 +1992,7 @@ describe('CompositeEditorService', () => {
       expect(productNameLabelElm.textContent).toBe('Produit');
       expect(compositeFooterCancelBtnElm.textContent).toBe('Annuler');
       expect(compositeFooterSaveBtnElm.textContent).toBe('Cloner');
-      expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Cloner');
+      expect(compositeFooterSaveBtnElm.ariaLabel).toBe('Cloner');
     });
 
     it('should have translated text when handling a saving of grid changes when "Mass Selection" save button is clicked', (done) => {
@@ -2037,9 +2037,9 @@ describe('CompositeEditorService', () => {
         expect(compositeTitleElm.textContent).toBe('Details');
         expect(field3LabelElm.textContent).toBe('Nom du Groupe - Durée');
         expect(compositeFooterCancelBtnElm.textContent).toBe('Annuler');
-        expect(compositeFooterCancelBtnElm.getAttribute('aria-label')).toBe('Annuler');
+        expect(compositeFooterCancelBtnElm.ariaLabel).toBe('Annuler');
         expect(compositeFooterSaveBtnElm.textContent).toBe('Mettre à jour la sélection');
-        expect(compositeFooterSaveBtnElm.getAttribute('aria-label')).toBe('Mettre à jour la sélection');
+        expect(compositeFooterSaveBtnElm.ariaLabel).toBe('Mettre à jour la sélection');
         expect(updateItemsSpy).toHaveBeenCalledWith([mockProduct]);
         expect(cancelCommitSpy).toHaveBeenCalled();
         expect(setActiveRowSpy).toHaveBeenCalledWith(0);

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -375,32 +375,26 @@ export class SlickCompositeEditorComponent implements ExternalResource {
           className: 'slick-editor-modal-title',
           innerHTML: sanitizeTextByAvailableSanitizer(this.gridOptions, parsedHeaderTitle),
         });
-        const modalCloseButtonElm = createDomElement('button', { type: 'button', textContent: '×', className: 'close', dataset: { action: 'close' } });
-        modalCloseButtonElm.setAttribute('aria-label', 'Close');
+        const modalCloseButtonElm = createDomElement('button', { type: 'button', ariaLabel: 'Close', textContent: '×', className: 'close', dataset: { action: 'close' } });
         if (this._options.showCloseButtonOutside) {
           modalHeaderTitleElm?.classList?.add('outside');
           modalCloseButtonElm?.classList?.add('outside');
         }
 
-        const modalHeaderElm = createDomElement('div', { className: 'slick-editor-modal-header' });
-        modalHeaderElm.setAttribute('aria-label', 'Close');
+        const modalHeaderElm = createDomElement('div', { ariaLabel: 'Close', className: 'slick-editor-modal-header' });
         modalHeaderElm.appendChild(modalHeaderTitleElm);
         modalHeaderElm.appendChild(modalCloseButtonElm);
 
         const modalBodyElm = createDomElement('div', { className: 'slick-editor-modal-body' });
-
-        this._modalBodyTopValidationElm = createDomElement('div', { className: 'validation-summary', style: { display: 'none' } });
-        modalBodyElm.appendChild(this._modalBodyTopValidationElm);
-
+        this._modalBodyTopValidationElm = createDomElement('div', { className: 'validation-summary', style: { display: 'none' } }, modalBodyElm);
         const modalFooterElm = createDomElement('div', { className: 'slick-editor-modal-footer' });
-
         const modalCancelButtonElm = createDomElement('button', {
           type: 'button',
+          ariaLabel: this.getLabelText('cancelButton', 'TEXT_CANCEL', 'Cancel'),
           className: 'btn btn-cancel btn-default btn-sm',
           textContent: this.getLabelText('cancelButton', 'TEXT_CANCEL', 'Cancel'),
           dataset: { action: 'cancel' },
         });
-        modalCancelButtonElm.setAttribute('aria-label', this.getLabelText('cancelButton', 'TEXT_CANCEL', 'Cancel'));
 
         let leftFooterText = '';
         let saveButtonText = '';
@@ -425,13 +419,13 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         const selectionCounterElm = createDomElement('div', { className: 'footer-status-text', textContent: leftFooterText });
         this._modalSaveButtonElm = createDomElement('button', {
           type: 'button', className: 'btn btn-save btn-primary btn-sm',
+          ariaLabel: saveButtonText,
           textContent: saveButtonText,
           dataset: {
             action: (modalType === 'create' || modalType === 'edit') ? 'save' : modalType,
             ariaLabel: saveButtonText
           }
         });
-        this._modalSaveButtonElm.setAttribute('aria-label', saveButtonText);
 
         const footerContainerElm = createDomElement('div', { className: 'footer-buttons' });
 
@@ -644,10 +638,10 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   protected createEditorResetButtonElement(columnId: string): HTMLButtonElement {
     const resetButtonElm = createDomElement('button', {
       type: 'button', name: columnId,
+      ariaLabel: 'Reset',
       title: this._options?.labels?.resetFormButton ?? 'Reset Form Input',
       className: 'btn btn-xs btn-editor-reset'
     });
-    resetButtonElm.setAttribute('aria-label', 'Reset');
 
     if (this._options?.resetEditorButtonCssClass) {
       const resetBtnClasses = this._options?.resetEditorButtonCssClass.split(' ');
@@ -666,11 +660,9 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    */
   protected createFormResetButtonElement(): HTMLDivElement {
     const resetButtonContainerElm = createDomElement('div', { className: 'reset-container' });
-    const resetButtonElm = createDomElement('button', { type: 'button', className: 'btn btn-sm reset-form' });
-    const resetIconSpanElm = createDomElement('span', { className: this._options?.resetFormButtonIconCssClass ?? '' });
-    resetButtonElm.appendChild(resetIconSpanElm);
+    const resetButtonElm = createDomElement('button', { type: 'button', className: 'btn btn-sm reset-form' }, resetButtonContainerElm);
+    createDomElement('span', { className: this._options?.resetFormButtonIconCssClass ?? '' }, resetButtonElm);
     resetButtonElm.appendChild(document.createTextNode(' Reset Form'));
-    resetButtonContainerElm.appendChild(resetButtonElm);
 
     return resetButtonContainerElm;
   }

--- a/packages/custom-footer-component/src/slick-footer.component.ts
+++ b/packages/custom-footer-component/src/slick-footer.component.ts
@@ -198,7 +198,7 @@ export class SlickFooterComponent {
       rightFooterElm.innerHTML = sanitizeTextByAvailableSanitizer(this.gridOptions, this.customFooterOptions.rightFooterText || '');
     } else if (!this.customFooterOptions.hideMetrics) {
       rightFooterElm.classList.add('metrics');
-      const lastUpdateElm = createDomElement('span', { className: 'timestamp' });
+      const lastUpdateElm = createDomElement('span', { className: 'timestamp' }, rightFooterElm);
 
       if (!this.customFooterOptions.hideLastUpdateTimestamp) {
         const footerLastUpdateElm = this.createFooterLastUpdate();
@@ -208,7 +208,6 @@ export class SlickFooterComponent {
       }
 
       // last update elements
-      rightFooterElm.appendChild(lastUpdateElm);
       rightFooterElm.appendChild(
         createDomElement('span', { className: 'item-count', textContent: `${this.metrics?.itemCount ?? '0'}` })
       );
@@ -245,15 +244,10 @@ export class SlickFooterComponent {
     const lastUpdateTimestamp = moment(this.metrics?.endTime).format(this.customFooterOptions.dateFormat);
     const lastUpdateContainerElm = createDomElement('span');
 
-    lastUpdateContainerElm.appendChild(
-      createDomElement('span', { className: 'text-last-update', textContent: lastUpdateText }));
+    lastUpdateContainerElm.appendChild(createDomElement('span', { className: 'text-last-update', textContent: lastUpdateText }));
     lastUpdateContainerElm.appendChild(document.createTextNode('\r\n'));
-    lastUpdateContainerElm.appendChild(
-      createDomElement('span', { className: 'last-update-timestamp', textContent: lastUpdateTimestamp })
-    );
-    lastUpdateContainerElm.appendChild(
-      createDomElement('span', { className: 'separator', textContent: ` ${this.customFooterOptions.metricSeparator || ''} ` })
-    );
+    lastUpdateContainerElm.appendChild(createDomElement('span', { className: 'last-update-timestamp', textContent: lastUpdateTimestamp }));
+    lastUpdateContainerElm.appendChild(createDomElement('span', { className: 'separator', textContent: ` ${this.customFooterOptions.metricSeparator || ''} ` }));
 
     return lastUpdateContainerElm;
   }

--- a/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
@@ -106,8 +106,11 @@ describe('Slick-Pagination Component', () => {
       const pageInfoTotalItems = document.querySelector('.page-info-total-items') as HTMLSpanElement;
 
       expect(translateService.getCurrentLanguage()).toBe('en');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" data-test="item-from" aria-label="Page Item From">10</span>-<span class="item-to" data-test="item-to" aria-label="Page Item To">15</span> <span class="text-of">of</span> ');
-      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" data-test="total-items" aria-label="Total Items">95</span> <span class="text-items">items</span> ');
+      expect(pageInfoFromTo.querySelector('span.item-from')!.ariaLabel).toBe('Page Item From'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
+      expect(pageInfoFromTo.querySelector('span.item-to')!.ariaLabel).toBe('Page Item To');
+      expect(pageInfoTotalItems.querySelector('span.total-items')!.ariaLabel).toBe('Total Items');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" data-test="item-from">10</span>-<span class="item-to" data-test="item-to">15</span> <span class="text-of">of</span> ');
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" data-test="total-items">95</span> <span class="text-items">items</span> ');
       component.dispose();
     });
   });

--- a/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
@@ -96,8 +96,11 @@ describe('Slick-Pagination Component', () => {
       const itemsPerPage = document.querySelector('.items-per-page') as HTMLSelectElement;
 
       expect(translateService.getCurrentLanguage()).toBe('en');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" data-test="item-from" aria-label="Page Item From">10</span>-<span class="item-to" data-test="item-to" aria-label="Page Item To">15</span> <span class="text-of">of</span> ');
-      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" data-test="total-items" aria-label="Total Items">95</span> <span class="text-items">items</span> ');
+      expect(pageInfoFromTo.querySelector('span.item-from')!.ariaLabel).toBe('Page Item From'); // JSDom doesn't support ariaLabel, but we can test attribute this way
+      expect(pageInfoFromTo.querySelector('span.item-to')!.ariaLabel).toBe('Page Item To');
+      expect(pageInfoTotalItems.querySelector('span.total-items')!.ariaLabel).toBe('Total Items');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" data-test="item-from">10</span>-<span class="item-to" data-test="item-to">15</span> <span class="text-of">of</span> ');
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" data-test="total-items">95</span> <span class="text-items">items</span> ');
       expect(itemsPerPage.selectedOptions[0].value).toBe('5');
     });
 
@@ -268,8 +271,11 @@ describe('with different i18n locale', () => {
       const pageInfoFromTo = document.querySelector('.page-info-from-to') as HTMLSpanElement;
       const pageInfoTotalItems = document.querySelector('.page-info-total-items') as HTMLSpanElement;
       expect(translateService.getCurrentLanguage()).toBe('fr');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span class="item-from" data-test="item-from" aria-label="Page Item From">10</span>-<span class="item-to" data-test="item-to" aria-label="Page Item To">15</span> <span class="text-of">de</span> `);
-      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe(`<span class="total-items" data-test="total-items" aria-label="Total Items">95</span> <span class="text-items">éléments</span> `);
+      expect(pageInfoFromTo.querySelector('span.item-from')!.ariaLabel).toBe('Page Item From'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
+      expect(pageInfoFromTo.querySelector('span.item-to')!.ariaLabel).toBe('Page Item To');
+      expect(pageInfoTotalItems.querySelector('span.total-items')!.ariaLabel).toBe('Total Items');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span class="item-from" data-test="item-from">10</span>-<span class="item-to" data-test="item-to">15</span> <span class="text-of">de</span> `);
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe(`<span class="total-items" data-test="total-items">95</span> <span class="text-items">éléments</span> `);
       done();
     }, 50);
   });

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -170,9 +170,7 @@ export class SlickPaginationComponent {
     const selectElm = document.querySelector<HTMLSelectElement>(`.${this.gridUid} .items-per-page`);
     if (selectElm && Array.isArray(this.availablePageSizes)) {
       for (const option of this.availablePageSizes) {
-        selectElm.appendChild(
-          createDomElement('option', { value: `${option}`, text: `${option}` })
-        );
+        selectElm.appendChild(createDomElement('option', { value: `${option}`, text: `${option}` }));
       }
     }
   }
@@ -273,12 +271,8 @@ export class SlickPaginationComponent {
     const ulElm = createDomElement('ul', { className: 'pagination' });
 
     for (const li of liElements) {
-      const liElm = createDomElement('li', { className: li.liClass });
-      const aElm = createDomElement('a', { className: li.aClass });
-      aElm.setAttribute('aria-label', li.ariaLabel);
-      aElm.role = 'button';
-      liElm.appendChild(aElm);
-      ulElm.appendChild(liElm);
+      createDomElement('li', { className: li.liClass }, ulElm)
+        .appendChild(createDomElement('a', { className: li.aClass, ariaLabel: li.ariaLabel, role: 'button' }));
     }
     navElm.appendChild(ulElm);
 
@@ -287,60 +281,42 @@ export class SlickPaginationComponent {
 
   protected createPageNumberSection() {
     const divElm = createDomElement('div', { className: 'slick-page-number' });
-    const spanTextPageElm = createDomElement('span', { className: 'text-page', textContent: 'Page' });
-    const input = createDomElement('input', {
+    createDomElement('span', { className: 'text-page', textContent: 'Page' }, divElm);
+    divElm.appendChild(document.createTextNode(' '));
+    createDomElement('input', {
       type: 'text', className: 'form-control page-number',
+      ariaLabel: 'Page Number',
       value: '1', size: 1,
       dataset: { test: 'page-number-input' },
-    });
-    input.setAttribute('aria-label', 'Page Number');
-    const spanTextOfElm = createDomElement('span', { className: 'text-of', textContent: 'of' });
-    const spanPageCountElm = createDomElement('span', { className: 'page-count', dataset: { test: 'page-count' } });
-    divElm.appendChild(spanTextPageElm);
+    }, divElm);
     divElm.appendChild(document.createTextNode(' '));
-    divElm.appendChild(input);
+    createDomElement('span', { className: 'text-of', textContent: 'of' }, divElm);
     divElm.appendChild(document.createTextNode(' '));
-    divElm.appendChild(spanTextOfElm);
-    divElm.appendChild(document.createTextNode(' '));
-    divElm.appendChild(spanPageCountElm);
+    createDomElement('span', { className: 'page-count', dataset: { test: 'page-count' } }, divElm);
 
     return divElm;
   }
 
   protected createPaginationSettingsSection() {
     const spanContainerElm = createDomElement('span', { className: 'slick-pagination-settings' });
-    const selectElm = createDomElement('select', { id: 'items-per-page-label', className: 'items-per-page' });
-    selectElm.setAttribute('aria-label', 'Items per Page');
-    const spanItemPerPageElm = createDomElement('span', { className: 'text-item-per-page', textContent: 'items per page' });
-    const spanPaginationCount = createDomElement('span', { className: 'slick-pagination-count' });
-    const spanInfoFromToElm = createDomElement('span', { className: 'page-info-from-to' });
-    const spanItemFromElm = createDomElement('span', { className: 'item-from', dataset: { test: 'item-from' } });
-    spanItemFromElm.setAttribute('aria-label', 'Page Item From');
-    const spanItemToElm = createDomElement('span', { className: 'item-to', dataset: { test: 'item-to' } });
-    spanItemToElm.setAttribute('aria-label', 'Page Item To');
-    const spanOfElm = createDomElement('span', { className: 'text-of', textContent: 'of' });
-    const spanInfoTotalElm = createDomElement('span', { className: 'page-info-total-items' });
-    const spanTotalItem = createDomElement('span', { className: 'total-items', dataset: { test: 'total-items' } });
-    spanTotalItem.setAttribute('aria-label', 'Total Items');
-    const spanTextItemsElm = createDomElement('span', { className: 'text-items', textContent: 'items' });
-
-    spanContainerElm.appendChild(selectElm);
+    createDomElement('select', { id: 'items-per-page-label', ariaLabel: 'Items per Page', className: 'items-per-page' }, spanContainerElm);
     spanContainerElm.appendChild(document.createTextNode(' '));
-    spanContainerElm.appendChild(spanItemPerPageElm);
+    createDomElement('span', { className: 'text-item-per-page', textContent: 'items per page' }, spanContainerElm);
     spanContainerElm.appendChild(document.createTextNode(', '));
-    spanInfoFromToElm.appendChild(spanItemFromElm);
+
+    const spanPaginationCount = createDomElement('span', { className: 'slick-pagination-count' }, spanContainerElm);
+    const spanInfoFromToElm = createDomElement('span', { className: 'page-info-from-to' }, spanPaginationCount);
+    createDomElement('span', { className: 'item-from', ariaLabel: 'Page Item From', dataset: { test: 'item-from' } }, spanInfoFromToElm);
     spanInfoFromToElm.appendChild(document.createTextNode('-'));
-    spanInfoFromToElm.appendChild(spanItemToElm);
+    createDomElement('span', { className: 'item-to', ariaLabel: 'Page Item To', dataset: { test: 'item-to' } }, spanInfoFromToElm);
     spanInfoFromToElm.appendChild(document.createTextNode(' '));
-    spanInfoFromToElm.appendChild(spanOfElm);
+    createDomElement('span', { className: 'text-of', textContent: 'of' }, spanInfoFromToElm);
     spanInfoFromToElm.appendChild(document.createTextNode(' '));
-    spanPaginationCount.appendChild(spanInfoFromToElm);
-    spanContainerElm.appendChild(spanPaginationCount);
-    spanInfoTotalElm.appendChild(spanTotalItem);
+    const spanInfoTotalElm = createDomElement('span', { className: 'page-info-total-items' }, spanPaginationCount);
+    createDomElement('span', { className: 'total-items', ariaLabel: 'Total Items', dataset: { test: 'total-items' } }, spanInfoTotalElm);
     spanInfoTotalElm.appendChild(document.createTextNode(' '));
-    spanInfoTotalElm.appendChild(spanTextItemsElm);
+    createDomElement('span', { className: 'text-items', textContent: 'items' }, spanInfoTotalElm);
     spanInfoTotalElm.appendChild(document.createTextNode(' '));
-    spanPaginationCount.appendChild(spanInfoTotalElm);
 
     return spanContainerElm;
   }

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -409,12 +409,12 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
       });
 
       it('should merge grid options with global options when slickgrid "getOptions" does not exist yet', () => {
-        mockGrid.getOptions = null;
+        mockGrid.getOptions = null as any;
         const setOptionSpy = jest.spyOn(mockGrid, 'setOptions');
         const sharedOptionSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'set');
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
 
-        component.gridOptions = { autoCommitEdit: false, autoResize: null };
+        component.gridOptions = { autoCommitEdit: false, autoResize: null as any };
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
@@ -424,12 +424,12 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
       });
 
       it('should merge grid options with global options and expect bottom padding to be calculated', () => {
-        mockGrid.getOptions = null;
+        mockGrid.getOptions = null as any;
         const setOptionSpy = jest.spyOn(mockGrid, 'setOptions');
         const sharedOptionSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'set');
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
 
-        component.gridOptions = { autoCommitEdit: false, autoResize: null };
+        component.gridOptions = { autoCommitEdit: false, autoResize: null as any };
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
@@ -573,9 +573,9 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
         component.dataset = mockData;
 
         setTimeout(() => {
-          expect(component.paginationOptions.pageSize).toBe(2);
-          expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
-          expect(component.paginationOptions.totalItems).toBe(expectedTotalItems);
+          expect(component.paginationOptions!.pageSize).toBe(2);
+          expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
+          expect(component.paginationOptions!.totalItems).toBe(expectedTotalItems);
           expect(refreshSpy).toHaveBeenCalledWith(mockData);
           done();
         });
@@ -600,9 +600,9 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
 
         setTimeout(() => {
           expect(getPagingSpy).toHaveBeenCalled();
-          expect(component.paginationOptions.pageSize).toBe(10);
-          expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
-          expect(component.paginationOptions.totalItems).toBe(expectedTotalItems);
+          expect(component.paginationOptions!.pageSize).toBe(10);
+          expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
+          expect(component.paginationOptions!.totalItems).toBe(expectedTotalItems);
           expect(refreshSpy).toHaveBeenCalledWith(mockData);
           done();
         });


### PR DESCRIPTION
- by adding a 3rd argument `appendToParent` when using `createDomElement()`, we can remove the need for temp variable in a few components and rely on the method to append the newly created element to a certain parent node. By doing this, we use less temp variables and lower the size of our build