### PR TITLE
feat: add sub-menu(s) to GridMenu plugin

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example01.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example01.ts
@@ -74,11 +74,39 @@ export default class Example1 {
           onColumnsChanged: (_e, args) => console.log('onColumnPickerColumnsChanged - visible columns count', args.visibleColumns.length),
         },
         gridMenu: {
-          // commandItems: [
-          //   { command: 'help', title: 'Help', positionOrder: 70, action: (e, args) => console.log(args) },
-          //   { command: '', divider: true, positionOrder: 72 },
-          //   { command: 'hello', title: 'Hello', positionOrder: 69, action: (e, args) => alert('Hello World'), cssClass: 'red', tooltip: 'Hello World', iconCssClass: 'mdi mdi-close' },
-          // ],
+          subItemChevronClass: 'mdi mdi-chevron-down mdi-rotate-270',
+          commandItems: [
+            { command: '', divider: true, positionOrder: 98 },
+            {
+              // we can also have multiple nested sub-menus
+              command: 'export', title: 'Exports', positionOrder: 99,
+              commandItems: [
+                { command: 'exports-txt', title: 'Text (tab delimited)' },
+                {
+                  command: 'sub-menu', title: 'Excel', cssClass: 'green', subMenuTitle: 'available formats', subMenuTitleCssClass: 'text-italic orange',
+                  commandItems: [
+                    { command: 'exports-csv', title: 'Excel (csv)' },
+                    { command: 'exports-xlsx', title: 'Excel (xlsx)' },
+                  ]
+                }
+              ]
+            },
+            {
+              command: 'feedback', title: 'Feedback', positionOrder: 100,
+              commandItems: [
+                { command: 'request-update', title: 'Request update from supplier', iconCssClass: 'mdi mdi-star', tooltip: 'this will automatically send an alert to the shipping team to contact the user for an update' },
+                'divider',
+                {
+                  command: 'sub-menu', title: 'Contact Us', iconCssClass: 'mdi mdi-account', subMenuTitle: 'contact us...', subMenuTitleCssClass: 'italic',
+                  commandItems: [
+                    { command: 'contact-email', title: 'Email us', iconCssClass: 'mdi mdi-pencil-outline' },
+                    { command: 'contact-chat', title: 'Chat with us', iconCssClass: 'mdi mdi-message-text-outline' },
+                    { command: 'contact-meeting', title: 'Book an appointment', iconCssClass: 'mdi mdi-coffee' },
+                  ]
+                }
+              ]
+            }
+          ],
           // menuUsabilityOverride: () => false,
           onBeforeMenuShow: () => {
             console.log('onGridMenuBeforeMenuShow');
@@ -88,7 +116,14 @@ export default class Example1 {
           onColumnsChanged: (_e, args) => console.log('onGridMenuColumnsChanged', args),
           onCommand: (_e, args) => {
             // e.preventDefault(); // preventing default event would keep the menu open after the execution
-            console.log('onGridMenuCommand', args.command);
+            const command = args.item?.command;
+            if (command.includes('exports-')) {
+              alert('Exporting as ' + args?.item.title);
+            } else if (command.includes('contact-')) {
+              alert('Command: ' + args?.command);
+            } else {
+              console.log('onGridMenuCommand', args.command);
+            }
           },
           onMenuClose: (_e, args) => console.log('onGridMenuMenuClose - visible columns count', args.visibleColumns.length),
         },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example04.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example04.ts
@@ -434,12 +434,12 @@ export default class Example4 {
             // we can also have multiple nested sub-menus
             command: 'export', title: 'Exports', positionOrder: 99,
             commandItems: [
-              { command: 'export-txt', title: 'Text (tab delimited)' },
+              { command: 'exports-txt', title: 'Text (tab delimited)' },
               {
                 command: 'sub-menu', title: 'Excel', cssClass: 'green', subMenuTitle: 'available formats', subMenuTitleCssClass: 'text-italic orange',
                 commandItems: [
-                  { command: 'export-csv', title: 'Excel (csv)' },
-                  { command: 'export-xlsx', title: 'Excel (xlsx)' },
+                  { command: 'exports-csv', title: 'Excel (csv)' },
+                  { command: 'exports-xlsx', title: 'Excel (xlsx)' },
                 ]
               }
             ]
@@ -447,7 +447,7 @@ export default class Example4 {
           {
             command: 'feedback', title: 'Feedback', positionOrder: 100,
             commandItems: [
-              { command: 'request-update', title: 'Request update from shipping team', iconCssClass: 'mdi mdi-star', tooltip: 'this will automatically send an alert to the shipping team to contact the user for an update' },
+              { command: 'request-update', title: 'Request update from supplier', iconCssClass: 'mdi mdi-star', tooltip: 'this will automatically send an alert to the shipping team to contact the user for an update' },
               'divider',
               {
                 command: 'sub-menu', title: 'Contact Us', iconCssClass: 'mdi mdi-account', subMenuTitle: 'contact us...', subMenuTitleCssClass: 'italic',
@@ -556,9 +556,9 @@ export default class Example4 {
       case 'command2':
         alert(args.item.title);
         break;
-      case 'export-csv':
-      case 'export-txt':
-      case 'export-xlsx':
+      case 'exports-csv':
+      case 'exports-txt':
+      case 'exports-xlsx':
         alert(`Exporting as ${args.item.title}`);
         break;
       case 'help':

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -202,6 +202,22 @@ export default class Example6 {
     (document.querySelector('input.search') as HTMLInputElement).value = '';
   }
 
+  executeCommand(_e, args) {
+    // const columnDef = args.column;
+    const command = args.command;
+
+    switch (command) {
+      case 'exports-csv':
+      case 'exports-txt':
+      case 'exports-xlsx':
+        alert(`Exporting as ${args.item.title}`);
+        break;
+      default:
+        alert('Command: ' + args.command);
+        break;
+    }
+  }
+
   searchFile(event: KeyboardEvent) {
     this.searchString = (event.target as HTMLInputElement)?.value || '';
     this.updateFilter();

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -158,7 +158,7 @@ export default class Example7 {
             }
           ],
           onOptionSelected: (_e, args) => {
-            this.changeCompletedOption(args.dataContext, args.item.option);
+            this.changeCompletedOption(args.dataContext, args.item.option as boolean);
           },
         }
       },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -100,12 +100,12 @@ export default class Example7 {
               // we can also have multiple nested sub-menus
               command: 'export', title: 'Exports', positionOrder: 99,
               commandItems: [
-                { command: 'export-txt', title: 'Text (tab delimited)' },
+                { command: 'exports-txt', title: 'Text (tab delimited)' },
                 {
                   command: 'sub-menu', title: 'Excel', cssClass: 'green', subMenuTitle: 'available formats', subMenuTitleCssClass: 'text-italic orange',
                   commandItems: [
-                    { command: 'export-csv', title: 'Excel (csv)' },
-                    { command: 'export-xlsx', title: 'Excel (xlsx)' },
+                    { command: 'exports-csv', title: 'Excel (csv)' },
+                    { command: 'exports-xlsx', title: 'Excel (xlsx)' },
                   ]
                 }
               ]
@@ -113,7 +113,7 @@ export default class Example7 {
             {
               command: 'feedback', title: 'Feedback', positionOrder: 100,
               commandItems: [
-                { command: 'request-update', title: 'Request update from shipping team', iconCssClass: 'mdi mdi-star', tooltip: 'this will automatically send an alert to the shipping team to contact the user for an update' },
+                { command: 'request-update', title: 'Request update from supplier', iconCssClass: 'mdi mdi-star', tooltip: 'this will automatically send an alert to the shipping team to contact the user for an update' },
                 'divider',
                 {
                   command: 'sub-menu', title: 'Contact Us', iconCssClass: 'mdi mdi-account', subMenuTitle: 'contact us...', subMenuTitleCssClass: 'italic',
@@ -127,16 +127,22 @@ export default class Example7 {
             }
           ],
           onCommand: (_e, args) => {
-            switch(args.command) {
-              // show alert only for export commands
-              case 'export-cks':
-              case 'export-txt':
-              case 'export-xlsx':
-                alert(`Exporting as ${args.item.title}`);
-                break;
-              default:
-                alert('Command: ' + args.command);
-                break;
+            // to keep menu open you can preventDefault & return false
+            // _e.preventDefault();
+            // return false;
+
+            if (!args.item?.action) {
+              switch (args.command) {
+                // show alert only for export commands
+                case 'exports-csv':
+                case 'exports-txt':
+                case 'exports-xlsx':
+                  alert(`Exporting as ${args.item.title}`);
+                  break;
+                default:
+                  alert('Command: ' + args.command);
+                  break;
+              }
             }
           },
           optionTitleKey: 'CHANGE_COMPLETED_FLAG',
@@ -437,8 +443,7 @@ export default class Example7 {
   }
 
   changeCompletedOption(dataContext: any, newValue: boolean) {
-    console.log('change', dataContext, newValue);
-    if (dataContext && dataContext.hasOwnProperty('completed')) {
+    if (dataContext?.hasOwnProperty('completed')) {
       dataContext.completed = newValue;
       this.sgb?.gridService.updateItem(dataContext);
     }

--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -235,6 +235,11 @@ describe('CellMenu Plugin', () => {
       let cellMenuElm = document.body.querySelector('.slick-cell-menu.slickgrid12345') as HTMLDivElement;
       expect(cellMenuElm).toBeTruthy();
 
+      // click inside menu shouldn't close it
+      cellMenuElm!.dispatchEvent(new Event('mousedown', { bubbles: true }));
+      expect(cellMenuElm).toBeTruthy();
+
+      // click anywhere else should close it
       document.body.dispatchEvent(new Event('mousedown', { bubbles: true }));
       cellMenuElm = document.body.querySelector('.slick-cell-menu.slickgrid12345') as HTMLDivElement;
 

--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -609,7 +609,7 @@ describe('CellMenu Plugin', () => {
         Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
 
         plugin.dispose();
-        plugin.init({ commandItems: deepCopy(commandItemsMock) });
+        plugin.init({ commandItems: deepCopy(commandItemsMock), dropSide: 'left' });
         (columnsMock[3].cellMenu!.commandItems![1] as MenuCommandItem).action = actionMock;
         plugin.addonOptions.subItemChevronClass = 'mdi mdi-chevron-right';
         plugin.addonOptions.autoAdjustDropOffset = '-780';

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -256,6 +256,11 @@ describe('ContextMenu Plugin', () => {
       let contextMenuElm = document.body.querySelector('.slick-context-menu.slickgrid12345') as HTMLDivElement;
       expect(contextMenuElm).toBeTruthy();
 
+      // click inside menu shouldn't close it
+      contextMenuElm!.dispatchEvent(new Event('mousedown', { bubbles: true }));
+      expect(contextMenuElm).toBeTruthy();
+
+      // click anywhere else should close it
       document.body.dispatchEvent(new Event('mousedown', { bubbles: true }));
       contextMenuElm = document.body.querySelector('.slick-context-menu.slickgrid12345') as HTMLDivElement;
 

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -238,8 +238,13 @@ describe('GridMenuControl', () => {
         const headerRowElm = document.querySelector('.slick-headerrow') as HTMLDivElement;
 
         expect(control.menuElement!.style.display).toBe('block');
-        expect(headerRowElm.style.width).toBe(`calc(100% - 16px)`)
+        expect(headerRowElm.style.width).toBe(`calc(100% - 16px)`);
 
+        // click inside menu shouldn't close it
+        control.menuElement!.dispatchEvent(new Event('mousedown', { bubbles: true }));
+        expect(control.menuElement).toBeTruthy();
+
+        // click anywhere else should close it
         const bodyElm = document.body;
         bodyElm.dispatchEvent(new Event('mousedown', { bubbles: true }));
 

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -884,153 +884,168 @@ describe('GridMenuControl', () => {
         expect(initSpy).toBeCalled();
       });
 
-      it('should create a Grid Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element aligned left when sub-menu is clicked', () => {
+      describe('with sub-menus', () => {
+        let mockCommandItems: any[] = [];
         const actionMock = jest.fn();
-        const disposeSubMenuSpy = jest.spyOn(control, 'disposeSubMenus');
-        Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
 
-        gridOptionsMock.gridMenu!.subItemChevronClass = 'mdi mdi-chevron-right';
-        gridOptionsMock.gridMenu!.dropSide = 'left';
-        gridOptionsMock.gridMenu!.commandItems = [
-          { command: 'help', title: 'Help', textCssClass: 'red bold' },
-          {
-            command: 'sub-commands', title: 'Sub Commands', subMenuTitle: 'Sub Command Title', action: actionMock, commandItems: [
-              { command: 'command3', title: 'Command 3', positionOrder: 70, },
-              { command: 'command4', title: 'Command 4', positionOrder: 71, },
-              {
-                command: 'more-sub-commands', title: 'More Sub Commands', subMenuTitle: 'Sub Command Title 2', subMenuTitleCssClass: 'color-warning', commandItems: [
-                  { command: 'command5', title: 'Command 5', positionOrder: 72, },
-                ]
-              }
-            ]
-          },
-          {
-            command: 'sub-commands2', title: 'Sub Commands 2', commandItems: [
-              { command: 'command33', title: 'Command 33', positionOrder: 70, },
-            ]
-          }
-        ];
-        control.columns = columnsMock;
-        control.init();
-        const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
-        buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-        const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
-        const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
-        Object.defineProperty(commandList1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
-        const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
-        Object.defineProperty(subCommands1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
-        const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
-        const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
+        beforeEach(() => {
+          mockCommandItems = [
+            { command: 'help', title: 'Help', textCssClass: 'red bold' },
+            {
+              command: 'sub-commands', title: 'Sub Commands', subMenuTitle: 'Sub Command Title', action: actionMock, commandItems: [
+                { command: 'command3', title: 'Command 3', positionOrder: 70, },
+                { command: 'command4', title: 'Command 4', positionOrder: 71, },
+                {
+                  command: 'more-sub-commands', title: 'More Sub Commands', subMenuTitle: 'Sub Command Title 2', subMenuTitleCssClass: 'color-warning', commandItems: [
+                    { command: 'command5', title: 'Command 5', positionOrder: 72, },
+                  ]
+                }
+              ]
+            },
+            {
+              command: 'sub-commands2', title: 'Sub Commands 2', commandItems: [
+                { command: 'command33', title: 'Command 33', positionOrder: 70, },
+              ]
+            }
+          ];
+        });
 
-        subCommands1Elm!.dispatchEvent(new Event('click'));
-        const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
-        const commandList2Elm = gridMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
-        const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
-        const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
+        it('should create a Grid Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element aligned left when sub-menu is clicked', () => {
+          const disposeSubMenuSpy = jest.spyOn(control, 'disposeSubMenus');
+          Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
 
-        subCommands2Elm!.dispatchEvent(new Event('click'));
-        const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
-        const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
-        const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;
-        const subMenuTitleElm = commandList3Elm.querySelector('.slick-menu-title') as HTMLDivElement;
+          gridOptionsMock.gridMenu!.subItemChevronClass = 'mdi mdi-chevron-right';
+          gridOptionsMock.gridMenu!.dropSide = 'left';
+          gridOptionsMock.gridMenu!.commandItems = mockCommandItems;
+          control.columns = columnsMock;
+          control.init();
+          const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+          buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+          const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
+          const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          Object.defineProperty(commandList1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
+          const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
+          Object.defineProperty(subCommands1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
+          const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
+          const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
 
-        expect(commandList1Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
-        expect(commandList2Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
-        expect(commandContentElm2.textContent).toBe('Sub Commands');
-        expect(subMenuTitleElm.textContent).toBe('Sub Command Title 2');
-        expect(subMenuTitleElm.className).toBe('slick-menu-title color-warning');
-        expect(commandChevronElm.className).toBe('sub-item-chevron mdi mdi-chevron-right');
-        expect(subCommand3Elm.textContent).toContain('Command 3');
-        expect(subCommand5Elm.textContent).toContain('Command 5');
-        expect(gridMenu1Elm.classList.contains('dropleft'));
+          subCommands1Elm!.dispatchEvent(new Event('click'));
+          const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
+          const commandList2Elm = gridMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
+          const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
 
-        // return Grid Menu menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
-        subCommands1Elm!.dispatchEvent(new Event('click'));
-        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
-        const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
-        subCommands12Elm!.dispatchEvent(new Event('click'));
-        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
-        expect(disposeSubMenuSpy).toHaveBeenCalled();
-      });
+          subCommands2Elm!.dispatchEvent(new Event('click'));
+          const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
+          const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;
+          const subMenuTitleElm = commandList3Elm.querySelector('.slick-menu-title') as HTMLDivElement;
 
-      it('should create a Cell Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element align right when sub-menu is clicked', () => {
-        // const actionMock = jest.fn();
-        // const disposeSubMenuSpy = jest.spyOn(plugin, 'disposeSubMenus');
-        // jest.spyOn(getEditorLockMock, 'commitCurrentEdit').mockReturnValue(true);
-        // Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
+          expect(commandList1Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+          expect(commandList2Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+          expect(commandContentElm2.textContent).toBe('Sub Commands');
+          expect(subMenuTitleElm.textContent).toBe('Sub Command Title 2');
+          expect(subMenuTitleElm.className).toBe('slick-menu-title color-warning');
+          expect(commandChevronElm.className).toBe('sub-item-chevron mdi mdi-chevron-right');
+          expect(subCommand3Elm.textContent).toContain('Command 3');
+          expect(subCommand5Elm.textContent).toContain('Command 5');
+          expect(gridMenu1Elm.classList.contains('dropleft'));
+          expect(gridMenu2Elm.classList.contains('dropup')).toBeFalsy();
+          expect(gridMenu2Elm.classList.contains('dropdown')).toBeTruthy();
 
-        // plugin.dispose();
-        // plugin.init({ commandItems: deepCopy(commandItemsMock) });
-        // (columnsMock[3].cellMenu!.commandItems![1] as MenuCommandItem).action = actionMock;
-        // plugin.addonOptions.subItemChevronClass = 'mdi mdi-chevron-right';
-        // plugin.addonOptions.autoAdjustDropOffset = '-780';
-        // plugin.addonOptions.dropSide = 'right';
-        // gridStub.onClick.notify({ cell: 3, row: 1, grid: gridStub }, eventData, gridStub);
+          // return Grid Menu menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
+          subCommands1Elm!.dispatchEvent(new Event('click'));
+          expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
+          const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
+          subCommands12Elm!.dispatchEvent(new Event('click'));
+          expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
+          expect(disposeSubMenuSpy).toHaveBeenCalled();
+        });
 
-        const actionMock = jest.fn();
-        const disposeSubMenuSpy = jest.spyOn(control, 'disposeSubMenus');
-        Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
+        it('should create a Cell Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element align right when sub-menu is clicked', () => {
+          const disposeSubMenuSpy = jest.spyOn(control, 'disposeSubMenus');
+          Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
 
-        gridOptionsMock.gridMenu!.subItemChevronClass = 'mdi mdi-chevron-right';
-        gridOptionsMock.gridMenu!.dropSide = 'right';
-        gridOptionsMock.gridMenu!.commandItems = [
-          { command: 'help', title: 'Help', textCssClass: 'red bold' },
-          {
-            command: 'sub-commands', title: 'Sub Commands', subMenuTitle: 'Sub Command Title', action: actionMock, commandItems: [
-              { command: 'command3', title: 'Command 3', positionOrder: 70, },
-              { command: 'command4', title: 'Command 4', positionOrder: 71, },
-              {
-                command: 'more-sub-commands', title: 'More Sub Commands', subMenuTitle: 'Sub Command Title 2', subMenuTitleCssClass: 'color-warning', commandItems: [
-                  { command: 'command5', title: 'Command 5', positionOrder: 72, },
-                ]
-              }
-            ]
-          },
-          {
-            command: 'sub-commands2', title: 'Sub Commands 2', commandItems: [
-              { command: 'command33', title: 'Command 33', positionOrder: 70, },
-            ]
-          }
-        ];
-        control.columns = columnsMock;
-        control.init();
-        const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
-        buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
-        const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
-        const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
-        const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
-        const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
-        const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
+          gridOptionsMock.gridMenu!.subItemChevronClass = 'mdi mdi-chevron-right';
+          gridOptionsMock.gridMenu!.dropSide = 'right';
+          gridOptionsMock.gridMenu!.commandItems = mockCommandItems;
+          control.columns = columnsMock;
+          control.init();
+          const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+          buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+          const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
+          const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
+          const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
+          const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
 
-        subCommands1Elm!.dispatchEvent(new Event('click'));
-        const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
-        const commandList2Elm = gridMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
-        const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
-        const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
+          subCommands1Elm!.dispatchEvent(new Event('click'));
+          const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
+          const commandList2Elm = gridMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
+          const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
 
-        subCommands2Elm!.dispatchEvent(new Event('click'));
-        const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
-        const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
-        const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;
-        const subMenuTitleElm = commandList3Elm.querySelector('.slick-menu-title') as HTMLDivElement;
+          subCommands2Elm!.dispatchEvent(new Event('click'));
+          const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
+          const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;
+          const subMenuTitleElm = commandList3Elm.querySelector('.slick-menu-title') as HTMLDivElement;
 
-        expect(commandList1Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
-        expect(commandList2Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
-        expect(commandContentElm2.textContent).toBe('Sub Commands');
-        expect(subMenuTitleElm.textContent).toBe('Sub Command Title 2');
-        expect(subMenuTitleElm.className).toBe('slick-menu-title color-warning');
-        expect(commandChevronElm.className).toBe('sub-item-chevron mdi mdi-chevron-right');
-        expect(subCommand3Elm.textContent).toContain('Command 3');
-        expect(subCommand5Elm.textContent).toContain('Command 5');
-        expect(gridMenu1Elm.classList.contains('dropright'));
+          expect(commandList1Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+          expect(commandList2Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+          expect(commandContentElm2.textContent).toBe('Sub Commands');
+          expect(subMenuTitleElm.textContent).toBe('Sub Command Title 2');
+          expect(subMenuTitleElm.className).toBe('slick-menu-title color-warning');
+          expect(commandChevronElm.className).toBe('sub-item-chevron mdi mdi-chevron-right');
+          expect(subCommand3Elm.textContent).toContain('Command 3');
+          expect(subCommand5Elm.textContent).toContain('Command 5');
+          expect(gridMenu1Elm.classList.contains('dropright'));
+          expect(gridMenu2Elm.classList.contains('dropup')).toBeFalsy();
+          expect(gridMenu2Elm.classList.contains('dropdown')).toBeTruthy();
 
-        // return menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
-        subCommands1Elm!.dispatchEvent(new Event('click'));
-        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
-        const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
-        subCommands12Elm!.dispatchEvent(new Event('click'));
-        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
-        expect(disposeSubMenuSpy).toHaveBeenCalled();
+          // return menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
+          subCommands1Elm!.dispatchEvent(new Event('click'));
+          expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
+          const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
+          subCommands12Elm!.dispatchEvent(new Event('click'));
+          expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
+          expect(disposeSubMenuSpy).toHaveBeenCalled();
+        });
+
+        it('should create a Grid Menu item with commands sub-menu items and expect sub-menu to be positioned on top (dropup)', () => {
+          Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
+
+          gridOptionsMock.gridMenu!.commandItems = mockCommandItems;
+          control.columns = columnsMock;
+          control.init();
+
+          const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+          buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+          const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
+          const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+          const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
+
+          subCommands1Elm!.dispatchEvent(new Event('click'));
+          const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
+          Object.defineProperty(gridMenu2Elm, 'clientHeight', { writable: true, configurable: true, value: 320 });
+
+          const divEvent = new MouseEvent('click', { bubbles: true, cancelable: true, composed: false })
+          const subMenuElm = document.createElement('div');
+          const menuItem = document.createElement('div');
+          menuItem.className = 'slick-menu-item';
+          menuItem.style.top = '465px';
+          jest.spyOn(menuItem, 'getBoundingClientRect').mockReturnValue({ top: 465, left: 25 } as any);
+          Object.defineProperty(menuItem, 'target', { writable: true, configurable: true, value: menuItem });
+          subMenuElm.className = 'slick-submenu';
+          Object.defineProperty(divEvent, 'target', { writable: true, configurable: true, value: subMenuElm });
+          menuItem.appendChild(subMenuElm);
+
+          control.repositionMenu(divEvent, gridMenu2Elm);
+          const gridMenu2Elm2 = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
+
+          expect(gridMenu2Elm2.classList.contains('dropup')).toBeTruthy();
+          expect(gridMenu2Elm2.classList.contains('dropdown')).toBeFalsy();
+        });
       });
 
       describe('addGridMenuCustomCommands method', () => {

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -879,6 +879,155 @@ describe('GridMenuControl', () => {
         expect(initSpy).toBeCalled();
       });
 
+      it('should create a Grid Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element aligned left when sub-menu is clicked', () => {
+        const actionMock = jest.fn();
+        const disposeSubMenuSpy = jest.spyOn(control, 'disposeSubMenus');
+        Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
+
+        gridOptionsMock.gridMenu!.subItemChevronClass = 'mdi mdi-chevron-right';
+        gridOptionsMock.gridMenu!.dropSide = 'left';
+        gridOptionsMock.gridMenu!.commandItems = [
+          { command: 'help', title: 'Help', textCssClass: 'red bold' },
+          {
+            command: 'sub-commands', title: 'Sub Commands', subMenuTitle: 'Sub Command Title', action: actionMock, commandItems: [
+              { command: 'command3', title: 'Command 3', positionOrder: 70, },
+              { command: 'command4', title: 'Command 4', positionOrder: 71, },
+              {
+                command: 'more-sub-commands', title: 'More Sub Commands', subMenuTitle: 'Sub Command Title 2', subMenuTitleCssClass: 'color-warning', commandItems: [
+                  { command: 'command5', title: 'Command 5', positionOrder: 72, },
+                ]
+              }
+            ]
+          },
+          {
+            command: 'sub-commands2', title: 'Sub Commands 2', commandItems: [
+              { command: 'command33', title: 'Command 33', positionOrder: 70, },
+            ]
+          }
+        ];
+        control.columns = columnsMock;
+        control.init();
+        const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+        buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+        const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
+        const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        Object.defineProperty(commandList1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
+        const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
+        Object.defineProperty(subCommands1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
+        const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
+        const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
+
+        subCommands1Elm!.dispatchEvent(new Event('click'));
+        const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
+        const commandList2Elm = gridMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
+        const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
+
+        subCommands2Elm!.dispatchEvent(new Event('click'));
+        const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
+        const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;
+        const subMenuTitleElm = commandList3Elm.querySelector('.slick-menu-title') as HTMLDivElement;
+
+        expect(commandList1Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+        expect(commandList2Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+        expect(commandContentElm2.textContent).toBe('Sub Commands');
+        expect(subMenuTitleElm.textContent).toBe('Sub Command Title 2');
+        expect(subMenuTitleElm.className).toBe('slick-menu-title color-warning');
+        expect(commandChevronElm.className).toBe('sub-item-chevron mdi mdi-chevron-right');
+        expect(subCommand3Elm.textContent).toContain('Command 3');
+        expect(subCommand5Elm.textContent).toContain('Command 5');
+        expect(gridMenu1Elm.classList.contains('dropleft'));
+
+        // return Grid Menu menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
+        subCommands1Elm!.dispatchEvent(new Event('click'));
+        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
+        const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
+        subCommands12Elm!.dispatchEvent(new Event('click'));
+        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
+        expect(disposeSubMenuSpy).toHaveBeenCalled();
+      });
+
+      it('should create a Cell Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element align right when sub-menu is clicked', () => {
+        // const actionMock = jest.fn();
+        // const disposeSubMenuSpy = jest.spyOn(plugin, 'disposeSubMenus');
+        // jest.spyOn(getEditorLockMock, 'commitCurrentEdit').mockReturnValue(true);
+        // Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
+
+        // plugin.dispose();
+        // plugin.init({ commandItems: deepCopy(commandItemsMock) });
+        // (columnsMock[3].cellMenu!.commandItems![1] as MenuCommandItem).action = actionMock;
+        // plugin.addonOptions.subItemChevronClass = 'mdi mdi-chevron-right';
+        // plugin.addonOptions.autoAdjustDropOffset = '-780';
+        // plugin.addonOptions.dropSide = 'right';
+        // gridStub.onClick.notify({ cell: 3, row: 1, grid: gridStub }, eventData, gridStub);
+
+        const actionMock = jest.fn();
+        const disposeSubMenuSpy = jest.spyOn(control, 'disposeSubMenus');
+        Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
+
+        gridOptionsMock.gridMenu!.subItemChevronClass = 'mdi mdi-chevron-right';
+        gridOptionsMock.gridMenu!.dropSide = 'right';
+        gridOptionsMock.gridMenu!.commandItems = [
+          { command: 'help', title: 'Help', textCssClass: 'red bold' },
+          {
+            command: 'sub-commands', title: 'Sub Commands', subMenuTitle: 'Sub Command Title', action: actionMock, commandItems: [
+              { command: 'command3', title: 'Command 3', positionOrder: 70, },
+              { command: 'command4', title: 'Command 4', positionOrder: 71, },
+              {
+                command: 'more-sub-commands', title: 'More Sub Commands', subMenuTitle: 'Sub Command Title 2', subMenuTitleCssClass: 'color-warning', commandItems: [
+                  { command: 'command5', title: 'Command 5', positionOrder: 72, },
+                ]
+              }
+            ]
+          },
+          {
+            command: 'sub-commands2', title: 'Sub Commands 2', commandItems: [
+              { command: 'command33', title: 'Command 33', positionOrder: 70, },
+            ]
+          }
+        ];
+        control.columns = columnsMock;
+        control.init();
+        const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+        buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+        const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
+        const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
+        const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
+        const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
+
+        subCommands1Elm!.dispatchEvent(new Event('click'));
+        const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
+        const commandList2Elm = gridMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
+        const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
+
+        subCommands2Elm!.dispatchEvent(new Event('click'));
+        const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
+        const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;
+        const subMenuTitleElm = commandList3Elm.querySelector('.slick-menu-title') as HTMLDivElement;
+
+        expect(commandList1Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+        expect(commandList2Elm.querySelectorAll('.slick-menu-item').length).toBe(3);
+        expect(commandContentElm2.textContent).toBe('Sub Commands');
+        expect(subMenuTitleElm.textContent).toBe('Sub Command Title 2');
+        expect(subMenuTitleElm.className).toBe('slick-menu-title color-warning');
+        expect(commandChevronElm.className).toBe('sub-item-chevron mdi mdi-chevron-right');
+        expect(subCommand3Elm.textContent).toContain('Command 3');
+        expect(subCommand5Elm.textContent).toContain('Command 5');
+        expect(gridMenu1Elm.classList.contains('dropright'));
+
+        // return menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
+        subCommands1Elm!.dispatchEvent(new Event('click'));
+        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
+        const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
+        subCommands12Elm!.dispatchEvent(new Event('click'));
+        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
+        expect(disposeSubMenuSpy).toHaveBeenCalled();
+      });
+
       describe('addGridMenuCustomCommands method', () => {
         beforeEach(() => {
           translateService.use('fr');

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -97,7 +97,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     // we need to somehow keep trace of which parent menu the tree belongs to
     // and we should keep ref of only the first sub-menu parent, we can use the command name (remove any whitespaces though)
     const subMenuCommandOrOption = (item as MenuCommandItem)?.command || (item as MenuOptionItem)?.option;
-    let subMenuId = (level === 1 && subMenuCommandOrOption) ? subMenuCommandOrOption.replace(/\s/g, '') : '';
+    let subMenuId = (level === 1 && subMenuCommandOrOption) ? String(subMenuCommandOrOption).replace(/\s/g, '') : '';
     if (subMenuId) {
       this._subMenuParentId = subMenuId;
     }

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -310,7 +310,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
   }
 
   protected populateCommandOrOptionCloseBtn(itemType: MenuType, closeButtonElm: HTMLButtonElement, commandOrOptionMenuElm: HTMLDivElement) {
-    this._bindEventService.bind(closeButtonElm, 'click', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) => this.handleCloseButtonClicked(e)) as EventListener);
+    this._bindEventService.bind(closeButtonElm, 'click', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) => this.handleCloseButtonClicked(e)) as EventListener, undefined, 'parent-menu');
     const commandOrOptionMenuHeaderElm = commandOrOptionMenuElm.querySelector<HTMLDivElement>(`.slick-${itemType}-header`) ?? createDomElement('div', { className: `slick-${itemType}-header` });
     commandOrOptionMenuHeaderElm?.appendChild(closeButtonElm);
     commandOrOptionMenuElm.appendChild(commandOrOptionMenuHeaderElm);

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -246,15 +246,6 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
       if (this.menuElement.contains(e.target) || parentMenuElm) {
         isMenuClicked = true;
       }
-      if (!isMenuClicked) {
-        document
-          .querySelectorAll(`.${this.menuCssClass}.slick-submenu${this.gridUidSelector}`)
-          .forEach(subElm => {
-            if (subElm.contains(e.target)) {
-              isMenuClicked = true;
-            }
-          });
-      }
 
       if (this.menuElement !== e.target && !isMenuClicked && !e.defaultPrevented || e.target.className === 'close' && parentMenuElm) {
         this.closeMenu(e, { cell: this._currentCell, row: this._currentRow, grid: this.grid });
@@ -413,12 +404,8 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
         if (dropSide === 'left' || (!isSubMenu && this._addonOptions.dropSide === 'left')) {
           menuElm.classList.remove('dropright');
           menuElm.classList.add('dropleft');
-          if (this._camelPluginName === 'cellMenu') {
-            if (isSubMenu) {
-              menuOffsetLeft -= Number(menuWidth) - sideOffset;
-            } else {
-              menuOffsetLeft -= Number(menuWidth) - parentCellWidth - sideOffset;
-            }
+          if (this._camelPluginName === 'cellMenu' && !isSubMenu) {
+            menuOffsetLeft -= Number(menuWidth) - parentCellWidth - sideOffset;
           } else {
             menuOffsetLeft -= Number(menuWidth) - sideOffset;
           }

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -359,15 +359,14 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
       const dropOffset = Number((this._addonOptions as CellMenu | ContextMenu).autoAdjustDropOffset || 0);
       const sideOffset = Number((this._addonOptions as CellMenu | ContextMenu).autoAlignSideOffset || 0);
 
-      // if autoAdjustDrop is enable, we first need to see what position the drop will be located (defaults to bottom)
+      // if autoAdjustDrop is enabled, we first need to see what position the drop will be located (defaults to bottom)
       // without necessary toggling it's position just yet, we just want to know the future position for calculation
       if ((this._addonOptions as CellMenu | ContextMenu).autoAdjustDrop || (this._addonOptions as CellMenu | ContextMenu).dropDirection) {
         // since we reposition menu below slick cell, we need to take it in consideration and do our calculation from that element
-        const spaceBottom = calculateAvailableSpace(parentElm).bottom;
-        const spaceTop = calculateAvailableSpace(parentElm).top;
-        const spaceBottomRemaining = spaceBottom + dropOffset - rowHeight;
-        const spaceTopRemaining = spaceTop - dropOffset + rowHeight;
-        const dropPosition = ((spaceBottomRemaining < menuHeight) && (spaceTopRemaining > spaceBottomRemaining)) ? 'top' : 'bottom';
+        const { bottom: spaceBottom, top: spaceTop } = calculateAvailableSpace(parentElm);
+        const availableSpaceBottom = spaceBottom + dropOffset - rowHeight;
+        const availableSpaceTop = spaceTop - dropOffset + rowHeight;
+        const dropPosition = ((availableSpaceBottom < menuHeight) && (availableSpaceTop > availableSpaceBottom)) ? 'top' : 'bottom';
         if (dropPosition === 'top' || (this._addonOptions as CellMenu | ContextMenu).dropDirection === 'top') {
           menuElm.classList.remove('dropdown');
           menuElm.classList.add('dropup');

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -113,7 +113,7 @@ export class SlickColumnPicker {
     addCloseButtomElement.call(this, this._menuElm);
 
     this._listElm = createDomElement('div', { className: 'slick-column-picker-list', role: 'menu' });
-    this._bindEventService.bind(this._menuElm, 'click', handleColumnPickerItemClick.bind(this) as EventListener);
+    this._bindEventService.bind(this._menuElm, 'click', handleColumnPickerItemClick.bind(this) as EventListener, undefined, 'parent-menu');
 
     // Hide the menu on outside click.
     this._bindEventService.bind(document.body, 'mousedown', this.handleBodyMouseDown.bind(this) as EventListener);

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -168,8 +168,8 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
             disabled: false,
             command: commandName,
             positionOrder: 50,
-            action: (_e: Event, args: MenuCommandItemCallbackArgs) => {
-              this.copyToClipboard(args);
+            action: (_e, args) => {
+              this.copyToClipboard(args as MenuCommandItemCallbackArgs);
             },
             itemUsabilityOverride: (args: MenuCallbackArgs) => {
               // make sure there's an item to copy before enabling this command

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -828,14 +828,6 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       // did we click inside the menu or any of its sub-menu(s)
       if (this.menuElement.contains(e.target) || parentMenuElm) {
         isMenuClicked = true;
-      } else {
-        document
-          .querySelectorAll(`.${this.menuCssClass}.slick-submenu${this.gridUidSelector}`)
-          .forEach(subElm => {
-            if (subElm.contains(e.target)) {
-              isMenuClicked = true;
-            }
-          });
       }
 
       if ((this._isMenuOpen && this.menuElement !== e.target && !isMenuClicked && !e.defaultPrevented) || (e.target.className === 'close' && parentMenuElm)) {

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -177,7 +177,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       this._listElm = createDomElement('div', { className: 'slick-column-picker-list', role: 'menu' });
 
       // update all columns on any of the column title button click from column picker
-      this._bindEventService.bind(this._menuElm, 'click', handleColumnPickerItemClick.bind(this) as EventListener);
+      this._bindEventService.bind(this._menuElm, 'click', handleColumnPickerItemClick.bind(this) as EventListener, undefined, 'parent-menu');
     }
   }
 

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -3,13 +3,13 @@ import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import type {
   Column,
   DOMEvent,
+  DOMMouseOrTouchEvent,
   GridMenu,
   GridMenuCommandItemCallbackArgs,
   GridMenuEventWithElementCallbackArgs,
   GridMenuItem,
   GridMenuOption,
   GridOption,
-  MenuCommandItem,
   SlickNamespace,
 } from '../interfaces/index';
 import { DelimiterType, FileType } from '../enums/index';
@@ -44,19 +44,13 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   protected _columns: Column[] = [];
   protected _columnCheckboxes: HTMLInputElement[] = [];
   protected _columnTitleElm!: HTMLDivElement;
-  protected _commandMenuElm!: HTMLDivElement;
-  protected _gridMenuOptions: GridMenu | null = null;
+  protected _commandMenuElm: HTMLDivElement | null = null;
   protected _gridMenuButtonElm!: HTMLButtonElement;
   protected _headerElm: HTMLDivElement | null = null;
   protected _isMenuOpen = false;
   protected _listElm!: HTMLSpanElement;
+  protected _subMenuParentId = '';
   protected _userOriginalGridMenu!: GridMenu;
-  onAfterMenuShow = new Slick.Event();
-  onBeforeMenuShow = new Slick.Event();
-  onMenuClose = new Slick.Event();
-  onCommand = new Slick.Event();
-  onColumnsChanged = new Slick.Event();
-
   protected _defaults = {
     dropSide: 'left',
     showButton: true,
@@ -71,6 +65,13 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     syncResizeTitle: 'Synchronous resize',
     headerColumnValueExtractor: (columnDef: Column) => columnDef.name
   } as GridMenuOption;
+
+  // public events
+  onAfterMenuShow = new Slick.Event();
+  onBeforeMenuShow = new Slick.Event();
+  onMenuClose = new Slick.Event();
+  onCommand = new Slick.Event();
+  onColumnsChanged = new Slick.Event();
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
   constructor(
@@ -92,7 +93,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   get addonOptions(): GridMenu {
-    return this._gridMenuOptions || {};
+    return this._addonOptions || {};
   }
 
   get columns(): Column[] {
@@ -104,6 +105,10 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
   get gridOptions(): GridOption {
     return this.grid.getOptions() || {};
+  }
+
+  get gridUidSelector(): string {
+    return this.gridUid ? `.${this.gridUid}` : '';
   }
 
   initEventHandlers() {
@@ -132,17 +137,17 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
     // keep original user grid menu, useful when switching locale to translate
     this._userOriginalGridMenu = { ...this.sharedService.gridOptions.gridMenu };
-    this._gridMenuOptions = { ...this._defaults, ...this.getDefaultGridMenuOptions(), ...this.sharedService.gridOptions.gridMenu };
-    this.sharedService.gridOptions.gridMenu = this._gridMenuOptions;
+    this._addonOptions = { ...this._defaults, ...this.getDefaultGridMenuOptions(), ...this.sharedService.gridOptions.gridMenu };
+    this.sharedService.gridOptions.gridMenu = this._addonOptions;
 
     // merge original user grid menu items with internal items
     // then sort all Grid Menu command items (sorted by pointer, no need to use the return)
     const gridMenuCommandItems = this._userOriginalGridMenu.commandItems;
     const originalCommandItems = this._userOriginalGridMenu && Array.isArray(gridMenuCommandItems) ? gridMenuCommandItems : [];
-    this._gridMenuOptions.commandItems = [...originalCommandItems, ...this.addGridMenuCustomCommands(originalCommandItems)];
-    this.extensionUtility.translateMenuItemsFromTitleKey(this._gridMenuOptions.commandItems || [], 'commandItems');
-    this.extensionUtility.sortItems(this._gridMenuOptions.commandItems, 'positionOrder');
-    this._gridMenuOptions.commandItems = this._gridMenuOptions.commandItems;
+    this._addonOptions.commandItems = [...originalCommandItems, ...this.addGridMenuCustomCommands(originalCommandItems)];
+    this.extensionUtility.translateMenuItemsFromTitleKey(this._addonOptions.commandItems || [], 'commandItems');
+    this.extensionUtility.sortItems(this._addonOptions.commandItems, 'positionOrder');
+    this._addonOptions.commandItems = this._addonOptions.commandItems;
 
     // create the Grid Menu DOM element
     this.createGridMenu();
@@ -156,17 +161,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
   deleteMenu() {
     this._bindEventService.unbindAll();
-    const gridMenuElm = document.querySelector<HTMLDivElement>(`div.slick-grid-menu.${this._gridUid}`);
-    if (gridMenuElm) {
-      gridMenuElm.style.display = 'none';
-    }
+    this._menuElm?.remove();
+    this._gridMenuButtonElm?.remove();
     if (this._headerElm) {
-      // put back original width (fixes width and frozen+gridMenu on left header)
+      // put back grid header original width (fixes width and frozen+gridMenu on left header)
       this._headerElm.style.width = '100%';
     }
-    this._gridMenuButtonElm?.remove();
-    this._menuElm?.remove();
-    this._commandMenuElm?.remove();
   }
 
   createColumnPickerContainer() {
@@ -181,19 +181,19 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
   }
 
+  /** Create parent grid menu container */
   createGridMenu() {
-    this._gridUid = this._gridUid ?? this.grid.getUID() ?? '';
     const gridUidSelector = this._gridUid ? `.${this._gridUid}` : '';
-    const gridMenuWidth = this._gridMenuOptions?.menuWidth || this._defaults.menuWidth;
+    const gridMenuWidth = this._addonOptions?.menuWidth || this._defaults.menuWidth;
     const headerSide = (this.gridOptions.hasOwnProperty('frozenColumn') && this.gridOptions.frozenColumn! >= 0) ? 'right' : 'left';
     this._headerElm = document.querySelector<HTMLDivElement>(`${gridUidSelector} .slick-header-${headerSide}`);
 
-    if (this._headerElm && this._gridMenuOptions) {
+    if (this._headerElm && this._addonOptions) {
       // resize the header row to include the hamburger menu icon
       this._headerElm.style.width = `calc(100% - ${gridMenuWidth}px)`;
 
       // if header row is enabled, we also need to resize its width
-      const enableResizeHeaderRow = this._gridMenuOptions.resizeOnShowHeaderRow ?? this._defaults.resizeOnShowHeaderRow;
+      const enableResizeHeaderRow = this._addonOptions.resizeOnShowHeaderRow ?? this._defaults.resizeOnShowHeaderRow;
       if (enableResizeHeaderRow && this.gridOptions.showHeaderRow) {
         const headerRowElm = document.querySelector<HTMLDivElement>(`${gridUidSelector} .slick-headerrow`);
         if (headerRowElm) {
@@ -201,11 +201,11 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         }
       }
 
-      const showButton = this._gridMenuOptions.showButton ?? this._defaults.showButton;
+      const showButton = this._addonOptions.showButton ?? this._defaults.showButton;
       if (showButton) {
         this._gridMenuButtonElm = createDomElement('button', { className: 'slick-grid-menu-button', ariaLabel: 'Grid Menu' });
-        if (this._gridMenuOptions?.iconCssClass) {
-          this._gridMenuButtonElm.classList.add(...this._gridMenuOptions.iconCssClass.split(' '));
+        if (this._addonOptions?.iconCssClass) {
+          this._gridMenuButtonElm.classList.add(...this._addonOptions.iconCssClass.split(' '));
         }
         this._headerElm.parentElement!.insertBefore(this._gridMenuButtonElm, this._headerElm.parentElement!.firstChild);
 
@@ -213,31 +213,11 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         this._bindEventService.bind(this._gridMenuButtonElm, 'click', this.showGridMenu.bind(this) as EventListener);
       }
 
-      this.sharedService.gridOptions.gridMenu = { ...this._defaults, ...this._gridMenuOptions };
+      this.sharedService.gridOptions.gridMenu = { ...this._defaults, ...this._addonOptions };
 
       // localization support for the picker
-      this.translateTitleLabels(this._gridMenuOptions);
+      this.translateTitleLabels(this._addonOptions);
       this.translateTitleLabels(this.sharedService.gridOptions.gridMenu);
-
-      this._menuElm = createDomElement('div', {
-        role: 'menu',
-        className: `slick-grid-menu ${this._gridUid}`,
-        style: { display: 'none' }
-      });
-
-      this._commandMenuElm = createDomElement('div', { className: 'slick-menu-command-list', role: 'menu' }, this._menuElm);
-
-      this.recreateCommandList(this._gridMenuOptions, {
-        grid: this.grid,
-        menu: this._menuElm,
-        columns: this.columns,
-        allColumns: this.getAllColumns(),
-        visibleColumns: this.getVisibleColumns()
-      } as GridMenuEventWithElementCallbackArgs);
-
-      this.createColumnPickerContainer();
-
-      document.body.appendChild(this._menuElm);
 
       // hide the menu on outside click.
       this._bindEventService.bind(document.body, 'mousedown', this.handleBodyMouseDown.bind(this) as EventListener);
@@ -245,6 +225,59 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       // destroy the picker if user leaves the page
       this._bindEventService.bind(document.body, 'beforeunload', this.dispose.bind(this) as EventListener);
     }
+  }
+
+  /** Create the menu or sub-menu(s) but without the column picker which is a separate single process */
+  createCommandMenu(commandItems: Array<GridMenuItem | 'divider'>, level = 0, item?: ExtractMenuType<ExtendableItemTypes, MenuType>) {
+    // to avoid having multiple sub-menu trees opened
+    // we need to somehow keep trace of which parent menu the tree belongs to
+    // and we should keep ref of only the first sub-menu parent, we can use the command name (remove any whitespaces though)
+    const subMenuCommand = (item as GridMenuItem)?.command;
+    let subMenuId = (level === 1 && subMenuCommand) ? subMenuCommand.replace(/\s/g, '') : '';
+    if (subMenuId) {
+      this._subMenuParentId = subMenuId;
+    }
+    if (level > 1) {
+      subMenuId = this._subMenuParentId;
+    }
+
+    const menuClasses = `${this.menuCssClass} slick-menu-level-${level} ${this._gridUid}`;
+    const bodyMenuElm = document.body.querySelector<HTMLDivElement>(`.${this.menuCssClass}.slick-menu-level-${level}${this.gridUidSelector}`);
+
+    // return menu/sub-menu if it's already opened unless we are on different sub-menu tree if so close them all
+    if (bodyMenuElm) {
+      if (bodyMenuElm.dataset.subMenuParent === subMenuId) {
+        return bodyMenuElm;
+      }
+      this.disposeSubMenus();
+    }
+
+    const menuElm = createDomElement('div', {
+      role: 'menu',
+      className: menuClasses,
+      ariaLabel: level > 1 ? 'SubMenu' : 'Grid Menu'
+    });
+    if (level > 0) {
+      menuElm.classList.add('slick-submenu');
+      if (subMenuId) {
+        menuElm.dataset.subMenuParent = subMenuId;
+      }
+    }
+
+    const callbackArgs = {
+      grid: this.grid,
+      menu: this._menuElm,
+      columns: this.columns,
+      allColumns: this.getAllColumns(),
+      visibleColumns: this.getVisibleColumns(),
+      level
+    } as GridMenuEventWithElementCallbackArgs;
+    this._commandMenuElm = this.recreateCommandList(commandItems, menuElm, callbackArgs, item);
+
+    // increment level for possible next sub-menus if exists
+    level++;
+
+    return menuElm;
   }
 
   /**
@@ -269,36 +302,37 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
    * @returns
    */
   hideMenu(event: Event) {
-    if (this._menuElm?.style?.display === 'block') {
-      const callbackArgs = {
-        grid: this.grid,
-        menu: this._menuElm,
-        allColumns: this.columns,
-        visibleColumns: this.getVisibleColumns()
-      } as GridMenuEventWithElementCallbackArgs;
+    const callbackArgs = {
+      grid: this.grid,
+      menu: this._menuElm,
+      allColumns: this.columns,
+      visibleColumns: this.getVisibleColumns()
+    } as GridMenuEventWithElementCallbackArgs;
 
-      // execute optional callback method defined by the user, if it returns false then we won't go further neither close the menu
-      this.pubSubService.publish('onGridMenuMenuClose', callbackArgs);
-      if ((typeof this._gridMenuOptions?.onMenuClose === 'function' && this._gridMenuOptions.onMenuClose(event, callbackArgs) === false) || this.onMenuClose.notify(callbackArgs, null, this).getReturnValue() === false) {
-        return;
-      }
+    // execute optional callback method defined by the user, if it returns false then we won't go further neither close the menu
+    this.pubSubService.publish('onGridMenuMenuClose', callbackArgs);
+    if ((typeof this._addonOptions?.onMenuClose === 'function' && this._addonOptions.onMenuClose(event, callbackArgs) === false) || this.onMenuClose.notify(callbackArgs, null, this).getReturnValue() === false) {
+      return;
+    }
 
-      this._menuElm.style.display = 'none';
-      this._menuElm.setAttribute('aria-expanded', 'false');
-      this._isMenuOpen = false;
+    this._isMenuOpen = false;
 
-      // we also want to resize the columns if the user decided to hide certain column(s)
-      if (typeof this.grid?.autosizeColumns === 'function') {
-        // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree)
-        const gridUid = this.grid.getUID() || '';
-        if (this._areVisibleColumnDifferent && gridUid && document.querySelector(`.${gridUid}`) !== null) {
-          if (this.gridOptions.enableAutoSizeColumns) {
-            this.grid.autosizeColumns();
-          }
-          this._areVisibleColumnDifferent = false;
+    // we also want to resize the columns if the user decided to hide certain column(s)
+    if (typeof this.grid?.autosizeColumns === 'function') {
+      // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree)
+      const gridUid = this.grid.getUID() || '';
+      if (this._areVisibleColumnDifferent && gridUid && document.querySelector(`.${gridUid}`) !== null) {
+        if (this.gridOptions.enableAutoSizeColumns) {
+          this.grid.autosizeColumns();
         }
+        this._areVisibleColumnDifferent = false;
       }
     }
+
+    // dispose of all sub-menus from the DOM and unbind all listeners
+    // this._bindEventService.unbindAll();
+    this.disposeSubMenus();
+    this._menuElm?.remove();
   }
 
   /** destroy and recreate the Grid Menu in the DOM */
@@ -307,72 +341,77 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     this.init();
   }
 
-  repositionMenu(e: MouseEvent | TouchEvent, addonOptions: GridMenu, showMenu = true) {
+  repositionMenu(e: MouseEvent | TouchEvent, menuElm: HTMLElement, buttonElm?: HTMLButtonElement, addonOptions?: GridMenu) {
     const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
-    if (this._menuElm) {
-      let buttonElm = (e.target as HTMLButtonElement).nodeName === 'BUTTON' ? (e.target as HTMLButtonElement) : (e.target as HTMLElement).querySelector('button') as HTMLButtonElement; // get button element
-      if (!buttonElm) {
-        buttonElm = (e.target as HTMLElement).parentElement as HTMLButtonElement; // external grid menu might fall in this last case if wrapped in a span/div
-      }
+    const isSubMenu = menuElm.classList.contains('slick-submenu');
+    const parentElm = isSubMenu
+      ? (e.target as HTMLElement)!.closest('.slick-menu-item') as HTMLDivElement
+      : targetEvent.target as HTMLElement;
 
-      // we need to display the menu to properly calculate its width but we can however make it invisible
-      this._menuElm.style.display = 'block';
-      this._menuElm.style.opacity = '0';
-      const menuIconOffset = getHtmlElementOffset(buttonElm as HTMLButtonElement);
-      const buttonComptStyle = getComputedStyle(buttonElm as HTMLButtonElement);
+    if (parentElm) {
+      const iconButtonElm = buttonElm || this._gridMenuButtonElm;
+      const menuIconOffset = getHtmlElementOffset(buttonElm); // get button offset position
+      const parentOffset = getHtmlElementOffset(parentElm);
+      const gridMenuOptions = addonOptions ?? this._addonOptions;
+      const buttonComptStyle = getComputedStyle(iconButtonElm as HTMLButtonElement);
       const buttonWidth = parseInt(buttonComptStyle?.width ?? this._defaults?.menuWidth, 10);
 
-      const menuWidth = this._menuElm?.offsetWidth ?? 0;
-      const contentMinWidth = addonOptions?.contentMinWidth ?? this._defaults.contentMinWidth ?? 0;
+      const menuWidth = menuElm?.offsetWidth ?? 0;
+      const contentMinWidth = gridMenuOptions?.contentMinWidth ?? this._defaults.contentMinWidth ?? 0;
       const currentMenuWidth = ((contentMinWidth > menuWidth) ? contentMinWidth : (menuWidth)) || 0;
       const nextPositionTop = menuIconOffset?.top ?? 0;
       const nextPositionLeft = menuIconOffset?.right ?? 0;
-      const menuMarginBottom = ((addonOptions?.marginBottom !== undefined) ? addonOptions.marginBottom : this._defaults.marginBottom) || 0;
-      const calculatedLeftPosition = addonOptions?.dropSide === 'right' ? nextPositionLeft - buttonWidth : nextPositionLeft - currentMenuWidth;
 
-      this._menuElm.style.top = `${nextPositionTop + buttonElm.offsetHeight}px`; // top position has to include button height so the menu is placed just below it
-      this._menuElm.style.left = `${calculatedLeftPosition}px`;
-      if (addonOptions.dropSide === 'left') {
-        this._menuElm.classList.remove('dropright');
-        this._menuElm.classList.add('dropleft');
+      let menuOffsetLeft;
+      let menuOffsetTop;
+      if (isSubMenu) {
+        menuOffsetLeft = parentOffset?.left ?? 0;
+        menuOffsetTop = parentOffset?.top ?? 0;
       } else {
-        this._menuElm.classList.remove('dropleft');
-        this._menuElm.classList.add('dropright');
+        menuOffsetLeft = gridMenuOptions?.dropSide === 'right' ? nextPositionLeft - buttonWidth : nextPositionLeft - currentMenuWidth;
+        menuOffsetTop = nextPositionTop + iconButtonElm.offsetHeight; // top position has to include button height so the menu is placed just below it
       }
-      this._menuElm.appendChild(this._listElm);
+
+      const gridPos = this.grid.getGridPosition();
+      let subMenuPosCalc = menuOffsetLeft + Number(menuWidth); // calculate coordinate at caller element far right
+      if (isSubMenu) {
+        subMenuPosCalc += parentElm.clientWidth;
+      }
+      const browserWidth = document.documentElement.clientWidth;
+      const dropSide = (subMenuPosCalc >= gridPos.width || subMenuPosCalc >= browserWidth) ? 'left' : 'right';
+      if (dropSide === 'left' || (!isSubMenu && gridMenuOptions?.dropSide === 'left')) {
+        menuElm.classList.remove('dropright');
+        menuElm.classList.add('dropleft');
+        if (isSubMenu) {
+          menuOffsetLeft -= Number(menuWidth);
+        }
+      } else {
+        menuElm.classList.remove('dropleft');
+        menuElm.classList.add('dropright');
+        if (isSubMenu) {
+          menuOffsetLeft += parentElm.offsetWidth;
+        }
+      }
+
+      menuElm.style.top = `${menuOffsetTop}px`;
+      menuElm.style.left = `${menuOffsetLeft}px`;
 
       if (contentMinWidth! > 0) {
-        this._menuElm.style.minWidth = `${contentMinWidth}px`;
+        menuElm.style.minWidth = `${contentMinWidth}px`;
       }
-
-      // set 'height' when defined OR ELSE use the 'max-height' with available window size and optional margin bottom
-      this._menuElm.style.minHeight = findWidthOrDefault(addonOptions.minHeight, '');
-
-      if (addonOptions?.height !== undefined) {
-        this._menuElm.style.height = findWidthOrDefault(addonOptions.height, '');
-      } else {
-        this._menuElm.style.maxHeight = findWidthOrDefault(addonOptions.maxHeight, `${window.innerHeight - targetEvent.clientY - menuMarginBottom}px`);
-      }
-
-      this._menuElm.style.display = 'block';
-      if (showMenu) {
-        this._menuElm.style.opacity = '1'; // restore its visibility
-      }
-
-      this._menuElm.setAttribute('aria-expanded', 'true');
-      this._menuElm.appendChild(this._listElm);
-      this._isMenuOpen = true;
+      menuElm.style.opacity = '1';
     }
   }
 
-  showGridMenu(e: MouseEvent, options?: GridMenuOption) {
+  /** show grid menu which in theory is recreated every time */
+  showGridMenu(e: MouseEvent | TouchEvent, options?: GridMenuOption) {
+    const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
     e.preventDefault();
 
-    // empty both the picker list & the command list
-    emptyElement(this._listElm);
-    emptyElement(this._commandMenuElm);
+    // empty the entire menu so that it's recreated every time it opens
+    emptyElement(this._menuElm);
 
-    if (this._gridMenuOptions) {
+    if (this._addonOptions) {
       const callbackArgs = {
         grid: this.grid,
         menu: this._menuElm,
@@ -381,10 +420,10 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         visibleColumns: this.getVisibleColumns()
       } as GridMenuEventWithElementCallbackArgs;
 
-      const addonOptions: GridMenu = { ...this._gridMenuOptions, ...options }; // merge optional picker option
+      const addonOptions: GridMenu = { ...this._addonOptions, ...options }; // merge optional picker option
 
-      this.recreateCommandList(addonOptions, callbackArgs);
-
+      this._menuElm = this.createCommandMenu(this._addonOptions?.commandItems ?? []);
+      this.createColumnPickerContainer();
       updateColumnPickerOrder.call(this);
       this._columnCheckboxes = [];
 
@@ -403,11 +442,34 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
       // load the column & create column picker list
       populateColumnPicker.call(this, addonOptions);
+      document.body.appendChild(this._menuElm);
 
       // calculate the necessary menu height/width and reposition twice because if we do it only once and the grid menu is wider than the original width,
       // it will be offset the 1st time we open the menu but if we do it twice then it will be at the correct position every time
-      this.repositionMenu(e, addonOptions, false);
-      this.repositionMenu(e, addonOptions, true);
+      this._menuElm.style.opacity = '0';
+
+      const menuMarginBottom = ((addonOptions?.marginBottom !== undefined) ? addonOptions.marginBottom : this._defaults.marginBottom) || 0;
+
+      // set 'height' when defined OR ELSE use the 'max-height' with available window size and optional margin bottom
+      this._menuElm.style.minHeight = findWidthOrDefault(addonOptions?.minHeight, '');
+
+      if (addonOptions?.height !== undefined) {
+        this._menuElm.style.height = findWidthOrDefault(addonOptions.height, '');
+      } else {
+        this._menuElm.style.maxHeight = findWidthOrDefault(addonOptions?.maxHeight, `${window.innerHeight - targetEvent.clientY - menuMarginBottom}px`);
+      }
+
+      let buttonElm = (e.target as HTMLButtonElement).nodeName === 'BUTTON' ? (e.target as HTMLButtonElement) : (e.target as HTMLElement).querySelector('button') as HTMLButtonElement; // get button element
+      if (!buttonElm) {
+        buttonElm = (e.target as HTMLElement).parentElement as HTMLButtonElement; // external grid menu might fall in this last case if wrapped in a span/div
+      }
+
+      this._menuElm.setAttribute('aria-expanded', 'true');
+      this._menuElm.appendChild(this._listElm);
+
+      // once we have both lists (commandItems + columnPicker), we are ready to reposition the menu since its height/width should be calculated by then
+      this.repositionMenu(e, this._menuElm, buttonElm, addonOptions);
+      this._isMenuOpen = true;
 
       // execute optional callback method defined by the user
       this.pubSubService.publish('onGridMenuAfterMenuShow', callbackArgs);
@@ -421,12 +483,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   /** Update the Titles of each sections (command, commandTitle, ...) */
   updateAllTitles(options: GridMenuOption) {
     if (this._commandTitleElm?.textContent && options.commandTitle) {
-      this._commandTitleElm.textContent = this._gridMenuOptions?.commandItems?.length ? options.commandTitle as string : '';
-      this._gridMenuOptions!.commandTitle = this._commandTitleElm.textContent;
+      this._commandTitleElm.textContent = this._addonOptions?.commandItems?.length ? options.commandTitle as string : '';
+      this._addonOptions!.commandTitle = this._commandTitleElm.textContent;
     }
     if (this._columnTitleElm?.textContent && options.columnTitle) {
       this._columnTitleElm.textContent = options.columnTitle;
-      this._gridMenuOptions!.columnTitle = options.columnTitle;
+      this._addonOptions!.columnTitle = options.columnTitle;
     }
   }
 
@@ -445,10 +507,10 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       // then sort all Grid Menu command items (sorted by pointer, no need to use the return)
       const originalCommandItems = this._userOriginalGridMenu && Array.isArray(this._userOriginalGridMenu.commandItems) ? this._userOriginalGridMenu.commandItems : [];
       this.sharedService.gridOptions.gridMenu.commandItems = [...originalCommandItems, ...this.addGridMenuCustomCommands(originalCommandItems)];
-      this.extensionUtility.translateMenuItemsFromTitleKey(this._gridMenuOptions?.commandItems || [], 'commandItems');
+      this.extensionUtility.translateMenuItemsFromTitleKey(this._addonOptions?.commandItems || [], 'commandItems');
       this.extensionUtility.sortItems(this.sharedService.gridOptions.gridMenu.commandItems, 'positionOrder');
       this.translateTitleLabels(this.sharedService.gridOptions.gridMenu);
-      this.translateTitleLabels(this._gridMenuOptions);
+      this.translateTitleLabels(this._addonOptions);
 
       // translate all columns (including non-visible)
       this.extensionUtility.translateItems(this._columns, 'nameKey', 'name');
@@ -477,15 +539,15 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     const gridMenuCommandItems: Array<GridMenuItem | 'divider'> = [];
     const gridOptions = this.gridOptions;
     const translationPrefix = getTranslationPrefix(gridOptions);
-    const commandLabels = this._gridMenuOptions?.commandLabels;
+    const commandLabels = this._addonOptions?.commandLabels;
 
     // show grid menu: Unfreeze Columns/Rows
-    if (this.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideClearFrozenColumnsCommand) {
+    if (this.gridOptions && this._addonOptions && !this._addonOptions.hideClearFrozenColumnsCommand) {
       const commandName = 'clear-pinning';
       if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
         gridMenuCommandItems.push(
           {
-            iconCssClass: this._gridMenuOptions.iconClearFrozenColumnsCommand || 'fa fa-times',
+            iconCssClass: this._addonOptions.iconClearFrozenColumnsCommand || 'fa fa-times',
             titleKey: `${translationPrefix}${commandLabels?.clearFrozenColumnsCommandKey ?? 'CLEAR_PINNING'}`,
             disabled: false,
             command: commandName,
@@ -497,12 +559,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
     if (this.gridOptions && (this.gridOptions.enableFiltering && !this.sharedService.hideHeaderRowAfterPageLoad)) {
       // show grid menu: Clear all Filters
-      if (this.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideClearAllFiltersCommand) {
+      if (this.gridOptions && this._addonOptions && !this._addonOptions.hideClearAllFiltersCommand) {
         const commandName = 'clear-filter';
         if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
           gridMenuCommandItems.push(
             {
-              iconCssClass: this._gridMenuOptions.iconClearAllFiltersCommand || 'fa fa-filter text-danger',
+              iconCssClass: this._addonOptions.iconClearAllFiltersCommand || 'fa fa-filter text-danger',
               titleKey: `${translationPrefix}${commandLabels?.clearAllFiltersCommandKey ?? 'CLEAR_ALL_FILTERS'}`,
               disabled: false,
               command: commandName,
@@ -513,12 +575,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       }
 
       // show grid menu: toggle filter row
-      if (this.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideToggleFilterCommand) {
+      if (this.gridOptions && this._addonOptions && !this._addonOptions.hideToggleFilterCommand) {
         const commandName = 'toggle-filter';
         if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
           gridMenuCommandItems.push(
             {
-              iconCssClass: this._gridMenuOptions.iconToggleFilterCommand || 'fa fa-random',
+              iconCssClass: this._addonOptions.iconToggleFilterCommand || 'fa fa-random',
               titleKey: `${translationPrefix}${commandLabels?.toggleFilterCommandKey ?? 'TOGGLE_FILTER_ROW'}`,
               disabled: false,
               command: commandName,
@@ -529,12 +591,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       }
 
       // show grid menu: refresh dataset
-      if (backendApi && this.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideRefreshDatasetCommand) {
+      if (backendApi && this.gridOptions && this._addonOptions && !this._addonOptions.hideRefreshDatasetCommand) {
         const commandName = 'refresh-dataset';
         if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
           gridMenuCommandItems.push(
             {
-              iconCssClass: this._gridMenuOptions.iconRefreshDatasetCommand || 'fa fa-refresh',
+              iconCssClass: this._addonOptions.iconRefreshDatasetCommand || 'fa fa-refresh',
               titleKey: `${translationPrefix}${commandLabels?.refreshDatasetCommandKey ?? 'REFRESH_DATASET'}`,
               disabled: false,
               command: commandName,
@@ -547,12 +609,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
     if (this.gridOptions.showPreHeaderPanel) {
       // show grid menu: toggle pre-header row
-      if (this.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideTogglePreHeaderCommand) {
+      if (this.gridOptions && this._addonOptions && !this._addonOptions.hideTogglePreHeaderCommand) {
         const commandName = 'toggle-preheader';
         if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
           gridMenuCommandItems.push(
             {
-              iconCssClass: this._gridMenuOptions.iconTogglePreHeaderCommand || 'fa fa-random',
+              iconCssClass: this._addonOptions.iconTogglePreHeaderCommand || 'fa fa-random',
               titleKey: `${translationPrefix}${commandLabels?.togglePreHeaderCommandKey ?? 'TOGGLE_PRE_HEADER_ROW'}`,
               disabled: false,
               command: commandName,
@@ -565,12 +627,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
     if (this.gridOptions.enableSorting) {
       // show grid menu: Clear all Sorting
-      if (this.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideClearAllSortingCommand) {
+      if (this.gridOptions && this._addonOptions && !this._addonOptions.hideClearAllSortingCommand) {
         const commandName = 'clear-sorting';
         if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
           gridMenuCommandItems.push(
             {
-              iconCssClass: this._gridMenuOptions.iconClearAllSortingCommand || 'fa fa-unsorted text-danger',
+              iconCssClass: this._addonOptions.iconClearAllSortingCommand || 'fa fa-unsorted text-danger',
               titleKey: `${translationPrefix}${commandLabels?.clearAllSortingCommandKey ?? 'CLEAR_ALL_SORTING'}`,
               disabled: false,
               command: commandName,
@@ -582,12 +644,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
 
     // show grid menu: Export to file
-    if (this.gridOptions?.enableTextExport && this._gridMenuOptions && !this._gridMenuOptions.hideExportCsvCommand) {
+    if (this.gridOptions?.enableTextExport && this._addonOptions && !this._addonOptions.hideExportCsvCommand) {
       const commandName = 'export-csv';
       if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
         gridMenuCommandItems.push(
           {
-            iconCssClass: this._gridMenuOptions.iconExportCsvCommand || 'fa fa-download',
+            iconCssClass: this._addonOptions.iconExportCsvCommand || 'fa fa-download',
             titleKey: `${translationPrefix}${commandLabels?.exportCsvCommandKey ?? 'EXPORT_TO_CSV'}`,
             disabled: false,
             command: commandName,
@@ -598,12 +660,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
 
     // show grid menu: Export to Excel
-    if (this.gridOptions && this.gridOptions.enableExcelExport && this._gridMenuOptions && !this._gridMenuOptions.hideExportExcelCommand) {
+    if (this.gridOptions && this.gridOptions.enableExcelExport && this._addonOptions && !this._addonOptions.hideExportExcelCommand) {
       const commandName = 'export-excel';
       if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
         gridMenuCommandItems.push(
           {
-            iconCssClass: this._gridMenuOptions.iconExportExcelCommand || 'fa fa-file-excel-o text-success',
+            iconCssClass: this._addonOptions.iconExportExcelCommand || 'fa fa-file-excel-o text-success',
             titleKey: `${translationPrefix}${commandLabels?.exportExcelCommandKey ?? 'EXPORT_TO_EXCEL'}`,
             disabled: false,
             command: commandName,
@@ -614,12 +676,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
 
     // show grid menu: export to text file as tab delimited
-    if (this.gridOptions?.enableTextExport && this._gridMenuOptions && !this._gridMenuOptions.hideExportTextDelimitedCommand) {
+    if (this.gridOptions?.enableTextExport && this._addonOptions && !this._addonOptions.hideExportTextDelimitedCommand) {
       const commandName = 'export-text-delimited';
       if (!originalCommandItems.some(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
         gridMenuCommandItems.push(
           {
-            iconCssClass: this._gridMenuOptions.iconExportTextDelimitedCommand || 'fa fa-download',
+            iconCssClass: this._addonOptions.iconExportTextDelimitedCommand || 'fa fa-download',
             titleKey: `${translationPrefix}${commandLabels?.exportTextDelimitedCommandKey ?? 'EXPORT_TO_TAB_DELIMITED'}`,
             disabled: false,
             command: commandName,
@@ -630,9 +692,9 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
 
     // add the custom "Commands" title if there are any commands
-    const commandItems = this._gridMenuOptions?.commandItems || [];
-    if (this.gridOptions && this._gridMenuOptions && (Array.isArray(gridMenuCommandItems) && gridMenuCommandItems.length > 0 || (Array.isArray(commandItems) && commandItems.length > 0))) {
-      this._gridMenuOptions.commandTitle = this._gridMenuOptions.commandTitle || this.extensionUtility.getPickerTitleOutputString('commandTitle', 'gridMenu');
+    const commandItems = this._addonOptions?.commandItems || [];
+    if (this.gridOptions && this._addonOptions && (Array.isArray(gridMenuCommandItems) && gridMenuCommandItems.length > 0 || (Array.isArray(commandItems) && commandItems.length > 0))) {
+      this._addonOptions.commandTitle = this._addonOptions.commandTitle || this.extensionUtility.getPickerTitleOutputString('commandTitle', 'gridMenu');
     }
 
     return gridMenuCommandItems;
@@ -752,66 +814,109 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Mouse down handler when clicking anywhere in the DOM body */
-  protected handleBodyMouseDown(event: DOMEvent<HTMLElement>) {
-    if ((this._menuElm !== event.target && !this._menuElm?.contains(event.target) && this._isMenuOpen) || event.target.className === 'close') {
-      this.hideMenu(event);
+  protected handleBodyMouseDown(e: DOMEvent<HTMLElement>) {
+    if (this.menuElement) {
+      let isMenuClicked = false;
+      const parentMenuElm = e.target.closest(`.${this.menuCssClass}`);
+
+      // did we click inside the menu or any of its sub-menu(s)
+      if (this.menuElement.contains(e.target) || parentMenuElm) {
+        isMenuClicked = true;
+      } else {
+        document
+          .querySelectorAll(`.${this.menuCssClass}.slick-submenu${this.gridUidSelector}`)
+          .forEach(subElm => {
+            if (subElm.contains(e.target)) {
+              isMenuClicked = true;
+            }
+          });
+      }
+
+      if ((this._isMenuOpen && this.menuElement !== e.target && !isMenuClicked && !e.defaultPrevented) || (e.target.className === 'close' && parentMenuElm)) {
+        this.hideMenu(e);
+      }
     }
   }
 
-  protected handleMenuItemCommandClick(event: Event, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>): boolean | void {
-    if (item === 'divider' || (item as MenuCommandItem).command && (item.disabled || (item as MenuCommandItem).divider)) {
-      return false;
+  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0) {
+    if (item !== 'divider' && !item.disabled && !(item as GridMenuItem).divider) {
+      const command = (item as GridMenuItem).command || '';
+
+      if (command && !(item as GridMenuItem).commandItems) {
+        const callbackArgs = {
+          grid: this.grid,
+          command: (item as GridMenuItem).command,
+          item,
+          allColumns: this.columns,
+          visibleColumns: this.getVisibleColumns()
+        } as GridMenuCommandItemCallbackArgs;
+
+        // execute Grid Menu callback with command,
+        // we'll also execute optional user defined onCommand callback when provided
+        this.executeGridMenuInternalCustomCommands(event, callbackArgs);
+        this.pubSubService.publish('onGridMenuCommand', callbackArgs);
+        if (typeof this._addonOptions?.onCommand === 'function') {
+          this._addonOptions.onCommand(event, callbackArgs);
+        }
+        this.onCommand.notify(callbackArgs, null, this);
+
+        // execute action callback when defined
+        if (typeof item.action === 'function') {
+          (item as GridMenuItem).action!.call(this, event, callbackArgs);
+        }
+
+        // does the user want to leave open the Grid Menu after executing a command?
+        if (!this._addonOptions?.leaveOpen && !event.defaultPrevented) {
+          this.hideMenu(event);
+        }
+
+        // Stop propagation so that it doesn't register as a header click event.
+        event.preventDefault();
+        event.stopPropagation();
+      } else if ((item as GridMenuItem).commandItems) {
+        this.repositionSubMenu(item, level, event);
+      }
     }
-
-    const callbackArgs = {
-      grid: this.grid,
-      command: (item as MenuCommandItem).command,
-      item,
-      allColumns: this.columns,
-      visibleColumns: this.getVisibleColumns()
-    } as unknown as GridMenuCommandItemCallbackArgs;
-
-    // execute Grid Menu callback with command,
-    // we'll also execute optional user defined onCommand callback when provided
-    this.executeGridMenuInternalCustomCommands(event, callbackArgs);
-    this.pubSubService.publish('onGridMenuCommand', callbackArgs);
-    if (typeof this._gridMenuOptions?.onCommand === 'function') {
-      this._gridMenuOptions.onCommand(event, callbackArgs);
-    }
-    this.onCommand.notify(callbackArgs, null, this);
-
-    // execute action callback when defined
-    if (typeof item.action === 'function') {
-      (item as MenuCommandItem).action!.call(this, event, callbackArgs as any);
-    }
-
-    // does the user want to leave open the Grid Menu after executing a command?
-    if (!this._gridMenuOptions?.leaveOpen && !event.defaultPrevented) {
-      this.hideMenu(event);
-    }
-
-    // Stop propagation so that it doesn't register as a header click event.
-    event.preventDefault();
-    event.stopPropagation();
   }
 
   /** Re/Create Command List by adding title, close & list of commands */
-  recreateCommandList(addonOptions: GridMenu, callbackArgs: GridMenuEventWithElementCallbackArgs) {
-    // add Close button
-    this.populateCommandOrOptionTitle('command', addonOptions, this._commandMenuElm, 0);
-    const commandMenuHeaderElm = this._commandMenuElm.querySelector<HTMLDivElement>(`.slick-command-header`) ?? createDomElement('div', { className: 'slick-command-header' });
-    commandMenuHeaderElm.classList.add('with-close');
-    addCloseButtomElement.call(this, commandMenuHeaderElm);
-    this._commandMenuElm.appendChild(commandMenuHeaderElm);
+  recreateCommandList(commandItems: Array<GridMenuItem | 'divider'>, menuElm: HTMLElement, callbackArgs: GridMenuEventWithElementCallbackArgs, item?: ExtractMenuType<ExtendableItemTypes, MenuType>) {
+    // -- Command List section
+    const level = callbackArgs.level || 0;
+    if (commandItems.length > 0) {
+      const commandMenuElm = createDomElement('div', { className: `${this._menuCssPrefix}-command-list`, role: 'menu' }, menuElm);
+      if (level === 0) {
+        this.populateCommandOrOptionTitle('command', this.addonOptions, commandMenuElm, level);
+        const commandMenuHeaderElm = menuElm.querySelector<HTMLDivElement>(`.slick-command-header`) ?? createDomElement('div', { className: 'slick-command-header' });
+        commandMenuHeaderElm.classList.add('with-close');
+        addCloseButtomElement.call(this, commandMenuHeaderElm);
+        commandMenuElm.appendChild(commandMenuHeaderElm);
+      }
 
-    // populate the command list
-    this.populateCommandOrOptionItems(
-      'command',
-      addonOptions,
-      this._commandMenuElm,
-      addonOptions?.commandItems || [] as any[],
-      callbackArgs,
-      this.handleMenuItemCommandClick,
-    );
+      // when creating sub-menu also add its sub-menu title when exists
+      if (item && level > 0) {
+        this.addSubMenuTitleWhenExists(item as GridMenuItem, commandMenuElm); // add sub-menu title when exists
+      }
+
+      this.populateCommandOrOptionItems(
+        'command',
+        this._addonOptions!,
+        commandMenuElm,
+        commandItems as Array<ExtractMenuType<ExtendableItemTypes, MenuType>>,
+        callbackArgs,
+        this.handleMenuItemCommandClick,
+      );
+      return commandMenuElm;
+    }
+    return null;
+  }
+
+  protected repositionSubMenu(item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number, e: DOMMouseOrTouchEvent<HTMLButtonElement | HTMLDivElement>) {
+    // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
+    const commandItems = (item as GridMenuItem)?.commandItems || [];
+    const subMenuElm = this.createCommandMenu(commandItems as Array<GridMenuItem | 'divider'>, level + 1, item);
+    subMenuElm.style.display = 'block';
+    document.body.appendChild(subMenuElm);
+    this.repositionMenu(e, subMenuElm);
   }
 }

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -333,6 +333,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     // this._bindEventService.unbindAll();
     this.disposeSubMenus();
     this._menuElm?.remove();
+    this._menuElm = null;
   }
 
   /** destroy and recreate the Grid Menu in the DOM */
@@ -400,10 +401,18 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         menuElm.style.minWidth = `${contentMinWidth}px`;
       }
       menuElm.style.opacity = '1';
+      menuElm.style.display = 'block';
     }
   }
 
-  /** show grid menu which in theory is recreated every time */
+  /** Open the Grid Menu */
+  openGridMenu() {
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, composed: false });
+    Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: createDomElement('button', { className: 'slick-grid-menu-button' }) });
+    this.showGridMenu(clickEvent);
+  }
+
+  /** show Grid Menu from the click event, which in theory will recreate the grid menu in the DOM */
   showGridMenu(e: MouseEvent | TouchEvent, options?: GridMenuOption) {
     const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
     e.preventDefault();
@@ -422,11 +431,6 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
       const addonOptions: GridMenu = { ...this._addonOptions, ...options }; // merge optional picker option
 
-      this._menuElm = this.createCommandMenu(this._addonOptions?.commandItems ?? []);
-      this.createColumnPickerContainer();
-      updateColumnPickerOrder.call(this);
-      this._columnCheckboxes = [];
-
       // run the override function (when defined), if the result is false then we won't go further
       if (addonOptions && !this.extensionUtility.runOverrideFunctionWhenExists<typeof callbackArgs>(addonOptions.menuUsabilityOverride, callbackArgs)) {
         return;
@@ -439,6 +443,11 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
           return;
         }
       }
+
+      this._menuElm = this.createCommandMenu(this._addonOptions?.commandItems ?? []);
+      this.createColumnPickerContainer();
+      updateColumnPickerOrder.call(this);
+      this._columnCheckboxes = [];
 
       // load the column & create column picker list
       populateColumnPicker.call(this, addonOptions);
@@ -514,9 +523,6 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
       // translate all columns (including non-visible)
       this.extensionUtility.translateItems(this._columns, 'nameKey', 'name');
-
-      // update the Titles of each sections (command, commandTitle, ...)
-      this.updateAllTitles(this.sharedService.gridOptions.gridMenu);
     }
   }
 

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -489,18 +489,6 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
   }
 
-  /** Update the Titles of each sections (command, commandTitle, ...) */
-  updateAllTitles(options: GridMenuOption) {
-    if (this._commandTitleElm?.textContent && options.commandTitle) {
-      this._commandTitleElm.textContent = this._addonOptions?.commandItems?.length ? options.commandTitle as string : '';
-      this._addonOptions!.commandTitle = this._commandTitleElm.textContent;
-    }
-    if (this._columnTitleElm?.textContent && options.columnTitle) {
-      this._columnTitleElm.textContent = options.columnTitle;
-      this._addonOptions!.columnTitle = options.columnTitle;
-    }
-  }
-
   /** Translate the Grid Menu titles and column picker */
   translateGridMenu() {
     // update the properties by pointers, that is the only way to get Grid Menu Control to see the new values

--- a/packages/common/src/interfaces/elementEventListener.interface.ts
+++ b/packages/common/src/interfaces/elementEventListener.interface.ts
@@ -2,4 +2,5 @@ export interface ElementEventListener {
   element: Element;
   eventName: string;
   listener: EventListenerOrEventListenerObject;
+  groupName?: string;
 }

--- a/packages/common/src/interfaces/gridMenu.interface.ts
+++ b/packages/common/src/interfaces/gridMenu.interface.ts
@@ -46,6 +46,9 @@ export interface GridMenuEventBaseCallbackArgs {
 export interface GridMenuEventWithElementCallbackArgs extends GridMenuEventBaseCallbackArgs {
   /** html DOM element of the menu */
   menu: HTMLElement;
+
+  /** menu/sub-menu level */
+  level?: number;
 }
 
 export interface onGridMenuColumnsChangedCallbackArgs extends GridMenuEventBaseCallbackArgs {

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -136,6 +136,9 @@ export interface GridMenuOption {
   /** Defaults to True, should we show bullets when icons are missing? */
   showBulletWhenIconMissing?: boolean;
 
+  /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
+  subItemChevronClass?: string;
+
   /** Defaults to "Synchronous resize" which is 1 of the last 2 checkbox title shown at the end of the picker list */
   syncResizeTitle?: string;
 

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -157,6 +157,6 @@ export interface GridMenuOption {
   /** Callback method to override the column name output used by the ColumnPicker/GridMenu. */
   headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string;
 
-  /** Callback method that user can override the default behavior of enabling/disabling an item from the list. */
+  /** Callback method that user can override to make the menu usable or not (the menu will not be showm when not considered usable). */
   menuUsabilityOverride?: (args: MenuCallbackArgs) => boolean;
 }

--- a/packages/common/src/interfaces/menuCallbackArgs.interface.ts
+++ b/packages/common/src/interfaces/menuCallbackArgs.interface.ts
@@ -17,5 +17,6 @@ export interface MenuCallbackArgs<T = any> {
   /** Cell Data Context(data object) */
   dataContext?: T;
 
+  /** Menu/sub-menu level, parent menu is always defined as 0 and sub-menus are at level 1 or higher */
   level?: number;
 }

--- a/packages/common/src/interfaces/menuOptionItem.interface.ts
+++ b/packages/common/src/interfaces/menuOptionItem.interface.ts
@@ -3,7 +3,7 @@ import type { MenuOptionItemCallbackArgs } from './menuOptionItemCallbackArgs.in
 
 export interface MenuOptionItem extends MenuItem {
   /** An option returned by the onOptionSelected (or action) event callback handler. */
-  option: number | string | null | undefined;
+  option: number | string | boolean | null | undefined;
 
   /** Array of Option Items (title, command, disabled, ...) */
   optionItems?: Array<MenuOptionItem | 'divider'>;

--- a/packages/common/src/interfaces/menuOptionItem.interface.ts
+++ b/packages/common/src/interfaces/menuOptionItem.interface.ts
@@ -3,7 +3,7 @@ import type { MenuOptionItemCallbackArgs } from './menuOptionItemCallbackArgs.in
 
 export interface MenuOptionItem extends MenuItem {
   /** An option returned by the onOptionSelected (or action) event callback handler. */
-  option: any;
+  option: number | string | null | undefined;
 
   /** Array of Option Items (title, command, disabled, ...) */
   optionItems?: Array<MenuOptionItem | 'divider'>;

--- a/packages/common/src/services/__tests__/bindingEvent.service.spec.ts
+++ b/packages/common/src/services/__tests__/bindingEvent.service.spec.ts
@@ -44,7 +44,6 @@ describe('BindingEvent Service', () => {
   });
 
   it('should be able to bind an event with single listener and options to multiple elements', () => {
-    const mockElm = { addEventListener: jest.fn() } as unknown as HTMLElement;
     const mockCallback = jest.fn();
     const elm1 = document.createElement('input');
     const elm2 = document.createElement('input');
@@ -65,8 +64,6 @@ describe('BindingEvent Service', () => {
 
   it('should call unbindAll and expect as many removeEventListener be called', () => {
     const mockElm = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as HTMLElement;
-    const addEventSpy = jest.spyOn(mockElm, 'addEventListener');
-    const removeEventSpy = jest.spyOn(mockElm, 'removeEventListener');
     const mockCallback1 = jest.fn();
     const mockCallback2 = jest.fn();
 
@@ -78,9 +75,42 @@ describe('BindingEvent Service', () => {
     service.unbindAll();
 
     expect(service.boundedEvents.length).toBe(0);
-    expect(addEventSpy).toHaveBeenCalledWith('keyup', mockCallback1, undefined);
-    expect(addEventSpy).toHaveBeenCalledWith('click', mockCallback2, { capture: true, passive: true });
-    expect(removeEventSpy).toHaveBeenCalledWith('keyup', mockCallback1);
-    expect(removeEventSpy).toHaveBeenCalledWith('click', mockCallback2);
+    expect(mockElm.addEventListener).toHaveBeenCalledWith('keyup', mockCallback1, undefined);
+    expect(mockElm.addEventListener).toHaveBeenCalledWith('click', mockCallback2, { capture: true, passive: true });
+    expect(mockElm.removeEventListener).toHaveBeenCalledWith('keyup', mockCallback1);
+    expect(mockElm.removeEventListener).toHaveBeenCalledWith('click', mockCallback2);
+  });
+
+  it('should call unbindAll with a group name and expect that group listeners to be removed but others kept', () => {
+    const mockElm1 = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as HTMLElement;
+    const mockElm2 = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as HTMLElement;
+    const mockCallback1 = jest.fn();
+    const mockCallback2 = jest.fn();
+    const mockCallback3 = jest.fn();
+    const mockCallback4 = jest.fn();
+    const mockCallback5 = jest.fn();
+
+    service = new BindingEventService();
+    service.bind(mockElm1, 'keyup', mockCallback1, false, 'same-group');
+    service.bind(mockElm1, 'keydown', mockCallback2, { capture: true, passive: true }, 'magic');
+    service.bind(mockElm2, 'click', mockCallback3, { capture: true, passive: true }); // no group
+    service.bind(mockElm2, 'mouseover', mockCallback4, { capture: false, passive: true }, 'same-group');
+    service.bind(mockElm2, 'mouseout', mockCallback5, { capture: false, passive: false }, 'wonderful');
+
+    expect(service.boundedEvents.length).toBe(5);
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('keyup', mockCallback1, false); // same-group
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('keydown', mockCallback2, { capture: true, passive: true });
+    expect(mockElm2.addEventListener).toHaveBeenCalledWith('click', mockCallback3, { capture: true, passive: true });
+    expect(mockElm2.addEventListener).toHaveBeenCalledWith('mouseover', mockCallback4, { capture: false, passive: true }); // same-group
+    expect(mockElm2.addEventListener).toHaveBeenCalledWith('mouseout', mockCallback5, { capture: false, passive: false });
+
+    service.unbindAll('same-group');
+
+    expect(service.boundedEvents.length).toBe(3);
+    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('keyup', mockCallback1); // same-group
+    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith();
+    expect(mockElm2.removeEventListener).not.toHaveBeenCalledWith();
+    expect(mockElm2.removeEventListener).toHaveBeenCalledWith('mouseover', mockCallback4); // same-group
+    expect(mockElm2.removeEventListener).not.toHaveBeenCalledWith();
   });
 });

--- a/packages/common/src/services/__tests__/bindingEvent.service.spec.ts
+++ b/packages/common/src/services/__tests__/bindingEvent.service.spec.ts
@@ -81,9 +81,8 @@ describe('BindingEvent Service', () => {
     expect(mockElm.removeEventListener).toHaveBeenCalledWith('click', mockCallback2);
   });
 
-  it('should call unbindAll with a group name and expect that group listeners to be removed but others kept', () => {
+  it('should call unbindAll with a single group name and expect that group listeners to be removed but others kept', () => {
     const mockElm1 = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as HTMLElement;
-    const mockElm2 = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as HTMLElement;
     const mockCallback1 = jest.fn();
     const mockCallback2 = jest.fn();
     const mockCallback3 = jest.fn();
@@ -91,26 +90,58 @@ describe('BindingEvent Service', () => {
     const mockCallback5 = jest.fn();
 
     service = new BindingEventService();
-    service.bind(mockElm1, 'keyup', mockCallback1, false, 'same-group');
+    service.bind(mockElm1, 'keyup', mockCallback1, false, 'wonderful');
     service.bind(mockElm1, 'keydown', mockCallback2, { capture: true, passive: true }, 'magic');
-    service.bind(mockElm2, 'click', mockCallback3, { capture: true, passive: true }); // no group
-    service.bind(mockElm2, 'mouseover', mockCallback4, { capture: false, passive: true }, 'same-group');
-    service.bind(mockElm2, 'mouseout', mockCallback5, { capture: false, passive: false }, 'wonderful');
+    service.bind(mockElm1, 'click', mockCallback3, { capture: true, passive: true }); // no group
+    service.bind(mockElm1, 'mouseover', mockCallback4, { capture: false, passive: true }, 'mouse-group');
+    service.bind(mockElm1, 'mouseout', mockCallback5, { capture: false, passive: false }, 'mouse-group');
 
     expect(service.boundedEvents.length).toBe(5);
-    expect(mockElm1.addEventListener).toHaveBeenCalledWith('keyup', mockCallback1, false); // same-group
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('keyup', mockCallback1, false);
     expect(mockElm1.addEventListener).toHaveBeenCalledWith('keydown', mockCallback2, { capture: true, passive: true });
-    expect(mockElm2.addEventListener).toHaveBeenCalledWith('click', mockCallback3, { capture: true, passive: true });
-    expect(mockElm2.addEventListener).toHaveBeenCalledWith('mouseover', mockCallback4, { capture: false, passive: true }); // same-group
-    expect(mockElm2.addEventListener).toHaveBeenCalledWith('mouseout', mockCallback5, { capture: false, passive: false });
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('click', mockCallback3, { capture: true, passive: true });
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('mouseover', mockCallback4, { capture: false, passive: true }); // mouse-group
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('mouseout', mockCallback5, { capture: false, passive: false }); // mouse-group
 
-    service.unbindAll('same-group');
+    service.unbindAll('mouse-group');
 
     expect(service.boundedEvents.length).toBe(3);
-    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('keyup', mockCallback1); // same-group
-    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith();
-    expect(mockElm2.removeEventListener).not.toHaveBeenCalledWith();
-    expect(mockElm2.removeEventListener).toHaveBeenCalledWith('mouseover', mockCallback4); // same-group
-    expect(mockElm2.removeEventListener).not.toHaveBeenCalledWith();
+    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith('keyup', mockCallback1);
+    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith('keydown', mockCallback2);
+    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith('click', mockCallback3);
+    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('mouseover', mockCallback4); // mouse-group
+    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('mouseout', mockCallback5); // mouse-group
+  });
+
+  it('should call unbindAll with a multiple group names and expect those group listeners to be removed but others kept', () => {
+    const mockElm1 = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as HTMLElement;
+    const mockCallback1 = jest.fn();
+    const mockCallback2 = jest.fn();
+    const mockCallback3 = jest.fn();
+    const mockCallback4 = jest.fn();
+    const mockCallback5 = jest.fn();
+
+    service = new BindingEventService();
+    service.bind(mockElm1, 'keyup', mockCallback1, false, 'wonderful');
+    service.bind(mockElm1, 'keydown', mockCallback2, { capture: true, passive: true }, 'magic');
+    service.bind(mockElm1, 'click', mockCallback3, { capture: true, passive: true }); // no group
+    service.bind(mockElm1, 'mouseover', mockCallback4, { capture: false, passive: true }, 'mouse-group');
+    service.bind(mockElm1, 'mouseout', mockCallback5, { capture: false, passive: false }, 'mouse-group');
+
+    expect(service.boundedEvents.length).toBe(5);
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('keyup', mockCallback1, false);
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('keydown', mockCallback2, { capture: true, passive: true });
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('click', mockCallback3, { capture: true, passive: true });
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('mouseover', mockCallback4, { capture: false, passive: true }); // mouse-group
+    expect(mockElm1.addEventListener).toHaveBeenCalledWith('mouseout', mockCallback5, { capture: false, passive: false }); // mouse-group
+
+    service.unbindAll(['magic', 'mouse-group']);
+
+    expect(service.boundedEvents.length).toBe(2);
+    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith('keyup', mockCallback1);
+    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('keydown', mockCallback2); // magic
+    expect(mockElm1.removeEventListener).not.toHaveBeenCalledWith('click', mockCallback3);
+    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('mouseover', mockCallback4); // mouse-group
+    expect(mockElm1.removeEventListener).toHaveBeenCalledWith('mouseout', mockCallback5); // mouse-group
   });
 });

--- a/packages/common/src/services/bindingEvent.service.ts
+++ b/packages/common/src/services/bindingEvent.service.ts
@@ -13,43 +13,62 @@ export class BindingEventService {
   }
 
   /** Bind an event listener to any element */
-  bind(elementOrElements: Element | NodeListOf<Element> | Window, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) {
+  bind(elementOrElements: Element | NodeListOf<Element> | Window, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject, listenerOptions?: boolean | AddEventListenerOptions, groupName = '') {
+    // convert to array for looping in next task
     const eventNames = (Array.isArray(eventNameOrNames)) ? eventNameOrNames : [eventNameOrNames];
 
     if ((elementOrElements as NodeListOf<HTMLElement>)?.forEach) {
-      (elementOrElements as NodeListOf<HTMLElement>)?.forEach(element => {
+      // multiple elements to bind to
+      (elementOrElements as NodeListOf<HTMLElement>).forEach(element => {
         for (const eventName of eventNames) {
-          element.addEventListener(eventName, listener, options);
+          element.addEventListener(eventName, listener, listenerOptions);
           this._boundedEvents.push({ element, eventName, listener });
         }
       });
     } else {
+      // single elements to bind to
       for (const eventName of eventNames) {
-        (elementOrElements as Element).addEventListener(eventName, listener, options);
-        this._boundedEvents.push({ element: (elementOrElements as Element), eventName, listener });
+        (elementOrElements as Element).addEventListener(eventName, listener, listenerOptions);
+        this._boundedEvents.push({ element: (elementOrElements as Element), eventName, listener, groupName });
       }
     }
   }
 
-  /** Unbind all will remove every every event handlers that were bounded earlier */
+  /** Unbind a specific listener that was bounded earlier */
   unbind(elementOrElements: Element | NodeListOf<Element>, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject) {
+    // convert to array for looping in next task
     const elements = (Array.isArray(elementOrElements)) ? elementOrElements : [elementOrElements];
     const eventNames = Array.isArray(eventNameOrNames) ? eventNameOrNames : [eventNameOrNames];
+
     for (const eventName of eventNames) {
       for (const element of elements) {
-        if (element?.removeEventListener) {
+        if (typeof element?.removeEventListener === 'function') {
           element.removeEventListener(eventName, listener);
         }
       }
     }
   }
 
-  /** Unbind all will remove every every event handlers that were bounded earlier */
-  unbindAll() {
-    while (this._boundedEvents.length > 0) {
-      const boundedEvent = this._boundedEvents.pop() as ElementEventListener;
-      const { element, eventName, listener } = boundedEvent;
-      this.unbind(element, eventName, listener);
+  /**
+   * Unbind all event listeners that were bounded, optionally provide a group name to unbind all listeners assigned to that specific group only.
+   */
+  unbindAll(groupName?: string) {
+    if (groupName) {
+      // unbind only the bounded event with a specific group
+      this._boundedEvents.forEach((boundedEvent, idx) => {
+        if (boundedEvent.groupName === groupName) {
+          const { element, eventName, listener } = boundedEvent;
+          this.unbind(element, eventName, listener);
+          this._boundedEvents.splice(idx, 1);
+        }
+      });
+    } else {
+      // unbind everything
+      while (this._boundedEvents.length > 0) {
+        const boundedEvent = this._boundedEvents.pop() as ElementEventListener;
+        const { element, eventName, listener } = boundedEvent;
+        this.unbind(element, eventName, listener);
+      }
     }
   }
 }

--- a/packages/common/src/services/bindingEvent.service.ts
+++ b/packages/common/src/services/bindingEvent.service.ts
@@ -52,16 +52,20 @@ export class BindingEventService {
   /**
    * Unbind all event listeners that were bounded, optionally provide a group name to unbind all listeners assigned to that specific group only.
    */
-  unbindAll(groupName?: string) {
+  unbindAll(groupName?: string | string[]) {
     if (groupName) {
+      const groupNames = Array.isArray(groupName) ? groupName : [groupName];
+
       // unbind only the bounded event with a specific group
-      this._boundedEvents.forEach((boundedEvent, idx) => {
-        if (boundedEvent.groupName === groupName) {
+      // Note: we need to loop in reverse order to avoid array reindexing (causing index offset) after a splice is called
+      for (let i = this._boundedEvents.length - 1; i >= 0; --i) {
+        const boundedEvent = this._boundedEvents[i];
+        if (groupNames.some(g => g === boundedEvent.groupName)) {
           const { element, eventName, listener } = boundedEvent;
           this.unbind(element, eventName, listener);
-          this._boundedEvents.splice(idx, 1);
+          this._boundedEvents.splice(i, 1);
         }
-      });
+      }
     } else {
       // unbind everything
       while (this._boundedEvents.length > 0) {

--- a/test/cypress/e2e/example01.cy.ts
+++ b/test/cypress/e2e/example01.cy.ts
@@ -558,4 +558,134 @@ describe('Example 01 - Basic Grids', { retries: 1 }, () => {
       .find('[data-test=total-items]')
       .contains('19');
   });
+
+  it('should be able to open Grid Menu and click on Export->Text and expect alert triggered with Text Export', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.grid2')
+      .find('button.slick-grid-menu-button')
+      .click({ force: true });
+
+    cy.get('.slick-grid-menu.slick-menu-level-0 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Exports')
+      .click();
+
+    cy.get('.slick-grid-menu.slick-menu-level-1 .slick-menu-command-list')
+      .should('exist')
+      .find('.slick-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    cy.get('.slick-grid-menu.slick-menu-level-1 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Text (tab delimited)')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Text (tab delimited)'));
+  });
+
+  it('should be able to open Grid Menu and click on Export->Excel->xlsx and expect alert triggered with Excel (xlsx) Export', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const subCommands2 = ['Excel (csv)', 'Excel (xlsx)'];
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.grid2')
+      .find('button.slick-grid-menu-button')
+      .click({ force: true });
+
+    cy.get('.slick-grid-menu.slick-menu-level-0 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Exports')
+      .click();
+
+    cy.get('.slick-grid-menu.slick-menu-level-1 .slick-menu-command-list')
+      .should('exist')
+      .find('.slick-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    cy.get('.slick-submenu').should('have.length', 1);
+    cy.get('.slick-grid-menu.slick-menu-level-1 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Excel')
+      .click();
+
+    cy.get('.slick-grid-menu.slick-menu-level-2 .slick-menu-command-list').as('subMenuList2');
+
+    cy.get('@subMenuList2')
+      .find('.slick-menu-title')
+      .contains('available formats');
+
+    cy.get('@subMenuList2')
+      .should('exist')
+      .find('.slick-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
+    cy.get('.slick-submenu').should('have.length', 2);
+
+    cy.get('.slick-grid-menu.slick-menu-level-2 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Excel (xlsx)')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Exporting as Excel (xlsx)'));
+    cy.get('.slick-submenu').should('have.length', 0);
+  });
+
+  it('should open Export->Excel context sub-menu then open Feedback->ContactUs sub-menus and expect previous Export menu to no longer exists', () => {
+    const subCommands1 = ['Text', 'Excel'];
+    const subCommands2 = ['Request update from supplier', '', 'Contact Us'];
+    const subCommands2_1 = ['Email us', 'Chat with us', 'Book an appointment'];
+
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('[data-test="external-gridmenu2-btn"]')
+      .click();
+
+    cy.get('.slick-grid-menu.slick-menu-level-0 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Export')
+      .click();
+
+    cy.get('.slick-grid-menu.slick-menu-level-1 .slick-menu-command-list')
+      .should('exist')
+      .find('.slick-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands1[index]));
+
+    // click different sub-menu
+    cy.get('.slick-grid-menu.slick-menu-level-0')
+      .find('.slick-menu-item')
+      .contains('Feedback')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 1);
+    cy.get('.slick-grid-menu.slick-menu-level-1')
+      .should('exist')
+      .find('.slick-menu-item')
+      .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
+
+    // click on Feedback->ContactUs
+    cy.get('.slick-grid-menu.slick-menu-level-1.dropright') // right align
+      .find('.slick-menu-item')
+      .contains('Contact Us')
+      .should('exist')
+      .click();
+
+    cy.get('.slick-submenu').should('have.length', 2);
+    cy.get('.slick-grid-menu.slick-menu-level-2.dropleft') // left align
+      .should('exist')
+      .find('.slick-menu-item')
+      .each(($command, index) => expect($command.text()).to.eq(subCommands2_1[index]));
+
+    cy.get('.slick-grid-menu.slick-menu-level-2');
+
+    cy.get('.slick-grid-menu.slick-menu-level-2 .slick-menu-command-list')
+      .find('.slick-menu-item')
+      .contains('Chat with us')
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: contact-chat'));
+
+    cy.get('.slick-submenu').should('have.length', 0);
+  });
 });

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -459,7 +459,7 @@ describe('Example 04 - Frozen Grid', { retries: 0 }, () => {
 
   it('should open Export->Excel context sub-menu then open Feedback->ContactUs sub-menus and expect previous Export menu to no longer exists', () => {
     const subCommands1 = ['Text', 'Excel'];
-    const subCommands2 = ['Request update from shipping team', '', 'Contact Us'];
+    const subCommands2 = ['Request update from supplier', '', 'Contact Us'];
     const subCommands2_1 = ['Email us', 'Chat with us', 'Book an appointment'];
 
     const stub = cy.stub();

--- a/test/cypress/e2e/example07.cy.ts
+++ b/test/cypress/e2e/example07.cy.ts
@@ -1131,7 +1131,7 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', { retries
 
   it('should open Export->Excel sub-menu then open Feedback->ContactUs sub-menus and expect previous Export menu to no longer exists', () => {
     const subCommands1 = ['Text', 'Excel'];
-    const subCommands2 = ['Request update from shipping team', '', 'Contact Us'];
+    const subCommands2 = ['Request update from supplier', '', 'Contact Us'];
     const subCommands2_1 = ['Email us', 'Chat with us', 'Book an appointment'];
 
     const stub = cy.stub();


### PR DESCRIPTION
- currently only works by `click` event on sub-menus, the `mouseover` will be implemented in a future PR

#### TODOs
- [x] add full unit test coverage
- [x] add Cypress E2E tests
- [x] sub-menus events are leaking, it needs to be fixed before merging
- [x] it might be nice to add auto-align top/bottom especially for sub-menus
- [x] instead of creating GridMenu then hiding it in the DOM, we should create it on the fly and destroy it when closed, meaning that if the user never clicks on it then we will never add it to the DOM but the previous was creating a GridMenu (and ColumnPicker) for every grids in the page

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/7670317e-2073-4002-9380-e82a72dbbfbc)
