### PR TITLE
chore: add slickCore & slickInteractions full unit tests coverage

### DIFF
--- a/packages/common/src/aggregators/countAggregator.ts
+++ b/packages/common/src/aggregators/countAggregator.ts
@@ -72,7 +72,7 @@ export class CountAggregator implements Aggregator {
       // when dealing with Tree Data, we also need to take the parent's total and add it to the final count
       itemCount += groupTotals[this._type][this._field] as number;
     } else {
-      itemCount = groupTotals.group.rows.length;
+      itemCount = groupTotals.group?.rows.length ?? 0;
     }
     groupTotals[this._type][this._field] = itemCount;
   }

--- a/packages/common/src/core/__tests__/slickCore.spec.ts
+++ b/packages/common/src/core/__tests__/slickCore.spec.ts
@@ -1,6 +1,139 @@
-import { SlickGroup, SlickGroupTotals, SlickRange } from '../slickCore';
+import { EditController } from '../../interfaces';
+import { SlickEditorLock, SlickEvent, SlickEventData, SlickEventHandler, SlickGroup, SlickGroupTotals, SlickRange } from '../slickCore';
 
 describe('slick.core file', () => {
+  describe('SlickEventData class', () => {
+    it('should call isPropagationStopped() and expect truthy when event propagation is stopped by calling stopPropagation()', () => {
+      const evt = new CustomEvent('click');
+      const ed = new SlickEventData(evt);
+
+      expect(ed.getNativeEvent()).toEqual(evt);
+      expect(ed.isPropagationStopped()).toBeFalsy();
+
+      ed.stopPropagation();
+
+      expect(ed.isPropagationStopped()).toBeTruthy();
+    });
+
+    it('should call isImmediatePropagationStopped() and expect truthy when event propagation is stopped by calling stopImmediatePropagation()', () => {
+      const evt = new CustomEvent('click');
+      const ed = new SlickEventData(evt);
+
+      expect(ed.isImmediatePropagationStopped()).toBeFalsy();
+
+      ed.stopImmediatePropagation();
+
+      expect(ed.isImmediatePropagationStopped()).toBeTruthy();
+    });
+
+    it('should call isDefaultPrevented() and expect truthy when event propagation is stopped by calling preventDefault()', () => {
+      const ed = new SlickEventData();
+
+      expect(ed.isDefaultPrevented()).toBeFalsy();
+
+      ed.preventDefault();
+
+      expect(ed.isDefaultPrevented()).toBeTruthy();
+    });
+
+    it('should be able to retrieve arguments provided by calling getArguments() method', () => {
+      const evt = new Event('click');
+      const mockArgs = { hello: 'world' };
+      const ed = new SlickEventData(evt, mockArgs);
+
+      expect(ed.getArguments()).toEqual(mockArgs);
+    });
+
+    it('should call isDefaultPrevented() and expect truthy when event propagation is stopped on a native event by calling preventDefault()', () => {
+      const evt = new Event('click');
+      const evtSpy = jest.spyOn(evt, 'preventDefault');
+      const ed = new SlickEventData(evt);
+
+      expect(ed.isDefaultPrevented()).toBeFalsy();
+
+      ed.preventDefault();
+      ed.stopPropagation();
+
+      expect(evtSpy).toHaveBeenCalled();
+    });
+
+    it('should be able to call addReturnValue() with input and expect the same first input value when calling getReturnValue(), calling it subsequently will always return first value', () => {
+      const ed = new SlickEventData();
+      ed.addReturnValue('last value');
+
+      expect(ed.getReturnValue()).toBe('last value');
+
+      ed.addReturnValue(false);
+      expect(ed.getReturnValue()).toBe('last value');
+    });
+  });
+
+  describe('SlickEvent class', () => {
+    it('should be able to subscribe to an event and call unsubscribe() and expect 1 subscriber to be dropped', () => {
+      const spy1 = jest.fn();
+      const spy2 = jest.fn();
+      const onClick = new SlickEvent();
+      onClick.subscribe(spy1);
+      onClick.subscribe(spy2);
+
+      expect(onClick.subscriberCount).toBe(2);
+
+      onClick.unsubscribe(spy1);
+      expect(onClick.subscriberCount).toBe(1);
+    });
+
+    it('should be able to subscribe to an event, call notify() and all subscribers to receive what was sent', () => {
+      const spy1 = jest.fn();
+      const spy2 = jest.fn();
+      const ed = new SlickEventData();
+      const onClick = new SlickEvent();
+      onClick.subscribe(spy1);
+      onClick.subscribe(spy2);
+
+      expect(onClick.subscriberCount).toBe(2);
+
+      onClick.notify({ hello: 'world' }, ed);
+
+      expect(spy1).toHaveBeenCalledWith(ed, { hello: 'world' });
+    });
+  });
+
+  describe('SlickEventHandler class', () => {
+    it('should be able to subscribe to multiple events and call unsubscribe() a single event', () => {
+      const spy1 = jest.fn();
+      const spy2 = jest.fn();
+      const eventHandler = new SlickEventHandler();
+      const onClick = new SlickEvent();
+      const onDblClick = new SlickEvent();
+
+      eventHandler.subscribe(onClick, spy1);
+      eventHandler.subscribe(onDblClick, spy2);
+
+      expect(eventHandler.subscriberCount).toBe(2);
+
+      eventHandler.unsubscribe(onClick, spy1);
+
+      expect(eventHandler.subscriberCount).toBe(1);
+    });
+
+    it('should be able to subscribe to multiple events and expect no more event handlers when calling unsubscribeAll()', () => {
+      const spy1 = jest.fn();
+      const spy2 = jest.fn();
+      const eventHandler = new SlickEventHandler();
+      const onClick = new SlickEvent();
+      const onDblClick = new SlickEvent();
+
+      eventHandler.subscribe(onClick, spy1);
+      eventHandler.subscribe(onDblClick, spy2);
+
+      expect(eventHandler.subscriberCount).toBe(2);
+
+      eventHandler.unsubscribeAll();
+
+      expect(eventHandler.subscriberCount).toBe(0);
+    });
+  });
+
   describe('SlickRange class', () => {
     it('should call isSingleCell() and expect truthy when fromRow equals toRow', () => {
       const range = new SlickRange(0, 2);
@@ -109,5 +242,105 @@ describe('slick.core file', () => {
       groupTotals.initialized = true;
       expect(groupTotals.initialized).toBeTruthy();
     });
-  })
+  });
+
+  describe('SlickEditorLock class', () => {
+    it('should activate an EditController and expect isActive() to be truthy', () => {
+      const commitSpy = jest.fn();
+      const cancelSpy = jest.fn();
+      const ec = { commitCurrentEdit: commitSpy, cancelCurrentEdit: cancelSpy, } as EditController;
+
+      const elock = new SlickEditorLock();
+      elock.activate(ec);
+
+      expect(elock.isActive()).toBeTruthy();
+    });
+
+    it('should throw when trying to call activate() with a second EditController', () => {
+      const commitSpy = jest.fn();
+      const cancelSpy = jest.fn();
+      const commit2Spy = jest.fn();
+      const cancel2Spy = jest.fn();
+      const ec = { commitCurrentEdit: commitSpy, cancelCurrentEdit: cancelSpy, } as EditController;
+      const ec2 = { commitCurrentEdit: commit2Spy, cancelCurrentEdit: cancel2Spy, } as EditController;
+
+      const elock = new SlickEditorLock();
+      elock.activate(ec);
+
+      expect(() => elock.activate(ec2)).toThrow(`SlickEditorLock.activate: an editController is still active, can't activate another editController`)
+    });
+
+    it('should throw when trying to call activate() with an EditController that forgot to implement commitCurrentEdit() method', () => {
+      const cancelSpy = jest.fn();
+      const ec = { cancelCurrentEdit: cancelSpy, } as any;
+
+      const elock = new SlickEditorLock();
+      expect(() => elock.activate(ec)).toThrow(`SlickEditorLock.activate: editController must implement .commitCurrentEdit()`)
+    });
+
+    it('should throw when trying to call activate() with an EditController that forgot to implement cancelCurrentEdit() method', () => {
+      const commitSpy = jest.fn();
+      const ec = { commitCurrentEdit: commitSpy, } as any;
+
+      const elock = new SlickEditorLock();
+      expect(() => elock.activate(ec)).toThrow(`SlickEditorLock.activate: editController must implement .cancelCurrentEdit()`)
+    });
+
+    it('should deactivate an EditController and expect isActive() to be falsy', () => {
+      const commitSpy = jest.fn();
+      const cancelSpy = jest.fn();
+      const ec = { commitCurrentEdit: commitSpy, cancelCurrentEdit: cancelSpy, } as EditController;
+
+      const elock = new SlickEditorLock();
+      elock.activate(ec);
+      expect(elock.isActive()).toBeTruthy();
+
+      elock.deactivate(ec);
+      expect(elock.isActive()).toBeFalsy();
+    });
+
+    it('should throw when trying to deactivate an EditController that does not equal to the currently active EditController', () => {
+      const commitSpy = jest.fn();
+      const cancelSpy = jest.fn();
+      const commit2Spy = jest.fn();
+      const cancel2Spy = jest.fn();
+      const ec = { commitCurrentEdit: commitSpy, cancelCurrentEdit: cancelSpy, } as EditController;
+      const ec2 = { commitCurrentEdit: commit2Spy, cancelCurrentEdit: cancel2Spy, } as EditController;
+
+      const elock = new SlickEditorLock();
+      elock.activate(ec);
+
+      expect(() => elock.deactivate(ec2)).toThrow(`SlickEditorLock.deactivate: specified editController is not the currently active one`)
+    });
+
+    it('should expect active EditController.commitCurrentEdit() being called when calling commitCurrentEdit() after it was activated', () => {
+      const commitSpy = jest.fn().mockReturnValue(true);
+      const cancelSpy = jest.fn().mockReturnValue(true);
+      const ec = { commitCurrentEdit: commitSpy, cancelCurrentEdit: cancelSpy, } as EditController;
+
+      const elock = new SlickEditorLock();
+      elock.activate(ec);
+      const committed = elock.commitCurrentEdit();
+
+      expect(elock.isActive()).toBeTruthy();
+      expect(commitSpy).toHaveBeenCalled();
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(committed).toBeTrue();
+    });
+
+    it('should expect active EditController.commitCurrentEdit() being called when calling commitCurrentEdit() after it was activated', () => {
+      const commitSpy = jest.fn().mockReturnValue(true);
+      const cancelSpy = jest.fn().mockReturnValue(true);
+      const ec = { commitCurrentEdit: commitSpy, cancelCurrentEdit: cancelSpy, } as EditController;
+
+      const elock = new SlickEditorLock();
+      elock.activate(ec);
+      const cancelled = elock.cancelCurrentEdit();
+
+      expect(elock.isActive()).toBeTruthy();
+      expect(cancelSpy).toHaveBeenCalled();
+      expect(commitSpy).not.toHaveBeenCalled();
+      expect(cancelled).toBeTrue();
+    });
+  });
 });

