### PR TITLE
fix: CJS fallbacks should be at the end not at beginning

### DIFF
--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/binding",
   "version": "3.0.1",
   "description": "Simple Vanilla Implementation of a Binding Engine & Helper to add properties/events 2 way bindings",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/common",
   "version": "3.0.1",
   "description": "SlickGrid-Universal Common Code",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "license": "MIT",
   "author": "Ghislain B.",
   "homepage": "https://github.com/ghiscoding/slickgrid-universal",

--- a/packages/composite-editor-component/package.json
+++ b/packages/composite-editor-component/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/composite-editor-component",
   "version": "3.0.1",
   "description": "Slick Composite Editor Component - Vanilla Implementation of a Composite Editor Modal Window Component",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-footer-component/package.json
+++ b/packages/custom-footer-component/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/custom-footer-component",
   "version": "3.0.1",
   "description": "Slick Custom Footer Component - Vanilla Implementation of a Custom Footer Component",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-tooltip-plugin/package.json
+++ b/packages/custom-tooltip-plugin/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/custom-tooltip-plugin",
   "version": "3.0.1",
   "description": "A plugin to add Custom Tooltip when hovering a cell, it subscribes to the cell",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/empty-warning-component/package.json
+++ b/packages/empty-warning-component/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/empty-warning-component",
   "version": "3.0.1",
   "description": "Slick Empty Warning Component - Vanilla Implementation of an Empty Dataset Warning Component",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/event-pub-sub/package.json
+++ b/packages/event-pub-sub/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/event-pub-sub",
   "version": "3.0.1",
   "description": "Simple Vanilla Implementation of an Event PubSub Service to do simply publish/subscribe inter-communication while optionally providing data in the event",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/excel-export/package.json
+++ b/packages/excel-export/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/excel-export",
   "version": "3.0.1",
   "description": "Excel Export (xls/xlsx) Service.",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/graphql",
   "version": "3.0.1",
   "description": "GraphQL Service to sync a grid with a GraphQL backend server",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/odata/package.json
+++ b/packages/odata/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/odata",
   "version": "3.0.1",
   "description": "Grid OData Service to sync a grid with an OData backend server",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pagination-component/package.json
+++ b/packages/pagination-component/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/pagination-component",
   "version": "3.0.1",
   "description": "Slick Pagination Component - Vanilla Implementation of a Pagination Component",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/row-detail-view-plugin/package.json
+++ b/packages/row-detail-view-plugin/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/row-detail-view-plugin",
   "version": "3.0.1",
   "description": "SlickRowDetail plugin - A plugin to add Row Detail Panel",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rxjs-observable/package.json
+++ b/packages/rxjs-observable/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/rxjs-observable",
   "version": "3.0.1",
   "description": "RxJS Observable Wrapper",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/text-export/package.json
+++ b/packages/text-export/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/text-export",
   "version": "3.0.1",
   "description": "Export to Text File (csv/txt) Service.",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/utils",
   "version": "3.0.1",
   "description": "Common set of small utilities",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/vanilla-bundle",
   "version": "3.0.1",
   "description": "Vanilla Slick Grid Bundle - Framework agnostic the output is to be used in vanilla JS/TS - Written in TypeScript and we also use Vite to bundle everything into a single JS file.",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -2,8 +2,6 @@
   "name": "@slickgrid-universal/vanilla-force-bundle",
   "version": "3.0.1",
   "description": "Vanilla Slick Grid Bundle (mostly exist for our Salesforce implementation) - Similar to Vanilla Bundle, the only difference is that it adds extra packages within its bundle (CustomTooltip, CompositeEditor & TextExport)",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -20,6 +18,8 @@
     }
   },
   "types": "dist/types/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- when defining the old CJS `main` and `module`, these properties should come after `exports` (new ESM prop) so that newer NodeJS will try `exports` first (we shouldn't try the fallback first), while for old NodeJS it will automatically use the fallbacks since `exports` won't work, see this TypeScript for more info (https://www.typescriptlang.org/docs/handbook/esm-node.html)