### PR TITLE
fix(grouping): DraggableGrouping could throw when leaving page

### DIFF
--- a/packages/common/src/extensions/extensionCommonUtils.ts
+++ b/packages/common/src/extensions/extensionCommonUtils.ts
@@ -76,7 +76,7 @@ export function handleColumnPickerItemClick(this: SlickColumnPicker | SlickGridM
     context.grid.setColumns(visibleColumns);
 
     // keep reference to the updated visible columns list
-    if (Array.isArray(visibleColumns) && visibleColumns.length !== context.sharedService.visibleColumns.length) {
+    if (!context.sharedService.visibleColumns || (Array.isArray(visibleColumns) && visibleColumns.length !== context.sharedService.visibleColumns.length)) {
       context.sharedService.visibleColumns = visibleColumns;
     }
 

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -28,11 +28,6 @@ import { sortByFieldType } from '../sortComparers';
 // using external SlickGrid JS libraries
 declare const Slick: SlickNamespace;
 
-// use global variable because "setupColumnReorder()" method is used as static
-// and doesn't have access to anything inside the class and we need to dipose/destroy cleanly of all Sortable instances
-// let sortableLeftInstance: SortableInstance;
-// let sortableRightInstance: SortableInstance;
-
 /**
  *
  * Draggable Grouping contributed by:  Muthukumar Selconstasu
@@ -215,12 +210,7 @@ export class SlickDraggableGrouping {
 
   /** Dispose the plugin. */
   dispose() {
-    if (this._sortableLeftInstance?.el) {
-      this._sortableLeftInstance?.destroy();
-    }
-    if (this._sortableRightInstance?.el) {
-      this._sortableRightInstance?.destroy();
-    }
+    this.destroySortableInstances();
     this.onGroupChanged.unsubscribe();
     this._eventHandler.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
@@ -242,6 +232,15 @@ export class SlickDraggableGrouping {
     this._dropzonePlaceholderElm.style.display = 'inline-block';
     if (this._groupToggler) {
       this._groupToggler.style.display = 'none';
+    }
+  }
+
+  destroySortableInstances() {
+    if (this._sortableLeftInstance?.el) {
+      this._sortableLeftInstance?.destroy();
+    }
+    if (this._sortableRightInstance?.el) {
+      this._sortableRightInstance?.destroy();
     }
   }
 
@@ -276,6 +275,7 @@ export class SlickDraggableGrouping {
    * @param trigger - callback to execute when triggering a column grouping
    */
   setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, _columns: Column[], getColumnIndex: (columnId: string) => number, _uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) {
+    this.destroySortableInstances();
     const dropzoneElm = grid.getPreHeaderPanel();
     const draggablePlaceholderElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-draggable-dropzone-placeholder');
     const groupTogglerElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-group-toggle-all');
@@ -545,7 +545,6 @@ export class SlickDraggableGrouping {
 
     this._droppableInstance = Sortable.create(dropzoneElm, {
       group: 'shared',
-      // chosenClass: 'slick-header-column-active',
       ghostClass: 'slick-droppable-sortitem-hover',
       draggable: '.slick-dropped-grouping',
       dragoverBubble: true,
@@ -554,7 +553,6 @@ export class SlickDraggableGrouping {
         if (el.getAttribute('id')?.replace(this._gridUid, '')) {
           this.handleGroupByDrop(dropzoneElm, (Sortable.utils as any).clone(evt.item));
         }
-        evt.clone.style.opacity = '.5';
         el.parentNode?.removeChild(el);
       },
       onUpdate: () => {


### PR DESCRIPTION
- this fixes 2 issues identified in Angular-Slickgrid, https://github.com/ghiscoding/Angular-Slickgrid/issues/1180
- when leaving a SPA page and going back to it, it could throw a bunch of errors. We simply need to make sure that any sortable instances are destroyed before recreating any new ones

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/3e6e38d8-78f2-4ffc-9d4c-1176189788d7)

The error comes from SortableJS from this line
https://github.com/SortableJS/Sortable/blob/7af63fdc5d7512e7f0b8abb10970d473521b31a5/Sortable.js#L1115

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/3c041a89-7fea-4b63-831a-507c9bd4ed94)
