### PR TITLE
bug/feat: Disable select all checkbox when there is nothing to select

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
@@ -35,6 +35,7 @@ const dataViewStub = {
   getIdPropertyName: () => 'id',
   onPagingInfoChanged: new Slick.Event(),
   onSelectedRowIdsChanged: new Slick.Event(),
+  onRowsChanged: new Slick.Event(),
   setSelectedIds: jest.fn(),
 };
 
@@ -720,6 +721,95 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       '_checkbox_selector',
       `<input id="header-selector${plugin.selectAllUid}" type="checkbox" checked="checked" aria-checked="true"><label for="header-selector${plugin.selectAllUid}"></label>`,
       'Select/Deselect All'
+    );
+  });
+
+  it('should trigger "onSelectedRowIdsChanged" event and invalidate row and render to be called also with "setSelectedRows" when checkSelectableOverride returns False and input select checkbox is all checked', () => {
+    const nodeElm = document.createElement('div');
+    nodeElm.className = 'slick-headerrow-column';
+    const invalidateRowSpy = jest.spyOn(gridStub, 'invalidateRow');
+    const renderSpy = jest.spyOn(gridStub, 'render');
+    const updateColumnHeaderSpy = jest.spyOn(gridStub, 'updateColumnHeader');
+    const setSelectedRowSpy = jest.spyOn(gridStub, 'setSelectedRows');
+    jest.spyOn(dataViewStub, 'getAllSelectedFilteredIds').mockReturnValueOnce([1, 2]);
+    jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit').mockReturnValue(true);
+    jest.spyOn(dataViewStub, 'getFilteredItems').mockReturnValueOnce([{ id: 22, firstName: 'John', lastName: 'Doe', age: 30 }]);
+    jest.spyOn(dataViewStub, 'getItemCount').mockReturnValueOnce(2);
+    jest.spyOn(dataViewStub, 'getItemByIdx').mockReturnValueOnce({ id: 22, firstName: 'John', lastName: 'Doe', age: 30 });
+
+    plugin = new SlickCheckboxSelectColumn(pubSubServiceStub, { hideInFilterHeaderRow: false, hideSelectAllCheckbox: false, selectableOverride: () => false });
+    plugin.init(gridStub);
+    plugin.selectedRowsLookup = { 1: false, 2: true };
+
+    gridStub.onHeaderRowCellRendered.notify({ column: { id: '_checkbox_selector', field: '_checkbox_selector' }, node: nodeElm, grid: gridStub });
+
+    const checkboxElm = document.createElement('input');
+    checkboxElm.type = 'checkbox';
+    const clickEvent = addVanillaEventPropagation(new Event('keyDown'), '', ' ', checkboxElm);
+    dataViewStub.onSelectedRowIdsChanged.notify({ rows: [0, 1], filteredIds: [1, 2], ids: [1, 2], selectedRowIds: [1, 2], dataView: dataViewStub, grid: gridStub }, clickEvent);
+
+    expect(plugin).toBeTruthy();
+    expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
+      '_checkbox_selector',
+      `<input id="header-selector${plugin.selectAllUid}" type="checkbox" checked="checked" aria-checked="true"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      'Select/Deselect All'
+    );
+  });
+
+  it('should disable the select all checkbox when there are no rows', () => {
+    const nodeElm = document.createElement('div');
+    nodeElm.className = 'slick-headerrow-column';
+    const updateColumnHeaderSpy = jest.spyOn(gridStub, 'updateColumnHeader');
+    jest.spyOn(dataViewStub, 'getFilteredItems').mockReturnValueOnce([]);
+
+    plugin = new SlickCheckboxSelectColumn(pubSubServiceStub, {
+      hideInFilterHeaderRow: false,
+      hideSelectAllCheckbox: false,
+      applySelectOnAllPages: false,
+      cssClass: 'slick-cell-checkboxsel',
+      selectableOverride: () => false,
+    });
+    plugin.init(gridStub);
+    plugin.selectedRowsLookup = { 1: false, 2: true };
+
+    const checkboxElm = document.createElement('input');
+    checkboxElm.type = 'checkbox';
+    const clickEvent = addVanillaEventPropagation(new Event('keyDown'), '', ' ', checkboxElm);
+    dataViewStub.onRowsChanged.notify({ dataView: dataViewStub, grid: gridStub }, clickEvent);
+
+    expect(plugin).toBeTruthy();
+    expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
+      '_checkbox_selector',
+      `<div class="slick-cell-checkboxsel"></div>`
+    );
+  });
+
+  it('should disable the select all checkbox when there are no rows that can be selected', () => {
+    const nodeElm = document.createElement('div');
+    nodeElm.className = 'slick-headerrow-column';
+    const updateColumnHeaderSpy = jest.spyOn(gridStub, 'updateColumnHeader');
+    jest.spyOn(gridStub, 'getOptions').mockReturnValue({ backendServiceApi: {} as any });
+    jest.spyOn(dataViewStub, 'getFilteredItems').mockReturnValueOnce([{ id: 22, firstName: 'John', lastName: 'Doe', age: 30 }]);
+
+    plugin = new SlickCheckboxSelectColumn(pubSubServiceStub, {
+      hideInFilterHeaderRow: false,
+      hideSelectAllCheckbox: false,
+      applySelectOnAllPages: false,
+      cssClass: 'slick-cell-checkboxsel',
+      selectableOverride: () => false,
+    });
+    plugin.init(gridStub);
+    plugin.selectedRowsLookup = { 1: false, 2: true };
+
+    const checkboxElm = document.createElement('input');
+    checkboxElm.type = 'checkbox';
+    const clickEvent = addVanillaEventPropagation(new Event('keyDown'), '', ' ', checkboxElm);
+    dataViewStub.onRowsChanged.notify({ dataView: dataViewStub, grid: gridStub }, clickEvent);
+
+    expect(plugin).toBeTruthy();
+    expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
+      '_checkbox_selector',
+      `<div class="slick-cell-checkboxsel"></div>`
     );
   });
 });


### PR DESCRIPTION
== Issue Reproduction ==
Setup: 
Page 1 has 10 items, 4 selectable, 6 non selectable
Page 2 has 10 items, none selectable

Repro:
1) Navigate to page 2
2) Check the select all checkbox. Nothing will be selected, but the select all will be ticked. This is OK since all selectable items are "selected" (even if that's 0)
3) Navigate to page 1. The select all checkbox will be ticked but nothing will selected, even though there are 4 items that could be selected.

Expected: Select all checkbox should be consistent with what's displayed on the table
Actual: Select all checkbox was selected, but nothing on the table was selected even though they could be

Fix:
First attempt to fix was to simply clear the select all checkbox by calling `gridState.setSelected([])`, but because the selection set wasn't actually changing, the `slickgCheckboxSelectColumn.handleSelectedRows()` wouldn't fire.

Second attempt is this PR which is when there is nothing to select, clear and disable the selectAll checkbox to prevent the user from putting it into an inconsistent state. Also had to respect to `applySelectOnAllPages` as we could not make assumptions on data that wasn't on the grid.