### PR TITLE
fix(common): throw when trying to preset sort on non-sortable column

### DIFF
--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -296,17 +296,24 @@ export class SortService {
       const tmpSorters = this._gridOptions.multiColumnSort ? sorters : sorters.slice(0, 1);
 
       tmpSorters.forEach((sorter: CurrentSorter) => {
-        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === sorter.columnId);
-        if (gridColumn) {
+        const column = this._columnDefinitions.find((col: Column) => col.id === sorter.columnId);
+        if (column) {
+          if (!column.sortable) {
+            let errorMsg = '[Slickgrid-Universal] Cannot add sort icon to a column that is not sortable, please add `sortable: true` to your column or remove it from your list of columns to sort.';
+            if (this._gridOptions.enableTreeData) {
+              errorMsg += ' Also note that TreeData feature requires the column holding the tree (expand/collapse icons) to be sortable.';
+            }
+            throw new Error(errorMsg);
+          }
           sortCols.push({
-            columnId: gridColumn.id,
+            columnId: column.id,
             sortAsc: ((sorter.direction.toUpperCase() === SortDirection.ASC) ? true : false),
-            sortCol: gridColumn
+            sortCol: column
           });
 
           // keep current sorters
           this._currentLocalSorters.push({
-            columnId: gridColumn.id + '',
+            columnId: String(column.id),
             direction: sorter.direction.toUpperCase() as SortDirectionString
           });
         }


### PR DESCRIPTION
when the user does not make the column `sortable`, it will now throw. This was caught after having trouble with a Tree Data grid, the column holding the Tree needs to be sortable since that is how the Tree Data feature is built on top of, if user removes the sorting it breaks the feature, so throwing an error seems to be the best for easier troubleshooting of the problem occurring

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/c2d92a78-9b32-4923-a28b-8da6aba6f9f2)
