### PR TITLE
fix: registered external resouces should keep singleton ref

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example02.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example02.ts
@@ -201,7 +201,7 @@ export default class Example2 {
         }
       },
       textExportOptions: { filename: 'my-export', sanitizeDataExport: true },
-      registerExternalResources: [this.excelExportService, new TextExportService()],
+      externalResources: [this.excelExportService, new TextExportService()],
       showCustomFooter: true, // display some metrics in the bottom custom footer
       customFooterOptions: {
         // optionally display some text on the left footer container

--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
@@ -292,7 +292,7 @@ export default class Example3 {
       excelExportOptions: {
         exportWithFormatter: true
       },
-      registerExternalResources: [new TextExportService(), this.excelExportService],
+      externalResources: [new TextExportService(), this.excelExportService],
       enableFiltering: true,
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)

--- a/examples/vite-demo-vanilla-bundle/src/examples/example04.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example04.ts
@@ -366,7 +366,7 @@ export default class Example4 {
         exportWithFormatter: true,
         sanitizeDataExport: true
       },
-      registerExternalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService()],
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false

--- a/examples/vite-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example05.ts
@@ -217,7 +217,7 @@ export default class Example5 {
       enableExcelExport: true,
       textExportOptions: { exportWithFormatter: true },
       excelExportOptions: { exportWithFormatter: true },
-      registerExternalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService()],
       enableFiltering: true,
       showCustomFooter: true, // display some metrics in the bottom custom footer
       customFooterOptions: {

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -39,7 +39,7 @@ export default class Example6 {
     this.datasetFlat = [];
     this.datasetHierarchical = this.mockDataset();
     const gridContainerElm = document.querySelector('.grid6') as HTMLDivElement;
-    this.sgb = new Slicker.GridBundle(gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, null as any, this.datasetHierarchical);
+    this.sgb = new Slicker.GridBundle(gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, undefined, this.datasetHierarchical);
     document.body.classList.add('material-theme');
   }
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -127,7 +127,7 @@ export default class Example6 {
       gridMenu: {
         iconCssClass: 'mdi mdi-dots-grid',
       },
-      registerExternalResources: [new ExcelExportService(), new TextExportService()],
+      externalResources: [new ExcelExportService(), new TextExportService()],
       enableFiltering: true,
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       multiColumnSort: false, // multi-column sorting is not supported with Tree Data, so you need to disable it

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -309,7 +309,7 @@ export default class Example7 {
       enableFiltering: true,
       enableTranslate: true,
       translater: this.translateService, // pass the TranslateService instance to the grid
-      registerExternalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService()],
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,

--- a/examples/vite-demo-vanilla-bundle/src/examples/example08.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example08.ts
@@ -69,7 +69,7 @@ export default class Example08 {
         exportWithFormatter: true,
         sanitizeDataExport: true
       },
-      registerExternalResources: [new TextExportService(), new ExcelExportService()],
+      externalResources: [new TextExportService(), new ExcelExportService()],
       enableCellNavigation: true,
       enableColumnReorder: false,
       enableSorting: true,

--- a/examples/vite-demo-vanilla-bundle/src/examples/example10.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example10.ts
@@ -270,7 +270,7 @@ export default class Example10 {
       setTimeout(() => {
         this.graphqlQuery = this.gridOptions.backendServiceApi!.service.buildQuery();
         if (this.isWithCursor) {
-          // When using cursor pagination, the pagination service needs to updated with the PageInfo data from the latest request
+          // When using cursor pagination, the pagination service needs to be updated with the PageInfo data from the latest request
           // This might be done automatically if using a framework specific slickgrid library
           // Note because of this timeout, this may cause race conditions with rapid clicks!
           this.sgb?.paginationService.setCursorPageInfo((mockedResult.data[GRAPHQL_QUERY_DATASET_NAME].pageInfo));

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -295,7 +295,7 @@ export default class Example11 {
       excelExportOptions: {
         exportWithFormatter: true
       },
-      registerExternalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService()],
       enableFiltering: true,
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)

--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -422,7 +422,7 @@ export default class Example12 {
       excelExportOptions: {
         exportWithFormatter: false
       },
-      registerExternalResources: [new ExcelExportService(), this.compositeEditorInstance],
+      externalResources: [new ExcelExportService(), this.compositeEditorInstance],
       enableFiltering: true,
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)

--- a/examples/vite-demo-vanilla-bundle/src/examples/example14.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example14.ts
@@ -436,7 +436,7 @@ export default class Example14 {
       excelExportOptions: {
         exportWithFormatter: false
       },
-      registerExternalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService()],
       enableFiltering: true,
       enableRowSelection: true,
       enableCheckboxSelector: true,

--- a/examples/vite-demo-vanilla-bundle/src/examples/example15.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example15.ts
@@ -175,7 +175,7 @@ export default class Example15 {
           this.getCustomerCallback(response);
         }
       } as OdataServiceApi,
-      registerExternalResources: [new RxJsResource(), new SlickCustomTooltip()]
+      externalResources: [new RxJsResource(), new SlickCustomTooltip()]
     };
   }
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example16.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example16.ts
@@ -340,7 +340,7 @@ export default class Example16 {
         thousandSeparator: ' '
       },
       // Custom Tooltip options can be defined in a Column or Grid Options or a mixed of both (first options found wins)
-      registerExternalResources: [new SlickCustomTooltip(), new ExcelExportService(), new TextExportService()],
+      externalResources: [new SlickCustomTooltip(), new ExcelExportService(), new TextExportService()],
       customTooltip: {
         formatter: this.tooltipFormatter.bind(this),
         headerFormatter: this.headerFormatter,

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -211,7 +211,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
                   format: FileType.csv,
                 });
               } else {
-                throw new Error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Context Menu. Example:: this.gridOptions = { enableTextExport: true, registerExternalResources: [new TextExportService()] };`);
+                throw new Error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Context Menu. Example:: this.gridOptions = { enableTextExport: true, externalResources: [new TextExportService()] };`);
               }
             },
           }