--- a/packages/common/src/core/__tests__/slickCore.spec.ts
+++ b/packages/common/src/core/__tests__/slickCore.spec.ts
@@ -252,6 +252,7 @@ describe('slick.core file', () => {
 
       const elock = new SlickEditorLock();
       elock.activate(ec);
+      elock.activate(ec); // calling 2x shouldn't cause problem
 
       expect(elock.isActive()).toBeTruthy();
     });
@@ -296,6 +297,7 @@ describe('slick.core file', () => {
       expect(elock.isActive()).toBeTruthy();
 
       elock.deactivate(ec);
+      elock.deactivate(ec); // calling 2x should yield to same problem
       expect(elock.isActive()).toBeFalsy();
     });
 

--- a/packages/common/src/core/__tests__/slickCore.spec.ts
+++ b/packages/common/src/core/__tests__/slickCore.spec.ts
@@ -1,0 +1,113 @@
+import { SlickGroup, SlickGroupTotals, SlickRange } from '../slickCore';
+
+describe('slick.core file', () => {
+  describe('SlickRange class', () => {
+    it('should call isSingleCell() and expect truthy when fromRow equals toRow', () => {
+      const range = new SlickRange(0, 2);
+      range.fromCell = 0;
+      range.toCell = 0;
+
+      expect(range.isSingleCell()).toBeTruthy();
+    });
+
+    it('should call isSingleCell() and expect falsy when fromRow does not equals toRow', () => {
+      const range = new SlickRange(0, 2);
+      range.fromCell = 0;
+      range.toCell = 2;
+
+      expect(range.isSingleCell()).toBeFalsy();
+    });
+
+    it('should call isSingleRow() and expect truthy when fromRow equals toRow', () => {
+      const range = new SlickRange(0, 0);
+      range.fromRow = 0;
+      range.toRow = 0;
+
+      expect(range.isSingleRow()).toBeTruthy();
+    });
+
+    it('should call isSingleRow() and expect falsy when fromRow does not equals toRow', () => {
+      const range = new SlickRange(0, 1);
+      range.fromRow = 0;
+      range.toRow = 2;
+
+      expect(range.isSingleRow()).toBeFalsy();
+    });
+
+    it('should call contains() and expect falsy when row is not found', () => {
+      const range = new SlickRange(0, 1, 2, 5);
+
+      expect(range.contains(4, 0)).toBeFalsy();
+    });
+
+    it('should call contains() and expect truthy when row is found within the range', () => {
+      const range = new SlickRange(0, 1, 2, 5);
+
+      expect(range.contains(1, 3)).toBeTruthy();
+    });
+
+    it('should call toString() and expect a readable stringified result for a single cell range', () => {
+      const range = new SlickRange(0, 1, 0, 1);
+
+      expect(range.toString()).toBe('(0:1)');
+    });
+
+    it('should call toString() and expect a readable stringified result for a range including multiple cells', () => {
+      const range = new SlickRange(0, 1, 2, 5);
+
+      expect(range.toString()).toBe('(0:1 - 2:5)');
+    });
+  });
+
+  describe('SlickGroup class', () => {
+    it('should call equals() and return truthy when groups are equal', () => {
+      const group = new SlickGroup();
+      group.value = '123';
+      group.count = 2;
+      group.collapsed = false;
+      group.level = 0;
+      group.title = 'my title';
+      const group2 = { ...group } as SlickGroup;
+
+      expect(group.equals(group2)).toBeTruthy();
+    });
+
+    it('should call equals() and return false when groups have differences', () => {
+      const group = new SlickGroup();
+      group.value = '123';
+      group.count = 2;
+      group.collapsed = false;
+      group.level = 0;
+      group.title = 'my title';
+
+      const group2 = { ...group } as SlickGroup;
+      group2.title = 'another title';
+      group.value = '222';
+
+      expect(group.equals(group2)).toBeFalsy();
+    });
+  });
+
+  describe('SlickGroupTotals class', () => {
+    it('should be able to create a SlickGroupTotals and assign a SlickGroup', () => {
+      const group = new SlickGroup();
+      group.value = '123';
+      group.count = 2;
+      group.collapsed = false;
+      group.level = 0;
+      group.title = 'my title';
+
+      const groupTotals = new SlickGroupTotals();
+      groupTotals.group = group;
+      group.totals = groupTotals;
+
+      expect(groupTotals).toBeTruthy();
+      expect(groupTotals.__nonDataRow).toBeTruthy();
+      expect(groupTotals.__groupTotals).toBeTruthy();
+      expect(groupTotals.initialized).toBeFalsy();
+
+      groupTotals.initialized = true;
+      expect(groupTotals.initialized).toBeTruthy();
+    });
+  })
+});

