### PR TITLE
feat(TreeData): add auto-recalc feature for Tree Totals w/Aggregators

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example01.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example01.ts
@@ -69,6 +69,7 @@ export default class Example1 {
       ...this.gridOptions1,
       ...{
         gridHeight: 255,
+        headerRowHeight: 40,
         columnPicker: {
           onColumnsChanged: (_e, args) => console.log('onColumnPickerColumnsChanged - visible columns count', args.visibleColumns.length),
         },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.html
@@ -20,6 +20,10 @@
       <span class="icon mdi mdi-plus"></span>
       <span>Add New Pop Song</span>
     </button>
+    <button onclick.delegate="deleteFile()" class="button is-small" data-test="remove-item-btn" disabled.bind="isRemoveLastInsertedPopSongDisabled">
+      <span class="icon mdi mdi-minus"></span>
+      <span>Remove Last Inserted Pop Song</span>
+    </button>
     <button onclick.delegate="collapseAll()" class="button is-small" data-test="collapse-all-btn">
       <span class="icon mdi mdi-arrow-collapse"></span>
       <span>Collapse All</span>
@@ -27,6 +31,10 @@
     <button onclick.delegate="expandAll()" class="button is-small" data-test="expand-all-btn">
       <span class="icon mdi mdi-arrow-expand"></span>
       <span>Expand All</span>
+    </button>
+    <button class="button is-small" data-test="clear-filters-btn" onclick.delegate="clearFilters()">
+      <span class="icon mdi mdi-close"></span>
+      <span>Clear Filters</span>
     </button>
     <button onclick.delegate="logFlatStructure()" class="button is-small" title="console.log of the Flat dataset">
       <span>Log Flat Structure</span>
@@ -82,6 +90,15 @@
           because none of the files have both criteria at the same time, however the column with the tree 'file' does pass the filter criteria 'music'
           and with this flag we tell the lib to skip any other filter(s) as soon as the with the tree (file in this demo) passes its own filter criteria">
       Skip Other Filter Criteria when Parent with Tree is valid
+    </span>
+  </label>
+  <label class="checkbox-inline control-label" for="autoRecalcTotalsOnFilterChange" style="margin-left: 20px">
+    <input type="checkbox" id="autoRecalcTotalsOnFilterChange" data-test="auto-recalc-totals"
+           checked.bind="isAutoRecalcTotalsOnFilterChange"
+           onclick.delegate="changeAutoRecalcTotalsOnFilterChange()">
+    <span
+          title="Should we recalculate Tree Data Totals (when Aggregators are defined) while filtering? This feature is disabled by default.">
+      auto-recalc Tree Data totals on filter changed
     </span>
   </label>
 </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -319,7 +319,6 @@ export default class Example7 {
     this.sgb.filterService.clearFilters();
   }
 
-
   allFilters() {
     const grid = this.sgb;
     const modalHtml = `<div id="modal-allFilter" class="modal is-active">

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -4,6 +4,15 @@ import type { Aggregator } from './aggregator.interface';
 import type { Formatter } from './formatter.interface';
 
 export interface TreeDataOption {
+  /** Tree Data Aggregators array that can be provided to aggregate the tree (avg, sum, ...) */
+  aggregators?: Aggregator[];
+
+  /** Defaults to 0, optional debounce to limit the number of recalc execution (when enabled) of Tree Totals (Aggregators), this is especially useful with large tree dataset. */
+  autoRecalcTotalsDebounce?: number;
+
+  /** Defaults to false, should we recalculate aggregator tree totals on a filter changed triggered */
+  autoRecalcTotalsOnFilterChange?: boolean;
+
   /** Column Id of which column in the column definitions has the Tree Data, there can only be one with a Tree Data. */
   columnId: string;
 
@@ -25,9 +34,6 @@ export interface TreeDataOption {
    *    - and the reason we do this is that we'll be able to show music files with "Size > 7" even though these files might not include the word "music"
    */
   excludeChildrenWhenFilteringTree?: boolean;
-
-  /** Grouping Aggregators array */
-  aggregators?: Aggregator[];
 
   /** Optionally define the initial sort column and direction */
   initialSort?: {
@@ -56,11 +62,11 @@ export interface TreeDataOption {
    */
   identifierPropName?: string;
 
-  /** Defaults to "__parentId", object property name used to designate the Parent Id */
-  parentPropName?: string;
-
   /** Defaults to "__treeLevel", object property name used to designate the Tree Level depth number */
   levelPropName?: string;
+
+  /** Defaults to "__parentId", object property name used to designate the Parent Id */
+  parentPropName?: string;
 
   /**
    * Defaults to 15px, margin to add from the left (calculated by the tree level multiplied by this number).

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -1073,7 +1073,7 @@ describe('FilterService', () => {
     });
 
     it('should return an empty array when column definitions returns nothing as well', () => {
-      gridStub.getColumns = undefined as any;
+      gridStub.getColumns = jest.fn().mockReturnValue(undefined);
 
       service.init(gridStub);
       const output = service.populateColumnFilterSearchTermPresets(undefined as any);

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -431,7 +431,7 @@ describe('FilterService', () => {
       tmpDivElm.className = 'some-classes';
       const inputEvent = new Event('input');
       Object.defineProperty(inputEvent, 'target', { writable: true, configurable: true, value: tmpDivElm });
-      service.getFiltersMetadata()[0].callback(inputEvent, { columnDef: mockColumn, operator: 'EQ', searchTerms: [''], shouldTriggerQuery: true, target: tmpDivElm });
+      service.getFiltersMetadata()[0].callback(inputEvent, { columnDef: mockColumn, operator: 'EQ', searchTerms: [''], shouldTriggerQuery: true, target: tmpDivElm } as any);
 
       expect(service.getColumnFilters()).toContainEntry(['firstName', expectationColumnFilter]);
       expect(spySearchChange).toHaveBeenCalledWith({
@@ -1786,7 +1786,8 @@ describe('FilterService', () => {
     });
 
     describe('bindLocalOnFilter method', () => {
-      let dataset = [];
+      let dataset: any[] = [];
+      let datasetHierarchical: any[] = [];
       let mockColumn1;
       let mockColumn2;
       let mockColumn3;
@@ -1814,7 +1815,26 @@ describe('FilterService', () => {
           { __hasChildren: true, __parentId: 21, __treeLevel: 1, file: 'xls', id: 7 },
           { __parentId: 7, __treeLevel: 2, dateModified: '2014-10-02T14:50:00.123Z', file: 'compilation.xls', id: 8, size: 2.3 },
           { __parentId: null, __treeLevel: 0, dateModified: '2015-03-03T03:50:00.123Z', file: 'something.txt', id: 18, size: 90 },
-        ] as any;
+        ];
+
+        datasetHierarchical = [
+          { id: 24, file: 'bucket-list.txt', dateModified: '2012-03-05T12:44:00.123Z', size: 0.5 },
+          { id: 18, file: 'something.txt', dateModified: '2015-03-03T03:50:00.123Z', size: 90 },
+          {
+            id: 21, file: 'documents', files: [
+              { id: 2, file: 'txt', files: [{ id: 3, file: 'todo.txt', dateModified: '2015-05-12T14:50:00.123Z', size: 0.7, }] },
+              {
+                id: 4, file: 'pdf', files: [
+                  { id: 5, file: 'map.pdf', dateModified: '2015-05-21T10:22:00.123Z', size: 3.1, },
+                  { id: 6, file: 'internet-bill.pdf', dateModified: '2015-05-12T14:50:00.123Z', size: 1.4, },
+                  { id: 23, file: 'phone-bill.pdf', dateModified: '2015-05-01T07:50:00.123Z', size: 1.4, },
+                ]
+              },
+              { id: 9, file: 'misc', files: [{ id: 10, file: 'todo.txt', dateModified: '2015-02-26T16:50:00.123Z', size: 0.4, }] },
+              { id: 7, file: 'xls', files: [{ id: 8, file: 'compilation.xls', dateModified: '2014-10-02T14:50:00.123Z', size: 2.3, }] },
+            ]
+          },
+        ];
 
         gridOptionMock.enableFiltering = true;
         gridOptionMock.backendServiceApi = undefined;
@@ -1827,6 +1847,7 @@ describe('FilterService', () => {
         jest.spyOn(dataViewStub, 'getItems').mockReturnValue(dataset);
         jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1, mockColumn2, mockColumn3]);
         sharedService.allColumns = [mockColumn1, mockColumn2, mockColumn3];
+        jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'get').mockReturnValue(datasetHierarchical);
       });
 
       afterEach(() => {
@@ -1851,6 +1872,36 @@ describe('FilterService', () => {
         await service.updateFilters([{ columnId: 'file', operator: '', searchTerms: ['map'] }], true, true, true);
         const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
 
+        expect(pubSubSpy).toHaveBeenCalledWith(`onBeforeFilterChange`, [{ columnId: 'file', operator: 'Contains', searchTerms: ['map',] }]);
+        expect(pubSubSpy).toHaveBeenCalledWith(`onFilterChanged`, [{ columnId: 'file', operator: 'Contains', searchTerms: ['map',] }]);
+        expect(output).toBe(true);
+        expect(preFilterSpy).toHaveBeenCalledWith(dataset, columnFilters);
+        expect(preFilterSpy).toHaveReturnedWith(initSetWithValues([21, 4, 5]));
+      });
+
+      it('should return True when item is found and its parent is not collapsed', async () => {
+        const pubSubSpy = jest.spyOn(pubSubServiceStub, 'publish');
+        const preFilterSpy = jest.spyOn(service, 'preFilterTreeData');
+        jest.spyOn(dataViewStub, 'getItemById').mockReturnValueOnce({ ...dataset[4] as any, __collapsed: false })
+          .mockReturnValueOnce(dataset[5])
+          .mockReturnValueOnce(dataset[6]);
+
+        gridOptionMock.treeDataOptions!.autoRecalcTotalsOnFilterChange = true;
+        const mockItem1 = { __parentId: 4, id: 5, file: 'map.pdf', dateModified: '2015-05-21T10:22:00.123Z', size: 3.1 };
+
+        service.init(gridStub);
+        service.bindLocalOnFilter(gridStub);
+        gridStub.onHeaderRowCellRendered.notify(mockArgs1 as any, new Slick.EventData(), gridStub);
+        gridStub.onHeaderRowCellRendered.notify(mockArgs2 as any, new Slick.EventData(), gridStub);
+
+        const columnFilters = { file: { columnDef: mockColumn1, columnId: 'file', operator: 'Contains', searchTerms: ['map'], parsedSearchTerms: ['map'], targetSelector: '', type: FieldType.string } } as ColumnFilters;
+        await service.updateFilters([{ columnId: 'file', operator: '', searchTerms: ['map'] }], true, true, true);
+        const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+        const pdfFolder = datasetHierarchical[2].files[1];
+        const mapPdfItem = pdfFolder.files[0];
+        expect(mapPdfItem.file).toBe('map.pdf');
+        expect(mapPdfItem.__filteredOut).toBe(false);
         expect(pubSubSpy).toHaveBeenCalledWith(`onBeforeFilterChange`, [{ columnId: 'file', operator: 'Contains', searchTerms: ['map',] }]);
         expect(pubSubSpy).toHaveBeenCalledWith(`onFilterChanged`, [{ columnId: 'file', operator: 'Contains', searchTerms: ['map',] }]);
         expect(output).toBe(true);

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -41,6 +41,7 @@ const dataViewStub = {
   reSort: jest.fn(),
   setItems: jest.fn(),
   updateItem: jest.fn(),
+  onRowCountChanged: new Slick.Event(),
 } as unknown as SlickDataView;
 
 const gridStub = {

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -11,6 +11,7 @@ import {
   cancellablePromise,
   CancelledException,
   castObservableToPromise,
+  debounce,
   flattenToParentChildArray,
   unflattenParentChildArrayToTree,
   decimalFormatted,
@@ -146,6 +147,35 @@ describe('Service/Utilies', () => {
       castObservableToPromise(rxjs, observable).then((outputArray) => {
         expect(outputArray).toBe(inputArray);
       });
+    });
+  });
+
+  describe('debounce method', () => {
+    it('should execute callback right away when debounce wait time is below 0', () => {
+      const callbackSpy = jest.fn();
+
+      debounce(callbackSpy, -1)();
+
+      expect(callbackSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT execute callback right away when debounce wait time is greater than 0', () => {
+      const callbackSpy = jest.fn();
+
+      debounce(callbackSpy, 1)();
+
+      expect(callbackSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should execute callback after debounce time is reached and is greater than 0', (done) => {
+      const callbackSpy = jest.fn();
+
+      debounce(callbackSpy, 1)();
+
+      setTimeout(() => {
+        expect(callbackSpy).toHaveBeenCalledTimes(1);
+        done();
+      }, 1);
     });
   });
 

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -347,7 +347,9 @@ export class FilterService {
         // when user enables Tree Data auto-recalc, we need to keep ref (only in hierarchical tree) of which datacontext was filtered or not
         if (treeDataOptions?.autoRecalcTotalsOnFilterChange) {
           const treeItem = findItemInTreeStructure(this.sharedService.hierarchicalDataset!, x => x[dataViewIdIdentifier] === item[dataViewIdIdentifier], childrenPropName);
-          treeItem.__filteredOut = !filtered;
+          if (treeItem) {
+            treeItem.__filteredOut = !filtered;
+          }
         }
         return filtered;
       }

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -16,7 +16,12 @@ import type {
   TreeToggledItem,
   TreeToggleStateChange,
 } from '../interfaces/index';
-import { findItemInTreeStructure, unflattenParentChildArrayToTree } from './utilities';
+import {
+  addTreeLevelAndAggregatorsByMutation,
+  debounce,
+  findItemInTreeStructure,
+  unflattenParentChildArrayToTree
+} from './utilities';
 import type { SharedService } from './shared.service';
 import type { SortService } from './sort.service';
 
@@ -24,15 +29,19 @@ import type { SortService } from './sort.service';
 declare const Slick: SlickNamespace;
 
 export class TreeDataService {
-  protected _isLastFullToggleCollapsed = false;
   protected _lastToggleStateChange!: Omit<TreeToggleStateChange, 'fromItemId'>;
   protected _currentToggledItems: TreeToggledItem[] = [];
   protected _grid!: SlickGrid;
   protected _eventHandler: SlickEventHandler;
+  protected _isLastFullToggleCollapsed = false;
+  protected _isOneCpuCyclePassed = false;
+  protected _isTreeDataEnabled = false;
   protected _subscriptions: EventSubscription[] = [];
+  protected _treeDataRecalcHandler: (() => void) | null = null;
 
   constructor(protected readonly pubSubService: BasePubSubService, protected readonly sharedService: SharedService, protected readonly sortService: SortService) {
     this._eventHandler = new Slick.EventHandler();
+    setTimeout(() => this._isOneCpuCyclePassed = true);
   }
 
   set currentToggledItems(newToggledItems: TreeToggledItem[]) {
@@ -60,8 +69,8 @@ export class TreeDataService {
     return this._grid?.getOptions?.() ?? {};
   }
 
-  get treeDataOptions(): TreeDataOption {
-    return this.gridOptions.treeDataOptions as TreeDataOption;
+  get treeDataOptions() {
+    return this.gridOptions.treeDataOptions;
   }
 
   dispose() {
@@ -72,7 +81,8 @@ export class TreeDataService {
 
   init(grid: SlickGrid) {
     this._grid = grid;
-    this._isLastFullToggleCollapsed = this.gridOptions?.treeDataOptions?.initiallyCollapsed ?? false;
+    this._isTreeDataEnabled = this.gridOptions?.enableTreeData ?? false;
+    this._isLastFullToggleCollapsed = this.treeDataOptions?.initiallyCollapsed ?? false;
     this._currentToggledItems = this.gridOptions.presets?.treeData?.toggledItems ?? [];
     this._lastToggleStateChange = {
       type: this._isLastFullToggleCollapsed ? 'full-collapse' : 'full-expand',
@@ -81,7 +91,7 @@ export class TreeDataService {
     };
 
     // there's a few limitations with Tree Data, we'll just throw error when that happens
-    if (this.gridOptions?.enableTreeData) {
+    if (this._isTreeDataEnabled) {
       if (this.gridOptions?.multiColumnSort) {
         throw new Error('[Slickgrid-Universal] It looks like you are trying to use Tree Data with multi-column sorting, unfortunately it is not supported because of its complexity, you can disable it via "multiColumnSort: false" grid option and/or help in providing support for this feature.');
       }
@@ -106,6 +116,17 @@ export class TreeDataService {
     this._subscriptions.push(
       this.pubSubService.subscribe('onGridMenuClearAllSorting', this.clearSorting.bind(this))
     );
+
+    // when Tree Data totals auto-recalc feature is enabled, we will define its handler to do the recalc
+    this._treeDataRecalcHandler = this.setAutoRecalcTotalsCallbackWhenFeatEnabled(this.gridOptions);
+
+    this._eventHandler.subscribe(this.dataView.onRowCountChanged, () => {
+      // call Tree Data recalc handler when defined but only when at least 1 CPU cycle is passed
+      // we wait for 1 CPU cycle to make sure that we only run it after filtering and grid initialization of tree & grid is over
+      if (typeof this._treeDataRecalcHandler === 'function' && this._isOneCpuCyclePassed) {
+        debounce(() => this._treeDataRecalcHandler?.(), this.treeDataOptions?.autoRecalcTotalsDebounce ?? 0)();
+      }
+    });
   }
 
   /**
@@ -305,6 +326,36 @@ export class TreeDataService {
   }
 
   /**
+   * Dynamically enable (or disable) Tree Totals auto-recalc feature when Aggregators exists
+   * @param {Boolean} [enableFeature=true]
+   */
+  enableAutoRecalcTotalsFeature(enableFeature = true) {
+    if (enableFeature && this._isTreeDataEnabled) {
+      this._treeDataRecalcHandler = this.recalculateTreeTotals.bind(this, this.gridOptions);
+    } else {
+      this._treeDataRecalcHandler = null;
+    }
+  }
+
+  /**
+   * Recalculate all Tree Data totals, this requires Aggregators to be defined.
+   * NOTE: this does **not** take the current filters in consideration
+   * @param gridOptions
+   */
+  recalculateTreeTotals(gridOptions: GridOption) {
+    const treeDataOptions = gridOptions.treeDataOptions;
+    const childrenPropName = (treeDataOptions?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP);
+    const levelPropName = treeDataOptions?.levelPropName ?? Constants.treeDataProperties.TREE_LEVEL_PROP;
+
+    if (treeDataOptions?.aggregators) {
+      treeDataOptions.aggregators.forEach((aggregator) => {
+        addTreeLevelAndAggregatorsByMutation(this.sharedService.hierarchicalDataset || [], { childrenPropName, levelPropName, aggregator });
+      });
+      this._grid.invalidate();
+    }
+  }
+
+  /**
    * Takes a hierarchical (tree) input array and sort it (if an `initialSort` exist, it will use that to sort)
    * @param {Array<Object>} hierarchicalDataset - inpu
    * @returns {Object} sort result object that includes both the flat & tree data arrays
@@ -428,5 +479,17 @@ export class TreeDataService {
         treeItemFound[collapsedPropName] = isCollapsed;
       }
     }
+  }
+
+  /**
+   * When using Tree Data with Aggregator and auto-recalc flag is enabled, we will define a callback handler
+   * @return {Function | undefined} Tree Data totals recalculate callback when enabled
+   */
+  protected setAutoRecalcTotalsCallbackWhenFeatEnabled(gridOptions: GridOption) {
+    // when using Tree Data with Aggregators, we might need to auto-recalc when necessary flag is enabled
+    if (gridOptions?.enableTreeData && gridOptions?.treeDataOptions?.autoRecalcTotalsOnFilterChange && gridOptions?.treeDataOptions?.aggregators) {
+      return this.recalculateTreeTotals.bind(this, gridOptions);
+    }
+    return null;
   }
 }

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -61,6 +61,23 @@ export function castObservableToPromise<T>(rxjs: RxJsFacade, input: Promise<T> |
 }
 
 /**
+ * Debounce to delay JS callback execution, a wait of (-1) could be provided to execute callback without delay.
+ * @param {Function} callback - callback method to execute
+ * @param {Number} wait - delay to wait before execution or -1 delay
+ */
+export function debounce(callback: (...args: any) => any, wait = -1) {
+  let timeoutId: any = null;
+  return (...args: any) => {
+    if (wait >= 0) {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => callback(...args), wait);
+    } else {
+      callback.apply(null);
+    }
+  };
+}
+
+/**
  * Mutate the original array and add a treeLevel (defaults to `__treeLevel`) property on each item.
  * @param {Array<Object>} treeArray - hierarchical tree array
  * @param {Object} options - options containing info like children & treeLevel property names
@@ -99,7 +116,7 @@ export function addTreeLevelAndAggregatorsByMutation<T = any>(treeArray: T[], op
           treeLevel--;
         }
 
-        if (parent && aggregator.isInitialized && typeof aggregator.accumulate === 'function') {
+        if (parent && aggregator.isInitialized && typeof aggregator.accumulate === 'function' && !(item as any)?.__filteredOut) {
           aggregator.accumulate(item, isParent);
           aggregator.storeResult((parent as any).__treeTotals);
         }

--- a/test/cypress/e2e/example01.cy.ts
+++ b/test/cypress/e2e/example01.cy.ts
@@ -18,7 +18,7 @@ describe('Example 01 - Basic Grids', { retries: 1 }, () => {
     cy.getCookie('serve-mode').its('value').should('eq', 'cypress');
   });
 
-  it('should have 2 grids of size 800 by 225px', () => {
+  it('should have 2 grids of size 800 * 225px and 800 * 255px', () => {
     cy.get('.grid1')
       .should('have.css', 'width', '800px');
 

--- a/test/cypress/e2e/example06.cy.ts
+++ b/test/cypress/e2e/example06.cy.ts
@@ -10,324 +10,451 @@ describe('Example 06 - Tree Data (from a Hierarchical Dataset)', { retries: 0 },
   const popMusicWith3ExtraSongs = ['music', 'mp3', 'other', 'pop', 'pop-79.mp3', 'pop-80.mp3', 'pop-81.mp3', 'song.mp3', 'theme.mp3',];
   const popMusicWith3ExtraSongsWithoutEmpty = ['music', 'mp3', 'pop', 'pop-79.mp3', 'pop-80.mp3', 'pop-81.mp3', 'song.mp3', 'theme.mp3',];
 
-  it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseUrl')}/example06`);
-    cy.get('h3').should('contain', 'Example 06 - Tree Data');
-    cy.get('h3 span.subtitle').should('contain', '(from a Hierarchical Dataset)');
-  });
-
-  it('should have exact column titles on 1st grid', () => {
-    cy.get('.grid6')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
-  });
-
-  it('should expect the "pdf" folder to be closed by the collapsed items grid preset with aggregators of Sum(8.8MB) / Avg(2.2MB)', () => {
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(0)`).should('contain', 'pdf');
-    cy.get(`.slick-group-toggle.collapsed`).should('have.length', 1);
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 8.8 MB / avg: 2.2 MB');
-
-    defaultGridPresetWithoutPdfDocs.forEach((_colName, rowIdx) => {
-      if (rowIdx < defaultGridPresetWithoutPdfDocs.length - 1) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultGridPresetWithoutPdfDocs[rowIdx]);
-      }
+  describe('without Auto-Recalc feature', () => {
+    it('should display Example title', () => {
+      cy.visit(`${Cypress.config('baseUrl')}/example06`);
+      cy.get('h3').should('contain', 'Example 06 - Tree Data');
+      cy.get('h3 span.subtitle').should('contain', '(from a Hierarchical Dataset)');
     });
-  });
 
-  it('should have documents folder with aggregation of Sum(14.46MB) / Avg(1.45MB)', () => {
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(0)`).should('contain', 'documents');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 14.46 MB / avg: 1.45 MB');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(0)`).should('contain', 'misc');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 0.4 MB / avg: 0.4 MB');
-  });
-
-  it('should expand "pdf" folder and expect all folders to be expanded', () => {
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`)
-      .click();
-
-    cy.get('.slick-viewport-top.slick-viewport-left')
-      .scrollTo('top', { force: true } as any);
-  });
-
-  it('should have default Files list', () => {
-    defaultSortAscList.forEach((_colName, rowIdx) => {
-      if (rowIdx > defaultSortAscList.length - 1) {
-        return;
-      }
-      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortAscList[rowIdx]);
+    it('should have exact column titles on 1st grid', () => {
+      cy.get('.grid6')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(titles[index]));
     });
-  });
 
-  it('should have pop songs folder with aggregation of Sum(53.3MB) / Avg(26.65MB)', () => {
-    cy.get('.slick-viewport-top.slick-viewport-left')
-      .scrollTo('center', { force: true } as any);
+    it('should expect the "pdf" folder to be closed by the collapsed items grid preset with aggregators of Sum(8.8MB) / Avg(2.2MB)', () => {
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(0)`).should('contain', 'pdf');
+      cy.get(`.slick-group-toggle.collapsed`).should('have.length', 1);
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 8.8 MB / avg: 2.2 MB');
 
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 151.3 MB / avg: 50.43 MB');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 151.3 MB / avg: 50.43 MB');
-    // next folder is "other" and is empty without aggregations
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 53.3 MB / avg: 26.65 MB');
-  });
-
-  it('should be able to add 2 new pop songs into the Music folder', () => {
-    cy.get('[data-test=add-item-btn]')
-      .contains('Add New Pop Song')
-      .click()
-      .click();
-
-    cy.get('.slick-group-toggle[level=3]')
-      .get('.slick-cell')
-      .contains('pop-79.mp3');
-
-    cy.get('.slick-group-toggle[level=3]')
-      .get('.slick-cell')
-      .contains('pop-80.mp3');
-
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 20}px"] > .slick-cell:nth(3)`).should('contain', '82 MB');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 21}px"] > .slick-cell:nth(3)`).should('contain', '83 MB');
-
-  });
-
-  it('should have pop songs folder with updated aggregation including new pop songs of Sum(218.3MB) / Avg(54.58MB)', () => {
-    cy.get('.slick-viewport-top.slick-viewport-left')
-      .scrollTo('bottom', { force: true } as any);
-
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
-    // next folder is "other" and is empty without aggregations
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 218.3 MB / avg: 54.58 MB');
-  });
-
-  it('should filter the Files column with the word "map" and expect only 4 rows left', () => {
-    const filteredFiles = ['documents', 'pdf', 'map.pdf', 'map2.pdf'];
-    const filteredSizes = ['', '', '3.1', '2.9'];
-
-    cy.get('.search-filter.filter-file')
-      .type('map');
-
-    cy.get('.grid6')
-      .find('.slick-row')
-      .each(($row, index) => {
-        cy.wrap($row).children('.slick-cell:nth(0)').should('contain', filteredFiles[index]);
-        cy.wrap($row).children('.slick-cell:nth(3)').should('contain', filteredSizes[index]);
+      defaultGridPresetWithoutPdfDocs.forEach((_colName, rowIdx) => {
+        if (rowIdx < defaultGridPresetWithoutPdfDocs.length - 1) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultGridPresetWithoutPdfDocs[rowIdx]);
+        }
       });
-  });
+    });
 
-  it('should add filter with "Size < 3" and expect 3 rows left', () => {
-    const filteredFiles = ['documents', 'pdf', 'map2.pdf'];
+    it('should have documents folder with aggregation of Sum(14.46MB) / Avg(1.45MB)', () => {
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(0)`).should('contain', 'documents');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 14.46 MB / avg: 1.45 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(0)`).should('contain', 'misc');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 0.4 MB / avg: 0.4 MB');
+    });
 
-    cy.get('.search-filter.filter-size')
-      .find('input')
-      .type('3');
+    it('should expand "pdf" folder and expect all folders to be expanded', () => {
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`)
+        .click();
 