@@ -236,7 +236,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
               if (excelService?.exportToExcel) {
                 excelService.exportToExcel();
               } else {
-                throw new Error(`[Slickgrid-Universal] You must register the ExcelExportService to properly use Export to Excel in the Context Menu. Example:: this.gridOptions = { enableExcelExport: true, registerExternalResources: [new ExcelExportService()] };`);
+                throw new Error(`[Slickgrid-Universal] You must register the ExcelExportService to properly use Export to Excel in the Context Menu. Example:: this.gridOptions = { enableExcelExport: true, externalResources: [new ExcelExportService()] };`);
               }
             },
           }
@@ -264,7 +264,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
                   format: FileType.txt,
                 });
               } else {
-                throw new Error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Context Menu. Example:: this.gridOptions = { enableTextExport: true, registerExternalResources: [new TextExportService()] };`);
+                throw new Error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Context Menu. Example:: this.gridOptions = { enableTextExport: true, externalResources: [new TextExportService()] };`);
               }
             },
           }

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -768,7 +768,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
               format: FileType.csv,
             });
           } else {
-            console.error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Grid Menu. Example:: this.gridOptions = { enableTextExport: true, registerExternalResources: [new TextExportService()] };`);
+            console.error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Grid Menu. Example:: this.gridOptions = { enableTextExport: true, externalResources: [new TextExportService()] };`);
           }
           break;
         case 'export-excel':
@@ -776,7 +776,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
           if (excelService?.exportToExcel) {
             excelService.exportToExcel();
           } else {
-            console.error(`[Slickgrid-Universal] You must register the ExcelExportService to properly use Export to Excel in the Grid Menu. Example:: this.gridOptions = { enableExcelExport: true, registerExternalResources: [new ExcelExportService()] };`);
+            console.error(`[Slickgrid-Universal] You must register the ExcelExportService to properly use Export to Excel in the Grid Menu. Example:: this.gridOptions = { enableExcelExport: true, externalResources: [new ExcelExportService()] };`);
           }
           break;
         case 'export-text-delimited':
