### PR TITLE
fix: adding dataset hierarchical item shouldn't cause scroll flickering

### DIFF
--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -193,7 +193,6 @@ export class SlickVanillaGridBundle {
 
     // when a hierarchical dataset is set afterward, we can reset the flat dataset and call a tree data sort that will overwrite the flat dataset
     if (this.dataView && newHierarchicalDataset && this.slickGrid && this.sortService?.processTreeDataInitialSort) {
-      this.dataView.setItems([], this._gridOptions?.datasetIdPropertyName ?? 'id');
       this.sortService.processTreeDataInitialSort();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh


### PR DESCRIPTION
- calling `datasetHierarchical` setter shouldn't cause scroll flickering, this was caused a call to the DataView `setItems` with an empty array which in terms always scroll back to top and that was meant to clear the dataset before recreating it, however this is certainly not needed since calling the `datasetHierarchical` setter will then trigger a new sort which will indirectly call DataView setItems anyway