--- a/packages/common/src/core/__tests__/slickCore.spec.ts
+++ b/packages/common/src/core/__tests__/slickCore.spec.ts
@@ -111,9 +111,28 @@ describe('slick.core file', () => {
 
       expect(eventHandler.subscriberCount).toBe(2);
 
-      eventHandler.unsubscribe(onClick, spy1);
+      const chain = eventHandler.unsubscribe(onClick, spy1);
 
+      expect(chain).toBeUndefined(); // returns undefined when handler is found
       expect(eventHandler.subscriberCount).toBe(1);
+    });
+
+    it('should return same amount of handlers when calling unsubscribe() on an event that is not found', () => {
+      const spy1 = jest.fn();
+      const spy2 = jest.fn();
+      const eventHandler = new SlickEventHandler();
+      const onClick = new SlickEvent();
+      const onDblClick = new SlickEvent();
+
+      eventHandler.subscribe(onClick, spy1);
+      eventHandler.subscribe(onDblClick, spy2);
+
+      expect(eventHandler.subscriberCount).toBe(2);
+
+      const chain = eventHandler.unsubscribe({} as any, spy1);
+
+      expect(chain).toEqual(eventHandler);
+      expect(eventHandler.subscriberCount).toBe(2);
     });
 
     it('should be able to subscribe to multiple events and expect no more event handlers when calling unsubscribeAll()', () => {
@@ -128,9 +147,10 @@ describe('slick.core file', () => {
 
       expect(eventHandler.subscriberCount).toBe(2);
 
-      eventHandler.unsubscribeAll();
+      const chain = eventHandler.unsubscribeAll();
 
       expect(eventHandler.subscriberCount).toBe(0);
+      expect(chain).toEqual(eventHandler);
     });
   });
 

