### PR TITLE
chore: remove leftover jQuery animations in all toggle methods

### DIFF
--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -830,23 +830,6 @@ export class Utils {
     }
   }
 
-  public static slideUp(el: HTMLElement | HTMLElement[], callback: () => void) {
-    return Utils.slideAnimation(el, 'slideUp', callback);
-  }
-
-  public static slideDown(el: HTMLElement | HTMLElement[], callback: () => void) {
-    return Utils.slideAnimation(el, 'slideDown', callback);
-  }
-
-  public static slideAnimation(el: HTMLElement | HTMLElement[], slideDirection: 'slideDown' | 'slideUp', callback: () => void) {
-    if ((window as any).jQuery !== undefined) {
-      (window as any).jQuery(el)[slideDirection]('fast', callback);
-      return;
-    }
-    (slideDirection === 'slideUp') ? Utils.hide(el) : Utils.show(el);
-    callback();
-  }
-
   public static applyDefaults(targetObj: any, srcObj: any) {
     for (const key in srcObj) {
       if (srcObj.hasOwnProperty(key) && !targetObj.hasOwnProperty(key)) {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3621,23 +3621,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return !Array.isArray(this.data);
   }
 
-  protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean, animate?: boolean) {
-    const animated = (animate === false) ? false : true;
-
+  protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean) {
     if (this._options[option] !== visible) {
       this._options[option] = visible as boolean;
       if (visible) {
-        if (animated) {
-          Utils.slideDown(container, this.resizeCanvas.bind(this));
-          return;
-        }
         Utils.show(container);
         this.resizeCanvas();
       } else {
-        if (animated) {
-          Utils.slideUp(container, this.resizeCanvas.bind(this));
-          return;
-        }
         Utils.hide(container);
         this.resizeCanvas();
       }
@@ -3645,48 +3635,43 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /**
-   * Set the Top Panel Visibility and optionally enable/disable animation (enabled by default)
+   * Set the Top Panel Visibility
    * @param {Boolean} [visible] - optionally set if top panel is visible or not
-   * @param {Boolean} [animate] - optionally enable an animation while toggling the panel
    */
-  setTopPanelVisibility(visible?: boolean, animate?: boolean) {
-    this.togglePanelVisibility('showTopPanel', this._topPanelScrollers, visible, animate);
+  setTopPanelVisibility(visible?: boolean) {
+    this.togglePanelVisibility('showTopPanel', this._topPanelScrollers, visible);
   }
 
   /**
-   * Set the Header Row Visibility and optionally enable/disable animation (enabled by default)
+   * Set the Header Row Visibility
    * @param {Boolean} [visible] - optionally set if header row panel is visible or not
-   * @param {Boolean} [animate] - optionally enable an animation while toggling the panel
    */
-  setHeaderRowVisibility(visible?: boolean, animate?: boolean) {
-    this.togglePanelVisibility('showHeaderRow', this._headerRowScroller, visible, animate);
+  setHeaderRowVisibility(visible?: boolean) {
+    this.togglePanelVisibility('showHeaderRow', this._headerRowScroller, visible);
   }
 
   /**
-   * Set the Column Header Visibility and optionally enable/disable animation (enabled by default)
+   * Set the Column Header Visibility
    * @param {Boolean} [visible] - optionally set if column header is visible or not
-   * @param {Boolean} [animate] - optionally enable an animation while toggling the panel
    */
-  setColumnHeaderVisibility(visible?: boolean, animate?: boolean) {
-    this.togglePanelVisibility('showColumnHeader', this._headerScroller, visible, animate);
+  setColumnHeaderVisibility(visible?: boolean) {
+    this.togglePanelVisibility('showColumnHeader', this._headerScroller, visible);
   }
 
   /**
-   * Set the Footer Visibility and optionally enable/disable animation (enabled by default)
+   * Set the Footer Visibility
    * @param {Boolean} [visible] - optionally set if footer row panel is visible or not
-   * @param {Boolean} [animate] - optionally enable an animation while toggling the panel
    */
-  setFooterRowVisibility(visible?: boolean, animate?: boolean) {
-    this.togglePanelVisibility('showFooterRow', this._footerRowScroller, visible, animate);
+  setFooterRowVisibility(visible?: boolean) {
+    this.togglePanelVisibility('showFooterRow', this._footerRowScroller, visible);
   }
 
   /**
-   * Set the Pre-Header Visibility and optionally enable/disable animation (enabled by default)
+   * Set the Pre-Header Visibility
    * @param {Boolean} [visible] - optionally set if pre-header panel is visible or not
-   * @param {Boolean} [animate] - optionally enable an animation while toggling the panel
    */
-  setPreHeaderPanelVisibility(visible?: boolean, animate?: boolean) {
-    this.togglePanelVisibility('showPreHeaderPanel', [this._preHeaderPanelScroller, this._preHeaderPanelScrollerR], visible, animate);
+  setPreHeaderPanelVisibility(visible?: boolean) {
+    this.togglePanelVisibility('showPreHeaderPanel', [this._preHeaderPanelScroller, this._preHeaderPanelScrollerR], visible);
   }
 
   /** Get Grid Canvas Node DOM Element */

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -29,7 +29,6 @@ export const GlobalGridOptions: Partial<GridOption> = {
   },
   columnGroupSeparator: ' - ',
   columnPicker: {
-    fadeSpeed: 0,
     hideForceFitButton: false,
     hideSyncResizeButton: true,
     headerColumnValueExtractor: pickerHeaderColumnValueExtractor

--- a/packages/common/src/interfaces/columnPicker.interface.ts
+++ b/packages/common/src/interfaces/columnPicker.interface.ts
@@ -21,9 +21,6 @@ export interface ColumnPickerOption {
   /** Defaults to "Force fit columns" which is 1 of the last 2 checkbox title shown at the end of the picker list */
   forceFitTitle?: string;
 
-  /** Animation fade speed when opening/closing the column picker */
-  fadeSpeed?: number;
-
   /** Defaults to True, show/hide 1 of the last 2 checkbox at the end of the picker list */
   hideForceFitButton?: boolean;
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1647,7 +1647,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.showHeaderRow(true);
 
-        expect(setHeaderRowSpy).toHaveBeenCalledWith(true, false);
+        expect(setHeaderRowSpy).toHaveBeenCalledWith(true);
         expect(setColumnSpy).toHaveBeenCalledTimes(1);
       });
 
@@ -1658,7 +1658,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.showHeaderRow(false);
 
-        expect(setHeaderRowSpy).toHaveBeenCalledWith(false, false);
+        expect(setHeaderRowSpy).toHaveBeenCalledWith(false);
         expect(setColumnSpy).not.toHaveBeenCalled();
       });
     });

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1069,7 +1069,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * @param showing
    */
   showHeaderRow(showing = true) {
-    this.slickGrid?.setHeaderRowVisibility(showing, false);
+    this.slickGrid?.setHeaderRowVisibility(showing);
     if (this.slickGrid && showing === true && this._isGridInitialized) {
       this.slickGrid.setColumns(this.columnDefinitions);
     }

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -617,7 +617,7 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.showHeaderRow(true);
 
-        expect(setHeaderRowSpy).toHaveBeenCalledWith(true, false);
+        expect(setHeaderRowSpy).toHaveBeenCalledWith(true);
         expect(setColumnSpy).toHaveBeenCalledTimes(1);
       });
 
@@ -628,7 +628,7 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.showHeaderRow(false);
 
-        expect(setHeaderRowSpy).toHaveBeenCalledWith(false, false);
+        expect(setHeaderRowSpy).toHaveBeenCalledWith(false);
         expect(setColumnSpy).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
- remove leftover jQuery slide/fade animations in all toggle methods, use CSS animation instead. We are removing the last `animate` boolean argument on all methods
  - `setTopPanelVisibility`
  - `setHeaderRowVisibility`
  - `setColumnHeaderVisibility`
  - `setFooterRowVisibility`
  - `setPreHeaderPanelVisibility`