-    cy.get('.search-filter.filter-size')
-      .find('.input-group-addon.operator select')
-      .select('<');
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('top', { force: true } as any);
+    });
 
-    cy.get('.grid6')
-      .find('.slick-row .slick-cell:nth(0)')
-      .each(($cell, index) => {
-        expect($cell.text().trim()).to.contain(filteredFiles[index]);
-      });
-  });
-
-  it('should add filter with Size >3 and expect 3 rows left', () => {
-    const filteredFiles = ['documents', 'pdf', 'map.pdf'];
-
-    cy.get('.search-filter.filter-size')
-      .find('.input-group-addon.operator select')
-      .select('>');
-
-    cy.get('.grid6')
-      .find('.slick-row .slick-cell:nth(0)')
-      .each(($cell, index) => {
-        expect($cell.text().trim()).to.contain(filteredFiles[index]);
-      });
-  });
-
-  it('should add filter with Size <=3.1 and expect 3 rows left', () => {
-    const filteredFiles = ['documents', 'pdf', 'map.pdf', 'map2.pdf'];
-
-    cy.get('.search-filter.filter-size')
-      .find('input')
-      .type('.1');
-
-    cy.get('.search-filter.filter-size')
-      .find('.input-group-addon.operator select')
-      .select('<=');
-
-    cy.get('.grid6')
-      .find('.slick-row .slick-cell:nth(0)')
-      .each(($cell, index) => {
-        expect($cell.text().trim()).to.contain(filteredFiles[index]);
-      });
-  });
-
-  it('should Clear all Filters and default list', () => {
-    cy.get('.grid6')
-      .find('button.slick-grid-menu-button')
-      .trigger('click')
-      .click({ force: true });
-
-    cy.get(`.slick-grid-menu:visible`)
-      .find('.slick-menu-item')
-      .first()
-      .find('span')
-      .contains('Clear all Filters')
-      .click({ force: true });
-
-    defaultSortAscList.forEach((_colName, rowIdx) => {
-      if (rowIdx < defaultSortAscList.length - 1) {
+    it('should have default Files list', () => {
+      defaultSortAscList.forEach((_colName, rowIdx) => {
+        if (rowIdx > defaultSortAscList.length - 1) {
+          return;
+        }
         cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortAscList[rowIdx]);
-      }
-    });
-  });
-
-  it('should click on "Files" column to sort descending', () => {
-    cy.get('.slick-header-columns .slick-header-column:nth(0)')
-      .click();
-
-    defaultSortDescListWithExtraSongs.forEach((_colName, rowIdx) => {
-      if (rowIdx < defaultSortDescListWithExtraSongs.length - 1) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortDescListWithExtraSongs[rowIdx]);
-      }
-    });
-  });
-
-  it('should filter the Files by the input search string and expect 4 rows and 1st column to have ', () => {
-    const filteredFiles = ['documents', 'pdf', 'map2.pdf', 'map.pdf'];
-
-    cy.get('[data-test=search-string]')
-      .type('map');
-
-    cy.get('.search-filter.filter-file')
-      .should(($input) => {
-        expect($input.val()).to.eq('map');
       });
+    });
 
-    cy.get('.grid6')
-      .find('.slick-row .slick-cell:nth(0)')
-      .each(($cell, index) => {
-        expect($cell.text().trim()).to.contain(filteredFiles[index]);
+    it('should have pop songs folder with aggregations of Sum(53.3MB) / Avg(26.65MB)', () => {
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('center', { force: true } as any);
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 151.3 MB / avg: 50.43 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 151.3 MB / avg: 50.43 MB');
+      // next folder is "other" and is empty without aggregations
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 53.3 MB / avg: 26.65 MB');
+    });
+
+    it('should be able to add 2 new pop songs into the Music folder', () => {
+      cy.get('[data-test=add-item-btn]')
+        .contains('Add New Pop Song')
+        .click()
+        .click();
+
+      cy.get('.slick-group-toggle[level=3]')
+        .get('.slick-cell')
+        .contains('pop-79.mp3');
+
+      cy.get('.slick-group-toggle[level=3]')
+        .get('.slick-cell')
+        .contains('pop-80.mp3');
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 20}px"] > .slick-cell:nth(3)`).should('contain', '82 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 21}px"] > .slick-cell:nth(3)`).should('contain', '83 MB');
+
+    });
+
+    it('should have pop songs folder with updated aggregations including new pop songs of Sum(218.3MB) / Avg(54.58MB)', () => {
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom', { force: true } as any);
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
+      // next folder is "other" and is empty without aggregations
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 218.3 MB / avg: 54.58 MB');
+    });
+
+    it('should filter the Files column with the word "map" and expect only 4 rows left', () => {
+      const filteredFiles = ['documents', 'pdf', 'map.pdf', 'map2.pdf'];
+      const filteredSizes = ['', '', '3.1', '2.9'];
+
+      cy.get('.search-filter.filter-file')
+        .type('map');
+
+      cy.get('.grid6')
+        .find('.slick-row')
+        .each(($row, index) => {
+          cy.wrap($row).children('.slick-cell:nth(0)').should('contain', filteredFiles[index]);
+          cy.wrap($row).children('.slick-cell:nth(3)').should('contain', filteredSizes[index]);
+        });
+    });
+
+    it('should add filter with "Size < 3" and expect 3 rows left', () => {
+      const filteredFiles = ['documents', 'pdf', 'map2.pdf'];
+
+      cy.get('.search-filter.filter-size')
+        .find('input')
+        .type('3');
+
+      cy.get('.search-filter.filter-size')
+        .find('.input-group-addon.operator select')
+        .select('<');
+
+      cy.get('.grid6')
+        .find('.slick-row .slick-cell:nth(0)')
+        .each(($cell, index) => {
+          expect($cell.text().trim()).to.contain(filteredFiles[index]);
+        });
+    });
+
+    it('should add filter with Size >3 and expect 3 rows left', () => {
+      const filteredFiles = ['documents', 'pdf', 'map.pdf'];
+
+      cy.get('.search-filter.filter-size')
+        .find('.input-group-addon.operator select')
+        .select('>');
+
+      cy.get('.grid6')
+        .find('.slick-row .slick-cell:nth(0)')
+        .each(($cell, index) => {
+          expect($cell.text().trim()).to.contain(filteredFiles[index]);
+        });
+    });
+
+    it('should add filter with Size <=3.1 and expect 3 rows left', () => {
+      const filteredFiles = ['documents', 'pdf', 'map.pdf', 'map2.pdf'];
+
+      cy.get('.search-filter.filter-size')
+        .find('input')
+        .type('.1');
+
+      cy.get('.search-filter.filter-size')
+        .find('.input-group-addon.operator select')
+        .select('<=');
+
+      cy.get('.grid6')
+        .find('.slick-row .slick-cell:nth(0)')
+        .each(($cell, index) => {
+          expect($cell.text().trim()).to.contain(filteredFiles[index]);
+        });
+    });
+
+    it('should Clear all Filters and expect default list', () => {
+      cy.get('.grid6')
+        .find('button.slick-grid-menu-button')
+        .trigger('click')
+        .click({ force: true });
+
+      cy.get(`.slick-grid-menu:visible`)
+        .find('.slick-menu-item')
+        .first()
+        .find('span')
+        .contains('Clear all Filters')
+        .click({ force: true });
+
+      defaultSortAscList.forEach((_colName, rowIdx) => {
+        if (rowIdx < defaultSortAscList.length - 1) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortAscList[rowIdx]);
+        }
       });
-  });
-
-  it('should clear search string and expect default list', () => {
-    cy.get('[data-test=clear-search-string]')
-      .click();
-
-    defaultSortDescListWithExtraSongs.forEach((_colName, rowIdx) => {
-      if (rowIdx < defaultSortDescListWithExtraSongs.length - 1) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortDescListWithExtraSongs[rowIdx]);
-      }
     });
-  });
 
-  it('should be able to add a 3rd new pop song into the Music folder and see it show up in the UI', () => {
-    cy.get('[data-test=add-item-btn]')
-      .contains('Add New Pop Song')
-      .click();
+    it('should click on "Files" column to sort descending', () => {
+      cy.get('.slick-header-columns .slick-header-column:nth(0)')
+        .click();
 
-    cy.get('.slick-group-toggle[level=3]')
-      .get('.slick-cell')
-      .contains('pop-81.mp3');
-
-    cy.get('.slick-group-toggle[level=3]')
-      .get('.slick-cell')
-      .contains('pop-81.mp3');
-  });
-
-  it('should return 8 rows when filtering the word "pop" music without excluding children', () => {
-    cy.get('.search-filter.filter-file')
-      .type('pop');
-
-    cy.get('.right-footer .item-count')
-      .contains('8');
-
-    popMusicWith3ExtraSongsWithoutEmpty.forEach((_colName, rowIdx) => {
-      if (rowIdx < popMusicWith3ExtraSongsWithoutEmpty.length - 1) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', popMusicWith3ExtraSongsWithoutEmpty[rowIdx]);
-      }
-    });
-  });
-
-  it('should return 6 rows when using same filter "pop" music AND selecting checkbox to "Exclude Children when Filtering Tree"', () => {
-    cy.get('[data-test="exclude-child-when-filtering"]')
-      .check();
-
-    cy.get('.right-footer .item-count')
-      .contains('6');
-
-    popMusicWith3ExtraSongsWithoutEmpty.forEach((_colName, rowIdx) => {
-      if (rowIdx < popMusicWith3ExtraSongsWithoutEmpty.length - 3) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', popMusicWith3ExtraSongsWithoutEmpty[rowIdx]);
-      }
-    });
-  });
-
-  it('should change filter to the word "music" and expect only 1 row (the music folder) to show up when still Excluding Children from the Tree', () => {
-    cy.get('[data-test=clear-search-string]')
-      .click();
-
-    cy.get('.search-filter.filter-file')
-      .type('music');
-
-    cy.get('.right-footer .item-count')
-      .contains('1');
-
-    cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(0)`).should('contain', 'music');
-  });
-
-  it('should use same filter "music" and now expect to see 10 rows (entire music folder content) to show up when "Exclude Children when Filtering Tree" becomes uncheck', () => {
-    cy.get('[data-test="exclude-child-when-filtering"]')
-      .uncheck();
-
-    cy.get('.right-footer .item-count')
-      .contains('11');
-
-    const allMusic = [...popMusicWith3ExtraSongs, 'rock', 'soft.mp3'];
-
-    allMusic.forEach((_colName, rowIdx) => {
-      if (rowIdx < allMusic.length - 3) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', allMusic[rowIdx]);
-      }
-    });
-  });
-
-  it('should use same filter "music" and add extra filter of "size >= 50" and expect 1+ songs (>=6 rows) to show up in the grid when "Exclude Children when Filtering Tree" is unchecked and "Skip Other Criteria..." is checked', () => {
-
-    cy.get('.search-filter.filter-size')
-      .find('input')
-      .type('50');
-
-    cy.get('.search-filter.filter-size')
-      .find('.input-group-addon.operator select')
-      .select('>=');
-
-    cy.wait(50)
-      .get('.right-footer .item-count')
-      .then($row => {
-        expect(+$row.text()).to.be.at.least(6);
+      defaultSortDescListWithExtraSongs.forEach((_colName, rowIdx) => {
+        if (rowIdx < defaultSortDescListWithExtraSongs.length - 1) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortDescListWithExtraSongs[rowIdx]);
+        }
       });
+    });
 