--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -1,0 +1,35 @@
+import { SlickDataView } from '../slickDataview';
+
+describe('SlickDatView core file', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'myGrid';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.textContent = '';
+  });
+
+  it('should be able to instantiate SlickDataView', () => {
+    const dv = new SlickDataView({});
+
+    expect(dv.getItems()).toEqual([]);
+  });
+
+  it('should be able to add items to the DataView', () => {
+    const mockData = [
+      { id: 1, firstName: 'John', lastName: 'Doe' },
+      { id: 2, firstName: 'Jane', lastName: 'Doe' },
+    ]
+    const dv = new SlickDataView({});
+    dv.addItem(mockData[0]);
+    dv.addItem(mockData[1]);
+
+    expect(dv.getLength()).toBe(2);
+    expect(dv.getItemCount()).toBe(2);
+    expect(dv.getItems()).toEqual(mockData);
+  });
+});

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1,0 +1,37 @@
+import { Column, GridOption } from '../../interfaces';
+import { SlickDataView } from '../slickDataview';
+import { SlickGrid } from '../slickGrid';
+
+describe('SlickGrid core file', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'myGrid';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.textContent = '';
+  });
+
+  it('should be able to instantiate SlickGrid without DataView', () => {
+    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
+    const options = { enableCellNavigation: true } as GridOption;
+    const grid = new SlickGrid<any, Column>('#myGrid', [], columns, options, true);
+
+    expect(grid).toBeTruthy();
+    expect(grid.getData()).toEqual([]);
+  });
+
+  it('should be able to instantiate SlickGrid with a DataView', () => {
+    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
+    const options = { enableCellNavigation: true } as GridOption;
+    const dv = new SlickDataView({});
+    const grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options, true);
+
+    expect(grid).toBeTruthy();
+    expect(grid.getData()).toEqual(dv);
+    expect(dv.getItems()).toEqual([]);
+  });
+});

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4,6 +4,7 @@ import { SlickGrid } from '../slickGrid';
 
 describe('SlickGrid core file', () => {
   let container: HTMLElement;
+  let grid: SlickGrid;
 
   beforeEach(() => {
     container = document.createElement('div');
@@ -13,12 +14,14 @@ describe('SlickGrid core file', () => {
 
   afterEach(() => {
     document.body.textContent = '';
+    grid?.destroy(true);
   });
 
   it('should be able to instantiate SlickGrid without DataView', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
     const options = { enableCellNavigation: true } as GridOption;
-    const grid = new SlickGrid<any, Column>('#myGrid', [], columns, options, true);
+    grid = new SlickGrid<any, Column>('#myGrid', [], columns, options, true);
+    grid.init();
 
     expect(grid).toBeTruthy();
     expect(grid.getData()).toEqual([]);
@@ -28,7 +31,8 @@ describe('SlickGrid core file', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
     const options = { enableCellNavigation: true } as GridOption;
     const dv = new SlickDataView({});
-    const grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options, true);
+    grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options, true);
+    grid.init();
 
     expect(grid).toBeTruthy();
     expect(grid.getData()).toEqual(dv);

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -144,11 +144,11 @@ describe('MouseWheel class', () => {
     const mdEvt = new Event('wheel');
     Object.defineProperty(mdEvt, 'wheelDelta', { writable: true, configurable: true, value: -120 });
     Object.defineProperty(mdEvt, 'axis', { writable: true, configurable: true, value: 3 });
-    Object.defineProperty(mdEvt, 'HORIZONTAL_AXIS', { writable: true, configurable: true, value: -120 });
+    Object.defineProperty(mdEvt, 'HORIZONTAL_AXIS', { writable: true, configurable: true, value: 3 });
     element.dispatchEvent(mdEvt);
 
     expect(mw).toBeTruthy();
-    expect(wheelSpy).toHaveBeenCalledWith(mdEvt, -1, 0, -1);
+    expect(wheelSpy).toHaveBeenCalledWith(mdEvt, -1, 1, 0);
     expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
   });
 });

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -1,0 +1,211 @@
+import { Draggable, MouseWheel, Resizable } from '../slickInteractions';
+
+describe('Draggable class', () => {
+  let containerElement: HTMLDivElement;
+  let dg: any;
+
+  beforeEach(() => {
+    containerElement = document.createElement('div');
+  });
+
+  afterEach(() => {
+    containerElement?.remove();
+    dg?.destroy();
+  });
+
+  it('should be able to instantiate the class', () => {
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell' });
+
+    expect(dg).toBeTruthy();
+  });
+
+  it('should be able to instantiate the class even without a valid containerElement', () => {
+    dg = Draggable({ allowDragFrom: 'div.slick-cell' });
+
+    expect(dg).toBeTruthy();
+  });
+
+  it('should trigger mousedown but NOT expect a dragInit to happen since it was not triggered by an allowed element', () => {
+    const dragInitSpy = jest.fn();
+
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragInitSpy });
+
+    containerElement.dispatchEvent(new Event('mousedown'));
+
+    expect(dg).toBeTruthy();
+    expect(dragInitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should trigger mousedown and expect a dragInit to happen since it was triggered by an allowed element but NOT expect a drag to actually happen since we did not move afterward', () => {
+    const dragInitSpy = jest.fn();
+    const dragSpy = jest.fn();
+    containerElement.className = 'slick-cell';
+
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragSpy, onDragInit: dragInitSpy });
+
+    containerElement.dispatchEvent(new Event('mousedown'));
+
+    expect(dg).toBeTruthy();
+    expect(dragInitSpy).toHaveBeenCalled();
+    expect(dragSpy).not.toHaveBeenCalled();
+
+    dg.destroy();
+  });
+
+  it('should trigger mousedown and expect a dragInit and a dragStart and drag to all happen since it was triggered by an allowed element and we did move afterward', () => {
+    const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
+    const dragInitSpy = jest.fn();
+    const dragSpy = jest.fn();
+    const dragStartSpy = jest.fn();
+    const dragEndSpy = jest.fn();
+    containerElement.className = 'slick-cell';
+
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragSpy, onDragInit: dragInitSpy, onDragStart: dragStartSpy, onDragEnd: dragEndSpy });
+
+    const mdEvt = new Event('mousedown');
+    Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
+    Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    containerElement.dispatchEvent(mdEvt);
+
+    const mmEvt = new Event('mousemove');
+    const muEvt = new Event('mouseup');
+    Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+    Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+    Object.defineProperty(muEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    document.body.dispatchEvent(mmEvt);
+    document.body.dispatchEvent(muEvt);
+
+    expect(dg).toBeTruthy();
+    expect(dragInitSpy).toHaveBeenCalledWith(mdEvt, { startX: 10, startY: 10, deltaX: 2, deltaY: 0, dragHandle: containerElement, dragSource: containerElement, target: document.body });
+    expect(dragStartSpy).toHaveBeenCalled();  // TODO: revisit calledWith X/Y pos, after migrating to TS class
+    expect(dragSpy).toHaveBeenCalled();
+    expect(dragEndSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
+  });
+});
+
+describe('MouseWheel class', () => {
+  let mw: any;
+
+  afterEach(() => {
+    mw?.destroy();
+  });
+
+  it('should be able to instantiate the class', () => {
+    mw = MouseWheel({ element: document.createElement('div') });
+
+    expect(mw).toBeTruthy();
+  });
+
+  it('should trigger mouse wheel event and expect onMouseWheel handler to be called old school way with regular mouse and WebKit browser event', () => {
+    const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
+    const wheelSpy = jest.fn();
+
+    const element = document.createElement('div');
+    mw = MouseWheel({ element, onMouseWheel: wheelSpy });
+
+    const mdEvt = new Event('wheel');
+    Object.defineProperty(mdEvt, 'wheelDelta', { writable: true, configurable: true, value: -120 });
+    Object.defineProperty(mdEvt, 'wheelDeltaX', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(mdEvt, 'wheelDeltaY', { writable: true, configurable: true, value: -120 });
+    element.dispatchEvent(mdEvt);
+
+    expect(mw).toBeTruthy();
+    expect(wheelSpy).toHaveBeenCalledWith(mdEvt, -1, -0, -1);
+    expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
+  });
+
+  it('should trigger mouse wheel event and expect onMouseWheel handler to be called new school way with touchpad multidimensional scroll', () => {
+    const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
+    const wheelSpy = jest.fn();
+
+    const element = document.createElement('div');
+    mw = MouseWheel({ element, onMouseWheel: wheelSpy });
+
+    const mdEvt = new Event('wheel');
+    Object.defineProperty(mdEvt, 'detail', { writable: true, configurable: true, value: 3 });
+    Object.defineProperty(mdEvt, 'wheelDeltaX', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(mdEvt, 'wheelDeltaY', { writable: true, configurable: true, value: -120 });
+    element.dispatchEvent(mdEvt);
+
+    expect(mw).toBeTruthy();
+    expect(wheelSpy).toHaveBeenCalledWith(mdEvt, -1, -0, -1);
+    expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
+  });
+
+  it('should trigger mouse wheel event and expect onMouseWheel handler to be called old school way with regular mouse and Gecko browser event', () => {
+    const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
+    const wheelSpy = jest.fn();
+
+    const element = document.createElement('div');
+    mw = MouseWheel({ element, onMouseWheel: wheelSpy });
+
+    const mdEvt = new Event('wheel');
+    Object.defineProperty(mdEvt, 'wheelDelta', { writable: true, configurable: true, value: -120 });
+    Object.defineProperty(mdEvt, 'axis', { writable: true, configurable: true, value: 3 });
+    Object.defineProperty(mdEvt, 'HORIZONTAL_AXIS', { writable: true, configurable: true, value: -120 });
+    element.dispatchEvent(mdEvt);
+
+    expect(mw).toBeTruthy();
+    expect(wheelSpy).toHaveBeenCalledWith(mdEvt, -1, 0, -1);
+    expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
+  });
+});
+
+describe('Resizable class', () => {
+  let rsz: any;
+  let containerElement;
+
+  beforeEach(() => {
+    containerElement = document.createElement('div');
+    containerElement.className = 'slick-container';
+  });
+
+  afterEach(() => {
+    rsz?.destroy();
+  });
+
+  it('should be able to instantiate the class', () => {
+    rsz = Resizable({
+      resizeableElement: document.createElement('div'),
+      resizeableHandleElement: document.createElement('div')
+    });
+
+    expect(rsz).toBeTruthy();
+  });
+
+  it('should throw when instantiating without a valid handle resizeable element', () => {
+    expect(() => Resizable({} as any)).toThrow('[SlickResizable] You did not provide a valid html element that will be used for the handle to resize.');
+  });
+
+  it('should trigger mousedown and expect a dragInit and a dragStart and drag to all happen since it was triggered by an allowed element and we did move afterward', () => {
+    const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
+    const resizeSpy = jest.fn();
+    const resizeStartSpy = jest.fn();
+    const resizeEndSpy = jest.fn();
+    containerElement.className = 'slick-cell';
+
+    rsz = Resizable({ resizeableElement: containerElement, resizeableHandleElement: containerElement, onResize: resizeSpy, onResizeStart: resizeStartSpy, onResizeEnd: resizeEndSpy });
+
+    const mdEvt = new Event('mousedown');
+    Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
+    Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    containerElement.dispatchEvent(mdEvt);
+
+    const mmEvt = new Event('mousemove');
+    const muEvt = new Event('mouseup');
+    Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+    Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+    Object.defineProperty(muEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    document.body.dispatchEvent(mmEvt);
+    document.body.dispatchEvent(muEvt);
+
+    expect(rsz).toBeTruthy();
+    expect(resizeStartSpy).toHaveBeenCalledWith(mdEvt, { resizeableElement: containerElement, resizeableHandleElement: containerElement });
+    expect(resizeSpy).toHaveBeenCalled();
+    expect(resizeEndSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledTimes(6 * 2 + 2);
+  });
+});

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -261,6 +261,14 @@ export class SlickRange {
     this.toRow = Math.max(fromRow, toRow as number);
   }
 
+  /**
+   * Returns whether a range represents a single cell.
+   * @method isSingleCell
+   * @return {Boolean}
+   */
+  isSingleCell() {
+    return this.fromRow === this.toRow && this.fromCell === this.toCell;
+  }
 
   /**
    * Returns whether a range represents a single row.
@@ -269,15 +277,6 @@ export class SlickRange {
    */
   isSingleRow() {
     return this.fromRow === this.toRow;
-  }
-
-  /**
-   * Returns whether a range represents a single cell.
-   * @method isSingleCell
-   * @return {Boolean}
-   */
-  isSingleCell() {
-    return this.fromRow === this.toRow && this.fromCell === this.toCell;
   }
 
   /**
@@ -346,7 +345,7 @@ export class SlickGroup extends SlickNonDataItem {
    * @property value
    * @type {Object}
    */
-  value = null;
+  value: any = null;
 
   /**
    * Formatted display value of the group.
@@ -401,6 +400,7 @@ export class SlickGroup extends SlickNonDataItem {
   constructor() {
     super();
   }
+
   /**
    * Compares two Group instances.
    * @method equals
@@ -432,7 +432,7 @@ export class SlickGroupTotals extends SlickNonDataItem {
    * @param group
    * @type {Group}
    */
-  group: SlickGroup = null as any;
+  group: SlickGroup | null = null;
 
   /**
    * Whether the totals have been fully initialized / calculated.

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -23,7 +23,6 @@ export class SlickEventData<ArgType = any> {
   protected _isPropagationStopped = false;
   protected _isImmediatePropagationStopped = false;
   protected _isDefaultPrevented = false;
-  protected returnValues: string[] = [];
   protected returnValue: any = undefined;
   protected target?: EventTarget | null;
   protected nativeEvent?: Event | null;
@@ -105,7 +104,6 @@ export class SlickEventData<ArgType = any> {
   }
 
   addReturnValue(value: any) {
-    this.returnValues.push(value);
     if (this.returnValue === undefined && value !== undefined) {
       this.returnValue = value;
     }
@@ -127,6 +125,10 @@ export class SlickEventData<ArgType = any> {
  */
 export class SlickEvent<ArgType = any> {
   protected handlers: Handler<ArgType>[] = [];
+
+  get subscriberCount() {
+    return this.handlers.length;
+  }
 
   /**
    * Adds an event handler to be called when the event is fired.
@@ -166,9 +168,7 @@ export class SlickEvent<ArgType = any> {
    *      If not specified, the scope will be set to the <code>Event</code> instance.
    */
   notify(args: ArgType, evt?: SlickEventData | Event | MergeTypes<SlickEventData, Event> | null, scope?: any) {
-    const sed: SlickEventData = evt instanceof SlickEventData
-      ? evt
-      : new SlickEventData(evt, args);
+    const sed = evt instanceof SlickEventData ? evt : new SlickEventData(evt, args);
     scope = scope || this;
 
     for (let i = 0; i < this.handlers.length && !(sed.isPropagationStopped() || sed.isImmediatePropagationStopped()); i++) {
@@ -182,6 +182,10 @@ export class SlickEvent<ArgType = any> {
 
 export class SlickEventHandler<ArgType = any> {
   protected handlers: Array<{ event: SlickEvent; handler: Handler<ArgType>; }> = [];
+
+  get subscriberCount() {
+    return this.handlers.length;
+  }
 
   subscribe(event: SlickEvent, handler: Handler<ArgType>) {
     this.handlers.push({ event, handler });
@@ -480,13 +484,13 @@ export class SlickEditorLock {
       return;
     }
     if (this.activeEditController !== null) {
-      throw new Error(`Slick.EditorLock.activate: an editController is still active, can't activate another editController`);
+      throw new Error(`SlickEditorLock.activate: an editController is still active, can't activate another editController`);
     }
     if (!editController.commitCurrentEdit) {
-      throw new Error('Slick.EditorLock.activate: editController must implement .commitCurrentEdit()');
+      throw new Error('SlickEditorLock.activate: editController must implement .commitCurrentEdit()');
     }
     if (!editController.cancelCurrentEdit) {
-      throw new Error('Slick.EditorLock.activate: editController must implement .cancelCurrentEdit()');
+      throw new Error('SlickEditorLock.activate: editController must implement .cancelCurrentEdit()');
     }
     this.activeEditController = editController;
   };
@@ -502,7 +506,7 @@ export class SlickEditorLock {
       return;
     }
     if (this.activeEditController !== editController) {
-      throw new Error('Slick.EditorLock.deactivate: specified editController is not the currently active one');
+      throw new Error('SlickEditorLock.deactivate: specified editController is not the currently active one');
     }
     this.activeEditController = null;
   };

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -432,7 +432,7 @@ export class SlickGroupTotals extends SlickNonDataItem {
    * @param group
    * @type {Group}
    */
-  group: SlickGroup | null = null;
+  group: SlickGroup | null = null; // pre-assign to null
 
   /**
    * Whether the totals have been fully initialized / calculated.

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -915,8 +915,8 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   protected calculateTotals(totals: SlickGroupTotals) {
-    const group = totals.group;
-    const gi = this.groupingInfos[group.level ?? 0];
+    const group = totals.group as SlickGroup;
+    const gi = this.groupingInfos[group?.level ?? 0];
     const isLeafLevel = (group.level === this.groupingInfos.length);
     let agg: Aggregator;
     let idx = gi.aggregators.length;

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -189,6 +189,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected canvas: HTMLCanvasElement | null = null;
   protected canvas_context: CanvasRenderingContext2D | null = null;
+  protected _devMode = false;
 
   // settings
   protected _options!: O;
@@ -491,7 +492,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Array<C>} columns - An array of column definitions.
    * @param {Object} [options] - Grid this._options.
    **/
-  constructor(protected container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], protected options: Partial<O>) {
+  constructor(protected container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], protected options: Partial<O>, protected devMode = false) {
     this.initialize();
   }
 
@@ -2381,8 +2382,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!this.stylesheet) {
       const sheets: any = (this._options.shadowRoot || document).styleSheets;
       for (i = 0; i < sheets.length; i++) {
-        if ((sheets[i].ownerNode || sheets[i].owningElement) === this._style) {
-          this.stylesheet = sheets[i];
+        const sheet = sheets[i];
+        if ((sheet.ownerNode || sheet.owningElement) === this._style || this.devMode) {
+          this.stylesheet = sheet;
           break;
         }
       }

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -37,10 +37,7 @@ export function Draggable(options: DraggableOption) {
   let dragStarted: boolean;
 
   if (!containerElement) {
-    containerElement = document;
-  }
-  if (!containerElement || typeof containerElement.addEventListener !== 'function') {
-    throw new Error('[Slick.Draggable] You did not provide a valid container html element that will be used for dragging.');
+    containerElement = document.body;
   }
 
   let originaldd: { dragSource: HTMLElement | Document | null, dragHandle: HTMLElement | null } = {
@@ -81,11 +78,11 @@ export function Draggable(options: DraggableOption) {
       originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
       executeDragCallbackWhenDefined(onDragInit as (e: DragEvent, dd: DragPosition) => boolean | void, event, originaldd);
 
-      document.addEventListener('mousemove', userMoved);
-      document.addEventListener('touchmove', userMoved);
-      document.addEventListener('mouseup', userReleased);
-      document.addEventListener('touchend', userReleased);
-      document.addEventListener('touchcancel', userReleased);
+      document.body.addEventListener('mousemove', userMoved);
+      document.body.addEventListener('touchmove', userMoved);
+      document.body.addEventListener('mouseup', userReleased);
+      document.body.addEventListener('touchend', userReleased);
+      document.body.addEventListener('touchcancel', userReleased);
     }
   }
 
@@ -109,11 +106,11 @@ export function Draggable(options: DraggableOption) {
     const { target } = event;
     originaldd = Object.assign(originaldd, { target });
     executeDragCallbackWhenDefined(onDragEnd, event, originaldd);
-    document.removeEventListener('mousemove', userMoved);
-    document.removeEventListener('touchmove', userMoved);
-    document.removeEventListener('mouseup', userReleased);
-    document.removeEventListener('touchend', userReleased);
-    document.removeEventListener('touchcancel', userReleased);
+    document.body.removeEventListener('mousemove', userMoved);
+    document.body.removeEventListener('touchmove', userMoved);
+    document.body.removeEventListener('mouseup', userReleased);
+    document.body.removeEventListener('touchend', userReleased);
+    document.body.removeEventListener('touchcancel', userReleased);
     dragStarted = false;
   }
 
@@ -205,7 +202,13 @@ export function MouseWheel(options: MouseWheelOption) {
 export function Resizable(options: ResizableOption) {
   const { resizeableElement, resizeableHandleElement, onResizeStart, onResize, onResizeEnd } = options;
   if (!resizeableHandleElement || typeof resizeableHandleElement.addEventListener !== 'function') {
-    throw new Error('[Slick.Resizable] You did not provide a valid html element that will be used for the handle to resize.');
+    throw new Error('[SlickResizable] You did not provide a valid html element that will be used for the handle to resize.');
+  }
+
+  function init() {
+    // add event listeners on the draggable element
+    resizeableHandleElement.addEventListener('mousedown', resizeStartHandler);
+    resizeableHandleElement.addEventListener('touchstart', resizeStartHandler);
   }
 
   function destroy() {
@@ -225,10 +228,10 @@ export function Resizable(options: ResizableOption) {
     e.preventDefault();
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
     executeResizeCallbackWhenDefined(onResizeStart, event);
-    document.addEventListener('mousemove', resizingHandler);
-    document.addEventListener('mouseup', resizeEndHandler);
-    document.addEventListener('touchmove', resizingHandler);
-    document.addEventListener('touchend', resizeEndHandler);
+    document.body.addEventListener('mousemove', resizingHandler);
+    document.body.addEventListener('mouseup', resizeEndHandler);
+    document.body.addEventListener('touchmove', resizingHandler);
+    document.body.addEventListener('touchend', resizeEndHandler);
   }
 
   function resizingHandler(e: MouseEvent | TouchEvent) {
@@ -238,7 +241,6 @@ export function Resizable(options: ResizableOption) {
     const event = ((e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e) as DOMMouseOrTouchEvent<HTMLDivElement>;
     if (typeof onResize === 'function') {
       onResize(event, { resizeableElement, resizeableHandleElement });
-      onResize(event, { resizeableElement, resizeableHandleElement });
     }
   }
 
@@ -246,15 +248,13 @@ export function Resizable(options: ResizableOption) {
   function resizeEndHandler(e: MouseEvent | TouchEvent) {
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
     executeResizeCallbackWhenDefined(onResizeEnd, event);
-    document.removeEventListener('mousemove', resizingHandler);
-    document.removeEventListener('mouseup', resizeEndHandler);
-    document.removeEventListener('touchmove', resizingHandler);
-    document.removeEventListener('touchend', resizeEndHandler);
+    document.body.removeEventListener('mousemove', resizingHandler);
+    document.body.removeEventListener('mouseup', resizeEndHandler);
+    document.body.removeEventListener('touchmove', resizingHandler);
+    document.body.removeEventListener('touchend', resizeEndHandler);
   }
 
-  // add event listeners on the draggable element
-  resizeableHandleElement.addEventListener('mousedown', resizeStartHandler);
-  resizeableHandleElement.addEventListener('touchstart', resizeStartHandler);
+  init();
 
   // public API
   return { destroy };

--- a/test/jest-global-mocks.ts
+++ b/test/jest-global-mocks.ts
@@ -1,5 +1,5 @@
 const mock = () => {
-  let storage = {};
+  let storage: any = {};
   return {
     getItem: (key: any) => key in storage ? storage[key] : null,
     setItem: (key: any, value: any) => storage[key] = value || '',

--- a/test/jest.config.ts
+++ b/test/jest.config.ts
@@ -7,7 +7,6 @@ const config: Config.InitialOptions = {
   collectCoverage: false,
   collectCoverageFrom: [
     'packages/**/*.ts',
-    'packages/**/core/*.ts',
     '!**/dist/**',
     '!src/assets/**',
     '!examples/vite-demo-vanilla-bundle/**',

--- a/test/jest.config.ts
+++ b/test/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config.InitialOptions = {
   collectCoverage: false,
   collectCoverageFrom: [
     'packages/**/*.ts',
+    'packages/**/core/*.ts',
     '!**/dist/**',
     '!src/assets/**',
     '!examples/vite-demo-vanilla-bundle/**',

--- a/test/jest.config.ts
+++ b/test/jest.config.ts
@@ -52,7 +52,6 @@ const config: Config.InitialOptions = {
   },
   transformIgnorePatterns: [
     'node_modules/(?!(@slickgrid-universal)/)',
-    '<rootDir>/node_modules/slickgrid/'
   ],
   testMatch: [
     '**/__tests__/**/*.+(ts|js)',


### PR DESCRIPTION
- add full test coverage for `slick.core` and `slick.interactions`
  - I'm saying it's full coverage on  `slick.core` because all the Utils stuff that is uncovered by tests will be moved in a future PR, so `slick.core` is by that definition fully covered
- add test spec file templates with basic unit tests for `slick.grid` and `slick.dataview`