### PR TITLE
feat(export): add `autoDetectCellFormat` flag to Excel Export Options

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -58,6 +58,7 @@ export default class Example6 {
       {
         id: 'size', name: 'Size', field: 'size', minWidth: 90,
         type: FieldType.number, exportWithFormatter: true,
+        excelExportOptions: { autoDetectCellFormat: false },
         filterable: true, filter: { model: Filters.compoundInputNumber },
         formatter: (_row, _cell, value) => isNaN(value) ? '' : `${value} MB`,
       },

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -150,6 +150,7 @@ export const GlobalGridOptions: GridOption = {
   explicitInitialization: true,
   excelExportOptions: {
     addGroupIndentation: true,
+    autoDetectCellFormat: true,
     exportWithFormatter: false,
     filename: 'export',
     format: FileType.xlsx,

--- a/packages/common/src/interfaces/columnExcelExportOption.interface.ts
+++ b/packages/common/src/interfaces/columnExcelExportOption.interface.ts
@@ -4,9 +4,12 @@ import type { GridOption } from './gridOption.interface';
 
 /** Excel custom export options (formatting & width) that can be applied to a column */
 export interface ColumnExcelExportOption {
+  /** Defaults to true, when enabled the system will try to find the best possible format to use when exporting. */
+  autoDetectCellFormat?: boolean;
+
   /**
    * Option to provide custom Excel styling
-   * NOTE: this option will completely override any detected column formatting
+   * NOTE: this option will completely override any detected cell styling
    */
   style?: ExcelCustomStyling;
 
@@ -20,7 +23,7 @@ export interface ColumnExcelExportOption {
 export interface GroupTotalExportOption {
   /**
    * Option to provide custom Excel styling
-   * NOTE: this option will completely override any detected column formatting
+   * NOTE: this option will completely override any detected cell styling
    */
   style?: ExcelCustomStyling;
 

--- a/packages/common/src/interfaces/excelExportOption.interface.ts
+++ b/packages/common/src/interfaces/excelExportOption.interface.ts
@@ -7,6 +7,9 @@ export interface ExcelExportOption {
   /** Defaults to true, when grid is using Grouping, it will show indentation of the text with collapsed/expanded symbol as well */
   addGroupIndentation?: boolean;
 
+  /** Defaults to true, when enabled the system will try to find the best possible format to use when exporting */
+  autoDetectCellFormat?: boolean;
+
   /** When defined, this will override header titles styling, when undefined the default will be a bold style */
   columnHeaderStyle?: ExcelCustomStyling;
 

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -566,7 +566,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
         // for column that are Date type, we'll always export with their associated Date Formatters unless `exportWithFormatter` is specifically set to false
         const exportOptions = { ...this._excelExportOptions };
-        if (columnDef?.exportWithFormatter !== false && isColumnDateType(fieldType)) {
+        if (columnDef.exportWithFormatter !== false && isColumnDateType(fieldType)) {
           exportOptions.exportWithFormatter = true;
         }
         itemData = exportWithFormatterWhenDefined(row, col, columnDef, itemObj, this._grid, exportOptions);
@@ -574,7 +574,8 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
         // auto-detect best possible Excel format, unless the user provide his own formatting,
         // we only do this check once per column (everything after that will be pull from temp ref)
         if (!this._regularCellExcelFormats.hasOwnProperty(columnDef.id)) {
-          const cellStyleFormat = useCellFormatByFieldType(this._stylesheet, this._stylesheetFormats, columnDef, this._grid);
+          const autoDetectCellFormat = columnDef.excelExportOptions?.autoDetectCellFormat ?? this._excelExportOptions?.autoDetectCellFormat;
+          const cellStyleFormat = useCellFormatByFieldType(this._stylesheet, this._stylesheetFormats, columnDef, this._grid, autoDetectCellFormat);
           // user could also override style and/or valueParserCallback
           if (columnDef.excelExportOptions?.style) {
             cellStyleFormat.stylesheetFormatterId = this._stylesheet.createFormat(columnDef.excelExportOptions.style).id;
@@ -638,7 +639,8 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
       // auto-detect best possible Excel format for Group Totals, unless the user provide his own formatting,
       // we only do this check once per column (everything after that will be pull from temp ref)
-      if (fieldType === FieldType.number) {
+      const autoDetectCellFormat = columnDef.excelExportOptions?.autoDetectCellFormat ?? this._excelExportOptions?.autoDetectCellFormat;
+      if (fieldType === FieldType.number && autoDetectCellFormat !== false) {
         let groupCellFormat = this._groupTotalExcelFormats[columnDef.id];
         if (!groupCellFormat?.groupType) {
           groupCellFormat = getExcelFormatFromGridFormatter(this._stylesheet, this._stylesheetFormats, columnDef, this._grid, 'group');

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -41,12 +41,12 @@ export function parseNumberWithFormatterOptions(value: any, column: Column, grid
 }
 
 /** use different Excel Stylesheet Format as per the Field Type */
-export function useCellFormatByFieldType(stylesheet: ExcelStylesheet, stylesheetFormatters: any, columnDef: Column, grid: SlickGrid) {
+export function useCellFormatByFieldType(stylesheet: ExcelStylesheet, stylesheetFormatters: any, columnDef: Column, grid: SlickGrid, autoDetect = true) {
   const fieldType = getColumnFieldType(columnDef);
   let stylesheetFormatterId: number | undefined;
   let callback: GetDataValueCallback = getExcelSameInputDataCallback;
 
-  if (fieldType === FieldType.number) {
+  if (fieldType === FieldType.number && autoDetect) {
     stylesheetFormatterId = getExcelFormatFromGridFormatter(stylesheet, stylesheetFormatters, columnDef, grid, 'cell').stylesheetFormatter.id;
     callback = getExcelNumberCallback;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
- prior to this PR, the auto-detect was always enabled especially when column has a number field type but sometime the auto-detection is wrong and we wish to disable it, so this PR is adding a flag that allow the user to disable the auto-detect cell format, it can be provided from either the grid options or from a column definition, but in both cases it has to be provided into the `excelExportOptions: { autoDetectCellFormat: false }`