### PR TITLE
feat: add `subMenuOpenByEvent` option to open sub-menus via mouseover

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -175,6 +175,7 @@ describe('CellMenu Plugin', () => {
       autoAdjustDropOffset: 0,
       autoAlignSideOffset: 0,
       hideMenuOnScroll: true,
+      subMenuOpenByEvent: 'mouseover'
     });
   });
 
@@ -627,7 +628,7 @@ describe('CellMenu Plugin', () => {
         const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
         const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
 
-        subCommands1Elm!.dispatchEvent(new Event('click'));
+        subCommands1Elm!.dispatchEvent(new Event('mouseover')); // mouseover or click should work
         const cellMenu2Elm = document.body.querySelector('.slick-cell-menu.slickgrid12345.slick-menu-level-1') as HTMLDivElement;
         const commandList2Elm = cellMenu2Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
         const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -658,6 +658,7 @@ describe('ContextMenu Plugin', () => {
 
       it('should create a Context Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element when sub-menu is clicked', () => {
         const actionMock = jest.fn();
+        const disposeSubMenuSpy = jest.spyOn(plugin, 'disposeSubMenus');
         jest.spyOn(getEditorLockMock, 'commitCurrentEdit').mockReturnValue(true);
 
         plugin.dispose();
@@ -668,6 +669,7 @@ describe('ContextMenu Plugin', () => {
 
         let contextMenu1Elm = document.body.querySelector('.slick-context-menu.slickgrid12345.slick-menu-level-0') as HTMLDivElement;
         const commandList1Elm = contextMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
+        const deleteRowCommandElm = commandList1Elm.querySelector('[data-command="delete-row"]') as HTMLDivElement;
         const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
         const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
         const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
@@ -706,6 +708,10 @@ describe('ContextMenu Plugin', () => {
         document.body.dispatchEvent(subCommandEvent);
         contextMenu2Elm = document.body.querySelector('.slick-context-menu.slickgrid12345.slick-menu-level-1') as HTMLDivElement;
         expect(contextMenu2Elm).toBeTruthy();
+
+        // calling another command on parent menu should dispose sub-menus
+        deleteRowCommandElm!.dispatchEvent(new Event('mouseover'));
+        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(4);
       });
 
       it('should create a Context Menu and expect the button click handler & "action" callback to be executed when defined', () => {

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -196,6 +196,7 @@ describe('ContextMenu Plugin', () => {
       hideMenuOnScroll: false,
       optionShownOverColumnIds: [],
       commandShownOverColumnIds: [],
+      subMenuOpenByEvent: 'mouseover'
     });
   });
 
@@ -677,7 +678,7 @@ describe('ContextMenu Plugin', () => {
         const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
         const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
 
-        subCommands2Elm!.dispatchEvent(new Event('click'));
+        subCommands2Elm!.dispatchEvent(new Event('mouseover')); // mouseover or click should work
         const contextMenu3Elm = document.body.querySelector('.slick-context-menu.slickgrid12345.slick-menu-level-2') as HTMLDivElement;
         const commandList3Elm = contextMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
         const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -935,7 +935,7 @@ describe('GridMenuControl', () => {
           const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
           const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
 
-          subCommands2Elm!.dispatchEvent(new Event('click'));
+          subCommands2Elm!.dispatchEvent(new Event('mouseover')); // mouseover or click should work
           const cellMenu3Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-2') as HTMLDivElement;
           const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
           const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -925,6 +925,7 @@ describe('GridMenuControl', () => {
           const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
           Object.defineProperty(commandList1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
           const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
+          const helpCommandElm = commandList1Elm.querySelector('[data-command="help"]') as HTMLDivElement;
           Object.defineProperty(subCommands1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
           const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
           const commandChevronElm = commandList1Elm.querySelector('.sub-item-chevron') as HTMLSpanElement;
@@ -957,9 +958,15 @@ describe('GridMenuControl', () => {
           subCommands1Elm!.dispatchEvent(new Event('click'));
           expect(disposeSubMenuSpy).toHaveBeenCalledTimes(0);
           const subCommands12Elm = commandList1Elm.querySelector('[data-command="sub-commands2"]') as HTMLDivElement;
-          subCommands12Elm!.dispatchEvent(new Event('click'));
+          subCommands12Elm!.dispatchEvent(new Event('mouseover'));
           expect(disposeSubMenuSpy).toHaveBeenCalledTimes(1);
           expect(disposeSubMenuSpy).toHaveBeenCalled();
+          subCommands1Elm!.dispatchEvent(new Event('mouseover'));
+          expect(disposeSubMenuSpy).toHaveBeenCalledTimes(2);
+
+          // calling another command on parent menu should dispose sub-menus
+          helpCommandElm!.dispatchEvent(new Event('mouseover'));
+          expect(disposeSubMenuSpy).toHaveBeenCalledTimes(3);
         });
 
         it('should create a Cell Menu item with commands sub-menu items and expect sub-menu list to show in the DOM element align right when sub-menu is clicked', () => {

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -155,6 +155,7 @@ describe('HeaderMenu Plugin', () => {
       hideSortCommands: false,
       minWidth: 100,
       title: '',
+      subMenuOpenByEvent: 'mouseover'
     });
   });
 
@@ -662,7 +663,7 @@ describe('HeaderMenu Plugin', () => {
         const subCommand3Elm = commandList2Elm.querySelector('[data-command="command3"]') as HTMLDivElement;
         const subCommands2Elm = commandList2Elm.querySelector('[data-command="more-sub-commands"]') as HTMLDivElement;
 
-        subCommands2Elm!.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+        subCommands2Elm!.dispatchEvent(new Event('mouseover', { bubbles: true, cancelable: true, composed: false })); // mouseover or click should work
         const cellMenu3Elm = document.body.querySelector('.slick-header-menu.slick-menu-level-2') as HTMLDivElement;
         const commandList3Elm = cellMenu3Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
         const subCommand5Elm = commandList3Elm.querySelector('[data-command="command5"]') as HTMLDivElement;

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -652,6 +652,7 @@ describe('HeaderMenu Plugin', () => {
         const headerMenu1Elm = gridContainerDiv.querySelector('.slick-header-menu.slick-menu-level-0') as HTMLDivElement;
         const commandList1Elm = headerMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
         Object.defineProperty(commandList1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
+        const helpCommandElm = commandList1Elm.querySelector('[data-command="help"]') as HTMLDivElement;
         const subCommands1Elm = commandList1Elm.querySelector('[data-command="sub-commands"]') as HTMLDivElement;
         Object.defineProperty(subCommands1Elm, 'clientWidth', { writable: true, configurable: true, value: 70 });
         const commandContentElm2 = subCommands1Elm.querySelector('.slick-menu-content') as HTMLDivElement;
@@ -688,6 +689,10 @@ describe('HeaderMenu Plugin', () => {
         subCommands12Elm!.dispatchEvent(new Event('click'));
         expect(disposeSubMenuSpy).toHaveBeenCalledTimes(2);
         expect(disposeSubMenuSpy).toHaveBeenCalled();
+
+        // calling another command on parent menu should dispose sub-menus
+        helpCommandElm!.dispatchEvent(new Event('mouseover'));
+        expect(disposeSubMenuSpy).toHaveBeenCalledTimes(3);
       });
 
       it('should create a Header Menu item with commands sub-menu commandItems and expect sub-menu list to show in the DOM element align right when sub-menu is clicked', () => {

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -38,6 +38,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
     autoAdjustDropOffset: 0,
     autoAlignSideOffset: 0,
     hideMenuOnScroll: true,
+    subMenuOpenByEvent: 'mouseover',
   } as unknown as CellMenuOption;
   pluginName: 'CellMenu' = 'CellMenu' as const;
 

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -43,6 +43,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
     hideMenuOnScroll: false,
     optionShownOverColumnIds: [],
     commandShownOverColumnIds: [],
+    subMenuOpenByEvent: 'mouseover',
   } as unknown as ContextMenuOption;
   pluginName: 'ContextMenu' = 'ContextMenu' as const;
 

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -63,6 +63,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     contentMinWidth: 0,
     resizeOnShowHeaderRow: false,
     syncResizeTitle: 'Synchronous resize',
+    subMenuOpenByEvent: 'mouseover',
     headerColumnValueExtractor: (columnDef: Column) => columnDef.name
   } as GridMenuOption;
 
@@ -879,8 +880,16 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         event.preventDefault();
         event.stopPropagation();
       } else if ((item as GridMenuItem).commandItems) {
-        this.repositionSubMenu(item, level, event);
+        this.repositionSubMenu(event, item, level);
       }
+    }
+  }
+
+  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0) {
+    if ((item as GridMenuItem).commandItems) {
+      this.repositionSubMenu(e, item, level);
+    } else if (level === 0) {
+      this.disposeSubMenus();
     }
   }
 
@@ -900,7 +909,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
 
       // when creating sub-menu also add its sub-menu title when exists
       if (item && level > 0) {
-        this.addSubMenuTitleWhenExists(item as GridMenuItem, commandMenuElm); // add sub-menu title when exists
+        this.addSubMenuTitleWhenExists(item as ExtractMenuType<ExtendableItemTypes, MenuType>, commandMenuElm); // add sub-menu title when exists
       }
 
       this.populateCommandOrOptionItems(
@@ -910,13 +919,14 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
         commandItems as Array<ExtractMenuType<ExtendableItemTypes, MenuType>>,
         callbackArgs,
         this.handleMenuItemCommandClick,
+        this.handleMenuItemMouseOver
       );
       return commandMenuElm;
     }
     return null;
   }
 
-  protected repositionSubMenu(item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number, e: DOMMouseOrTouchEvent<HTMLButtonElement | HTMLDivElement>) {
+  protected repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement>, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number) {
     // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
     const commandItems = (item as GridMenuItem)?.commandItems || [];
     const subMenuElm = this.createCommandMenu(commandItems as Array<GridMenuItem | 'divider'>, level + 1, item);

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -48,6 +48,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     hideColumnHideCommand: false,
     hideSortCommands: false,
     title: '',
+    subMenuOpenByEvent: 'mouseover',
   } as unknown as HeaderMenuOption;
   pluginName: 'HeaderMenu' = 'HeaderMenu' as const;
 
@@ -124,14 +125,14 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     this._activeHeaderColumnElm?.classList.remove('slick-header-column-active');
   }
 
-  repositionSubMenu(item: HeaderMenuCommandItem, columnDef: Column, level: number, e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement>, item: HeaderMenuCommandItem, level: number, columnDef: Column) {
     // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
     const subMenuElm = this.createCommandMenu(item.commandItems || item.items || [], columnDef, level + 1, item);
     document.body.appendChild(subMenuElm);
     this.repositionMenu(e, subMenuElm);
   }
 
-  repositionMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>, menuElm: HTMLDivElement) {
+  repositionMenu(e: DOMMouseOrTouchEvent<HTMLElement>, menuElm: HTMLDivElement) {
     const buttonElm = e.target as HTMLDivElement; // get header button createElement
     const isSubMenu = menuElm.classList.contains('slick-submenu');
     const parentElm = isSubMenu
@@ -315,8 +316,16 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
         event.preventDefault();
         event.stopPropagation();
       } else if ((item as HeaderMenuCommandItem).commandItems || (item as HeaderMenuCommandItem).items) {
-        this.repositionSubMenu(item as HeaderMenuCommandItem, columnDef as Column, level, event);
+        this.repositionSubMenu(event, item as HeaderMenuCommandItem, level, columnDef as Column);
       }
+    }
+  }
+
+  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column) {
+    if ((item as HeaderMenuCommandItem).commandItems || (item as HeaderMenuCommandItem).items) {
+      this.repositionSubMenu(e, item as HeaderMenuCommandItem, level, columnDef as Column);
+    } else if (level === 0) {
+      this.disposeSubMenus();
     }
   }
 
@@ -614,6 +623,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
       commandItems,
       callbackArgs,
       this.handleMenuItemCommandClick,
+      this.handleMenuItemMouseOver
     );
 
     // increment level for possible next sub-menus if exists

--- a/packages/common/src/interfaces/cellMenuOption.interface.ts
+++ b/packages/common/src/interfaces/cellMenuOption.interface.ts
@@ -71,6 +71,9 @@ export interface CellMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   // --
   // action/override callbacks
 

--- a/packages/common/src/interfaces/contextMenuOption.interface.ts
+++ b/packages/common/src/interfaces/contextMenuOption.interface.ts
@@ -119,6 +119,9 @@ export interface ContextMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   // --
   // action/override callbacks
 

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -139,6 +139,9 @@ export interface GridMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   /** Defaults to "Synchronous resize" which is 1 of the last 2 checkbox title shown at the end of the picker list */
   syncResizeTitle?: string;
 

--- a/packages/common/src/interfaces/headerMenuOption.interface.ts
+++ b/packages/common/src/interfaces/headerMenuOption.interface.ts
@@ -70,6 +70,9 @@ export interface HeaderMenuOption {
   /** CSS class that can be added on the right side of a sub-item parent (typically a chevron-right icon) */
   subItemChevronClass?: string;
 
+  /** Defaults to "mouseover", what event type shoud we use to open sub-menu(s), 2 options are available: "mouseover" or "click" */
+  subMenuOpenByEvent?: 'mouseover' | 'click';
+
   /** Menu item text. */
   title?: string;
 

--- a/test/cypress/e2e/example01.cy.ts
+++ b/test/cypress/e2e/example01.cy.ts
@@ -657,7 +657,7 @@ describe('Example 01 - Basic Grids', { retries: 1 }, () => {
       .find('.slick-menu-item')
       .contains('Feedback')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 1);
     cy.get('.slick-grid-menu.slick-menu-level-1')

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -497,7 +497,7 @@ describe('Example 04 - Frozen Grid', { retries: 1 }, () => {
       .find('.slick-menu-item .slick-menu-content')
       .contains('Contact Us')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 2);
     cy.get('.slick-context-menu.slick-menu-level-2.dropright') // right align

--- a/test/cypress/e2e/example07.cy.ts
+++ b/test/cypress/e2e/example07.cy.ts
@@ -1171,7 +1171,7 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', { retries
       .find('.slick-menu-item .slick-menu-content')
       .contains('Contact Us')
       .should('exist')
-      .click();
+      .trigger('mouseover'); // mouseover or click should work
 
     cy.get('.slick-submenu').should('have.length', 2);
     cy.get('.slick-cell-menu.slick-menu-level-2.dropright') // right align

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -201,7 +201,7 @@ describe('Example 14 - Columns Resize by Content', { retries: 1 }, () => {
       cy.get('.slick-menu-item.slick-menu-item')
         .contains('Hello')
         .should('exist')
-        .click();
+        .trigger('mouseover'); // mouseover or click should work
 
       cy.get('.slick-header-menu.slick-menu-level-1.dropright')
         .should('exist')
@@ -260,7 +260,7 @@ describe('Example 14 - Columns Resize by Content', { retries: 1 }, () => {
         .find('.slick-menu-item.slick-menu-item')
         .contains('Contact Us')
         .should('exist')
-        .click();
+        .trigger('mouseover'); // mouseover or click should work
 
       cy.get('.slick-submenu').should('have.length', 2);
       cy.get('.slick-header-menu.slick-menu-level-2.dropright') // right align


### PR DESCRIPTION
- when first implemented sub-menus, I thought it was complex to add open sub-menus via mouseover (not just click event) but it turns out to be quite easy with the latest code that was put in place for sub-menus. So this PR adds the mouseover option and does make it the default event (we have 2 options: `click` or `mouseover` and the latter is the default)
- this new mouseover will be the default but user could change it to work via click event only by changing the option to `subMenuOpenByEvent: 'click'` (instead of the default which is `subMenuOpenByEvent: 'mouseover'`)

![wLm68CTQhu](https://github.com/ghiscoding/slickgrid-universal/assets/643976/3c8eefc6-0fa9-4ba9-9af0-b2362cdf2e2a)
