### PR TITLE
fix: improve build & types exports for all targets, Node, CJS/ESM

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -27,7 +27,7 @@
     "fetch-jsonp": "^1.3.0",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^0.6.1",
+    "multiple-select-vanilla": "^0.6.2",
     "rxjs": "^7.8.1",
     "whatwg-fetch": "^3.6.19"
   },

--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/binding",
   "version": "3.5.0",
   "description": "Simple Vanilla Implementation of a Binding Engine & Helper to add properties/events 2 way bindings",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/common",
   "version": "3.5.0",
   "description": "SlickGrid-Universal Common Code",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "license": "MIT",
   "author": "Ghislain B.",
   "homepage": "https://github.com/ghiscoding/slickgrid-universal",
@@ -78,7 +79,7 @@
     "dompurify": "^3.0.6",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^0.6.1",
+    "multiple-select-vanilla": "^0.6.2",
     "slickgrid": "^4.1.3",
     "sortablejs": "^1.15.0",
     "un-flatten-tree": "^2.0.12"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,7 @@
       "require": "./dist/commonjs/index.js",
       "default": "./dist/esm/index.js"
     },
+    "./dist/styles/*": "./dist/styles/*",
     "./package.json": "./package.json"
   },
   "license": "MIT",

--- a/packages/composite-editor-component/package.json
+++ b/packages/composite-editor-component/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/composite-editor-component",
   "version": "3.5.0",
   "description": "Slick Composite Editor Component - Vanilla Implementation of a Composite Editor Modal Window Component",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-footer-component/package.json
+++ b/packages/custom-footer-component/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/custom-footer-component",
   "version": "3.5.0",
   "description": "Slick Custom Footer Component - Vanilla Implementation of a Custom Footer Component",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-tooltip-plugin/package.json
+++ b/packages/custom-tooltip-plugin/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/custom-tooltip-plugin",
   "version": "3.5.0",
   "description": "A plugin to add Custom Tooltip when hovering a cell, it subscribes to the cell",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -1,14 +1,15 @@
 import { delay, of, throwError } from 'rxjs';
-import { Column, GridOption, SlickDataView, SlickGrid, SlickNamespace, SharedService, } from '@slickgrid-universal/common';
-import * as utilities from '@slickgrid-universal/common/dist/commonjs/services/utilities';
+import { Column, getHtmlElementOffset, GridOption, SlickDataView, SlickGrid, SlickNamespace, SharedService, } from '@slickgrid-universal/common';
 
 import { SlickCustomTooltip } from '../slickCustomTooltip';
 import { ContainerServiceStub } from '../../../../test/containerServiceStub';
 import { RxJsResourceStub } from '../../../../test/rxjsResourceStub';
 
-const mockGetHtmlElementOffset = jest.fn();
-// @ts-ignore:2540
-utilities.getHtmlElementOffset = mockGetHtmlElementOffset;
+// mocked modules
+jest.mock('@slickgrid-universal/common', () => ({
+  ...(jest.requireActual('@slickgrid-universal/common') as any),
+  getHtmlElementOffset: jest.fn(),
+}));
 
 declare const Slick: SlickNamespace;
 const GRID_UID = 'slickgrid12345';
