### PR TITLE
chore: remove some more `innerHTML` assignment

### DIFF
--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -21,6 +21,7 @@ const gridOptionMock = {
 } as GridOption;
 
 const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
   getOptions: jest.fn(),
   getColumns: jest.fn(),
   getHeaderRowColumn: jest.fn(),

--- a/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
@@ -19,6 +19,7 @@ const gridOptionMock = {
 } as GridOption;
 
 const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
   getOptions: jest.fn(),
   getColumns: jest.fn(),
   getHeaderRowColumn: jest.fn(),

--- a/packages/common/src/filters/__tests__/compoundInputNumberFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputNumberFilter.spec.ts
@@ -15,6 +15,7 @@ const gridOptionMock = {
 } as GridOption;
 
 const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
   getOptions: () => gridOptionMock,
   getColumns: jest.fn(),
   getHeaderRowColumn: jest.fn(),

--- a/packages/common/src/filters/__tests__/compoundInputPasswordFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputPasswordFilter.spec.ts
@@ -15,6 +15,7 @@ const gridOptionMock = {
 } as GridOption;
 
 const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
   getOptions: () => gridOptionMock,
   getColumns: jest.fn(),
   getHeaderRowColumn: jest.fn(),

--- a/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
@@ -21,6 +21,7 @@ const gridOptionMock = {
 } as GridOption;
 
 const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
   getOptions: () => gridOptionMock,
   getColumns: jest.fn(),
   getHeaderRowColumn: jest.fn(),

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -362,7 +362,7 @@ export class DateFilter implements Filter {
 
       return this._filterDivInputElm;
     } else {
-      this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.gridOptions);
+      this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.grid);
       const filterContainerElm = createDomElement('div', { className: `form-group search-filter filter-${columnId}` });
       const containerInputGroupElm = createDomElement('div', { className: 'input-group flatpickr' }, filterContainerElm);
       const operatorInputGroupAddonElm = createDomElement('div', { className: 'input-group-addon input-group-prepend operator' }, containerInputGroupElm);

--- a/packages/common/src/filters/filterUtilities.ts
+++ b/packages/common/src/filters/filterUtilities.ts
@@ -1,22 +1,23 @@
 import { Constants } from '../constants';
 import type { Column, GridOption, Locale, OperatorDetail } from '../interfaces/index';
 import type { Observable, RxJsFacade, Subject, Subscription } from '../services/rxjsFacade';
-import { createDomElement, htmlEncodeWithPadding, sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
+import { createDomElement, htmlEncodeWithPadding, } from '../services/domUtilities';
 import { castObservableToPromise, getDescendantProperty, getTranslationPrefix, } from '../services/utilities';
 import type { TranslaterService } from '../services/translater.service';
+import type { SlickGrid } from '../core';
 
 /**
  * Create and return a select dropdown HTML element with a list of Operators with descriptions
  * @param {Array<Object>} optionValues - list of operators and their descriptions
  * @returns {Object} selectElm - Select Dropdown HTML Element
  */
-export function buildSelectOperator(optionValues: OperatorDetail[], gridOptions: GridOption): HTMLSelectElement {
+export function buildSelectOperator(optionValues: OperatorDetail[], grid: SlickGrid): HTMLSelectElement {
   const selectElm = createDomElement('select', { className: 'form-control' });
 
   for (const option of optionValues) {
     const optionElm = document.createElement('option');
     optionElm.value = option.operator;
-    optionElm.innerHTML = sanitizeTextByAvailableSanitizer(gridOptions, `${htmlEncodeWithPadding(option.operatorAlt || option.operator, 3)}${option.descAlt || option.desc}`);
+    grid.applyHtmlCode(optionElm, `${htmlEncodeWithPadding(option.operatorAlt || option.operator, 3)}${option.descAlt || option.desc}`);
     selectElm.appendChild(optionElm);
   }
 

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -283,7 +283,7 @@ export class InputFilter implements Filter {
     } else {
       // compound filter
       this._filterInputElm.classList.add('compound-input');
-      this._selectOperatorElm = buildSelectOperator(this.getCompoundOperatorOptionValues(), this.gridOptions);
+      this._selectOperatorElm = buildSelectOperator(this.getCompoundOperatorOptionValues(), this.grid);
       this._filterContainerElm = createDomElement('div', { className: `form-group search-filter filter-${columnId}` });
       const containerInputGroupElm = createDomElement('div', { className: 'input-group' }, this._filterContainerElm);
       const operatorInputGroupAddonElm = createDomElement('div', { className: 'input-group-addon input-group-prepend operator' }, containerInputGroupElm);

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -275,7 +275,7 @@ export class SliderFilter implements Filter {
     // create Operator dropdown DOM element
     if (this.sliderType === 'compound') {
       const spanPrependElm = createDomElement('span', { className: 'input-group-addon input-group-prepend operator' });
-      this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.gridOptions);
+      this._selectOperatorElm = buildSelectOperator(this.getOperatorOptionValues(), this.grid);
       spanPrependElm.appendChild(this._selectOperatorElm);
     }
 

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -4,6 +4,7 @@ import { SlickGrid } from '../../core/index';
 import { getHTMLFromFragment } from '../../services';
 
 const gridStub = {
+  applyHtmlCode: (elm, val) => elm.innerHTML = val || '',
   getData: jest.fn(),
   getOptions: jest.fn(),
 } as unknown as SlickGrid;

--- a/packages/common/src/formatters/treeFormatter.ts
+++ b/packages/common/src/formatters/treeFormatter.ts
@@ -1,7 +1,7 @@
 import { Constants } from '../constants';
 import { type Formatter } from './../interfaces/index';
 import { parseFormatterWhenExist } from './formatterUtilities';
-import { createDomElement, sanitizeTextByAvailableSanitizer, } from '../services/domUtilities';
+import { createDomElement } from '../services/domUtilities';
 import { getCellValueFromQueryFieldGetter, } from '../services/utilities';
 
 /** Formatter that must be use with a Tree Data column */
@@ -39,12 +39,11 @@ export const treeFormatter: Formatter = (row, cell, value, columnDef, dataContex
   if (treeDataOptions?.titleFormatter) {
     outputValue = parseFormatterWhenExist(treeDataOptions.titleFormatter, row, cell, columnDef, dataContext, grid);
   }
-  const sanitizedOutputValue = sanitizeTextByAvailableSanitizer(gridOptions, outputValue, { ADD_ATTR: ['target'] });
   const spanToggleClass = `slick-group-toggle ${toggleClass}`.trim();
 
   const spanIconElm = createDomElement('div', { className: spanToggleClass, ariaExpanded: String(toggleClass === 'expanded') });
   const spanTitleElm = createDomElement('span', { className: 'slick-tree-title' });
-  spanTitleElm.innerHTML = sanitizedOutputValue;
+  grid.applyHtmlCode(spanTitleElm, outputValue);
   spanTitleElm.setAttribute('level', treeLevel);
 
   const containerElm = gridOptions?.preventDocumentFragmentUsage ? document.createElement('span') : new DocumentFragment();


### PR DESCRIPTION
- use `applyHtmlCode()` anywhere we can so that at the end there is only 1 place to modify if need be