### PR TITLE
fix(common): SlickCellRangeSelector shouldn't stop editor event bubbling

### DIFF
--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -138,10 +138,7 @@ export class CheckboxEditor implements Editor {
   focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
-
-    if (this._input) {
-      this._input.focus();
-    }
+    this._input?.focus();
   }
 
   /** pre-click, when enabled, will simply toggle the checkbox without requiring to double-click */

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -160,10 +160,7 @@ export class InputEditor implements Editor {
   focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
-
-    if (this._input) {
-      this._input.focus();
-    }
+    this._input?.focus();
   }
 
   show() {

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -159,10 +159,7 @@ export class SliderEditor implements Editor {
   focus() {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
-
-    if (this._inputElm) {
-      this._inputElm.focus();
-    }
+    this._inputElm?.focus();
   }
 
   show() {

--- a/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
@@ -19,6 +19,11 @@ const mockGridOptions = {
   rowHeight: 30,
 } as GridOption;
 
+const getEditorLockMock = {
+  commitCurrentEdit: jest.fn(),
+  isActive: jest.fn(),
+};
+
 const gridStub = {
   canCellBeSelected: jest.fn(),
   getAbsoluteColumnMinWidth: jest.fn(),
@@ -30,6 +35,7 @@ const gridStub = {
   getCellFromPoint: jest.fn(),
   getCellNodeBox: jest.fn(),
   getDisplayedScrollbarDimensions: jest.fn(),
+  getEditorLock: () => getEditorLockMock,
   getOptions: () => mockGridOptions,
   getUID: () => GRID_UID,
   focus: jest.fn(),
@@ -69,6 +75,8 @@ describe('CellRangeSelector Plugin', () => {
   beforeEach(() => {
     plugin = new SlickCellRangeSelector();
     jest.spyOn(gridStub, 'getCellFromPoint').mockReturnValue({ cell: 4, row: 5 });
+    jest.spyOn(gridStub.getEditorLock(), 'isActive').mockReturnValue(false);
+    jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit').mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -122,7 +130,7 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
 
     plugin.init(gridStub);
     const decoratorHideSpy = jest.spyOn(plugin.getCellDecorator(), 'hide');
@@ -166,7 +174,7 @@ describe('CellRangeSelector Plugin', () => {
     const scrollSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
     jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
 
     plugin.init(gridStub);
     const decoratorShowSpy = jest.spyOn(plugin.getCellDecorator(), 'show');
@@ -209,7 +217,7 @@ describe('CellRangeSelector Plugin', () => {
     const scrollSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
     const onBeforeCellSpy = jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
 
     plugin.init(gridStub);
     const decoratorShowSpy = jest.spyOn(plugin.getCellDecorator(), 'show');
@@ -254,10 +262,10 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     const onBeforeCellRangeSpy = jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const onCellRangeSpy = jest.spyOn(plugin.onCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
 
     plugin.init(gridStub);
     const decoratorHideSpy = jest.spyOn(plugin.getCellDecorator(), 'hide');
@@ -312,10 +320,10 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     const onBeforeCellRangeSpy = jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const onCellRangeSpy = jest.spyOn(plugin.onCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const scrollSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
     const onCellRangeSelectingSpy = jest.spyOn(plugin.onCellRangeSelecting, 'notify');
 
@@ -366,10 +374,10 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     const onBeforeCellRangeSpy = jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const onCellRangeSpy = jest.spyOn(plugin.onCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const scrollSpy = jest.spyOn(gridStub, 'scrollCellIntoView');
     const onCellRangeSelectingSpy = jest.spyOn(plugin.onCellRangeSelecting, 'notify');
 
@@ -428,7 +436,7 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     const onBeforeCellRangeSpy = jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
 
     plugin.init(gridStub);
     const decoratorShowSpy = jest.spyOn(plugin.getCellDecorator(), 'show');
@@ -475,7 +483,7 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     const onBeforeCellRangeSpy = jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
 
     plugin.init(gridStub);
     const decoratorShowSpy = jest.spyOn(plugin.getCellDecorator(), 'show');
@@ -527,7 +535,7 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const getCellFromPointSpy = jest.spyOn(gridStub, 'getCellFromPoint');
     const onCellRangeSelectingSpy = jest.spyOn(plugin.onCellRangeSelecting, 'notify');
 
@@ -582,7 +590,7 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const getCellFromPointSpy = jest.spyOn(gridStub, 'getCellFromPoint');
     const onCellRangeSelectingSpy = jest.spyOn(plugin.onCellRangeSelecting, 'notify');
 
@@ -645,7 +653,7 @@ describe('CellRangeSelector Plugin', () => {
     const focusSpy = jest.spyOn(gridStub, 'focus');
     jest.spyOn(plugin.onBeforeCellRangeSelected, 'notify').mockReturnValue({
       getReturnValue: () => true
-    });
+    } as any);
     const getCellFromPointSpy = jest.spyOn(gridStub, 'getCellFromPoint');
     const onCellRangeSelectingSpy = jest.spyOn(plugin.onCellRangeSelecting, 'notify');
 

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -344,8 +344,11 @@ export class SlickCellRangeSelector {
     }
 
     // prevent the grid from cancelling drag'n'drop by default
-    e.stopImmediatePropagation();
-    e.preventDefault();
+    // unless an editor is open if so keep bubbling the event to avoid breaking editor inputs focusing/selecting
+    if (!this._grid.getEditorLock().isActive()) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
   }
 
   protected handleDragStart(e: DOMMouseOrTouchEvent<HTMLDivElement>, dd: DragPosition) {


### PR DESCRIPTION
- when opening an editor while clicking the cell is actually triggering the SlickCellRangeSelector dragInit which was cancelling event bubbling and was breaking editor input usability
- this issue was reported in Angular-Slickgrid [issue 1303](https://github.com/ghiscoding/Angular-Slickgrid/issues/1303)

#### before fix (with bug)

![msedge_rFhugkCLfZ](https://github.com/ghiscoding/slickgrid-universal/assets/643976/64a7ff77-ef11-4d16-8c00-f98e9faddd2b)

#### after fix

![msedge_4nAd3Y2Ung](https://github.com/ghiscoding/slickgrid-universal/assets/643976/21f6cabe-1e00-4642-b29c-da8d2951f6db)
