### PR TITLE
chore: do not recall Vite dev script since root package already does it

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "3.0.0",
   "scripts": {
-    "dev": "vite --mode development",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "build:demo": "tsc && vite build --mode production",

--- a/packages/common/build-watch.mjs
+++ b/packages/common/build-watch.mjs
@@ -34,7 +34,7 @@ async function run() {
       copyfiles(
         [relativeFile, 'dist/styles/sass'],
         { up: true },
-        (err) => { err ? console.error(err) : console.log(`Copied "${fileWithExtension}" to "dist/styles/sass"`) }
+        (err) => { err ? console.error(err) : console.log(`Copied "${fileWithExtension}" to "dist/styles/sass"`); }
       );
     }
   }


### PR DESCRIPTION
- when using Lerna-Lite watch, our `dev:watch` script in the root is already calling the `dev` script when a file changes so that tsc rebuilds all TS files, but we also had a `dev` script for Vite as well, so this was causing the Vite server to open another thread with a different port every time a file changed which wasn't correct. We don't need the `dev` script in the demo since we use `vite:dev` to start Vite and we only need to start it one time only