### PR TITLE
feat: add pageUp/pageDown/home/end to SlickCellSelection

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/app-routing.ts
+++ b/examples/vite-demo-vanilla-bundle/src/app-routing.ts
@@ -19,6 +19,7 @@ import Example15 from './examples/example15';
 import Example16 from './examples/example16';
 import Example17 from './examples/example17';
 import Example18 from './examples/example18';
+import Example19 from './examples/example19';
 
 export class AppRouting {
   constructor(private config: RouterConfig) {
@@ -43,6 +44,7 @@ export class AppRouting {
       { route: 'example16', name: 'example16', view: './examples/example16.html', viewModel: Example16, title: 'Example16', },
       { route: 'example17', name: 'example17', view: './examples/example17.html', viewModel: Example17, title: 'Example17', },
       { route: 'example18', name: 'example18', view: './examples/example18.html', viewModel: Example18, title: 'Example18', },
+      { route: 'example19', name: 'example19', view: './examples/example19.html', viewModel: Example19, title: 'Example19', },
       { route: '', redirect: 'example01' },
       { route: '**', redirect: 'example01' }
     ];

--- a/examples/vite-demo-vanilla-bundle/src/app.html
+++ b/examples/vite-demo-vanilla-bundle/src/app.html
@@ -89,6 +89,9 @@
           <a class="navbar-item" onclick.delegate="loadRoute('example18')">
             Example18 - Real-Time Trading Platform
           </a>
+          <a class="navbar-item" onclick.delegate="loadRoute('example19')">
+            Example19 - ExcelCopyBuffer with Cell Selection
+          </a>
         </div>
       </div>
     </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.html
@@ -1,23 +1,27 @@
 <h3 class="title is-3">
   Example 19 - ExcelCopyBuffer with Cell Selection
-  <span class="subtitle">(with Material Theme)</span>
+  <span class="subtitle">(with Salesforce Theme)</span>
   <div class="subtitle" style="float: right; margin-top: -20px">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
-      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example18.ts">
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example19.ts">
       <span class="mdi mdi-link-variant mdi-v-align-sub"></span> code
     </a>
   </div>
 </h3>
 
-<h5 class="title is-5">
+<h5 class="title is-5 mb-3">
   Grid - using <code>enableExcelCopyBuffer</code> which uses <code>SlickCellSelectionModel</code>
-  <button class="button is-small" onclick.delegate="togglePagination()" style="margin-left: 10px"
+</h5>
+<h6 class="title is-6">
+  <button class="button is-small" onclick.delegate="togglePagination()"
     data-text="toggle-pagination-btn">
     <span class="icon mdi mdi-swap-vertical"></span>
     <span>Toggle Pagination</span>
   </button>
-</h5>
+  <label class="ml-3">Range Selection</label>
+  <span id="selectionRange"></span>
+</h6>
 
 <div class="grid19">
 </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.html
@@ -10,6 +10,14 @@
   </div>
 </h3>
 
-<h5 class="title is-5">Grid - Enable <code>enableExcelCopyBuffer</code> which uses <code>SlickCellSelectionModel</code></h5>
-  <div class="grid19">
-  </div>
+<h5 class="title is-5">
+  Grid - using <code>enableExcelCopyBuffer</code> which uses <code>SlickCellSelectionModel</code>
+  <button class="button is-small" onclick.delegate="togglePagination()" style="margin-left: 10px"
+    data-text="toggle-pagination-btn">
+    <span class="icon mdi mdi-swap-vertical"></span>
+    <span>Toggle Pagination</span>
+  </button>
+</h5>
+
+<div class="grid19">
+</div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.html
@@ -1,0 +1,15 @@
+<h3 class="title is-3">
+  Example 19 - ExcelCopyBuffer with Cell Selection
+  <span class="subtitle">(with Material Theme)</span>
+  <div class="subtitle" style="float: right; margin-top: -20px">
+    <span class="is-size-6">see</span>
+    <a class="is-size-5" target="_blank"
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example18.ts">
+      <span class="mdi mdi-link-variant mdi-v-align-sub"></span> code
+    </a>
+  </div>
+</h3>
+
+<h5 class="title is-5">Grid - Enable <code>enableExcelCopyBuffer</code> which uses <code>SlickCellSelectionModel</code></h5>
+  <div class="grid19">
+  </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.scss
@@ -1,0 +1,10 @@
+/** override slick-cell to make it look like Excel sheet */
+.grid19 {
+  --slick-border-color: #d4d4d4;
+  --slick-cell-odd-background-color: #fbfbfb;
+  --slick-cell-border-left: 1px solid var(--slick-border-color);
+  --slick-header-menu-display: none;
+  --slick-header-column-height: 20px;
+  --slick-grid-border-color: #d4d4d4;
+  --slick-row-selected-color: #d4ebfd;
+}

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.ts
@@ -1,17 +1,13 @@
-import {
-  Column,
-  FieldType,
-  Filters,
-  Formatters,
-  GridOption,
-} from '@slickgrid-universal/common';
+import { CellRange, Column, GridOption, SlickEventHandler, SlickNamespace, } from '@slickgrid-universal/common';
 import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import { ExampleGridOptions } from './example-grid-options';
-import '../material-styles.scss';
+import '../salesforce-styles.scss';
+import './example19.scss';
 
-const NB_ITEMS = 500;
-
+const NB_ITEMS = 100;
+declare const Slick: SlickNamespace;
 export default class Example34 {
+  protected _eventHandler: SlickEventHandler;
   title = 'Example 19: ExcelCopyBuffer with Cell Selection';
   subTitle = `Cell Selection using "Shift+{key}" where "key" can be any of:
   <ul>
@@ -24,75 +20,76 @@ export default class Example34 {
   columnDefinitions: Column[] = [];
   dataset: any[] = [];
   gridOptions!: GridOption;
+  gridContainerElm: HTMLDivElement;
   isWithPagination = true;
   sgb: SlickVanillaGridBundle;
 
   attached() {
+    this._eventHandler = new Slick.EventHandler();
+
     // define the grid options & columns and then create the grid itself
     this.defineGrid();
 
     // mock some data (different in each dataset)
     this.dataset = this.getData(NB_ITEMS);
+    this.gridContainerElm = document.querySelector<HTMLDivElement>(`.grid19`) as HTMLDivElement;
     this.sgb = new Slicker.GridBundle(document.querySelector(`.grid19`) as HTMLDivElement, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, this.dataset);
-    document.body.classList.add('material-theme');
+    document.body.classList.add('salesforce-theme');
+
+    // bind any of the grid events
+    const cellSelectionModel = this.sgb.slickGrid!.getSelectionModel();
+    this._eventHandler.subscribe(cellSelectionModel!.onSelectedRangesChanged, (_e, args: CellRange[]) => {
+      const targetRange = document.querySelector('#selectionRange') as HTMLSpanElement;
+      targetRange.textContent = '';
+
+      for (const slickRange of args) {
+        targetRange.textContent += JSON.stringify(slickRange);
+      }
+    });
   }
 
   dispose() {
+    this._eventHandler.unsubscribeAll();
     this.sgb?.dispose();
-    document.body.classList.remove('material-theme');
+    this.gridContainerElm.remove();
+    document.body.classList.remove('salesforce-theme');
   }
 
   /* Define grid Options and Columns */
   defineGrid() {
-    // the columns field property is type-safe, try to add a different string not representing one of DataItems properties
     this.columnDefinitions = [
-      { id: 'title', name: 'Title', field: 'title', sortable: true, type: FieldType.string, width: 70, filterable: true },
-      { id: 'phone', name: 'Phone Number using mask', field: 'phone', sortable: true, type: FieldType.number, minWidth: 100, formatter: Formatters.mask, params: { mask: '(000) 000-0000' }, filterable: true },
       {
-        id: 'duration', name: 'Duration (days)', field: 'duration', formatter: Formatters.decimal, params: { minDecimal: 1, maxDecimal: 2 },
-        sortable: true, type: FieldType.number, minWidth: 90, exportWithFormatter: true, filterable: true, filter: { model: Filters.compoundInputNumber }
-      },
-      { id: 'complete', name: '% Complete', field: 'percentComplete', formatter: Formatters.percentCompleteBar, type: FieldType.number, sortable: true, minWidth: 100, filterable: true, filter: { model: Filters.slider } },
-      { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso, sortable: true, type: FieldType.date, minWidth: 90, exportWithFormatter: true, filterable: true },
-      { id: 'finish', name: 'Finish', field: 'finish', formatter: Formatters.dateIso, sortable: true, type: FieldType.date, minWidth: 90, exportWithFormatter: true, filterable: true },
-      {
-        id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', type: FieldType.boolean, sortable: true, minWidth: 100 , filterable: true,
-        formatter: (_row, _cell, value) => {
-          // you can return a string of a object (of type FormatterResultObject), the 2 types are shown below
-          return value ? `<i class="mdi mdi-fire color-danger" aria-hidden="true"></i>` : { text: '<i class="mdi mdi-snowflake color-info-light" aria-hidden="true"></i>', toolTip: 'Freezing' };
-        },
-        filter: {
-          enableRenderHtml: true,
-          collection: [
-            { value: '', label: '' },
-            { value: true, labelPrefix: '<i class="mdi-v-align-middle mdi mdi-fire color-danger" aria-hidden="true"></i> ', label: 'a lot of effort' },
-            { value: false, labelPrefix: '<i class="mdi-v-align-middle mdi mdi-snowflake color-info-light" aria-hidden="true"></i> ', label: 'not that much' }
-          ],
-          model: Filters.singleSelect
-        },
-      },
-      {
-        id: 'completed', name: 'Completed', field: 'completed', type: FieldType.boolean, sortable: true, minWidth: 100, filterable: true,
-        formatter: (_row, _cell, value) => value ? '<i class="mdi mdi-check"></i>' : '',
-        filter: {
-          collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }],
-          model: Filters.singleSelect
-        },
+        id: 'selector',
+        name: '',
+        field: 'num',
+        width: 30
       }
     ];
+
+    for (let i = 0; i < NB_ITEMS; i++) {
+      this.columnDefinitions.push({
+        id: i,
+        name: i < 26
+          ? String.fromCharCode('A'.charCodeAt(0) + (i % 26))
+          : String.fromCharCode('A'.charCodeAt(0) + ((i / 26) | 0) -1) + String.fromCharCode('A'.charCodeAt(0) + (i % 26)),
+        field: i as any,
+        minWidth: 60,
+        width: 60,
+      });
+    }
 
     this.gridOptions = {
       autoResize: {
         container: '.demo-container',
       },
       enableCellNavigation: true,
-      enableFiltering: true,
       enablePagination: true,
       pagination: {
         pageSizes: [5, 10, 15, 20, 25, 50, 75, 100],
-        pageSize: 10
+        pageSize: 20
       },
-      rowHeight: 40,
+      headerRowHeight: 35,
+      rowHeight: 30,
 
       // when using the ExcelCopyBuffer, you can see what the selection range is
       enableExcelCopyBuffer: true,
@@ -108,24 +105,11 @@ export default class Example34 {
     // mock a dataset
     const datasetTmp: any[] = [];
     for (let i = 0; i < itemCount; i++) {
-      const randomYear = 2000 + Math.floor(Math.random() * 20);
-      const randomMonth = Math.floor(Math.random() * 11);
-      const randomDay = Math.floor((Math.random() * 29));
-      const randomPercent = Math.round(Math.random() * 100);
-
-      datasetTmp[i] = {
-        id: i,
-        title: 'Task ' + i,
-        phone: this.generatePhoneNumber(),
-        duration: Math.random() * 100 + '',
-        percentComplete: randomPercent,
-        percentCompleteNumber: randomPercent,
-        start: new Date(randomYear, randomMonth, randomDay),
-        finish: new Date(randomYear, (randomMonth + 1), randomDay),
-        effortDriven: (i % 4 === 0),
-        completed: (i % 3 === 0)
-      };
+      const d: any = (datasetTmp[i] = {});
+      d['id'] = i;
+      d['num'] = i;
     }
+
     return datasetTmp;
   }
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.ts
@@ -1,0 +1,138 @@
+import {
+  Column,
+  FieldType,
+  Filters,
+  Formatters,
+  GridOption,
+} from '@slickgrid-universal/common';
+import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+import { ExampleGridOptions } from './example-grid-options';
+import '../material-styles.scss';
+
+const NB_ITEMS = 500;
+
+export default class Example34 {
+  title = 'Example 19: ExcelCopyBuffer with Cell Selection';
+  subTitle = `Cell Selection using "Shift+{key}" where "key" can be any of:
+  <ul>
+    <li>Arrow Up/Down/Left/Right</li>
+    <li>Page Up/Down</li>
+    <li>Home</li>
+    <li>End</li>
+  </ul>`;
+
+  columnDefinitions: Column[] = [];
+  dataset: any[] = [];
+  gridOptions!: GridOption;
+  sgb: SlickVanillaGridBundle;
+
+  attached() {
+    // define the grid options & columns and then create the grid itself
+    this.defineGrid();
+
+    // mock some data (different in each dataset)
+    this.dataset = this.getData(NB_ITEMS);
+    this.sgb = new Slicker.GridBundle(document.querySelector(`.grid19`) as HTMLDivElement, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, this.dataset);
+    document.body.classList.add('material-theme');
+  }
+
+  dispose() {
+    this.sgb?.dispose();
+    document.body.classList.remove('material-theme');
+  }
+
+  /* Define grid Options and Columns */
+  defineGrid() {
+    // the columns field property is type-safe, try to add a different string not representing one of DataItems properties
+    this.columnDefinitions = [
+      { id: 'title', name: 'Title', field: 'title', sortable: true, type: FieldType.string, width: 70, filterable: true },
+      { id: 'phone', name: 'Phone Number using mask', field: 'phone', sortable: true, type: FieldType.number, minWidth: 100, formatter: Formatters.mask, params: { mask: '(000) 000-0000' }, filterable: true },
+      {
+        id: 'duration', name: 'Duration (days)', field: 'duration', formatter: Formatters.decimal, params: { minDecimal: 1, maxDecimal: 2 },
+        sortable: true, type: FieldType.number, minWidth: 90, exportWithFormatter: true, filterable: true, filter: { model: Filters.compoundInputNumber }
+      },
+      { id: 'complete', name: '% Complete', field: 'percentComplete', formatter: Formatters.percentCompleteBar, type: FieldType.number, sortable: true, minWidth: 100, filterable: true, filter: { model: Filters.slider } },
+      { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso, sortable: true, type: FieldType.date, minWidth: 90, exportWithFormatter: true, filterable: true },
+      { id: 'finish', name: 'Finish', field: 'finish', formatter: Formatters.dateIso, sortable: true, type: FieldType.date, minWidth: 90, exportWithFormatter: true, filterable: true },
+      {
+        id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', type: FieldType.boolean, sortable: true, minWidth: 100 , filterable: true,
+        formatter: (_row, _cell, value) => {
+          // you can return a string of a object (of type FormatterResultObject), the 2 types are shown below
+          return value ? `<i class="mdi mdi-fire color-danger" aria-hidden="true"></i>` : { text: '<i class="mdi mdi-snowflake color-info-light" aria-hidden="true"></i>', toolTip: 'Freezing' };
+        },
+        filter: {
+          enableRenderHtml: true,
+          collection: [
+            { value: '', label: '' },
+            { value: true, labelPrefix: '<i class="mdi-v-align-middle mdi mdi-fire color-danger" aria-hidden="true"></i> ', label: 'a lot of effort' },
+            { value: false, labelPrefix: '<i class="mdi-v-align-middle mdi mdi-snowflake color-info-light" aria-hidden="true"></i> ', label: 'not that much' }
+          ],
+          model: Filters.singleSelect
+        },
+      },
+      {
+        id: 'completed', name: 'Completed', field: 'completed', type: FieldType.boolean, sortable: true, minWidth: 100, filterable: true,
+        formatter: (_row, _cell, value) => value ? '<i class="mdi mdi-check"></i>' : '',
+        filter: {
+          collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }],
+          model: Filters.singleSelect
+        },
+      }
+    ];
+
+    this.gridOptions = {
+      autoResize: {
+        container: '.demo-container',
+      },
+      enableCellNavigation: true,
+      enableFiltering: true,
+      enablePagination: true,
+      pagination: {
+        pageSizes: [5, 10, 15, 20, 25, 50, 75, 100],
+        pageSize: 10
+      },
+      rowHeight: 40,
+
+      // when using the ExcelCopyBuffer, you can see what the selection range is
+      enableExcelCopyBuffer: true,
+      // excelCopyBufferOptions: {
+      //   onCopyCells: (e, args: { ranges: SelectedRange[] }) => console.log('onCopyCells', args.ranges),
+      //   onPasteCells: (e, args: { ranges: SelectedRange[] }) => console.log('onPasteCells', args.ranges),
+      //   onCopyCancelled: (e, args: { ranges: SelectedRange[] }) => console.log('onCopyCancelled', args.ranges),
+      // }
+    };
+  }
+
+  getData(itemCount: number) {
+    // mock a dataset
+    const datasetTmp: any[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const randomYear = 2000 + Math.floor(Math.random() * 20);
+      const randomMonth = Math.floor(Math.random() * 11);
+      const randomDay = Math.floor((Math.random() * 29));
+      const randomPercent = Math.round(Math.random() * 100);
+
+      datasetTmp[i] = {
+        id: i,
+        title: 'Task ' + i,
+        phone: this.generatePhoneNumber(),
+        duration: Math.random() * 100 + '',
+        percentComplete: randomPercent,
+        percentCompleteNumber: randomPercent,
+        start: new Date(randomYear, randomMonth, randomDay),
+        finish: new Date(randomYear, (randomMonth + 1), randomDay),
+        effortDriven: (i % 4 === 0),
+        completed: (i % 3 === 0)
+      };
+    }
+    return datasetTmp;
+  }
+
+  generatePhoneNumber(): string {
+    let phone = '';
+    for (let i = 0; i < 10; i++) {
+      phone += Math.round(Math.random() * 9) + '';
+    }
+    return phone;
+  }
+}

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.ts
@@ -24,6 +24,7 @@ export default class Example34 {
   columnDefinitions: Column[] = [];
   dataset: any[] = [];
   gridOptions!: GridOption;
+  isWithPagination = true;
   sgb: SlickVanillaGridBundle;
 
   attached() {
@@ -134,5 +135,14 @@ export default class Example34 {
       phone += Math.round(Math.random() * 9) + '';
     }
     return phone;
+  }
+
+  // Toggle the Grid Pagination
+  // IMPORTANT, the Pagination MUST BE CREATED on initial page load before you can start toggling it
+  // Basically you cannot toggle a Pagination that doesn't exist (must created at the time as the grid)
+  togglePagination() {
+    this.isWithPagination = !this.isWithPagination;
+    this.sgb.paginationService!.togglePaginationVisibility(this.isWithPagination);
+    this.sgb.slickGrid!.setSelectedRows([]);
   }
 }

--- a/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
@@ -123,7 +123,6 @@ describe('CellSelectionModel Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.canvas).toBeTruthy();
     expect(plugin.addonOptions).toEqual({ selectActiveCell: true });
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
   });
@@ -135,7 +134,6 @@ describe('CellSelectionModel Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.canvas).toBeTruthy();
     expect(plugin.addonOptions).toEqual({ selectActiveCell: false });
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
   });
@@ -148,7 +146,6 @@ describe('CellSelectionModel Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.canvas).toBeTruthy();
     expect(plugin.addonOptions).toEqual({ selectActiveCell: true, cellRangeSelector: mockCellRangeSelector });
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
   });
@@ -167,7 +164,6 @@ describe('CellSelectionModel Plugin', () => {
     plugin.refreshSelections();
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.canvas).toBeTruthy();
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
     expect(setSelectedRangesSpy).toHaveBeenCalledWith([
       { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4 },
@@ -332,8 +328,10 @@ describe('CellSelectionModel Plugin', () => {
     const notifyingRowNumber = 3;
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
     jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
 
     plugin.init(gridStub);
+    plugin.resetPageRowCount();
     plugin.setSelectedRanges([
       { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: () => false },
       { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 4, contains: () => false }
@@ -350,6 +348,7 @@ describe('CellSelectionModel Plugin', () => {
       },
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith((notifyingRowNumber + CALCULATED_PAGE_ROW_COUNT), 2, false);
   });
 
   it('should call "setSelectedRanges" with Slick Range from current position to the last row index when using Shift+PageDown key combo but there is less rows than an actual page left to display', () => {
@@ -357,6 +356,7 @@ describe('CellSelectionModel Plugin', () => {
     const lastRowIndex = NB_ITEMS - 1;
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
     jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
 
     plugin.init(gridStub);
     plugin.setSelectedRanges([
@@ -375,6 +375,7 @@ describe('CellSelectionModel Plugin', () => {
       },
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(lastRowIndex, 2, false);
   });
 
   it('should call "setSelectedRanges" with Slick Range from current position to a calculated size of a page up when using Shift+PageUp key combo when triggered by "onKeyDown"', () => {
@@ -382,6 +383,7 @@ describe('CellSelectionModel Plugin', () => {
     const CALCULATED_PAGE_ROW_COUNT = 23;
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
     jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
 
     plugin.init(gridStub);
     plugin.setSelectedRanges([
@@ -400,6 +402,7 @@ describe('CellSelectionModel Plugin', () => {
       },
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith((notifyingRowNumber - CALCULATED_PAGE_ROW_COUNT), 2, false);
   });
 
   it('should call "setSelectedRanges" with Slick Range from current position to the first row index when using Shift+PageUp key combo but there is less rows than an actual page left to display', () => {
@@ -407,6 +410,7 @@ describe('CellSelectionModel Plugin', () => {
     const firstRowIndex = 0;
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
     jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
 
     plugin.init(gridStub);
     plugin.setSelectedRanges([
@@ -425,6 +429,7 @@ describe('CellSelectionModel Plugin', () => {
       },
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(firstRowIndex, 2, false);
   });
 
   it('should call "setSelectedRanges" with Slick Range from current position to row index 0 when using Shift+Home key combo when triggered by "onKeyDown"', () => {
@@ -432,6 +437,7 @@ describe('CellSelectionModel Plugin', () => {
     const expectedRowZeroIdx = 0;
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
     jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
 
     plugin.init(gridStub);
     plugin.setSelectedRanges([
@@ -450,6 +456,7 @@ describe('CellSelectionModel Plugin', () => {
       },
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(expectedRowZeroIdx, 2, false);
   });
 
   it('should call "setSelectedRanges" with Slick Range from current position to last row index when using Shift+End key combo when triggered by "onKeyDown"', () => {
@@ -457,6 +464,7 @@ describe('CellSelectionModel Plugin', () => {
     const expectedLastRowIdx = NB_ITEMS - 1;
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
     jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
 
     plugin.init(gridStub);
     plugin.setSelectedRanges([
@@ -475,6 +483,7 @@ describe('CellSelectionModel Plugin', () => {
       },
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(expectedLastRowIdx, 2, false);
   });
 
   it('should call "rangesAreEqual" and expect True when both ranges are equal', () => {

--- a/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
@@ -30,6 +30,10 @@ const getEditorLockMock = {
   isActive: jest.fn(),
 };
 
+const dataViewStub = {
+  getPagingInfo: () => ({ pageSize: 5 }),
+};
+
 const gridStub = {
   canCellBeSelected: jest.fn(),
   getActiveCell: jest.fn(),
@@ -38,9 +42,12 @@ const gridStub = {
   getCellFromEvent: jest.fn(),
   getCellFromPoint: jest.fn(),
   getCellNodeBox: jest.fn(),
+  getData: () => dataViewStub,
   getEditorLock: () => getEditorLockMock,
   getOptions: () => mockGridOptions,
   getUID: () => GRID_UID,
+  getScrollbarDimensions: jest.fn(),
+  getViewportNode: jest.fn(),
   focus: jest.fn(),
   registerPlugin: jest.fn(),
   setActiveCell: jest.fn(),

--- a/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
@@ -6,6 +6,8 @@ import { SlickCellSelectionModel } from '../slickCellSelectionModel';
 
 declare const Slick: SlickNamespace;
 const GRID_UID = 'slickgrid_12345';
+const NB_ITEMS = 200;
+const CALCULATED_PAGE_ROW_COUNT = 23; // pageRowCount with our mocked sizes is 23 => ((600 - 17) / 25)
 jest.mock('flatpickr', () => { });
 
 const addVanillaEventPropagation = function (event, commandKey = '', keyName = '') {
@@ -23,6 +25,7 @@ const addVanillaEventPropagation = function (event, commandKey = '', keyName = '
 const mockGridOptions = {
   frozenColumn: 1,
   frozenRow: -1,
+  rowHeight: 25
 } as GridOption;
 
 const getEditorLockMock = {
@@ -31,7 +34,8 @@ const getEditorLockMock = {
 };
 
 const dataViewStub = {
-  getPagingInfo: () => ({ pageSize: 5 }),
+  getLength: () => NB_ITEMS,
+  getPagingInfo: () => ({ pageSize: 0 }),
 };
 
 const gridStub = {
@@ -43,10 +47,11 @@ const gridStub = {
   getCellFromPoint: jest.fn(),
   getCellNodeBox: jest.fn(),
   getData: () => dataViewStub,
+  getDataLength: jest.fn(),
   getEditorLock: () => getEditorLockMock,
   getOptions: () => mockGridOptions,
   getUID: () => GRID_UID,
-  getScrollbarDimensions: jest.fn(),
+  getScrollbarDimensions: () => ({ height: 17, width: 17}),
   getViewportNode: jest.fn(),
   focus: jest.fn(),
   registerPlugin: jest.fn(),
@@ -88,6 +93,8 @@ describe('CellSelectionModel Plugin', () => {
 
   beforeEach(() => {
     plugin = new SlickCellSelectionModel();
+    jest.spyOn(gridStub, 'getViewportNode').mockReturnValue(viewportElm);
+    Object.defineProperty(viewportElm, 'clientHeight', { writable: true, configurable: true, value: 600 });
   });
 
   afterEach(() => {
@@ -236,6 +243,9 @@ describe('CellSelectionModel Plugin', () => {
   });
 
   it('should call "setSelectedRanges" with Slick Range with a Right direction when triggered by "onKeyDown" with key combo of Shift+ArrowRight', () => {
+    // let's test this one without a DataView (aka SlickGrid only)
+    jest.spyOn(gridStub, 'getData').mockReturnValueOnce([]);
+    jest.spyOn(gridStub, 'getDataLength').mockReturnValueOnce(NB_ITEMS);
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: 3 });
 
     plugin.init(gridStub);
@@ -253,7 +263,7 @@ describe('CellSelectionModel Plugin', () => {
     }]);
   });
 
-  it('should call "setSelectedRanges" with Slick Range with a Right direction when triggered by "onKeyDown" with key combo of Shift+ArrowUp', () => {
+  it('should call "setSelectedRanges" with Slick Range with an Up direction when triggered by "onKeyDown" with key combo of Shift+ArrowUp', () => {
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: 3 });
 
     plugin.init(gridStub);
@@ -271,7 +281,7 @@ describe('CellSelectionModel Plugin', () => {
     }]);
   });
 
-  it('should call "setSelectedRanges" with Slick Range with a Right direction when triggered by "onKeyDown" with key combo of Shift+ArrowDown', () => {
+  it('should call "setSelectedRanges" with Slick Range with a Down direction when triggered by "onKeyDown" with key combo of Shift+ArrowDown', () => {
     jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: 3 });
 
     plugin.init(gridStub);
@@ -316,6 +326,155 @@ describe('CellSelectionModel Plugin', () => {
     expect(scrollCellSpy).toHaveBeenCalledWith(4, 2, false);
     expect(scrollRowSpy).toHaveBeenCalledWith(4);
     expect(onSelectedRangeSpy).toHaveBeenCalledWith(expectedRangeCalled, expect.objectContaining({ detail: { caller: 'SlickCellSelectionModel.setSelectedRanges' } }));
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to a calculated size of a page down when using Shift+PageDown key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 3;
+    jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 4, contains: () => false }
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = jest.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), 'shiftKey', 'PageDown');
+    gridStub.onKeyDown.notify({ cell: 2, row: 3, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: expect.toBeFunction(), } as unknown as SlickRange,
+      {
+        fromCell: 2, fromRow: 3, toCell: 2, toRow: (notifyingRowNumber + CALCULATED_PAGE_ROW_COUNT),
+        contains: expect.toBeFunction(), toString: expect.toBeFunction(), isSingleCell: expect.toBeFunction(), isSingleRow: expect.toBeFunction(),
+      },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to the last row index when using Shift+PageDown key combo but there is less rows than an actual page left to display', () => {
+    const notifyingRowNumber = NB_ITEMS - 10; // will be less than a page size (row count)
+    const lastRowIndex = NB_ITEMS - 1;
+    jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 4, contains: () => false }
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = jest.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), 'shiftKey', 'PageDown');
+    gridStub.onKeyDown.notify({ cell: 2, row: 3, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: expect.toBeFunction(), } as unknown as SlickRange,
+      {
+        fromCell: 2, fromRow: notifyingRowNumber, toCell: 2, toRow: lastRowIndex,
+        contains: expect.toBeFunction(), toString: expect.toBeFunction(), isSingleCell: expect.toBeFunction(), isSingleRow: expect.toBeFunction(),
+      },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to a calculated size of a page up when using Shift+PageUp key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    const CALCULATED_PAGE_ROW_COUNT = 23;
+    jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false }
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = jest.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), 'shiftKey', 'PageUp');
+    gridStub.onKeyDown.notify({ cell: 2, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.toBeFunction(), } as unknown as SlickRange,
+      {
+        fromCell: 2, fromRow: (notifyingRowNumber - CALCULATED_PAGE_ROW_COUNT), toCell: 2, toRow: 100,
+        contains: expect.toBeFunction(), toString: expect.toBeFunction(), isSingleCell: expect.toBeFunction(), isSingleRow: expect.toBeFunction(),
+      },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to the first row index when using Shift+PageUp key combo but there is less rows than an actual page left to display', () => {
+    const notifyingRowNumber = 10; // will be less than a page size (row count)
+    const firstRowIndex = 0;
+    jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 4, contains: () => false }
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = jest.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), 'shiftKey', 'PageUp');
+    gridStub.onKeyDown.notify({ cell: 2, row: 3, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 2, toCell: 3, toRow: 4, contains: expect.toBeFunction(), } as unknown as SlickRange,
+      {
+        fromCell: 2, fromRow: firstRowIndex, toCell: 2, toRow: notifyingRowNumber,
+        contains: expect.toBeFunction(), toString: expect.toBeFunction(), isSingleCell: expect.toBeFunction(), isSingleRow: expect.toBeFunction(),
+      },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to row index 0 when using Shift+Home key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    const expectedRowZeroIdx = 0;
+    jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false }
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = jest.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), 'shiftKey', 'Home');
+    gridStub.onKeyDown.notify({ cell: 2, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.toBeFunction(), } as unknown as SlickRange,
+      {
+        fromCell: 2, fromRow: expectedRowZeroIdx, toCell: 2, toRow: 100,
+        contains: expect.toBeFunction(), toString: expect.toBeFunction(), isSingleCell: expect.toBeFunction(), isSingleRow: expect.toBeFunction(),
+      },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to last row index when using Shift+End key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    const expectedLastRowIdx = NB_ITEMS - 1;
+    jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    jest.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false }
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = jest.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), 'shiftKey', 'End');
+    gridStub.onKeyDown.notify({ cell: 2, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.toBeFunction(), } as unknown as SlickRange,
+      {
+        fromCell: 2, fromRow: notifyingRowNumber, toCell: 2, toRow: expectedLastRowIdx,
+        contains: expect.toBeFunction(), toString: expect.toBeFunction(), isSingleCell: expect.toBeFunction(), isSingleRow: expect.toBeFunction(),
+      },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
   });
 
   it('should call "rangesAreEqual" and expect True when both ranges are equal', () => {

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -47,11 +47,6 @@ export class SlickCellSelectionModel {
     return this._selector;
   }
 
-  /** Getter of SlickGrid DataView object */
-  get dataView(): SlickDataView {
-    return this._grid?.getData() ?? {} as SlickDataView;
-  }
-
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
   }
@@ -203,7 +198,6 @@ export class SlickCellSelectionModel {
     }
 
     if (active && e.shiftKey && !metaKey && !e.altKey && this.isKeyAllowed(e.key)) {
-
       ranges = this.getSelectedRanges().slice();
       if (!ranges.length) {
         ranges.push(new Slick.Range(active.row, active.cell));
@@ -222,7 +216,6 @@ export class SlickCellSelectionModel {
         // walking direction
         const dirRow = active.row === last.fromRow ? 1 : -1;
         const dirCell = active.cell === last.fromCell ? 1 : -1;
-        const pageRowCount = this.getViewportRowCount();
         const isSingleKeyMove = e.key.startsWith('Arrow');
         let toRow = 0;
 
@@ -239,7 +232,8 @@ export class SlickCellSelectionModel {
           }
           toRow = active.row + dirRow * dRow;
         } else {
-          // multiple cell moves: (Home, End, Page{Up/Down})
+          // multiple cell moves: (Home, End, Page{Up/Down}), we need to know how many rows are displayed on a page
+          const pageRowCount = this.getViewportRowCount();
           if (this._prevSelectedRow === undefined) {
             this._prevSelectedRow = active.row;
           }

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -274,10 +274,10 @@ export class SlickCellSelectionModel {
           const viewCell = dirCell > 0 ? newLast.toCell : newLast.fromCell;
           if (isSingleKeyMove) {
             this._grid.scrollRowIntoView(viewRow);
-            this._grid.scrollCellIntoView(viewRow, viewCell);
+            this._grid.scrollCellIntoView(viewRow, viewCell, false);
           } else {
             this._grid.scrollRowIntoView(toRow);
-            this._grid.scrollCellIntoView(toRow, viewCell);
+            this._grid.scrollCellIntoView(toRow, viewCell, false);
           }
         } else {
           ranges.push(last);

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -320,6 +320,7 @@ $slick-column-picker-title-width:                           calc(100% - #{$slick
 $slick-column-picker-z-index:                               9000 !default;
 
 /* Grid Menu - hamburger menu */
+$slick-grid-menu-button-display:                            inline-flex !default;
 $slick-grid-menu-button-padding:                            0 2px !default;
 $slick-grid-menu-label-margin:                              4px !default;
 $slick-grid-menu-label-font-weight:                         normal !default;

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -198,16 +198,17 @@ li.hidden {
 }
 
 .slick-grid-menu-button {
-  position: absolute;
-  cursor: pointer;
-  right: 0;
-  padding: var(--slick-grid-menu-button-padding, $slick-grid-menu-button-padding);
-  margin-top: var(--slick-grid-menu-icon-top-margin, $slick-grid-menu-icon-top-margin);
   background-color: transparent;
   border: 0;
+  cursor: pointer;
+  right: 0;
+  position: absolute;
   width: 22px;
-  font-size: var(--slick-grid-menu-icon-font-size, $slick-grid-menu-icon-font-size);
   z-index: 2;
+  display: var(--slick-grid-menu-button-display, $slick-grid-menu-button-display);
+  font-size: var(--slick-grid-menu-icon-font-size, $slick-grid-menu-icon-font-size);
+  padding: var(--slick-grid-menu-button-padding, $slick-grid-menu-button-padding);
+  margin-top: var(--slick-grid-menu-icon-top-margin, $slick-grid-menu-icon-top-margin);
 }
 
 .slick-grid-menu-list {

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   video: false,
   projectId: 'p5zxx6',
   viewportWidth: 1200,
-  viewportHeight: 900,
+  viewportHeight: 950,
   fixturesFolder: 'test/cypress/fixtures',
   screenshotsFolder: 'test/cypress/screenshots',
   videosFolder: 'test/cypress/videos',

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   video: false,
   projectId: 'p5zxx6',
   viewportWidth: 1200,
-  viewportHeight: 950,
+  viewportHeight: 900,
   fixturesFolder: 'test/cypress/fixtures',
   screenshotsFolder: 'test/cypress/screenshots',
   videosFolder: 'test/cypress/videos',

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -95,8 +95,8 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () 
         .should('have.text', '{"fromRow":8,"fromCell":2,"toRow":10,"toCell":2}');
     });
 
-    it('should click on cell D10 then PageDown 2 times w/selection D10-D52 ', () => {
-      // 52 is because of a page row count found to be 21 for current browser resolution set in Cypress => 21*2+10 = 52
+    it('should click on cell D10 then PageDown 2 times w/selection D10-D50 ', () => {
+      // 50 is because of a page row count found to be 21 for current browser resolution set in Cypress => 21*2+10 = 50
       cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
         .as('cell_D10')
         .click();
@@ -105,10 +105,10 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () 
         .type('{shift}{pagedown}{pagedown}');
 
       cy.get('#selectionRange')
-        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":52,"toCell":4}');
+        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":50,"toCell":4}');
     });
 
-    it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D52', () => {
+    it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D50', () => {
       cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
         .as('cell_D10')
         .click();
@@ -117,19 +117,19 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () 
         .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
 
       cy.get('#selectionRange')
-        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":52,"toCell":4}');
+        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":50,"toCell":4}');
     });
 
-    it('should click on cell E12 then End key w/selection E52-E99', () => {
-      cy.getCell(52, 5, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
-        .as('cell_E52')
+    it('should click on cell E12 then End key w/selection E50-E99', () => {
+      cy.getCell(50, 5, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_E50')
         .click();
 
-      cy.get('@cell_E52')
+      cy.get('@cell_E50')
         .type('{shift}{end}');
 
       cy.get('#selectionRange')
-        .should('have.text', '{"fromRow":52,"fromCell":5,"toRow":99,"toCell":5}');
+        .should('have.text', '{"fromRow":50,"fromCell":5,"toRow":99,"toCell":5}');
     });
 
     it('should click on cell C85 then End key w/selection C0-C85', () => {

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -1,6 +1,10 @@
-describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 1 }, () => {
-  const titles = ['Title', 'Phone Number using mask', 'Duration (days)', '% Complete', 'Start', 'Finish', 'Effort Driven', 'Completed'];
-  const GRID_ROW_HEIGHT = 40;
+describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () => {
+  const titles = [
+    '', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+    'Z', 'AA', 'AB', 'AC', 'AD', 'AE', 'AF', 'AG', 'AH', 'AI', 'AJ', 'AK'
+  ];
+  const GRID_ROW_HEIGHT = 30;
 
   it('should display Example title', () => {
     cy.visit(`${Cypress.config('baseUrl')}/example19`);
@@ -11,15 +15,133 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 1 }, () 
     cy.get('.grid19')
       .find('.slick-header-columns')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+      .each(($child, index) => {
+        if (index < titles.length) {
+          expect($child.text()).to.eq(titles[index]);
+        }
+      });
   });
 
-  it('should check first 5 rows and expect certain data', () => {
-    for (let i = 0; i < 5; i++) {
-      cy.get(`[style="top:${GRID_ROW_HEIGHT * i}px"] > .slick-cell:nth(0)`).contains(`Task ${i}`);
-      cy.get(`[style="top:${GRID_ROW_HEIGHT * i}px"] > .slick-cell:nth(1)`).contains(/\(\d{3}\)\s\d{3}\-\d{4}/);
-      cy.get(`[style="top:${GRID_ROW_HEIGHT * i}px"] > .slick-cell:nth(2)`).contains(/[0-9\.]*/);
-    }
+  describe('with Pagination of size 20', () => {
+    it('should click on cell B14 then Shift+End w/selection B14-19', () => {
+      cy.getCell(14, 2, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_B14')
+        .click();
+
+      cy.get('@cell_B14')
+        .type('{shift}{end}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":14,"fromCell":2,"toRow":19,"toCell":2}');
+    });
+
+    it('should click on cell C19 then Shift+End w/selection C0-19', () => {
+      cy.getCell(19, 2, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_C19')
+        .click();
+
+      cy.get('@cell_C19')
+        .type('{shift}{home}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":0,"fromCell":2,"toRow":19,"toCell":2}');
+    });
+
+    it('should click on cell E3 then Shift+PageDown multiple times with current page selection starting at E3 w/selection E3-19', () => {
+      cy.getCell(3, 5, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_E3')
+        .click();
+
+      cy.get('@cell_E3')
+        .type('{shift}{pagedown}{pagedown}{pagedown}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":3,"fromCell":5,"toRow":19,"toCell":5}');
+    });
+
+    it('should change to 2nd page then click on cell D41 then Shift+PageUp multiple times with current page selection w/selection D25-41', () => {
+      cy.get('.slick-pagination .icon-seek-next').click();
+
+      cy.getCell(15, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_D41')
+        .click();
+
+      cy.get('@cell_D41')
+        .type('{shift}{pageup}{pageup}{pageup}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":0,"fromCell":4,"toRow":15,"toCell":4}');
+    });
   });
 
+  describe('no Pagination - showing all', () => {
+    it('should hide Pagination', () => {
+      cy.get('[data-text="toggle-pagination-btn"]')
+        .click();
+    });
+
+    it('should click on cell B10 and ArrowUp 3 times and ArrowDown 1 time and expect cell selection B8-B10', () => {
+      cy.getCell(10, 2, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_B10')
+        .click();
+
+      cy.get('@cell_B10')
+        .type('{shift}{uparrow}{uparrow}{uparrow}{downarrow}');
+
+      cy.get('.slick-cell.l2.r2.selected')
+        .should('have.length', 3);
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":8,"fromCell":2,"toRow":10,"toCell":2}');
+    });
+
+    it('should click on cell D10 then PageDown 2 times w/selection D10-D52 ', () => {
+      // 52 is because of a page row count found to be 21 for current browser resolution set in Cypress => 21*2+10 = 52
+      cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_D10')
+        .click();
+
+      cy.get('@cell_D10')
+        .type('{shift}{pagedown}{pagedown}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":52,"toCell":4}');
+    });
+
+    it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D52', () => {
+      cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_D10')
+        .click();
+
+      cy.get('@cell_D10')
+        .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":52,"toCell":4}');
+    });
+
+    it('should click on cell E12 then End key w/selection E52-E99', () => {
+      cy.getCell(52, 5, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_E52')
+        .click();
+
+      cy.get('@cell_E52')
+        .type('{shift}{end}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":52,"fromCell":5,"toRow":99,"toCell":5}');
+    });
+
+    it('should click on cell C85 then End key w/selection C0-C85', () => {
+      cy.getCell(85, 3, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_C85')
+        .click();
+
+      cy.get('@cell_C85')
+        .type('{shift}{home}');
+
+      cy.get('#selectionRange')
+        .should('have.text', '{"fromRow":0,"fromCell":3,"toRow":85,"toCell":3}');
+    });
+  });
 });

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -1,0 +1,25 @@
+describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 1 }, () => {
+  const titles = ['Title', 'Phone Number using mask', 'Duration (days)', '% Complete', 'Start', 'Finish', 'Effort Driven', 'Completed'];
+  const GRID_ROW_HEIGHT = 40;
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example19`);
+    cy.get('h3').should('contain', 'Example 19 - ExcelCopyBuffer with Cell Selection');
+  });
+
+  it('should have exact column titles on 1st grid', () => {
+    cy.get('.grid19')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(titles[index]));
+  });
+
+  it('should check first 5 rows and expect certain data', () => {
+    for (let i = 0; i < 5; i++) {
+      cy.get(`[style="top:${GRID_ROW_HEIGHT * i}px"] > .slick-cell:nth(0)`).contains(`Task ${i}`);
+      cy.get(`[style="top:${GRID_ROW_HEIGHT * i}px"] > .slick-cell:nth(1)`).contains(/\(\d{3}\)\s\d{3}\-\d{4}/);
+      cy.get(`[style="top:${GRID_ROW_HEIGHT * i}px"] > .slick-cell:nth(2)`).contains(/[0-9\.]*/);
+    }
+  });
+
+});

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -95,8 +95,8 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () 
         .should('have.text', '{"fromRow":8,"fromCell":2,"toRow":10,"toCell":2}');
     });
 
