### PR TITLE
fix(plugins): RowMoveManager shouldn't add cssClass when not usable

### DIFF
--- a/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
@@ -139,7 +139,6 @@ describe('SlickRowMoveManager Plugin', () => {
   it('should call the "create" method and expect plugin to be created with checkbox column to be created at position 0 when using default', () => {
     const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
     const rowMoveColumnMock = {
-      cssClass: 'slick-row-move-column',
       excludeFromColumnPicker: true,
       excludeFromExport: true,
       excludeFromGridMenu: true,
@@ -188,7 +187,6 @@ describe('SlickRowMoveManager Plugin', () => {
     expect(plugin).toBeTruthy();
     expect(mockColumns[1]).toEqual({
       behavior: 'selectAndMove',
-      cssClass: 'slick-row-move-column',
       excludeFromColumnPicker: true,
       excludeFromExport: true,
       excludeFromGridMenu: true,
@@ -227,7 +225,7 @@ describe('SlickRowMoveManager Plugin', () => {
     const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
 
     expect(plugin).toBeTruthy();
-    expect(output).toEqual({ addClasses: 'cell-reorder dnd', text: '' });
+    expect(output).toEqual({ addClasses: 'cell-reorder dnd slick-row-move-column', text: '' });
   });
 
   it('should process the "checkboxSelectionFormatter" and expect necessary Formatter to return regular formatter when usabilityOverride is not a function', () => {
@@ -236,7 +234,7 @@ describe('SlickRowMoveManager Plugin', () => {
     const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: '_move', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
 
     expect(plugin).toBeTruthy();
-    expect(output).toEqual({ addClasses: 'cell-reorder dnd', text: '' });
+    expect(output).toEqual({ addClasses: 'cell-reorder dnd slick-row-move-column', text: '' });
   });
 
   it('should create the plugin and trigger "dragInit" event and expect "stopImmediatePropagation" to be called', () => {

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -133,7 +133,6 @@ export class SlickRowMoveManager {
       id: columnId,
       name: '',
       behavior: 'selectAndMove',
-      cssClass: this._addonOptions.cssClass,
       excludeFromExport: true,
       excludeFromColumnPicker: true,
       excludeFromGridMenu: true,
@@ -321,7 +320,7 @@ export class SlickRowMoveManager {
     if (!this.checkUsabilityOverride(row, dataContext, grid)) {
       return '';
     } else {
-      return { addClasses: 'cell-reorder dnd', text: '' };
+      return { addClasses: `cell-reorder dnd ${this._addonOptions.cssClass || ''}`, text: '' };
     }
   }
 }


### PR DESCRIPTION
- when `usabilityOverride` returns false on some rows, we shouldn't add the `cssClass` on the parent div

This issue came up in SlickGrid example while using an override function that returns false on every odd rows and it caused UI issue shown below

#### UI bug showing up
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/dc16c9af-f233-4102-a90a-184b7eda15a5)

#### After fix
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/ec6040c9-7f15-40de-a556-43d3cae5ae8d)