-    const expectedFiles = ['music', 'mp3', 'pop', 'pop-79.mp3', 'rock', 'soft.mp3'];
+    it('should filter the Files by the input search string and expect 4 rows and 1st column to have ', () => {
+      const filteredFiles = ['documents', 'pdf', 'map2.pdf', 'map.pdf'];
 
-    expectedFiles.forEach((_colName, rowIdx) => {
-      if (rowIdx < expectedFiles.length - 3) {
-        cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', expectedFiles[rowIdx]);
-      }
+      cy.get('[data-test=search-string]')
+        .type('map');
+
+      cy.get('.search-filter.filter-file')
+        .should(($input) => {
+          expect($input.val()).to.eq('map');
+        });
+
+      cy.get('.grid6')
+        .find('.slick-row .slick-cell:nth(0)')
+        .each(($cell, index) => {
+          expect($cell.text().trim()).to.contain(filteredFiles[index]);
+        });
+    });
+
+    it('should clear search string and expect default list', () => {
+      cy.get('[data-test=clear-search-string]')
+        .click();
+
+      defaultSortDescListWithExtraSongs.forEach((_colName, rowIdx) => {
+        if (rowIdx < defaultSortDescListWithExtraSongs.length - 1) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', defaultSortDescListWithExtraSongs[rowIdx]);
+        }
+      });
+    });
+
+    it('should be able to add a 3rd new pop song into the Music folder and see it show up in the UI', () => {
+      cy.get('[data-test=add-item-btn]')
+        .contains('Add New Pop Song')
+        .click();
+
+      cy.get('.slick-group-toggle[level=3]')
+        .get('.slick-cell')
+        .contains('pop-81.mp3');
+
+      cy.get('.slick-group-toggle[level=3]')
+        .get('.slick-cell')
+        .contains('pop-81.mp3');
+    });
+
+    it('should have pop songs folder with updated aggregations including 4 pop songs of Sum(400.3MB) / Avg(66.72MB)', () => {
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom', { force: true } as any);
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 400.3 MB / avg: 66.72 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 400.3 MB / avg: 66.72 MB');
+      // next folder is "other" and is empty without aggregations
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 302.3 MB / avg: 60.46 MB');
+    });
+
+    it('should return 8 rows when filtering the word "pop" music without excluding children', () => {
+      cy.get('.search-filter.filter-file')
+        .type('pop');
+
+      cy.get('.right-footer .item-count')
+        .contains('8');
+
+      popMusicWith3ExtraSongsWithoutEmpty.forEach((_colName, rowIdx) => {
+        if (rowIdx < popMusicWith3ExtraSongsWithoutEmpty.length - 1) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', popMusicWith3ExtraSongsWithoutEmpty[rowIdx]);
+        }
+      });
+    });
+
+    it('should return 6 rows when using same filter "pop" music AND selecting checkbox to "Exclude Children when Filtering Tree"', () => {
+      cy.get('[data-test="exclude-child-when-filtering"]')
+        .check();
+
+      cy.get('.right-footer .item-count')
+        .contains('6');
+
+      popMusicWith3ExtraSongsWithoutEmpty.forEach((_colName, rowIdx) => {
+        if (rowIdx < popMusicWith3ExtraSongsWithoutEmpty.length - 3) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', popMusicWith3ExtraSongsWithoutEmpty[rowIdx]);
+        }
+      });
+    });
+
+    it('should change filter to the word "music" and expect only 1 row (the music folder) to show up when still Excluding Children from the Tree', () => {
+      cy.get('[data-test=clear-search-string]')
+        .click();
+
+      cy.get('.search-filter.filter-file')
+        .type('music');
+
+      cy.get('.right-footer .item-count')
+        .contains('1');
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+    });
+
+    it('should use same filter "music" and now expect to see 10 rows (entire music folder content) to show up when "Exclude Children when Filtering Tree" becomes uncheck', () => {
+      cy.get('[data-test="exclude-child-when-filtering"]')
+        .uncheck();
+
+      cy.get('.right-footer .item-count')
+        .contains('11');
+
+      const allMusic = [...popMusicWith3ExtraSongs, 'rock', 'soft.mp3'];
+
+      allMusic.forEach((_colName, rowIdx) => {
+        if (rowIdx < allMusic.length - 3) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', allMusic[rowIdx]);
+        }
+      });
+    });
+
+    it('should use same filter "music" and add extra filter of "size >= 50" and expect 1+ songs (>=6 rows) to show up in the grid when "Exclude Children when Filtering Tree" is unchecked and "Skip Other Criteria..." is checked', () => {
+      cy.get('.search-filter.filter-size')
+        .find('input')
+        .type('50');
+
+      cy.get('.search-filter.filter-size')
+        .find('.input-group-addon.operator select')
+        .select('>=');
+
+      cy.wait(50)
+        .get('.right-footer .item-count')
+        .then($row => {
+          expect(+$row.text()).to.be.at.least(6);
+        });
+
+      const expectedFiles = ['music', 'mp3', 'pop', 'pop-79.mp3', 'rock', 'soft.mp3'];
+
+      expectedFiles.forEach((_colName, rowIdx) => {
+        if (rowIdx < expectedFiles.length - 3) {
+          cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * rowIdx}px"] > .slick-cell:nth(0)`).should('contain', expectedFiles[rowIdx]);
+        }
+      });
+    });
+
+    it('should use same filter "music" and "size > 70" then unchecked "Skip Other Criteria..." and now expect 0 rows in the grid because there 0 rows having these 2 filters criteria', () => {
+      cy.get('[data-test="auto-approve-parent-item"]')
+        .uncheck();
+
+      cy.get('.right-footer .item-count')
+        .contains('0');
+    });
+
+    it('should clear all filters', () => {
+      cy.get('[data-test="clear-filters-btn"]')
+        .click();
+    });
+
+    it('should have pop songs folder with updated aggregations including 4 pop songs of Sum(400.3MB) / Avg(66.72MB)', () => {
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('center', { force: true } as any);
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 400.3 MB / avg: 66.72 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 400.3 MB / avg: 66.72 MB');
+      // next folder is "other" and is empty without aggregations
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 302.3 MB / avg: 60.46 MB');
+    });
+
+    it('should remove last inserted pop song 81 and expect aggregations to be updated with Sum(316.3MB) / Avg(63.26MB)', () => {
+      cy.get('[data-test="remove-item-btn"]')
+        .click();
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
+      // next folder is "other" and is empty without aggregations
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 218.3 MB / avg: 54.58 MB');
     });
   });
 
