### PR TITLE
chore: move HeaderButton handler callback into SlickHeaderButton

### DIFF
--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -286,12 +286,6 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
         level > 0 ? 'sub-menu' : 'parent-menu'
       );
 
-      // Header Button can have an optional handler
-      if ((item as HeaderButtonItem).handler && !(item as HeaderButtonItem).disabled) {
-        this._bindEventService.bind(commandLiElm, 'click', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) =>
-          (item as HeaderButtonItem).handler!.call(this, e)) as EventListener);
-      }
-
       // the option/command item could be a sub-menu if it has another list of commands/options
       if ((item as MenuCommandItem).commandItems || (item as MenuOptionItem).optionItems) {
         const chevronElm = document.createElement('span');

--- a/packages/common/src/extensions/slickHeaderButtons.ts
+++ b/packages/common/src/extensions/slickHeaderButtons.ts
@@ -3,6 +3,7 @@ import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import type {
   Column,
   DOMEvent,
+  DOMMouseOrTouchEvent,
   HeaderButton,
   HeaderButtonItem,
   HeaderButtonOnCommandArgs,
@@ -96,6 +97,12 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
       while (i--) {
         const buttonItem = column.header.buttons[i];
         const itemElm = this.populateSingleCommandOrOptionItem('command', this.addonOptions, null, buttonItem, args, this.handleButtonClick.bind(this));
+
+        // Header Button can have an optional handler
+        if (itemElm && buttonItem.handler && !buttonItem.disabled) {
+          this._bindEventService.bind(itemElm, 'click', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) =>
+            buttonItem.handler!.call(this, e)) as EventListener);
+        }
 
         if (itemElm) {
           this._buttonElms.push(itemElm);


### PR DESCRIPTION
- instead of having special HeaderButton code inside `menuBaseClass` file, we can simply move the code to where it belongs which is in the dedicate SlickHeaderButtons file