### PR TITLE
fix(common): cell range decorator should be hidden after onDragEnd

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
@@ -152,7 +152,7 @@ describe('CellRangeSelector Plugin', () => {
     gridStub.onDragEnd.notify({ startX: 3, startY: 4, range: { start: { cell: 2, row: 3 }, end: { cell: 4, row: 5 } }, grid: gridStub } as any, dragEventEnd, gridStub);
 
     expect(focusSpy).not.toHaveBeenCalled();
-    expect(decoratorHideSpy).not.toHaveBeenCalled();
+    expect(decoratorHideSpy).toHaveBeenCalled();
     expect(decoratorShowSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -301,12 +301,13 @@ export class SlickCellRangeSelector {
   }
 
   protected handleDragEnd(e: any, dd: DragPosition) {
+    this._decorator.hide();
+
     if (this._dragging) {
       this._dragging = false;
       e.stopImmediatePropagation();
 
       this.stopIntervalTimer();
-      this._decorator.hide();
       this.onCellRangeSelected.notify({
         range: new Slick.Range(dd.range.start.row, dd.range.start.cell, dd.range.end.row, dd.range.end.cell)
       });


### PR DESCRIPTION
- issue was found when user has an Editor open and then click on a row checkbox and start dragging that row checkbox cell, then the cell range decorator appears but never goes away because checkbox plugin has prevents event bubbling when having an editor and in turns wasn't destroying the cell range decorator when it should, the cell range decorator isn't visible but it has a z-index of 9999 and even though it's invisible it was showing on top of everything else making the cell behind it unclickable for the size of the cell range decorator (usually about the size of 2-3 cells)