@@ -787,7 +787,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
               format: FileType.txt,
             });
           } else {
-            console.error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Grid Menu. Example:: this.gridOptions = { enableTextExport: true, registerExternalResources: [new TextExportService()] };`);
+            console.error(`[Slickgrid-Universal] You must register the TextExportService to properly use Export to File in the Grid Menu. Example:: this.gridOptions = { enableTextExport: true, externalResources: [new TextExportService()] };`);
           }
           break;
         case 'toggle-filter':

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -551,8 +551,11 @@ export interface GridOption {
   /** Preselect certain rows by their row index ("enableCheckboxSelector" must be enabled) */
   preselectedRows?: number[];
 
-  /** Register any external Resources (Components, Services) like the ExcelExportService, TextExportService, SlickCompositeEditorComponent, ... */
+  /** @deprecated @use `externalResources` instead. */
   registerExternalResources?: ExternalResource[];
+
+  /** Register any external Resources (Components, Services) like the ExcelExportService, TextExportService, SlickCompositeEditorComponent, ... */
+  externalResources?: ExternalResource[];
 
   /** Defaults to true, should we reset (rollback) the search filter input value to its previous value when the `onBeforeSearchChange` event bubbling is prevented? */
   resetFilterSearchValueAfterOnBeforeCancellation?: boolean;

--- a/packages/custom-tooltip-plugin/README.md
+++ b/packages/custom-tooltip-plugin/README.md
@@ -46,7 +46,7 @@ export class MyExample {
         formatter: tooltipTaskFormatter,
         // ...
       },
-      registerExternalResources: [new SlickCustomTooltip(), this.excelExportService],
+      externalResources: [new SlickCustomTooltip(), this.excelExportService],
     };
   }
 }

--- a/packages/excel-export/README.md
+++ b/packages/excel-export/README.md
@@ -38,7 +38,7 @@ export class MyExample {
       excelExportOptions: {
         sanitizeDataExport: true
       },
-      registerExternalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService()],
     }
   }
 }
@@ -61,7 +61,7 @@ export class MyExample {
       excelExportOptions: {
         sanitizeDataExport: true
       },
-      registerExternalResources: [this.excelExportService],
+      externalResources: [this.excelExportService],
     }
   }
 

--- a/packages/rxjs-observable/README.md
+++ b/packages/rxjs-observable/README.md
@@ -49,7 +49,7 @@ export class MyExample {
       } as OdataServiceApi,
 
       // ...
-      registerExternalResources: [new RxJsResource()],
+      externalResources: [new RxJsResource()],
     };
   }
 }

--- a/packages/text-export/README.md
+++ b/packages/text-export/README.md
@@ -42,7 +42,7 @@ export class MyExample {
       textExportOptions: {
         sanitizeDataExport: true
       },
-      registerExternalResources: [new TextExportService()],
+      externalResources: [new TextExportService()],
     }
   }
 }
@@ -65,7 +65,7 @@ export class MyExample {
       textExportOptions: {
         sanitizeDataExport: true
       },
-      registerExternalResources: [this.exportService],
+      externalResources: [this.exportService],
     }
   }
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -977,6 +977,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const paginationServiceSpy = jest.spyOn(paginationServiceStub, 'addRxJsResource');
 
         component.gridOptions = { externalResources: [rxjsMock] } as unknown as GridOption;
+        component.resetExternalResources();
         component.registerExternalResources([rxjsMock], true);
         component.initialization(divContainer, slickEventHandler);
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -756,7 +756,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: of(mockCollection) } }] as Column[];
 
         const rxjsMock = new RxJsResourceStub();
-        component.gridOptions = { registerExternalResources: [rxjsMock] } as unknown as GridOption;
+        component.gridOptions = { externalResources: [rxjsMock] } as unknown as GridOption;
+        component.registerExternalResources([rxjsMock], true);
         component.initialization(divContainer, slickEventHandler);
         component.columnDefinitions = mockColDefs;
 
@@ -975,7 +976,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const sortServiceSpy = jest.spyOn(sortServiceStub, 'addRxJsResource');
         const paginationServiceSpy = jest.spyOn(paginationServiceStub, 'addRxJsResource');
 
-        component.gridOptions = { registerExternalResources: [rxjsMock] } as unknown as GridOption;
+        component.gridOptions = { externalResources: [rxjsMock] } as unknown as GridOption;
+        component.registerExternalResources([rxjsMock], true);
         component.initialization(divContainer, slickEventHandler);
 
         expect(backendUtilitySpy).toHaveBeenCalled();
@@ -1258,7 +1260,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
         const backendExecuteSpy = jest.spyOn(backendUtilityServiceStub, 'executeBackendProcessesCallback');
 
-        component.gridOptions.registerExternalResources = [rxjsMock];
+        component.gridOptions.externalResources = [rxjsMock];
+        component.registerExternalResources([rxjsMock], true);
         component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 
@@ -1319,7 +1322,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
         const backendErrorSpy = jest.spyOn(backendUtilityServiceStub, 'onBackendError');
 
-        component.gridOptions.registerExternalResources = [rxjsMock];
+        component.gridOptions.externalResources = [rxjsMock];
+        component.registerExternalResources([rxjsMock], true);
         component.gridOptions.backendServiceApi!.service.options = { executeProcessCommandOnInit: true };
         component.initialization(divContainer, slickEventHandler);
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -328,7 +328,11 @@ export class SlickVanillaGridBundle {
 
     // save resource refs to register before the grid options are merged and possibly deep copied
     // since a deep copy of grid options would lose original resource refs but we want to keep them as singleton
-    this._registeredResources = options?.registerExternalResources || [];
+    this._registeredResources = options?.externalResources || options?.registerExternalResources || [];
+    /* istanbul ignore if */
+    if (options?.registerExternalResources) {
+      console.warn('[Slickgrid-Universal] Please note that the grid option `registerExternalResources` was deprecated, please use `externalResources` instead.');
+    }
 
     this._gridOptions = this.mergeGridOptions(options || {});
     const isDeepCopyDataOnPageLoadEnabled = !!(this._gridOptions?.enableDeepCopyDatasetOnPageLoad);
@@ -425,15 +429,7 @@ export class SlickVanillaGridBundle {
     this.universalContainerService?.dispose();
 
     // dispose all registered external resources
-    if (Array.isArray(this._registeredResources)) {
-      while (this._registeredResources.length > 0) {
-        const resource = this._registeredResources.pop();
-        if (resource?.dispose) {
-          resource.dispose();
-        }
-      }
-      this._registeredResources = [];
-    }
+    this.disposeExternalResources();
 
     // dispose the Components
     this.slickFooter?.dispose();
@@ -475,6 +471,18 @@ export class SlickVanillaGridBundle {
     }
     this._eventPubSubService?.dispose();
     this._slickerGridInstances = null as any;
+  }
+
+  disposeExternalResources() {
+    if (Array.isArray(this._registeredResources)) {
+      while (this._registeredResources.length > 0) {
+        const res = this._registeredResources.pop();
+        if (res?.dispose) {
+          res.dispose();
+        }
+      }
+    }
+    this._registeredResources = [];
   }
 
   initialization(gridContainerElm: HTMLElement, eventHandler: SlickEventHandler) {
@@ -1325,6 +1333,19 @@ export class SlickVanillaGridBundle {
     }
   }
 
+  /** Add a register a new external resource, user could also optional dispose all previous resources before pushing any new resources to the resources array list. */
+  registerExternalResources(resources: ExternalResource[], disposePreviousResources = false) {
+    if (disposePreviousResources) {
+      this.disposeExternalResources();
+    }
+    resources.forEach(res => this._registeredResources.push(res));
+    this.initializeExternalResources(resources);
+  }
+
+  resetExternalResources() {
+    this._registeredResources = [];
+  }
+
   /** Pre-Register any Resource that don't require SlickGrid to be instantiated (for example RxJS Resource) */
   protected preRegisterResources() {
     // bind & initialize all Components/Services that were tagged as enabled
@@ -1333,6 +1354,16 @@ export class SlickVanillaGridBundle {
       for (const resource of this._registeredResources) {
         if (resource?.className === 'RxJsResource') {
           this.registerRxJsResource(resource as RxJsFacade);
+        }
+      }
+    }
+  }
+
+  protected initializeExternalResources(resources: ExternalResource[]) {
+    if (Array.isArray(resources)) {
+      for (const resource of resources) {
+        if (this.slickGrid && typeof resource.init === 'function') {
+          resource.init(this.slickGrid, this.universalContainerService);
         }
       }
     }
@@ -1368,13 +1399,7 @@ export class SlickVanillaGridBundle {
 
     // bind & initialize all Components/Services that were tagged as enabled
     // register all services by executing their init method and providing them with the Grid object
-    if (Array.isArray(this._registeredResources)) {
-      for (const resource of this._registeredResources) {
-        if (this.slickGrid && typeof resource.init === 'function') {
-          resource.init(this.slickGrid, this.universalContainerService);
-        }
-      }
-    }
+    this.initializeExternalResources(this._registeredResources);
   }
 
   /** Register the RxJS Resource in all necessary services which uses */

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -325,6 +325,11 @@ export class SlickVanillaGridBundle {
     if (this._columnDefinitions.length > 0) {
       this.copyColumnWidthsReference(this._columnDefinitions);
     }
+
+    // save resource refs to register before the grid options are merged and possibly deep copied
+    // since a deep copy of grid options would lose original resource refs but we want to keep them as singleton
+    this._registeredResources = options?.registerExternalResources || [];
+
     this._gridOptions = this.mergeGridOptions(options || {});
     const isDeepCopyDataOnPageLoadEnabled = !!(this._gridOptions?.enableDeepCopyDatasetOnPageLoad);
 
@@ -1322,8 +1327,6 @@ export class SlickVanillaGridBundle {
 
   /** Pre-Register any Resource that don't require SlickGrid to be instantiated (for example RxJS Resource) */
   protected preRegisterResources() {
-    this._registeredResources = this.gridOptions.registerExternalResources || [];
-
     // bind & initialize all Components/Services that were tagged as enabled
     // register all services by executing their init method and providing them with the Grid object
     if (Array.isArray(this._registeredResources)) {

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -499,6 +499,7 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should initialize ExportService when "enableTextExport" is set when using Salesforce', () => {
         component.gridOptions = { enableTextExport: true, useSalesforceDefaultGridOptions: true } as unknown as GridOption;
+        component.resetExternalResources();
         component.initialization(divContainer, slickEventHandler);
 
         expect(TextExportService).toHaveBeenCalled();
@@ -513,7 +514,8 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
         const sortServiceSpy = jest.spyOn(sortServiceStub, 'addRxJsResource');
         const paginationServiceSpy = jest.spyOn(paginationServiceStub, 'addRxJsResource');
 
-        component.gridOptions = { registerExternalResources: [rxjsMock] } as unknown as GridOption;
+        component.gridOptions = { externalResources: [rxjsMock] } as unknown as GridOption;
+        component.registerExternalResources([rxjsMock], true);
         component.initialization(divContainer, slickEventHandler);
 
         expect(backendUtilitySpy).toHaveBeenCalled();


### PR DESCRIPTION
- external resources can be provided through the grid options, but these options are sometime deep copied and that might have the side effect of losing the singleton ref of the instantiate services/resources, instead we can simply keep these singleton refs before any grid options merge can happen and that is in the constructor before the grid initializes and before the grid options are merged and sometime deep copied with global options