### PR TITLE
chore: use settimeout for debouncing of tree totals auto-recalc

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.html
@@ -11,8 +11,10 @@
   </div>
 </h3>
 <h6 class="title is-6 italic">
-  NOTE: The grid will automatically sort Ascending with the column that has the Tree Data, you could add a
+  NOTE #1: The grid will automatically sort in Ascending order with the column that has the Tree Data, you could add a
   "sortByFieldId" in your column "treeData" option if you wish to sort on a different column
+<br/>
+  NOTE #2: Tree Totals are only calculated once and are <b>NOT</b> recalculated while filtering data, if you do want that feature then you will need to enable <code>autoRecalcTotalsOnFilterChange</code> <i>(see checkbox below)</i>
 </h6>
 <div class="columns">
   <div class="column">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -74,21 +74,13 @@ export default class Example6 {
         // if you wish to use any of the GroupTotalFormatters (or even regular Formatters), we can do so with the code below
         // use `treeTotalsFormatter` or `groupTotalsFormatter` to show totals in a Tree Data grid
         // provide any regular formatters inside the params.formatters
-        // IMPORTANT: DO NOT USE Formatters.multiple (that will fail), Formatters.treeParseTotals already accepts multiple params.formatters and IT MUST BE the Formatter entry point
 
         // formatter: Formatters.treeParseTotals,
         // treeTotalsFormatter: GroupTotalFormatters.sumTotalsBold,
         // // groupTotalsFormatter: GroupTotalFormatters.sumTotalsBold,
         // params: {
-        //   formatters: [
-        //     // providing extra formatters for regular cell dataContext, it will only be used when `__treeTotals` is NOT detected (so when it's not a Tree Data total)
-        //     (_row, _cell, value) => isNaN(value) ? '' : `${decimalFormatted(value, 0, 2)} MB`,
-        //     italicFormatter,
-        //   ],
         //   // we can also supply extra params for Formatters/GroupTotalFormatters like min/max decimals
-        //   groupFormatterSuffix: ' MB',
-        //   minDecimal: 0,
-        //   maxDecimal: 2,
+        //   groupFormatterSuffix: ' MB', minDecimal: 0, maxDecimal: 2,
         // },
 
         // OR option #2 (custom Formatter)
@@ -139,6 +131,7 @@ export default class Example6 {
       enableFiltering: true,
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       multiColumnSort: false, // multi-column sorting is not supported with Tree Data, so you need to disable it
+      rowHeight: 40,
       treeDataOptions: {
         columnId: 'file',
         childrenPropName: 'files',
@@ -166,7 +159,7 @@ export default class Example6 {
         autoRecalcTotalsOnFilterChange: this.isAutoRecalcTotalsOnFilterChange,
 
         // add optional debounce time to limit number of execution that recalc is called, mostly useful on large dataset
-        autoRecalcTotalsDebounce: 750
+        // autoRecalcTotalsDebounce: 250
       },
       showCustomFooter: true,
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -166,7 +166,7 @@ export default class Example6 {
         autoRecalcTotalsOnFilterChange: this.isAutoRecalcTotalsOnFilterChange,
 
         // add optional debounce time to limit number of execution that recalc is called, mostly useful on large dataset
-        // autoRecalcTotalsDebounce: 750
+        autoRecalcTotalsDebounce: 750
       },
       showCustomFooter: true,
 

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -11,7 +11,6 @@ import {
   cancellablePromise,
   CancelledException,
   castObservableToPromise,
-  debounce,
   flattenToParentChildArray,
   unflattenParentChildArrayToTree,
   decimalFormatted,
@@ -147,35 +146,6 @@ describe('Service/Utilies', () => {
       castObservableToPromise(rxjs, observable).then((outputArray) => {
         expect(outputArray).toBe(inputArray);
       });
-    });
-  });
-
-  describe('debounce method', () => {
-    it('should execute callback right away when debounce wait time is below 0', () => {
-      const callbackSpy = jest.fn();
-
-      debounce(callbackSpy, -1)();
-
-      expect(callbackSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should NOT execute callback right away when debounce wait time is greater than 0', () => {
-      const callbackSpy = jest.fn();
-
-      debounce(callbackSpy, 1)();
-
-      expect(callbackSpy).toHaveBeenCalledTimes(0);
-    });
-
-    it('should execute callback after debounce time is reached and is greater than 0', (done) => {
-      const callbackSpy = jest.fn();
-
-      debounce(callbackSpy, 1)();
-
-      setTimeout(() => {
-        expect(callbackSpy).toHaveBeenCalledTimes(1);
-        done();
-      }, 1);
     });
   });
 

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -61,23 +61,6 @@ export function castObservableToPromise<T>(rxjs: RxJsFacade, input: Promise<T> |
 }
 
 /**
- * Debounce to delay JS callback execution, a wait of (-1) could be provided to execute callback without delay.
- * @param {Function} callback - callback method to execute
- * @param {Number} wait - delay to wait before execution or -1 delay
- */
-export function debounce(callback: (...args: any) => any, wait = -1) {
-  let timeoutId: any = null;
-  return (...args: any) => {
-    if (wait >= 0) {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => callback(...args), wait);
-    } else {
-      callback.apply(null);
-    }
-  };
-}
-
-/**
  * Mutate the original array and add a treeLevel (defaults to `__treeLevel`) property on each item.
  * @param {Array<Object>} treeArray - hierarchical tree array
  * @param {Object} options - options containing info like children & treeLevel property names

--- a/test/cypress/e2e/example06.cy.ts
+++ b/test/cypress/e2e/example06.cy.ts
@@ -1,5 +1,5 @@
 describe('Example 06 - Tree Data (from a Hierarchical Dataset)', { retries: 0 }, () => {
-  const GRID_ROW_HEIGHT = 45;
+  const GRID_ROW_HEIGHT = 40;
   const titles = ['Files', 'Date Modified', 'Description', 'Size'];
   // const defaultSortAscList = ['bucket-list.txt', 'documents', 'misc', 'warranties.txt', 'pdf', 'internet-bill.pdf', 'map.pdf', 'map2.pdf', 'phone-bill.pdf', 'txt', 'todo.txt', 'unclassified.csv', 'unresolved.csv', 'xls', 'compilation.xls', 'music', 'mp3', 'other', 'pop', 'song.mp3', 'theme.mp3', 'rock', 'soft.mp3', 'something.txt'];
   // const defaultSortDescList = ['something.txt', 'music', 'mp3', 'rock', 'soft.mp3', 'other', 'pop', 'theme.mp3', 'song.mp3', 'documents', 'xls', 'compilation.xls', 'txt', 'todo.txt', 'unclassified.csv', 'unresolved.csv', 'pdf', 'phone-bill.pdf', 'map2.pdf', 'map.pdf', 'internet-bill.pdf', 'misc', 'todo.txt', 'bucket-list.txt'];


### PR DESCRIPTION
- remove previous `debounce` method since it doesn't work well when used within an event that can be triggered multiple times. The debounce method did work but we had to keep a copy of the debounced assignment and then also provide all arguments to the inner debounce which seems like a lot of work when in reality the setTimeout is only 3 lines of code which comes to about the same if we need to keep a debounced instantiation every time