### PR TITLE
feat(GraphQL): Provide ability to specify operationName

### DIFF
--- a/packages/graphql/src/interfaces/graphqlServiceOption.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlServiceOption.interface.ts
@@ -16,7 +16,7 @@ export interface GraphqlServiceOption extends BackendServiceOption {
   /** What is the dataset, this is required for the GraphQL query to be built */
   datasetName: string;
 
-  /** Use for defining the operation name when building the GraphQL query */
+  /** Used for defining the operation name when building the GraphQL query */
   operationName?: string;
 
   /**

--- a/packages/graphql/src/interfaces/graphqlServiceOption.interface.ts
+++ b/packages/graphql/src/interfaces/graphqlServiceOption.interface.ts
@@ -16,6 +16,9 @@ export interface GraphqlServiceOption extends BackendServiceOption {
   /** What is the dataset, this is required for the GraphQL query to be built */
   datasetName: string;
 
+  /** Use for defining the operation name when building the GraphQL query */
+  operationName?: string;
+
   /**
    * Extra query arguments that be passed in addition to the default query arguments
    * For example in GraphQL, if we want to pass "userId" and we want the query to look like

--- a/packages/graphql/src/services/__tests__/graphql.service.spec.ts
+++ b/packages/graphql/src/services/__tests__/graphql.service.spec.ts
@@ -418,6 +418,21 @@ describe('GraphqlService', () => {
 
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
+
+    it('should include the operationName if provided', () => {
+      const expectation = `query foo {users(first:10, offset:0, userId:123, firstName:"John"){ totalCount, nodes{id,field1,field2}}}`;
+      const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(columns);
+
+      service.init({
+        datasetName: 'users',
+        operationName: 'foo',
+        extraQueryArguments: [{ field: 'userId', value: 123 }, { field: 'firstName', value: 'John' }],
+      }, paginationOptions, gridStub);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
   });
 
   describe('buildFilterQuery method', () => {

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -93,7 +93,7 @@ export class GraphqlService implements BackendService {
     let columnDefinitions = this._columnDefinitions || [];
     columnDefinitions = columnDefinitions.filter((column: Column) => !column.excludeFromQuery);
 
-    const queryQb = new QueryBuilder('query');
+    const queryQb = new QueryBuilder(`query ${this.options.operationName ?? ''}`);
     const datasetQb = new QueryBuilder(this.options.datasetName);
     const nodesQb = new QueryBuilder('nodes');
 


### PR DESCRIPTION
-- Background --
By default when using Graphql (Apollo), all network requests hit the same endpoint, and as such they all have the same name in the devtools. e.g: `graphql`.  This makes performance monitoring and diagnosing problematic queries difficult. To get around this, we append the operationName of a graphql query to the url. e.g `graphql?GetUsers`, `graphql?getUserData` so we can uniquely identify each query.
https://stackoverflow.com/questions/64642948/is-there-a-way-to-name-graphql-requests-in-the-devtool-network-tab

-- Problem --
The dynamically built query in slickgrid does not allow specifying an operationName and so all queries generated by slickgrid have an operationName of `undefined`
eg: `query { datasetName (....) } `
https://stackoverflow.com/questions/57049366/get-query-mutation-operation-name

As such, all the slickgrid queries look like `graphql?undefined` when looking in devtools.

-- Solution -- 
Provide an optional GraphQlOption `operationName` that if provided will be used during `GraphQlService.buildQuery`
eg: `query operationName { datasetName (...) }`