### PR TITLE
feat: Graphql verbatim search terms

### DIFF
--- a/packages/common/src/interfaces/currentFilter.interface.ts
+++ b/packages/common/src/interfaces/currentFilter.interface.ts
@@ -16,4 +16,7 @@ export interface CurrentFilter {
 
   /** Target element selector from which the filter was triggered from. */
   targetSelector?: string;
+
+  /** If true, stringifies the search terms as is without modification */
+  verbatim?: boolean;
 }

--- a/packages/common/src/interfaces/currentFilter.interface.ts
+++ b/packages/common/src/interfaces/currentFilter.interface.ts
@@ -18,5 +18,5 @@ export interface CurrentFilter {
   targetSelector?: string;
 
   /** If true, stringifies the search terms as is without modification */
-  verbatim?: boolean;
+  verbatimSearchTerms?: boolean;
 }

--- a/packages/graphql/src/services/__tests__/graphql.service.spec.ts
+++ b/packages/graphql/src/services/__tests__/graphql.service.spec.ts
@@ -1239,21 +1239,21 @@ describe('GraphqlService', () => {
 
     describe("Verbatim ColumnFilters", () => {
       describe.each`
-        description                                         | verbatim | operator    | searchTerms            | expectation
-        ${"Verbatim false, Filter for null"}                | ${false} | ${'EQ'}     | ${null}                | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Filter for null"}                | ${true}  | ${'EQ'}     | ${null}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"null"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, Empty String"}                   | ${false} | ${'EQ'}     | ${''}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Empty String"}                   | ${true}  | ${'EQ'}     | ${''}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"\\"\\""}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, Empty List"}                     | ${false} | ${'IN'}     | ${[]}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Empty List"}                     | ${true}  | ${'IN'}     | ${[]}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, Filter for null (List version)"} | ${false} | ${'IN'}     | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Filter for null (List version)"} | ${true}  | ${'IN'}     | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[null]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, Empty String (List Version)"}    | ${false} | ${'IN'}     | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Empty String (List Version)"}    | ${true}  | ${'IN'}     | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, Filter for females"}             | ${false} | ${'IN'}     | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Filter for females"}             | ${true}  | ${'IN'}     | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, Filter for female/male"}         | ${false} | ${'IN'}     | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female, male"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  Filter for female/male"}         | ${true}  | ${'IN'}     | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\", \\"male\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        description                                             | verbatim | operator  | searchTerms            | expectation
+        ${"Verbatim false, Filter for null"}                    | ${false} | ${'EQ'}   | ${null}                | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for null"}                    | ${true}  | ${'EQ'}   | ${null}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"null"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Empty string"}                       | ${false} | ${'EQ'}   | ${''}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Empty string"}                       | ${true}  | ${'EQ'}   | ${''}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"\\"\\""}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Empty list"}                         | ${false} | ${'IN'}   | ${[]}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Empty list"}                         | ${true}  | ${'IN'}   | ${[]}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for null (in list)"}          | ${false} | ${'IN'}   | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for null (in list)"}          | ${true}  | ${'IN'}   | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[null]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for empty string (in list)"}  | ${false} | ${'IN'}   | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for empty string (in list)"}  | ${true}  | ${'IN'}   | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for female"}                  | ${false} | ${'IN'}   | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for female"}                  | ${true}  | ${'IN'}   | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for female/male"}             | ${false} | ${'IN'}   | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female, male"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for female/male"}             | ${true}  | ${'IN'}   | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\", \\"male\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
       `(`$description`, ({ description, verbatim, operator, searchTerms, expectation }) => {
 
         const mockColumn = { id: 'gender', field: 'gender' } as Column;
@@ -1261,7 +1261,7 @@ describe('GraphqlService', () => {
 
         beforeEach(() => {
           mockColumnFilters = {
-            gender: { columnId: 'gender', columnDef: mockColumn, searchTerms, operator, type: FieldType.string, verbatim },
+            gender: { columnId: 'gender', columnDef: mockColumn, searchTerms, operator, type: FieldType.string, verbatimSearchTerms: verbatim },
           } as ColumnFilters;
 
           service.init(serviceOptions, paginationOptions, gridStub);

--- a/packages/graphql/src/services/__tests__/graphql.service.spec.ts
+++ b/packages/graphql/src/services/__tests__/graphql.service.spec.ts
@@ -1239,31 +1239,29 @@ describe('GraphqlService', () => {
 
     describe("Verbatim ColumnFilters", () => {
       describe.each`
-        description                               | verbatim | searchTerms            | expectation
-        ${"Verbatim false, searchTerms: null"}    | ${false} | ${null}                | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  searchTerms: null"}    | ${true}  | ${null}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"null"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, searchTerms: ''"}      | ${false} | ${''}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  searchTerms: ''"}      | ${true}  | ${''}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"\\"\\""}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, searchTerms: []"}      | ${false} | ${[]}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  searchTerms: []"}      | ${true}  | ${[]}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, searchTerms: [null]"}  | ${false} | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  searchTerms: [null]"}  | ${true}  | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[null]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, searchTerms: [null]"}  | ${false} | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  searchTerms: [null]"}  | ${true}  | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, 1 search term"}        | ${false} | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  1 search term"}        | ${true}  | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim false, 2 search terms"}       | ${false} | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female, male"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-        ${"Verbatim true,  2 search terms"}       | ${true}  | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\", \\"male\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
-
-
-      `(`$description`, ({ description, verbatim, searchTerms, expectation }) => {
+        description                                         | verbatim | operator    | searchTerms            | expectation
+        ${"Verbatim false, Filter for null"}                | ${false} | ${'EQ'}     | ${null}                | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for null"}                | ${true}  | ${'EQ'}     | ${null}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"null"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Empty String"}                   | ${false} | ${'EQ'}     | ${''}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Empty String"}                   | ${true}  | ${'EQ'}     | ${''}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"\\"\\""}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Empty List"}                     | ${false} | ${'IN'}     | ${[]}                  | ${'query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Empty List"}                     | ${true}  | ${'IN'}     | ${[]}                  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for null (List version)"} | ${false} | ${'IN'}     | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for null (List version)"} | ${true}  | ${'IN'}     | ${[null]}              | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[null]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Empty String (List Version)"}    | ${false} | ${'IN'}     | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:""}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Empty String (List Version)"}    | ${true}  | ${'IN'}     | ${['']}                | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for females"}             | ${false} | ${'IN'}     | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for females"}             | ${true}  | ${'IN'}     | ${['female']}          | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim false, Filter for female/male"}         | ${false} | ${'IN'}     | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"female, male"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+        ${"Verbatim true,  Filter for female/male"}         | ${true}  | ${'IN'}     | ${['female', 'male']}  | ${'query{users(first:10, offset:0, filterBy:[{field:gender, operator:IN, value:"[\\"female\\", \\"male\\"]"}]) { totalCount,nodes{ id,company,gender,name } }}'}
+      `(`$description`, ({ description, verbatim, operator, searchTerms, expectation }) => {
 
         const mockColumn = { id: 'gender', field: 'gender' } as Column;
         let mockColumnFilters: ColumnFilters;
 
         beforeEach(() => {
           mockColumnFilters = {
-            gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: searchTerms, operator: 'IN', type: FieldType.string, verbatim: verbatim },
+            gender: { columnId: 'gender', columnDef: mockColumn, searchTerms, operator, type: FieldType.string, verbatim },
           } as ColumnFilters;
 
           service.init(serviceOptions, paginationOptions, gridStub);

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -407,7 +407,7 @@ export class GraphqlService implements BackendService {
           throw new Error(`GraphQL filter could not find the field name to query the search, your column definition must include a valid "field" or "name" (optionally you can also use the "queryfield").`);
         }
 
-        if (columnFilter.verbatim) {
+        if (columnFilter.verbatimSearchTerms) {
           searchByArray.push({ field: fieldName, operator: columnFilter.operator, value: JSON.stringify(columnFilter.searchTerms) });
           continue;
         }

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -407,6 +407,11 @@ export class GraphqlService implements BackendService {
           throw new Error(`GraphQL filter could not find the field name to query the search, your column definition must include a valid "field" or "name" (optionally you can also use the "queryfield").`);
         }
 
+        if (columnFilter.verbatim) {
+          searchByArray.push({ field: fieldName, operator: columnFilter.operator, value: JSON.stringify(columnFilter.searchTerms) });
+          continue;
+        }
+
         fieldSearchValue = (fieldSearchValue === undefined || fieldSearchValue === null) ? '' : `${fieldSearchValue}`; // make sure it's a string
 
         // run regex to find possible filter operators unless the user disabled the feature


### PR DESCRIPTION
==== Purpose of this PR ===
A PR to use filter search terms in a query "verbatim" without modification

Currently the backendService `updateFilters()` performs some manipulation of the columnFilter.searchTerms property. The flag on the column `columnFilter.verbatimSearchTerms` bypasses this manipulation and stringifies the search terms "as is".

Some examples of problematic manipulation are searching for columns that can be nullable
```
{ columnId: 'x', operator: 'in', searchTerms: 'null}
// Current: 
query{users(first:10, offset:0) { totalCount,nodes{ id,company,gender,name } }}
// withVerbatim:
query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"null"}]) { totalCount,nodes{ id,company,gender,name } }} 
```

Please see unit tests for more output differences.

=== Usage ===
```
{
    columnId: "gender",
    operator: OperatorType.in,
    searchTerms: this.genders, // supports ['male'], ['female'], ['male'/'female'], []    
    verbatimSearchTerms: true,
} as any,
```

I did consider putting the flag on the backend service instead of the column, but it's possible that different backend end points may want to treat properties differently for backwards compatibility. By putting the flag on the column itself it allows for more flexibility.

=== TODO ===
Currently this flag is only respected on the graphqlService. This needs to be applied to other backend services.