### PR TITLE
chore: add `preventDocumentFragmentUsage` grid option

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example18.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example18.ts
@@ -23,7 +23,7 @@ const currencyFormatter: Formatter = (_cell, _row, value: string) =>
 
 const priceFormatter: Formatter = (_cell, _row, value, _col, dataContext) => {
   const direction = dataContext.priceChange >= 0 ? 'up' : 'down';
-  const fragment = document.createDocumentFragment();
+  const fragment = new DocumentFragment();
   const spanElm = document.createElement('span');
   spanElm.className = `mdi mdi-arrow-${direction} color-${direction === 'up' ? 'success' : 'danger'}`;
   fragment.appendChild(spanElm);

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -2,6 +2,7 @@ import { SlickEventHandler, Utils as SlickUtils, type SlickDataView, SlickGroup,
 import type {
   Column,
   DOMEvent,
+  GridOption,
   GroupingFormatterItem,
   GroupItemMetadataProviderOption,
   ItemMetadata,
@@ -51,6 +52,10 @@ export class SlickGroupItemMetadataProvider {
   /** Getter of SlickGrid DataView object */
   protected get dataView(): SlickDataView {
     return this._grid?.getData<SlickDataView>() ?? {};
+  }
+
+  get gridOptions(): GridOption {
+    return this._grid?.getOptions() || {};
   }
 
   init(grid: SlickGrid, inputOptions?: GroupItemMetadataProviderOption) {
@@ -119,7 +124,7 @@ export class SlickGroupItemMetadataProvider {
     const toggleClass = item.collapsed ? this._options.toggleCollapsedCssClass : this._options.toggleExpandedCssClass;
 
     // use a DocumentFragment to avoid creating an extra div container
-    const containerElm = document.createDocumentFragment();
+    const containerElm = this.gridOptions?.preventDocumentFragmentUsage ? document.createElement('span') : new DocumentFragment();
 
     // 1. group toggle span
     containerElm.appendChild(createDomElement('span', {

--- a/packages/common/src/formatters/__tests__/formatterUtilities.spec.ts
+++ b/packages/common/src/formatters/__tests__/formatterUtilities.spec.ts
@@ -115,7 +115,7 @@ describe('formatterUtilities', () => {
     let mockColumn: Column;
     const myBoldHtmlFormatter: Formatter = (_row, _cell, value) => value !== null ? { text: value ? `<b>${value}</b>` : '' } : null as any;
     const myUppercaseFormatter: Formatter = (_row, _cell, value) => {
-      const fragment = document.createDocumentFragment();
+      const fragment = new DocumentFragment();
       if (value) {
         fragment.textContent = value.toUpperCase();
       }

--- a/packages/common/src/formatters/__tests__/maskFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/maskFormatter.spec.ts
@@ -1,5 +1,14 @@
+import { SlickGrid } from '../../core/index';
 import { Column } from '../../interfaces/index';
 import { maskFormatter } from '../maskFormatter';
+
+const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
+  focus: jest.fn(),
+  getActiveCell: jest.fn(),
+  getOptions: jest.fn(),
+  getColumns: jest.fn(),
+} as unknown as SlickGrid;
 
 describe('the ArrayObjectToCsv Formatter', () => {
   it('should throw an error when omitting to pass "propertyNames" to "params"', () => {
@@ -9,56 +18,73 @@ describe('the ArrayObjectToCsv Formatter', () => {
 
   it('should throw an error when omitting to pass "propertyNames" to "params"', () => {
     const params = { mask: '' };
-    expect(() => maskFormatter(0, 0, 'anything', { field: 'user', params } as Column, {}, {} as any))
+    expect(() => maskFormatter(0, 0, 'anything', { field: 'user', params } as Column, {}, gridStub))
       .toThrowError('You must provide a "mask" via the generic "params" options');
   });
 
   it('should return null when no value is provided', () => {
     const input = null;
     const params = { mask: '(000) 000-0000' };
-    const result = maskFormatter(0, 0, input, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, input, { field: 'user', params } as Column, {}, gridStub);
+
     expect(result).toBe(null);
   });
 
   it('should return formatted output according to mask when mask includes only numbers', () => {
     const params = { mask: '(000) 000-0000' };
     const inputValue = '123456789013';
-    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
     expect((result as DocumentFragment).textContent).toBe('(123) 456-7890');
   });
 
   it('should return formatted output without extra digits that are not included in the mask', () => {
     const params = { mask: '(000) 000-0000' };
     const inputValue = '1234567890135455454';
-    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
     expect((result as DocumentFragment).textContent).toBe('(123) 456-7890');
   });
 
   it('should return partially formatted output when input (digits only) length is shorter than mask', () => {
     const params = { mask: '(000) 000-0000' };
     const inputValue = '123456';
-    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
     expect((result as DocumentFragment).textContent).toBe('(123) 456-');
   });
 
   it('should return formatted output (postal code) according to mask when mask includes both numbers and characters', () => {
     const params = { mask: 'A0A 0A0' };
     const inputValue = 'H0H0H0';
-    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
     expect((result as DocumentFragment).textContent).toBe('H0H 0H0');
   });
 
   it('should return formatted output (postal code) without extra characters that are not included in the mask', () => {
     const params = { mask: 'A0A 0A0' };
     const inputValue = 'H0H0H0324343asdds';
-    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
     expect((result as DocumentFragment).textContent).toBe('H0H 0H0');
   });
 
   it('should return partially formatted output when input (characters only) length is shorter than mask', () => {
     const params = { mask: 'A0A 0A0' };
     const inputValue = 'H0H0';
-    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, {} as any);
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
     expect((result as DocumentFragment).textContent).toBe('H0H 0');
+  });
+
+  it('should wrap the formatter output in a span element when "allowDocumentFragmentUsage" grid option is disabled', () => {
+    const params = { mask: '(000) 000-0000' };
+    const inputValue = '123456789013';
+    jest.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ preventDocumentFragmentUsage: true });
+
+    const result = maskFormatter(0, 0, inputValue, { field: 'user', params } as Column, {}, gridStub);
+
+    expect((result as HTMLElement).outerHTML).toBe('<span>(123) 456-7890</span>');
   });
 });

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -56,6 +56,15 @@ describe('Tree Formatter', () => {
       .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="0">Barbara</span>`);
   });
 
+  it('should return the Tree content wrapped inside a span HTML element when "allowDocumentFragmentUsage" grid option is disabled', () => {
+    jest.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ ...mockGridOptions, preventDocumentFragmentUsage: true });
+    const output = treeFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub) as FormatterResultWithHtml;
+
+    expect(output.addClasses).toBe('slick-tree-level-0');
+    expect((output.html as HTMLElement).outerHTML)
+      .toEqual(`<span><span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="0">Barbara</span></span>`);
+  });
+
   it('should return a span without any toggle icon and have a 15px indentation with tree level 3', () => {
     const output = treeFormatter(1, 1, dataset[6]['firstName'], {} as Column, dataset[6], gridStub) as FormatterResultWithHtml;
 

--- a/packages/common/src/formatters/maskFormatter.ts
+++ b/packages/common/src/formatters/maskFormatter.ts
@@ -4,7 +4,7 @@ import { type Formatter } from './../interfaces/index';
  * Takes a value display it according to a mask provided
  * e.: 1234567890 with mask "(000) 000-0000" will display "(123) 456-7890"
  */
-export const maskFormatter: Formatter = (_row, _cell, value, columnDef) => {
+export const maskFormatter: Formatter = (_row, _cell, value, columnDef, data, grid) => {
   const params = columnDef.params || {};
   const mask = params.mask;
 
@@ -15,9 +15,10 @@ export const maskFormatter: Formatter = (_row, _cell, value, columnDef) => {
   if (value) {
     let i = 0;
     const v = value.toString();
-    const fragment = document.createDocumentFragment();
-    fragment.textContent = mask.replace(/[09A]/gi, () => v[i++] || '');
-    return fragment;
+    const gridOptions = grid.getOptions() || {};
+    const containerElm = gridOptions?.preventDocumentFragmentUsage ? document.createElement('span') : new DocumentFragment();
+    containerElm.textContent = mask.replace(/[09A]/gi, () => v[i++] || '');
+    return containerElm;
   }
   return value;
 };

--- a/packages/common/src/formatters/treeFormatter.ts
+++ b/packages/common/src/formatters/treeFormatter.ts
@@ -45,10 +45,10 @@ export const treeFormatter: Formatter = (row, cell, value, columnDef, dataContex
   spanTitleElm.innerHTML = sanitizedOutputValue;
   spanTitleElm.setAttribute('level', treeLevel);
 
-  const fragment = document.createDocumentFragment();
-  fragment.appendChild(indentSpacerElm);
-  fragment.appendChild(spanIconElm);
-  fragment.appendChild(spanTitleElm);
+  const containerElm = gridOptions?.preventDocumentFragmentUsage ? document.createElement('span') : new DocumentFragment();
+  containerElm.appendChild(indentSpacerElm);
+  containerElm.appendChild(spanIconElm);
+  containerElm.appendChild(spanTitleElm);
 
-  return { addClasses: slickTreeLevelClass, html: fragment };
+  return { addClasses: slickTreeLevelClass, html: containerElm };
 };

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -58,6 +58,7 @@ export interface CssStyleHash {
 }
 
 export interface GridOption<C extends Column = Column> {
+  /** Defaults to true, should we always allow the use of horizontal scrolling? */
   alwaysAllowHorizontalScroll?: boolean;
 
   /** CSS class name used on newly added row */
@@ -596,6 +597,9 @@ export interface GridOption<C extends Column = Column> {
 
   /** Query presets before grid load (filters, sorters, pagination) */
   presets?: GridState;
+
+  /** Defaults to false, do we want prevent the usage of DocumentFragment by the library (might not be supported by all environments, e.g. not supported by Salesforce) */
+  preventDocumentFragmentUsage?: boolean;
 
   /** Preselect certain rows by their row index ("enableCheckboxSelector" must be enabled) */
   preselectedRows?: number[];

--- a/packages/common/src/services/__tests__/domUtilities.spec.ts
+++ b/packages/common/src/services/__tests__/domUtilities.spec.ts
@@ -105,7 +105,7 @@ describe('Service/domUtilies', () => {
       const div = document.createElement('div');
       const span = document.createElement('span');
       span.textContent = 'some text';
-      const fragment = document.createDocumentFragment();
+      const fragment = new DocumentFragment();
       div.appendChild(span);
       fragment.appendChild(div);
 
@@ -118,7 +118,7 @@ describe('Service/domUtilies', () => {
       const div = document.createElement('div');
       const span = document.createElement('span');
       span.textContent = 'some text';
-      const fragment = document.createDocumentFragment();
+      const fragment = new DocumentFragment();
       div.appendChild(span);
       fragment.appendChild(div);
 

--- a/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
+++ b/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
@@ -60,6 +60,7 @@ export const SalesforceGlobalGridOptions = {
     iconSortAscCommand: 'fa fa-sort-amount-asc mdi mdi-arrow-up',
     iconSortDescCommand: 'fa fa-sort-amount-desc mdi mdi-arrow-down',
   },
+  preventDocumentFragmentUsage: true,
   sanitizer: (dirtyHtml: string) => typeof dirtyHtml === 'string' ? dirtyHtml.replace(/(\b)(on[a-z]+)(\s*)=|javascript:([^>]*)[^>]*|(<\s*)(\/*)script([<>]*).*(<\s*)(\/*)script(>*)|(&lt;)(\/*)(script|script defer)(.*)(&gt;|&gt;">)/gi, '') : dirtyHtml,
   showCustomFooter: true,
   customFooterOptions: {


### PR DESCRIPTION
- it seems that DocumentFragment is not supported by all environment, e.g. Salesforce doesn't seem to support it yet