@@ -474,7 +475,7 @@ describe('SlickCustomTooltip plugin', () => {
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
     jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
     jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
-    mockGetHtmlElementOffset.mockReturnValue({ top: 100, left: 1030, height: 75, width: 400 }); // mock cell position
+    (getHtmlElementOffset as any).mockReturnValue({ top: 100, left: 1030, height: 75, width: 400 }); // mock cell position
 
     plugin.init(gridStub, container);
     plugin.setOptions({
@@ -589,7 +590,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('name title tooltip');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseEnter" is triggered', () => {
@@ -618,7 +619,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header tooltip text');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseEnter" is triggered', () => {
@@ -647,6 +648,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header row tooltip text');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 });

--- a/packages/empty-warning-component/package.json
+++ b/packages/empty-warning-component/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/empty-warning-component",
   "version": "3.5.0",
   "description": "Slick Empty Warning Component - Vanilla Implementation of an Empty Dataset Warning Component",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/event-pub-sub/package.json
+++ b/packages/event-pub-sub/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/event-pub-sub",
   "version": "3.4.0",
   "description": "Simple Vanilla Implementation of an Event PubSub Service to do simply publish/subscribe inter-communication while optionally providing data in the event",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/excel-export/package.json
+++ b/packages/excel-export/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/excel-export",
   "version": "3.5.0",
   "description": "Excel Export (xls/xlsx) Service.",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/graphql",
   "version": "3.5.0",
   "description": "GraphQL Service to sync a grid with a GraphQL backend server",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/odata/package.json
+++ b/packages/odata/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/odata",
   "version": "3.5.0",
   "description": "Grid OData Service to sync a grid with an OData backend server",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pagination-component/package.json
+++ b/packages/pagination-component/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/pagination-component",
   "version": "3.5.0",
   "description": "Slick Pagination Component - Vanilla Implementation of a Pagination Component",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/row-detail-view-plugin/package.json
+++ b/packages/row-detail-view-plugin/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/row-detail-view-plugin",
   "version": "3.5.0",
   "description": "SlickRowDetail plugin - A plugin to add Row Detail Panel",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rxjs-observable/package.json
+++ b/packages/rxjs-observable/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/rxjs-observable",
   "version": "3.5.0",
   "description": "RxJS Observable Wrapper",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/text-export/package.json
+++ b/packages/text-export/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/text-export",
   "version": "3.5.0",
   "description": "Export to Text File (csv/txt) Service.",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/utils",
   "version": "3.4.0",
   "description": "Common set of small utilities",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/vanilla-bundle",
   "version": "3.5.0",
   "description": "Vanilla Slick Grid Bundle - Framework agnostic the output is to be used in vanilla JS/TS - Written in TypeScript and we also use Vite to bundle everything into a single JS file.",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1,6 +1,7 @@
 import 'jest-extended';
 import { of, throwError } from 'rxjs';
 import {
+  autoAddEditorFormatterToColumnsWithEditor,
   BackendServiceApi,
   BackendUtilityService,
   Column,
@@ -44,7 +45,6 @@ import {
 } from '@slickgrid-universal/common';
 import { GraphqlService, GraphqlPaginatedResult, GraphqlServiceApi, GraphqlServiceOption } from '@slickgrid-universal/graphql';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
-import * as formatterUtilities from '@slickgrid-universal/common/dist/commonjs/formatters/formatterUtilities';
 
 import { SlickVanillaGridBundle } from '../slick-vanilla-grid-bundle';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
@@ -53,8 +53,10 @@ import { MockSlickEvent, MockSlickEventHandler } from '../../../../../test/mockS
 import { UniversalContainerService } from '../../services/universalContainer.service';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub';
 
-const mockAutoAddCustomEditorFormatter = jest.fn();
-(formatterUtilities.autoAddEditorFormatterToColumnsWithEditor as any) = mockAutoAddCustomEditorFormatter;
+jest.mock('@slickgrid-universal/common', () => ({
+  ...(jest.requireActual('@slickgrid-universal/common') as any),
+  autoAddEditorFormatterToColumnsWithEditor: jest.fn(),
+}));
 
 declare const Slick: any;
 const slickEventHandler = new MockSlickEventHandler() as unknown as SlickEventHandler;
@@ -460,12 +462,10 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
     describe('autoAddCustomEditorFormatter grid option', () => {
       it('should initialize the grid and automatically add custom Editor Formatter when provided in the grid options', () => {
-        const autoAddFormatterSpy = jest.spyOn(formatterUtilities, 'autoAddEditorFormatterToColumnsWithEditor');
-
         component.gridOptions = { autoAddCustomEditorFormatter: customEditableInputFormatter };
         component.initialization(divContainer, slickEventHandler);
 
-        expect(autoAddFormatterSpy).toHaveBeenCalledWith([{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }], customEditableInputFormatter);
+        expect(autoAddEditorFormatterToColumnsWithEditor).toHaveBeenCalledWith([{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }], customEditableInputFormatter);
       });
     });
 
@@ -497,7 +497,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const renderSpy = jest.spyOn(extensionServiceStub, 'renderColumnHeaders');
         const eventSpy = jest.spyOn(eventPubSubService, 'publish');
         const addPubSubSpy = jest.spyOn(component.translaterService as TranslaterService, 'addPubSubMessaging');
-        const autoAddFormatterSpy = jest.spyOn(formatterUtilities, 'autoAddEditorFormatterToColumnsWithEditor');
         const mockColDefs = [{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }];
 
         component.gridOptions = { enableTranslate: false, autoAddCustomEditorFormatter: customEditableInputFormatter };
@@ -510,7 +509,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(eventSpy).toHaveBeenCalledTimes(4);
         expect(updateSpy).toHaveBeenCalledWith(mockColDefs);
         expect(renderSpy).toHaveBeenCalledWith(mockColDefs, true);
-        expect(autoAddFormatterSpy).toHaveBeenCalledWith([{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }], customEditableInputFormatter);
+        expect(autoAddEditorFormatterToColumnsWithEditor).toHaveBeenCalledWith([{ id: 'name', field: 'name', editor: undefined, internalColumnEditor: {} }], customEditableInputFormatter);
       });
     });
 

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -2,24 +2,25 @@
   "name": "@slickgrid-universal/vanilla-force-bundle",
   "version": "3.5.0",
   "description": "Vanilla Slick Grid Bundle (mostly exist for our Salesforce implementation) - Similar to Vanilla Bundle, the only difference is that it adds extra packages within its bundle (CustomTooltip, CompositeEditor & TextExport)",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/commonjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
   "typesVersions": {
-    "*": {
+    ">=4.2": {
       "*": [
-        "./dist/types/index.d.ts"
+        "dist/types/*"
       ]
     }
   },
-  "types": "dist/types/index.d.ts",
-  "main": "dist/commonjs/index.js",
-  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -6,7 +6,6 @@ import {
   ExtensionService,
   ExtensionUtility,
   FilterService,
-  Formatter,
   GridEventService,
   GridOption,
   GridService,
@@ -31,15 +30,11 @@ import { SlickCompositeEditorComponent } from '@slickgrid-universal/composite-ed
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { TextExportService } from '@slickgrid-universal/text-export';
 import { UniversalContainerService } from '@slickgrid-universal/vanilla-bundle';
-import * as formatterUtilities from '@slickgrid-universal/common/dist/commonjs/formatters/formatterUtilities';
 
 import { VanillaForceGridBundle } from '../vanilla-force-bundle';
 import { TranslateServiceStub } from '../../../../test/translateServiceStub';
 import { MockSlickEvent, MockSlickEventHandler } from '../../../../test/mockSlickEvent';
 import { RxJsResourceStub } from '../../../../test/rxjsResourceStub';
-
-const mockAutoAddCustomEditorFormatter = jest.fn();
-(formatterUtilities.autoAddEditorFormatterToColumnsWithEditor as any) = mockAutoAddCustomEditorFormatter;
 
 declare const Slick: any;
 const slickEventHandler = new MockSlickEventHandler() as unknown as SlickEventHandler;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -229,8 +229,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       slickgrid:
         specifier: ^4.1.3
         version: 4.1.3
@@ -7098,8 +7098,8 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /multiple-select-vanilla@0.6.1:
-    resolution: {integrity: sha512-Go9ObwfAfBhN+RoAb9E2hSCyJ2sXC+H+3uETrCZ7WUYMbQleaYSum9MVYci/0+3MWzXSKeG2Wh5t5EwRSc4Ypg==}
+  /multiple-select-vanilla@0.6.2:
+    resolution: {integrity: sha512-BxN/Jh796aOzOi8oMyMlAqnvUbXKWNl8I+4zDRLNXT0vxMy3MjdR3wjZ7r+FVRMUb2VdYfZ1MODfgE1T3JohPw==}
     dev: false
 
   /mute-stream@1.0.0:


### PR DESCRIPTION
- previous implementation didn't pass all type exports as can be shown in [Are the types wrong?](https://arethetypeswrong.github.io/?p=%40slickgrid-universal%2Fcommon%403.5.0) website, already applied the changes in `multiple-select-vanilla` library with a much greater success
- better approach came from RxJS [package.json](https://github.com/ReactiveX/rxjs/blob/master/packages/rxjs/package.json) great implementation of it

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/ddc51b63-8581-4871-b1da-5f484a2ead6b)