-    it('should click on cell D10 then PageDown 2 times w/selection D10-D50 ', () => {
-      // 50 is because of a page row count found to be 21 for current browser resolution set in Cypress => 21*2+10 = 50
+    it('should click on cell D10 then PageDown 2 times w/selection D10-D50 (or D10-D52)', () => {
+      // 52 is because of a page row count found to be 21 for current browser resolution set in Cypress => 21*2+10 = 52
       cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
         .as('cell_D10')
         .click();
@@ -105,10 +105,10 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () 
         .type('{shift}{pagedown}{pagedown}');
 
       cy.get('#selectionRange')
-        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":50,"toCell":4}');
+        .should('contains', /{"fromRow":10,"fromCell":4,"toRow":5[0-2],"toCell":4}/);
     });
 
-    it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D50', () => {
+    it('should click on cell D10 then PageDown 3 times then PageUp 1 time w/selection D10-D50 (or D10-D52)', () => {
       cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
         .as('cell_D10')
         .click();
@@ -117,19 +117,19 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', { retries: 0 }, () 
         .type('{shift}{pagedown}{pagedown}{pagedown}{pageup}');
 
       cy.get('#selectionRange')
-        .should('have.text', '{"fromRow":10,"fromCell":4,"toRow":50,"toCell":4}');
+        .should('contains', /{"fromRow":10,"fromCell":4,"toRow":5[0-2],"toCell":4}/);
     });
 
-    it('should click on cell E12 then End key w/selection E50-E99', () => {
-      cy.getCell(50, 5, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
-        .as('cell_E50')
+    it('should click on cell E12 then End key w/selection E52-E99', () => {
+      cy.getCell(52, 5, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT })
+        .as('cell_E52')
         .click();
 
-      cy.get('@cell_E50')
+      cy.get('@cell_E52')
         .type('{shift}{end}');
 
       cy.get('#selectionRange')
-        .should('have.text', '{"fromRow":50,"fromCell":5,"toRow":99,"toCell":5}');
+        .should('have.text', '{"fromRow":52,"fromCell":5,"toRow":99,"toCell":5}');
     });
 
     it('should click on cell C85 then End key w/selection C0-C85', () => {


### PR DESCRIPTION
- adding "pageUp/pageDown/home/end" to SlickCellSelection when using selection with "Shift+{key}"
- add new Example 19 demo to manually test updated Cell Selection feature w/wo Pagination

### TODOs
- [x] tested manually, it should expect the following:
   - [x] doing pageDown twice then pageUp once should equal to 1 pageDown
   - [x] doing Shift+Home from anywhere should select all cells from current position to first row
   - [x] doing Shift+End from should select all cells from current position to last row
   - [x] using Pagination and doing Shift+{key} should select cells in current page only and not outside of it
- [x] add new Example to test Cell Selection with Pagination as detailed above
- [x] add full unit test coverage
- [x] add Cypress E2E tests

#### basic SlickGrid example
![brave_jXaDZf7bB1](https://github.com/6pac/SlickGrid/assets/643976/fa5e6e89-245f-467b-8db4-b33ab9ab566b)

#### with DataView & Pagination example
![brave_LARcl6SVGz](https://github.com/6pac/SlickGrid/assets/643976/11816ade-9c12-4338-8f30-cfadda9a7431)