-  it('should use same filter "music" and "size > 70" then uncked "Skip Other Criteria..." and now expect 0 rows in the grid because there 0 rows having these 2 filters criteria', () => {
-    cy.get('[data-test="auto-approve-parent-item"]')
-      .uncheck();
+  describe('Auto-Recalc Tree Totals feature enabled', () => {
+    it('should enable auto-recalc Tree Totals', () => {
+      cy.get('[data-test="auto-recalc-totals"]')
+        .check();
+    });
 
-    cy.get('.right-footer .item-count')
-      .contains('0');
+    it('should have pop songs folder with aggregation reflecting what is displayed, Sum(316.3MB) / Avg(63.26MB)', () => {
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('center', { force: true } as any);
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(0)`).should('contain', 'music');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 16}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 17}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 316.3 MB / avg: 63.26 MB');
+      // next folder is "other" and is empty without aggregations
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(0)`).should('contain', 'pop');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 19}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 218.3 MB / avg: 54.58 MB');
+    });
+
+    it('should have documents with same Sum as the beginning since auto-recalc is disabled, aggregation should be Sum(14.46MB) / Avg(1.45MB)', () => {
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('top', { force: true } as any);
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(0)`).should('contain', 'documents');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 14.46 MB / avg: 1.45 MB (total)');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(0)`).should('contain', 'misc');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 0.4 MB / avg: 0.4 MB (sub-total)');
+    });
+
+    it('should retype filter "map" and expect totals to be updated with a lower Sum(6MB) / Avg(3MB) of only what is displayed', () => {
+      cy.get('.search-filter.filter-file')
+        .type('map');
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(0)`).should('contain', 'documents');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 6 MB / avg: 3 MB (total)');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(0)`).should('contain', 'pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 6 MB / avg: 3 MB (sub-total)');
+
+
+      cy.get('.right-footer .item-count').contains('4');
+      cy.get('.right-footer .total-count').contains('31');
+    });
+
+    it('should enable auto-recalc Tree Totals', () => {
+      cy.get('[data-test="clear-filters-btn"]')
+        .click();
+    });
+
+    it('should type filter "b" and expect totals to be updated with a lower Sum(6MB) / Avg(3MB) of only what is displayed', () => {
+      cy.get('.search-filter.filter-file')
+        .type('b');
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(0)`).should('contain', 'bucket-list.txt');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(0)`).should('contain', 'documents');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 4.02 MB / avg: 1.34 MB (total)');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(0)`).should('contain', 'pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 2.8 MB / avg: 1.4 MB (sub-total)');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(0)`).should('contain', 'internet-bill.pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(3)`).should('contain', '1.3 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(0)`).should('contain', 'phone-bill.pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 4}px"] > .slick-cell:nth(3)`).should('contain', '1.5 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(0)`).should('contain', 'zebra.dll');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 5}px"] > .slick-cell:nth(3)`).should('contain', '1.22 MB');
+
+      cy.get('.right-footer .item-count').contains('6');
+      cy.get('.right-footer .total-count').contains('31');
+    });
+
+    it('should type filter "b" and expect totals to be updated with a lower Sum(6MB) / Avg(3MB) of only what is displayed', () => {
+      cy.get('.search-filter.filter-file')
+        .type('i'); // will become "bi"
+
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(0)`).should('contain', 'documents');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 2.8 MB / avg: 1.4 MB (total)');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(0)`).should('contain', 'pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(3)`).should('contain', 'sum: 2.8 MB / avg: 1.4 MB (sub-total)');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(0)`).should('contain', 'internet-bill.pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(3)`).should('contain', '1.3 MB');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(0)`).should('contain', 'phone-bill.pdf');
+      cy.get(`.grid6 [style="top:${GRID_ROW_HEIGHT * 3}px"] > .slick-cell:nth(3)`).should('contain', '1.5 MB');
+
+      cy.get('.right-footer .item-count').contains('4');
+      cy.get('.right-footer .total-count').contains('31');
+    });
   });
 });


### PR DESCRIPTION
- add a new auto-recalc tree totals feature which is disabled by default, this new feature comes with 2 new properties
  - `autoRecalcTotalsOnFilterChange` to enabled the feature
  - `autoRecalcTotalsDebounce` to limit recalc execution when used with large tree dataset
- add more functionalities into Example 6 to not just add new file but also remove last inserted song

### TODOs
- [x] add Jest unit tests
- [x] add Cypress E2E tests