### PR TITLE
feat: add option to cancel Row Detail opening

### DIFF
--- a/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
@@ -306,10 +306,13 @@ describe('SlickRowDetailView plugin', () => {
     expect(stopPropagationSpy).not.toHaveBeenCalled();
   });
 
-  it('should trigger onClick and ', () => {
+  it('should trigger onClick and NOT expect Row Detail to be toggled when onBeforeRowDetailToggle returns false', () => {
     const mockProcess = jest.fn();
     const expandDetailViewSpy = jest.spyOn(plugin, 'expandDetailView');
-    const beforeRowDetailToggleSpy = jest.spyOn(plugin.onBeforeRowDetailToggle, 'notify');
+    const onBeforeSlickEventData = new Slick.EventData();
+    jest.spyOn(onBeforeSlickEventData, 'getReturnValue').mockReturnValue(false);
+    const beforeRowDetailToggleSpy = jest.spyOn(plugin.onBeforeRowDetailToggle, 'notify').mockReturnValueOnce(onBeforeSlickEventData);
+    const afterRowDetailToggleSpy = jest.spyOn(plugin.onAfterRowDetailToggle, 'notify');
     const itemMock = { id: 123, firstName: 'John', lastName: 'Doe', _collapsed: true };
     const detailView = `<span>loading...</span>`;
     jest.spyOn(gridStub.getEditorLock(), 'isActive').mockReturnValue(false);
@@ -328,6 +331,34 @@ describe('SlickRowDetailView plugin', () => {
     gridStub.onClick.notify({ row: 0, cell: 1, grid: gridStub }, clickEvent);
 
     expect(beforeRowDetailToggleSpy).toHaveBeenCalled();
+    expect(afterRowDetailToggleSpy).not.toHaveBeenCalled();
+    expect(expandDetailViewSpy).not.toHaveBeenCalled();
+  });
+
+  it('should trigger onClick and expect Row Detail to be toggled', () => {
+    const mockProcess = jest.fn();
+    const expandDetailViewSpy = jest.spyOn(plugin, 'expandDetailView');
+    const beforeRowDetailToggleSpy = jest.spyOn(plugin.onBeforeRowDetailToggle, 'notify');
+    const afterRowDetailToggleSpy = jest.spyOn(plugin.onAfterRowDetailToggle, 'notify');
+    const itemMock = { id: 123, firstName: 'John', lastName: 'Doe', _collapsed: true };
+    const detailView = `<span>loading...</span>`;
+    jest.spyOn(gridStub.getEditorLock(), 'isActive').mockReturnValue(false);
+    jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit').mockReturnValue(true);
+    jest.spyOn(gridStub, 'getDataItem').mockReturnValue(itemMock);
+    jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    jest.spyOn(gridStub, 'getOptions').mockReturnValue({ ...gridOptionsMock, rowDetailView: { process: mockProcess, columnIndexPosition: 0, useRowClick: true, maxRows: 2, panelRows: 2 } as any });
+
+    plugin.init(gridStub);
+    plugin.onAsyncResponse.notify({ item: itemMock, itemDetail: itemMock, detailView, }, new Slick.EventData());
+
+    const clickEvent = new Event('click');
+    Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: document.createElement('div') });
+    Object.defineProperty(clickEvent, 'isPropagationStopped', { writable: true, configurable: true, value: jest.fn() });
+    Object.defineProperty(clickEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: jest.fn() });
+    gridStub.onClick.notify({ row: 0, cell: 1, grid: gridStub }, clickEvent);
+
+    expect(beforeRowDetailToggleSpy).toHaveBeenCalled();
+    expect(afterRowDetailToggleSpy).toHaveBeenCalled();
     expect(expandDetailViewSpy).toHaveBeenCalledWith({
       _collapsed: false, _detailContent: undefined, _detailViewLoaded: true,
       _height: 75, _sizePadding: 3, firstName: 'John', id: 123, lastName: 'Doe'
@@ -410,7 +441,7 @@ describe('SlickRowDetailView plugin', () => {
         _collapsed: true, _detailViewLoaded: true, _sizePadding: 0, _height: 150, _detailContent: '<span>loading...</span>',
         id: 123, firstName: 'John', lastName: 'Doe',
       }
-    });
+    }, expect.anything(), expect.anything());
     expect(afterRowDetailToggleSpy).toHaveBeenCalledWith({
       grid: gridStub,
       item: {

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -682,10 +682,10 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
         }
 
         // trigger an event before toggling
-        this.onBeforeRowDetailToggle.notify({
-          grid: this._grid,
-          item: dataContext
-        });
+        // user could cancel the Row Detail opening when event is returning false
+        if (this.onBeforeRowDetailToggle.notify({ grid: this._grid, item: dataContext }, e, this).getReturnValue() === false) {
+          return;
+        }
 
         this.toggleRowSelection(args.row, dataContext);
 


### PR DESCRIPTION
- user can now prevent event and return false on `onBeforeRowDetailToggle` event to cancel opening certain Row Detail, for example the code below would block opening Row Detail when its id is `1`

```ts
detailView.onBeforeRowDetailToggle.subscribe(function(e, args) {
  // you coud cancel opening certain rows
  if (args.item.id === 1) {
    e.preventDefault();
    return false;
  }
  console.log('before toggling row detail', args.item);
});
```

![Code_OXS6TTs2AJ](https://github.com/6pac/SlickGrid/assets/643976/c19d3f57-aa64-4a0d-83a0-bb0983396701)
