### PR TITLE
fix(common): Select Filter/Editor regular text shouldn't be html encoded

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -27,7 +27,7 @@
     "fetch-jsonp": "^1.2.3",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^0.4.3",
+    "multiple-select-vanilla": "^0.4.4",
     "rxjs": "^7.8.1",
     "whatwg-fetch": "^3.6.2"
   },

--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -28,7 +28,7 @@
     "fetch-jsonp": "^1.2.3",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^0.3.1",
+    "multiple-select-vanilla": "^0.4.1",
     "rxjs": "^7.8.1",
     "whatwg-fetch": "^3.6.2"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -78,7 +78,7 @@
     "dompurify": "^3.0.3",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^0.4.3",
+    "multiple-select-vanilla": "^0.4.4",
     "slickgrid": "^4.0.0",
     "sortablejs": "^1.15.0",
     "un-flatten-tree": "^2.0.12"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -78,7 +78,7 @@
     "dompurify": "^3.0.3",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^0.3.1",
+    "multiple-select-vanilla": "^0.4.1",
     "slickgrid": "^4.0.0",
     "sortablejs": "^1.15.0",
     "un-flatten-tree": "^2.0.12"

--- a/packages/common/src/filters/selectFilter.ts
+++ b/packages/common/src/filters/selectFilter.ts
@@ -416,6 +416,7 @@ export class SelectFilter implements Filter {
       filter: false,  // input search term on top of the select option list
       maxHeight: 275,
       single: true,
+      useSelectOptionLabelToHtml: this.columnFilter?.enableRenderHtml ?? false,
       sanitizer: (dirtyHtml: string) => sanitizeTextByAvailableSanitizer(this.gridOptions, dirtyHtml),
       // we will subscribe to the onClose event for triggering our callback
       // also add/remove "filled" class for styling purposes

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -295,16 +295,19 @@ export function findWidthOrDefault(inputWidth?: number | string, defaultValue = 
  * HTML encode using a plain <div>
  * Create a in-memory div, set it's inner text(which a div can encode)
  * then grab the encoded contents back out.  The div never exists on the page.
+ * @param {String} inputValue - input value to be encoded
+ * @return {String}
  */
 export function htmlEncode(inputValue: string): string {
-  const entityMap = {
+  const val = typeof inputValue === 'string' ? inputValue : String(inputValue);
+  const entityMap: { [char: string]: string; } = {
     '&': '&amp;',
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
-    '\'': '&#39;'
+    '\'': '&#39;',
   };
-  return (inputValue || '').toString().replace(/[&<>"']/g, (s) => (entityMap as any)[s]);
+  return (val || '').toString().replace(/[&<>"']/g, (s) => entityMap[s as keyof { [char: string]: string; }]);
 }
 
 /**

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -88,9 +88,7 @@ export function buildMultipleSelectDataCollection(type: 'editor' | 'filter', col
         if (isRenderHtmlEnabled) {
           // sanitize any unauthorized html tags like script and others
           // for the remaining allowed tags we'll permit all attributes
-          optionText = sanitizeTextByAvailableSanitizer(gridOptions, optionText, sanitizedOptions);
-        } else {
-          optionText = htmlEncode(optionText);
+          optionText = htmlEncode(sanitizeTextByAvailableSanitizer(gridOptions, optionText, sanitizedOptions));
         }
         selectOption.text = optionText;
 

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -88,7 +88,7 @@ export function buildMultipleSelectDataCollection(type: 'editor' | 'filter', col
         if (isRenderHtmlEnabled) {
           // sanitize any unauthorized html tags like script and others
           // for the remaining allowed tags we'll permit all attributes
-          optionText = htmlEncode(sanitizeTextByAvailableSanitizer(gridOptions, optionText, sanitizedOptions));
+          optionText = sanitizeTextByAvailableSanitizer(gridOptions, optionText, sanitizedOptions);
         }
         selectOption.text = optionText;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^0.4.3
-        version: 0.4.3
+        specifier: ^0.4.4
+        version: 0.4.4
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -243,8 +243,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^0.4.3
-        version: 0.4.3
+        specifier: ^0.4.4
+        version: 0.4.4
       slickgrid:
         specifier: ^4.0.0
         version: 4.0.0
@@ -7079,8 +7079,8 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /multiple-select-vanilla@0.4.3:
-    resolution: {integrity: sha512-l3MNcn/eB1TZKPUlGuNFEKix16vbKCkeksHFUeNCWHSZsgTo0GezpHiT82BSwtDLzjwx1Q4ykKvXKG/49Jk8Wg==}
+  /multiple-select-vanilla@0.4.4:
+    resolution: {integrity: sha512-R6Sl93PyYAGL8LFUkp8W+ojdBEdVNZYd/eV2H+37rcolMKgyssjA5KsHO1d+5JnO6rr4Xm7npAmGfuHNehBM0g==}
     dev: false
 
   /mute-stream@1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.4.1
+        version: 0.4.1
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -243,8 +243,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.4.1
+        version: 0.4.1
       slickgrid:
         specifier: ^4.0.0
         version: 4.0.0
@@ -7079,8 +7079,8 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /multiple-select-vanilla@0.3.1:
-    resolution: {integrity: sha512-HJy4bYAcSSYcvGei82lhjxvch4y3/ypC5J5+shss5Hnwnpumw/+Rz4jEHl805XnmqME2/WCa0rwxnQnvmDSurA==}
+  /multiple-select-vanilla@0.4.1:
+    resolution: {integrity: sha512-LdWvT7PL7TH/BjK+RYMbjM2p1sm6vadiqDwkv1VBcyOFET/EIPUKwBLqha0WEf5ijC0ZW/XgOi2vKP/854DIFg==}
     dev: false
 
   /mute-stream@1.0.0:


### PR DESCRIPTION
- fix a regression bug introduced by PR #976 when migrating from ms-select to ms-select-vanilla, the text should be encode only when `renderHtmlEnabled` is enabled and not encoded when it's the flag is disabled, basically the html encode was set on the wrong condition
- in other words and in a shorter description, we should only html encode text when `enableRenderHtml` is enabled
- regression [commit](https://github.com/ghiscoding/slickgrid-universal/commit/4e3e1d394247be75d1717feece833e200fce21dc#diff-b2a170f113dc78eb35a2c240a583d68a7a1d37bbfa04bc7e2ec0c89620caa147) ref
- there was an issue in both libs to fix this regression which came from v3.0 when we removed jQuery and start using the new ms-select-vanilla lib
   - Multiple-Select-Vanilla [PR 86](https://github.com/ghiscoding/multiple-select-vanilla/pull/86)
   - and this PR here for Slickgrid-Universal


#### Regression bug 
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/555f7ebc-52f8-45c5-b318-908b7b62c885)

#### Before Fix
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/85499d4c-9ab0-4db2-b0c2-284cc2b6977e)

#### After Fix
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/f204db00-88b5-44ca-aaed-f937dc51d2a1)


#### when `renderOptionLabelAsHtml` is disabled
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/fc1cf660-94b1-45be-85e4-90e0415f5f6d)

#### when `renderOptionLabelAsHtml` is enabled
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/f45c87ef-6995-404e-9bd5-d615ea689a88)
