### PR TITLE
chore: remove inline style from all examples & fix `applyHtmlCode()`

### DIFF
--- a/examples/vite-demo-vanilla-bundle/index.html
+++ b/examples/vite-demo-vanilla-bundle/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      img-src 'self' data: https://img.shields.io/github/stars/ https://flags.fmcdn.net/data/flags/mini/;
+      script-src 'self' 'unsafe-inline' 'unsafe-eval';
+      script-src-elem 'self' gd.geobytes.com/AutoCompleteCity;
+      style-src 'self' 'unsafe-inline';
+    ">
   </head>
   <body>
     <div id="app"></div>

--- a/examples/vite-demo-vanilla-bundle/src/app.html
+++ b/examples/vite-demo-vanilla-bundle/src/app.html
@@ -101,6 +101,6 @@
   </div>
 </nav>
 
-<div class="demo-container container is-fluid" style="padding-top: 20px">
+<div class="demo-container container is-fluid">
   <view-route></view-route>
 </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example01.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example01.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">Example 01 - Basic Grids
   <span class="subtitle">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -15,7 +15,7 @@
 </div>
 
 <div class="column is-half">
-  <hr style="margin: 16px 0" />
+  <hr class="my-4" />
 </div>
 
 <div class="columns">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example02.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example02.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 02 - Grouping &amp; Aggregators
   <span class="subtitle">(with Material Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -12,7 +12,7 @@
 </h3>
 
 <section>
-  <div class="row" style="margin-bottom: 4px;">
+  <div class="row mb=1">
     <button class="button is-small" data-test="add-500-rows-btn" onclick.delegate="loadData(500)">
       500 rows
     </button>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example02.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example02.ts
@@ -261,7 +261,7 @@ export default class Example02 {
   groupByDuration() {
     this.sgb?.dataView?.setGrouping({
       getter: 'duration',
-      formatter: (g) => `Duration: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+      formatter: (g) => `Duration: ${g.value} <span class="text-green">(${g.count} items)</span>`,
       comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
       aggregators: [
         new Aggregators.Avg('percentComplete'),
@@ -280,7 +280,7 @@ export default class Example02 {
     this.sgb?.slickGrid?.setSortColumns([]);
     this.sgb?.dataView?.setGrouping({
       getter: 'duration',
-      formatter: (g) => `Duration: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+      formatter: (g) => `Duration: ${g.value} <span class="text-green">(${g.count} items)</span>`,
       comparer: (a, b) => a.count - b.count,
       aggregators: [
         new Aggregators.Avg('percentComplete'),
@@ -297,7 +297,7 @@ export default class Example02 {
     this.sgb?.dataView?.setGrouping([
       {
         getter: 'duration',
-        formatter: (g) => `Duration: ${g.value}  <span style="color:green">(${g.count} items)</span>`,
+        formatter: (g) => `Duration: ${g.value}  <span class="text-green">(${g.count} items)</span>`,
         aggregators: [
           new Aggregators.Sum('duration'),
           new Aggregators.Sum('cost')
@@ -307,7 +307,7 @@ export default class Example02 {
       },
       {
         getter: 'effortDriven',
-        formatter: (g) => `Effort-Driven: ${(g.value ? 'True' : 'False')} <span style="color:green">(${g.count} items)</span>`,
+        formatter: (g) => `Effort-Driven: ${(g.value ? 'True' : 'False')} <span class="text-green">(${g.count} items)</span>`,
         aggregators: [
           new Aggregators.Avg('percentComplete'),
           new Aggregators.Sum('cost')
@@ -328,7 +328,7 @@ export default class Example02 {
     this.sgb?.dataView?.setGrouping([
       {
         getter: 'duration',
-        formatter: (g) => `Duration: ${g.value}  <span style="color:green">(${g.count} items)</span>`,
+        formatter: (g) => `Duration: ${g.value}  <span class="text-green">(${g.count} items)</span>`,
         aggregators: [
           new Aggregators.Sum('duration'),
           new Aggregators.Sum('cost')
@@ -338,7 +338,7 @@ export default class Example02 {
       },
       {
         getter: 'effortDriven',
-        formatter: (g) => `Effort-Driven: ${(g.value ? 'True' : 'False')}  <span style="color:green">(${g.count} items)</span>`,
+        formatter: (g) => `Effort-Driven: ${(g.value ? 'True' : 'False')}  <span class="text-green">(${g.count} items)</span>`,
         aggregators: [
           new Aggregators.Sum('duration'),
           new Aggregators.Sum('cost')
@@ -347,7 +347,7 @@ export default class Example02 {
       },
       {
         getter: 'percentComplete',
-        formatter: (g) => `% Complete: ${g.value}  <span style="color:green">(${g.count} items)</span>`,
+        formatter: (g) => `% Complete: ${g.value}  <span class="text-green">(${g.count} items)</span>`,
         aggregators: [
           new Aggregators.Avg('percentComplete')
         ],

--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 03 - Draggable Grouping
   <span class="subtitle">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -37,7 +37,7 @@
     </button>
   </div>
 
-  <div class="row" style="margin-top: 4px;">
+  <div class="row mt-1">
     <button class="button is-small" data-test="group-duration-sort-value-btn"
             onclick.delegate="groupByDurationOrderByCount(false)">
       Group by duration &amp; sort groups by value

--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
@@ -85,7 +85,7 @@ export default class Example03 {
         filterable: true,
         grouping: {
           getter: 'title',
-          formatter: (g) => `Title: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Title: ${g.value} <span class="text-green">(${g.count} items)</span>`,
           aggregators: [new Aggregators.Sum('cost')],
           aggregateCollapsed: false,
           collapsed: false
@@ -105,7 +105,7 @@ export default class Example03 {
         groupTotalsFormatter: GroupTotalFormatters.sumTotals,
         grouping: {
           getter: 'duration',
-          formatter: (g) => `Duration: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Duration: ${g.value} <span class="text-green">(${g.count} items)</span>`,
           comparer: (a, b) => {
             return this.durationOrderByCount ? (a.count - b.count) : SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc);
           },
@@ -126,7 +126,7 @@ export default class Example03 {
         type: FieldType.number,
         grouping: {
           getter: 'cost',
-          formatter: (g) => `Cost: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Cost: ${g.value} <span class="text-green">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('cost')
           ],
@@ -147,7 +147,7 @@ export default class Example03 {
         groupTotalsFormatter: GroupTotalFormatters.avgTotalsPercentage,
         grouping: {
           getter: 'percentComplete',
-          formatter: (g) => `% Complete:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `% Complete:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('cost')
           ],
@@ -165,7 +165,7 @@ export default class Example03 {
         editor: { model: Editors.date },
         grouping: {
           getter: 'start',
-          formatter: (g) => `Start: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Start: ${g.value} <span class="text-green">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('cost')
           ],
@@ -182,7 +182,7 @@ export default class Example03 {
         filterable: true, filter: { model: Filters.dateRange },
         grouping: {
           getter: 'finish',
-          formatter: (g) => `Finish: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Finish: ${g.value} <span class="text-green">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('cost')
           ],
@@ -204,7 +204,7 @@ export default class Example03 {
         formatter: Formatters.checkmarkMaterial,
         grouping: {
           getter: 'effortDriven',
-          formatter: (g) => `Effort-Driven: ${g.value ? 'True' : 'False'} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Effort-Driven: ${g.value ? 'True' : 'False'} <span class="text-green">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('cost')
           ],
@@ -280,6 +280,9 @@ export default class Example03 {
       editable: true,
       autoResize: {
         container: '.demo-container',
+      },
+      dataView: {
+        useCSPSafeFilter: true
       },
       enableAutoSizeColumns: true,
       enableAutoResize: true,

--- a/examples/vite-demo-vanilla-bundle/src/examples/example04.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example04.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 04 - Pinned (frozen) Columns/Rows
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -22,14 +22,14 @@
       Set
     </button>
   </span>
-  <span style="margin-left: 10px">
+  <span class="ml-1">
     <label for="">Pinned Columns: </label>
     <input type="number" class="frozen-column-count" value.bind="frozenColumnCount">
     <button class="btn btn-default btn-xs" onclick.delegate="changeFrozenColumnCount()">
       Set
     </button>
   </span>
-  <span style="margin-left: 15px">
+  <span class="ml-3">
     <button class="button is-small" onclick.delegate="setFrozenColumns(-1)"
             data-test="remove-frozen-column-button">
       <span class="icon mdi mdi-close"></span>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example05.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example05.html
@@ -2,7 +2,7 @@
   Example 05 - Tree Data
   <span class="mdi mdi-file-tree mdi-25px subtitle"></span>
   <span class="subtitle">(from a flat dataset with <code>parentId</code> references)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -17,7 +17,7 @@
 </h6>
 <div class="columns">
   <div class="column is-narrow">
-    <div class="row" style="margin-bottom: 4px;">
+    <div class="row mb-1">
       <button class="button is-small" data-test="add-500-rows-btn" onclick.delegate="loadData(500)">
         500 rows
       </button>
@@ -44,7 +44,7 @@
       </button>
     </div>
 
-    <div class="row" style="margin-bottom: 4px;">
+    <div class="row mb-1">
       <button onclick.delegate="addNewRow()" data-test="add-item-btn" class="button is-small is-info">
         <span class="icon mdi mdi-plus"></span>
         <span>Add New Item (in 1st group)</span>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example05.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example05.ts
@@ -256,7 +256,7 @@ export default class Example05 {
           }
           titleResult += `<span class="bold">${value}</span>`;
           if (dataContext.parentId) {
-            titleResult += ` <span style="font-size:11px; margin-left: 15px;">(parentId: ${dataContext.parentId})</span>`;
+            titleResult += ` <span class="font-11px ml-2">(parentId: ${dataContext.parentId})</span>`;
           }
           return titleResult;
         },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">Example 06 - Tree Data with Aggregators
   <span class="mdi mdi-file-tree mdi-25px subtitle"></span>
   <span class="subtitle">(from a Hierarchical Dataset)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -63,7 +63,7 @@
             </p>
             <p class="control pointer" onclick.delegate="clearSearch()" data-test="clear-search-string">
               <a class="button is-static is-small">
-                <span class="icon mdi mdi-close-thick" style="margin-top: 2px"></span>
+                <span class="icon mdi mdi-close-thick mt-1"></span>
               </a>
             </p>
           </div>
@@ -74,7 +74,7 @@
 </div>
 
 <div>
-  <label class="checkbox-inline control-label" for="excludeChildWhenFiltering" style="margin-left: 20px">
+  <label class="checkbox-inline control-label ml-3" for="excludeChildWhenFiltering">
     <input type="checkbox" id="excludeChildWhenFiltering" data-test="exclude-child-when-filtering"
            checked.bind="isExcludingChildWhenFiltering"
            onclick.delegate="changeExcludeChildWhenFiltering()">
@@ -83,7 +83,7 @@
       Exclude Children when Filtering Tree
     </span>
   </label>
-  <label class="checkbox-inline control-label" for="autoApproveParentItem" style="margin-left: 20px">
+  <label class="checkbox-inline control-label ml-3" for="autoApproveParentItem">
     <input type="checkbox" id="autoApproveParentItem" data-test="auto-approve-parent-item"
            checked.bind="isAutoApproveParentItemWhenTreeColumnIsValid"
            onclick.delegate="changeAutoApproveParentItem()">
@@ -94,7 +94,7 @@
       Skip Other Filter Criteria when Parent with Tree is valid
     </span>
   </label>
-  <label class="checkbox-inline control-label" for="autoRecalcTotalsOnFilterChange" style="margin-left: 20px">
+  <label class="checkbox-inline control-label ml-3" for="autoRecalcTotalsOnFilterChange">
     <input type="checkbox" id="autoRecalcTotalsOnFilterChange" data-test="auto-recalc-totals"
            checked.bind="isAutoRecalcTotalsOnFilterChange"
            onclick.delegate="changeAutoRecalcTotalsOnFilterChange()">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.scss
@@ -34,3 +34,11 @@
     @include recolor(#686868, 0.9);
   }
 }
+.display-inline-block {
+  display: inline-block;
+}
+
+// font-5px up to font-50px
+@for $i from 1 through 6 {
+  .width-#{$i*15}px { width: #{$i * 15}px; }
+}

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.ts
@@ -241,7 +241,7 @@ export default class Example06 {
     const treeLevel = dataContext[treeLevelPropName];
 
     value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const spacer = `<span style="display:inline-block; width:${(15 * treeLevel)}px;"></span>`;
+    const spacer = `<span class="display-inline-block width-${(15 * treeLevel)}px"></span>`;
 
     if (data[idx + 1]?.[treeLevelPropName] > data[idx][treeLevelPropName] || data[idx]['__hasChildren']) {
       const folderPrefix = `<i class="mdi mdi-22px ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></i>`;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 07 - Row Move &amp; Row Selections
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
       href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example07.ts">
@@ -32,7 +32,7 @@
     <span>Delete item</span>
   </button>
 
-  <div style="margin: 5px 0"></div>
+  <div class="mx-2 my-1"></div>
 
   <button class="button is-small" data-test="disable-filters-btn" onclick.delegate="disableFilters()">
     <span class="icon mdi mdi-filter-off-outline"></span>
@@ -58,12 +58,12 @@
     <span class="icon mdi mdi-text-box-search-outline"></span>
     <span>Modal Filters</span>
   </button>
-  <span style="margin-left: 20px">
+  <span class="ml-4">
     <button class="button is-small" onclick.delegate="switchLanguage()" data-test="language-button">
       Switch Language
     </button>
     <b>Locale:</b>
-    <span style="font-style: italic" data-test="selected-locale" textcontent.bind="selectedLanguageFile">
+    <span class="text-italic" data-test="selected-locale" textcontent.bind="selectedLanguageFile">
     </span>
   </span>
 </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -76,7 +76,7 @@ export default class Example07 {
       {
         id: 'action', name: 'Action', field: 'action', minWidth: 60, maxWidth: 60,
         excludeFromExport: true, excludeFromHeaderMenu: true,
-        formatter: () => `<div class="button-style margin-auto" style="width: 35px; margin-top: -1px;"><span class="mdi mdi-chevron-down mdi-22px color-primary"></span></div>`,
+        formatter: () => `<div class="button-style margin-auto action-btn"><span class="mdi mdi-chevron-down mdi-22px color-primary"></span></div>`,
         cellMenu: {
           hideCloseButton: false,
           subItemChevronClass: 'mdi mdi-chevron-down mdi-rotate-270',

--- a/examples/vite-demo-vanilla-bundle/src/examples/example08.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example08.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 08 - Column Span &amp; Header Grouping
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -16,12 +16,12 @@
 
 <hr />
 
-<div class="title is-4" style="margin-bottom: 12px">
+<div class="title is-4 mb-3">
   Grid 2
   <small>(with Header Grouping &amp; Frozen/Pinned Columns)</small>
 </div>
 
-<div class="column" style="padding-top: 10px; padding: 8px 0;">
+<div class="column pt-1 px-1">
   <div class="form-inline flex-container">
     <div>
       <label class="my-1 mr-2" for="columnSelect">Single Search:</label>
@@ -44,15 +44,15 @@
       </p>
       <p class="control pointer" onclick.delegate="cleargrid2SearchInput()" data-test="clear-search-input">
         <a class="button is-static is-small">
-          <span class="icon mdi mdi-close-thick" style="margin-top: 2px"></span>
+          <span class="icon mdi mdi-close-thick mt-1"></span>
         </a>
       </p>
     </div>
     <div>&nbsp;&nbsp;</div>
-    <div style="padding-left: 8px">
+    <div class="pl-2">
       <button class="button is-small" onclick.delegate="setFrozenColumns2(-1)"
               data-test="remove-frozen-column-button">
-        <span class="icon mdi mdi-close" style="margin-top: 2px"></span>
+        <span class="icon mdi mdi-close mt-1"></span>
         <span>Remove Frozen Columns</span>
       </button>
       <button class="button is-small" onclick.delegate="setFrozenColumns2(2)" data-test="set-3frozen-columns">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example09.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example09.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 09 - Grid with OData Backend Service
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -29,7 +29,7 @@
   <button class="button is-small" data-test="set-dynamic-sorting" onclick.delegate="setSortingDynamically()">
     Set Sorting Dynamically
   </button>
-  <button class="button is-small is-danger is-outlined" style="margin-left: 75px" data-test="throw-page-error-btn"
+  <button class="button is-small is-danger is-outlined ml-6" data-test="throw-page-error-btn"
           onclick.delegate="throwPageChangeError()">
     <span>Throw Error Going to Last Page... </span>
     <i class="mdi mdi-page-last"></i>
@@ -50,7 +50,7 @@
       </button>
     </span>
 
-    <span style="margin-left: 10px">
+    <span class="ml-1">
       <label>OData Version: </label>
       <span data-test="radioVersion">
         <label class="radio-inline control-label" for="radio2">
@@ -63,31 +63,31 @@
         </label>
       </span>
     </span>
-    <label class="checkbox-inline control-label" for="enableCount" style="margin-left: 20px">
+    <label class="checkbox-inline control-label ml-2" for="enableCount">
       <input type="checkbox" id="enableCount" data-test="enable-count" checked.bind="isCountEnabled"
              onclick.delegate="changeCountEnableFlag()">
-      <span style="font-weight: bold">Enable Count</span> (add to OData query)
+      <span class="text-bold">Enable Count</span> (add to OData query)
     </label>
-    <label class="checkbox-inline control-label" for="enableSelect" style="margin-left: 20px">
+    <label class="checkbox-inline control-label ml-2" for="enableSelect">
       <input type="checkbox" id="enableSelect" data-test="enable-select" checked.bind="isSelectEnabled"
         onclick.delegate="changeEnableSelectFlag()">
-      <span style="font-weight: bold">Enable Select</span> (add to OData query)
+      <span class="text-bold">Enable Select</span> (add to OData query)
     </label>
-    <label class="checkbox-inline control-label" for="enableExpand" style="margin-left: 20px">
+    <label class="checkbox-inline control-label ml-2" for="enableExpand">
       <input type="checkbox" id="enableExpand" data-test="enable-expand" checked.bind="isExpandEnabled"
         onclick.delegate="changeEnableExpandFlag()">
-      <span style="font-weight: bold">Enable Expand</span> (add to OData query)
+      <span class="text-bold">Enable Expand</span> (add to OData query)
     </label>
   </div>
 
-  <div class="column is-narrow" style="padding: 0">
-    <div class.bind="errorStatusClass" style="padding: 0.75rem 1.0rem" data-test="error-status">
+  <div class="column is-narrow px-0">
+    <div class.bind="errorStatusClass" data-test="error-status">
       <em><strong>Backend Error:</strong> <span textcontent.bind="errorStatus"></span></em>
     </div>
   </div>
 </div>
 
-<div class="columns" style="margin-top: 5px">
+<div class="columns mt-1">
   <div class="column">
     <div class="notification is-info is-light" data-test="alert-odata-query">
       <strong>OData Query:</strong>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example10.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example10.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 10 - Grid with GraphQL Backend Service
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example10.ts">
@@ -9,7 +9,7 @@
   </div>
 </h3>
 <h6 class="title is-6 italic">
-  <span style="color: red">(*) NO DATA SHOWN</span>
+  <span class="text-red">(*) NO DATA SHOWN</span>
   - just change any of Filters/Sorting/Pages and look at the "GraphQL Query" changing :)
 </h6>
 
@@ -33,7 +33,7 @@
   </button>
 
   <label for="serverdelay" class="ml-4">Server Delay: </label>
-  <input id="serverdelay" type="number" data-test="server-delay" style="width: 55px"
+  <input id="serverdelay" type="number" data-test="server-delay" class="is-narrow"
         value.bind="serverWaitDelay"
         title="input a fake timer delay to simulate slow server response" />
 
@@ -53,7 +53,7 @@
         Switch Language
       </button>
       <b>Locale:</b>
-      <span style="font-style: italic" data-test="selected-locale" textcontent.bind="selectedLanguageFile">
+      <span class="text-italic" data-test="selected-locale" textcontent.bind="selectedLanguageFile">
       </span>
     </span>
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11-modal.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11-modal.html
@@ -12,7 +12,7 @@
       <br />
       <div class="modal-grid"></div>
     </section>
-    <footer class="modal-card-foot" style="justify-content: flex-end;">
+    <footer class="modal-card-foot is-justify-content-flex-end">
       <button class="button close">Cancel</button>
       <button class="button is-info" onclick.delegate="saveMassUpdate('mass')">Mass Update</button>
       <button class="button is-success" onclick.delegate="saveMassUpdate('selection')">Update Selected Rows</button>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 11 - Batch Editing
   <span class="subtitle has-text-grey-dark">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -40,11 +40,11 @@
   <section class="column field has-addons is-narrow">
     <div class="row">
       <label for="selectedView">Change Views: </label>
-      <select class="select is-small selected-view" style="margin-left: 5px" id="selectedView"
+      <select class="select is-small selected-view ml-1" id="selectedView"
               name="selectedView"
               onchange.delegate="usePredefinedView(event.target.value)">
       </select>
-      <div class="dropdown action" style="margin-left: -6px">
+      <div class="dropdown action ml-1-negative">
         <div class="dropdown-trigger">
           <button class="button is-small" aria-haspopup="true" aria-controls="dropdown-menu">
             <span>Action</span>
@@ -69,7 +69,7 @@
           </div>
         </div>
       </div>
-      <span style="margin-left: 5px">
+      <span class="ml-1">
         <button class="button is-small" onclick.delegate="clearLocalStorage()" data-test="clear-storage-btn">
           <span class="icon mdi mdi-close-circle mdi-14px"></span>
           <span>Clear LocalStorage</span>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.scss
@@ -14,3 +14,10 @@ $slick-autocomplete-max-height: 250px;
   color: #afafaf;
   cursor: default;
 }
+.ml-1-negative {
+  margin-left: -5px;
+}
+.action-btns {
+  display: inline-block;
+  line-height: 18px;
+}

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -259,8 +259,8 @@ export default class Example11 {
       {
         id: 'action', name: 'Action', field: 'action', minWidth: 70, width: 75, maxWidth: 75,
         excludeFromExport: true,
-        formatter: () => `<span class="button-style padding-1px" style="display: inline-block; line-height: 18px;" title"Delete the Row"><span class="mdi mdi-close color-danger" title="Delete Current Row"></span></span>
-        &nbsp;<span class="button-style padding-1px" style="display: inline-block; line-height: 18px;" title="Mark as Completed"><span class="mdi mdi-check-underline"></span></span>`,
+        formatter: () => `<span class="button-style padding-1px action-btns"title"Delete the Row"><span class="mdi mdi-close color-danger" title="Delete Current Row"></span></span>
+        &nbsp;<span class="button-style padding-1px action-btns" title="Mark as Completed"><span class="mdi mdi-check-underline"></span></span>`,
         onCellClick: (event: Event, args) => {
           const dataContext = args.dataContext;
           if ((event.target as HTMLElement).classList.contains('mdi-close')) {

--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 12 - Composite Editor Modal
   <span class="subtitle is-size-5 has-text-grey-dark">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"

--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -358,7 +358,7 @@ export default class Example12 {
       {
         id: 'action', name: 'Action', field: 'action', width: 70, minWidth: 70, maxWidth: 70,
         excludeFromExport: true,
-        formatter: () => `<div class="button-style margin-auto" style="width: 35px; margin-top: -1px;"><span class="mdi mdi-dots-vertical mdi-22px color-primary"></span></div>`,
+        formatter: () => `<div class="button-style margin-auto action-btn"><span class="mdi mdi-dots-vertical mdi-22px color-primary"></span></div>`,
         cellMenu: {
           hideCloseButton: false,
           commandTitle: 'Commands',

--- a/examples/vite-demo-vanilla-bundle/src/examples/example13.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example13.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 13 - Header Button Plugin
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"

--- a/examples/vite-demo-vanilla-bundle/src/examples/example13.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example13.ts
@@ -132,10 +132,11 @@ export default class Example13 {
         type: FieldType.number,
         editor: { model: Editors.integer },
         formatter: (_row, _cell, value, columnDef) => {
-          if (gridNo === 1 && columns1WithHighlightingById[columnDef.id] && value < 0) {
-            return `<div style="color:red; font-weight:bold;">${value}</div>`;
-          } else if (gridNo === 2 && columns2WithHighlightingById[columnDef.id] && value < 0) {
-            return `<div style="color:red; font-weight:bold;">${value}</div>`;
+          if (
+            gridNo === 1 && columns1WithHighlightingById[columnDef.id] && value < 0 ||
+            gridNo === 2 && columns2WithHighlightingById[columnDef.id] && value < 0
+          ) {
+            return `<div class="text-red text-bold">${value}</div>`;
           }
           return value;
         },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example14.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example14.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 14 - Columns Resize by Content
   <span class="subtitle is-size-5 has-text-grey-dark">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -76,7 +76,7 @@
 </div>
 
 <!-- https://www.w3docs.com/snippets/html/how-to-make-a-div-fill-the-height-of-the-remaining-space.html -->
-<div style="width: 1000px; height: calc(100vh - 320px)" class="grid-container">
+<div class="grid-container grid14-container">
   <div class="grid14">
   </div>
 </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example14.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example14.scss
@@ -10,3 +10,7 @@ $control-height: 2.4em;
 .green {
   color: rgb(127, 196, 24);
 }
+.grid14-container {
+  width: 1000px;
+  height: calc(100vh - 320px);
+}

--- a/examples/vite-demo-vanilla-bundle/src/examples/example14.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example14.ts
@@ -326,7 +326,7 @@ export default class Example14 {
       {
         id: 'action', name: 'Action', field: 'action', width: 70, minWidth: 70, maxWidth: 70,
         excludeFromExport: true,
-        formatter: () => `<div class="button-style margin-auto" style="width: 35px; margin-top: -1px;"><span class="mdi mdi-chevron-down mdi-22px color-primary"></span></div>`,
+        formatter: () => `<div class="button-style margin-auto action-btn"><span class="mdi mdi-chevron-down mdi-22px color-primary"></span></div>`,
         cellMenu: {
           hideCloseButton: false,
           commandTitle: 'Commands',

--- a/examples/vite-demo-vanilla-bundle/src/examples/example15.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example15.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">
   Example 15 - Grid with OData Backend Service using RxJS Observables
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -29,11 +29,11 @@
   <button class="button is-small" data-test="set-dynamic-sorting-btn" onclick.delegate="setSortingDynamically()">
     Set Sorting Dynamically
   </button>
-  <button class="button is-small" style="margin-left: 10px" data-test="add-gender-btn"
+  <button class="button is-small ml-1" data-test="add-gender-btn"
           onclick.delegate="addOtherGender()" disabled.bind="isOtherGenderAdded">
     Add Other Gender via RxJS
   </button>
-  <button class="button is-small is-danger is-outlined" style="margin-left: 50px" data-test="throw-page-error-btn"
+  <button class="button is-small is-danger is-outlined ml-6" data-test="throw-page-error-btn"
           onclick.delegate="throwPageChangeError()">
     <span>Throw Error Going to Last Page... </span>
     <i class="mdi mdi-page-last"></i>
@@ -54,7 +54,7 @@
       </button>
     </span>
 
-    <span style="margin-left: 10px">
+    <span class="ml-1">
       <label>OData Version: </label>
       <span data-test="radioVersion">
         <label class="radio-inline control-label" for="radio2">
@@ -67,20 +67,20 @@
         </label>
       </span>
     </span>
-    <label class="checkbox-inline control-label" for="enableCount" style="margin-left: 20px">
+    <label class="checkbox-inline control-label ml-2" for="enableCount">
       <input type="checkbox" id="enableCount" data-test="enable-count" checked.bind="isCountEnabled"
              onclick.delegate="changeCountEnableFlag()">
-      <span style="font-weight: bold">Enable Count</span> (add to OData query)
+      <span class="text-bold">Enable Count</span> (add to OData query)
     </label>
   </div>
-  <div class="column is-narrow" style="padding: 0">
-    <div class.bind="errorStatusClass" style="padding: 0.75rem 1.0rem" data-test="error-status">
+  <div class="column is-narrow px-0">
+    <div class.bind="errorStatusClass" data-test="error-status">
       <em><strong>Backend Error:</strong> <span textcontent.bind="errorStatus"></span></em>
     </div>
   </div>
 </div>
 
-<div class="columns" style="margin-top: 5px">
+<div class="columns mt-1">
   <div class="column">
     <div class="notification is-info is-light" data-test="alert-odata-query">
       <strong>OData Query:</strong>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example15.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example15.ts
@@ -423,7 +423,7 @@ export default class Example15 {
 
     // display random address and zip code to simulate company address
     const randomStreet = dataContext.id % 3 ? 'Belleville' : 'Hollywood';
-    return `<div class="color-se-danger" style="font-weight: bold">${tooltipTitle}</div>
+    return `<div class="color-se-danger text-bold">${tooltipTitle}</div>
       <div class="tooltip-2cols-row"><div>Address:</div> <div>${dataContext.__params.doorNumber.toFixed(0)} ${randomStreet} blvd</div></div>
       <div class="tooltip-2cols-row"><div>Zip:</div> <div>${dataContext.__params.zip.toFixed(0)}</div></div>`;
   }

--- a/examples/vite-demo-vanilla-bundle/src/examples/example16.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example16.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 16 - Regular & Custom Tooltips
   <span class="subtitle">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5"
        target="_blank"
@@ -14,7 +14,7 @@
 <div class="row">
   <span>
     <label for="server-delay">Simulated Server Delay (ms): </label>
-    <input type="number" id="server-delay" data-test="server-delay" style="width: 60px" value.bind="serverApiDelay">
+    <input type="number" id="server-delay" class="is-narrow" data-test="server-delay" value.bind="serverApiDelay">
   </span>
 </div>
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example16.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example16.ts
@@ -269,7 +269,7 @@ export default class Example16 {
       },
       {
         id: 'action', name: 'Action', field: 'action', width: 70, minWidth: 70, maxWidth: 70,
-        formatter: () => `<div class="button-style margin-auto" style="width: 35px; margin-top: -1px;"><span class="mdi mdi-chevron-down mdi-22px color-primary"></span></div>`,
+        formatter: () => `<div class="button-style margin-auto action-btn"><span class="mdi mdi-chevron-down mdi-22px color-primary"></span></div>`,
         excludeFromExport: true,
         // customTooltip: {
         //   formatter: () => `Click to open Cell Menu`, // return empty so it won't show any pre-tooltip

--- a/examples/vite-demo-vanilla-bundle/src/examples/example17.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example17.html
@@ -1,6 +1,6 @@
 <h3 class="title is-3">Example 17 - Auto-Scroll with Range Selector
   <span class="subtitle">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
       href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example17.ts">
@@ -12,22 +12,22 @@
   Dragging from 2nd column to make a selection, and the viewport will auto scroll.
 </h6>
 
-<div style="min-height: 975px">
+<div>
   <div class="row scroll-configs">
     <span>
       <label for="min-internal">MIN interval to show next cell (ms): </label>
       <input id="min-internal" type="number" data-test="min-interval-input" value.bind="minInterval" />
-      <label for="max-internal" style="margin-left: 15px;">MAX delay to show next cell (ms): </label>
+      <label for="max-internal" class="ml-2">MAX delay to show next cell (ms): </label>
       <input id="max-internal" type="number" data-test="max-interval-input" value.bind="maxInterval" />
-      <label for="delay-cursor" style="margin-left: 15px;">Delay when cursor outside 1px (ms): </label>
+      <label for="delay-cursor" class="ml-2">Delay when cursor outside 1px (ms): </label>
       <input id="delay-cursor" type="number" data-test="delay-cursor-input" value.bind="delayCursor" />
     </span>
   </div>
-  <div class="row" style="margin-bottom: 15px;">
+  <div class="row my-1">
     <label for="is-autoscroll">Auto Scroll: (need click Set Options): </label>
     <input id="is-autoscroll" type="checkbox" data-test="is-autoscroll-chk" checked.bind="isAutoScroll" />
 
-    <span style="margin-left: 20px;">
+    <span class="ml-2">
       <button class="button is-small" data-test="set-options-btn" onclick.delegate="setOptions()">
         Set Options
       </button>
@@ -48,7 +48,7 @@
   </div>
 
   <div class="column is-half">
-    <hr style="margin: 16px 0" />
+    <hr class="my-4" />
   </div>
 
   <h5 class="title is-5">Grid 2 - Using <code>SlickCellRangeSelector</code> and <code>SlickRowSelectionModel</code></h5>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example17.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example17.ts
@@ -115,7 +115,7 @@ export default class Example17 {
   groupByDuration1() {
     this.sgb1.dataView?.setGrouping({
       getter: 'duration',
-      formatter: (g) => `Duration: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+      formatter: (g) => `Duration: ${g.value} <span class="text-green">(${g.count} items)</span>`,
       aggregators: [
         new Aggregators.Avg('percentComplete'),
         new Aggregators.Sum('cost')
@@ -128,7 +128,7 @@ export default class Example17 {
   groupByDuration2() {
     this.sgb2.dataView?.setGrouping({
       getter: 'duration',
-      formatter: (g) => `Duration: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+      formatter: (g) => `Duration: ${g.value} <span class="text-green">(${g.count} items)</span>`,
       aggregators: [
         new Aggregators.Avg('percentComplete'),
         new Aggregators.Sum('cost')

--- a/examples/vite-demo-vanilla-bundle/src/examples/example18.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example18.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 18 - Real-Time Trading Platform
   <span class="subtitle">(with Material Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
       href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example18.ts">
@@ -46,7 +46,7 @@
         <label for="highlight-input">Highlight Duration(ms)</label>
         <input type="number" id="highlight-input" data-test="highlight-input" value.bind="highlightDuration">
       </span>
-      <span style="float: right">
+      <span class="float-right">
         <button class="button is-small" onclick.delegate="toggleFullScreen()">
           <span class.bind="toggleClassName"></span>
           <span>Toggle Full-Screen</span>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example18.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example18.ts
@@ -93,7 +93,7 @@ export default class Example18 {
         },
         grouping: {
           getter: 'currency',
-          formatter: (g) => `Currency: <span style="color: #003597; font-weight: bold;">${g.value}</span>  <span style="color: #659bff;">(${g.count} items)</span>`,
+          formatter: (g) => `Currency: <span class="text-bluenavy text-bold">${g.value}</span>  <span class="text-violet">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('amount')
           ],
@@ -106,7 +106,7 @@ export default class Example18 {
         id: 'market', name: 'Market', field: 'market', filterable: true, sortable: true, minWidth: 75, width: 75,
         grouping: {
           getter: 'market',
-          formatter: (g) => `Market: <span style="color: #003597; font-weight: bold;">${g.value}</span>  <span style="color: #659bff;">(${g.count} items)</span>`,
+          formatter: (g) => `Market: <span class="text-bluenavy text-bold">${g.value}</span>  <span class="text-violet">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('amount')
           ],
@@ -124,7 +124,7 @@ export default class Example18 {
         },
         grouping: {
           getter: 'trsnType',
-          formatter: (g) => `Type: <span style="color: #003597; font-weight: bold;">${g.value}</span>  <span style="color: #659bff;">(${g.count} items)</span>`,
+          formatter: (g) => `Type: <span class="text-bluenavy text-bold">${g.value}</span>  <span class="text-violet">(${g.count} items)</span>`,
           aggregators: [
             new Aggregators.Sum('amount')
           ],

--- a/examples/vite-demo-vanilla-bundle/src/examples/example19.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example19.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 19 - ExcelCopyBuffer with Cell Selection
   <span class="subtitle">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
       href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example19.ts">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example20.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example20.html
@@ -1,7 +1,7 @@
 <h3 class="title is-3">
   Example 20 - Basic grid inside a Shadow DOM
   <span class="subtitle">(with Salesforce Theme)</span>
-  <div class="subtitle" style="float: right; margin-top: -20px">
+  <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
       href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example20.ts">

--- a/examples/vite-demo-vanilla-bundle/src/examples/icons.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/icons.html
@@ -8,7 +8,7 @@
     <span>
       Material Design Icons - Official Website (+5000 icons)</span>
   </a>
-  <p style="font-style: italic;">
+  <p class="text-italic">
     We only keep a small subset of the Material Design Icons, scroll to the bottom to see which ones are included in the
     lib.
   </p>
@@ -70,7 +70,7 @@
   Padding &amp; Icons Styled as a Button
   <span class=" subtitle has-text-grey-dark">(padding from 0px up to 30px)</span>
 </h5>
-<p style="margin-bottom: 18px; margin-top: -12px;">
+<p class="note-negative">
   <i>Note, you can use the same pattern with "margin-0px", "padding-0x" and "font-5px"</i>
 </p>
 
@@ -331,11 +331,11 @@
     <span class="mdi mdi-help-circle mdi-22px color-disabled-dark"></span>
     <span class="color-disabled-dark">color-disabled-dark</span>
   </div>
-  <div class="slick-col-medium-2" style="background-color: #3F3E3E;">
+  <div class="slick-col-medium-2 bg-gray">
     <span class="mdi mdi-help-circle mdi-22px color-light"></span>
     <span class="color-light">color-light</span>
   </div>
-  <div class="slick-col-medium-2" style="background-color: #3F3E3E;">
+  <div class="slick-col-medium-2 bg-gray">
     <span class="mdi mdi-help-circle mdi-22px color-white"></span>
     <span class="color-white">color-white</span>
   </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/icons.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/icons.scss
@@ -11,3 +11,10 @@
     border-right: 1px solid #bebebe;
   }
 }
+.note-negative {
+  margin-bottom: 18px;
+  margin-top: -12px;
+}
+.bg-gray {
+  background-color: #3F3E3E;
+}

--- a/examples/vite-demo-vanilla-bundle/src/index.html
+++ b/examples/vite-demo-vanilla-bundle/src/index.html
@@ -1,7 +1,0 @@
-<head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title><%- title %></title>
-    <%- injectScript %>
-  </head>

--- a/examples/vite-demo-vanilla-bundle/src/styles.scss
+++ b/examples/vite-demo-vanilla-bundle/src/styles.scss
@@ -10,6 +10,7 @@ $slick-link-color: #006DCC;
 @import './bulma.scss';
 
 .demo-container.container {
+  padding-top: 20px;
   margin-top: 50px;
 }
 .fake-hyperlink {
@@ -33,4 +34,36 @@ $slick-link-color: #006DCC;
 }
 .faded:hover {
   opacity: 1;
+}
+.subtitle.code-link {
+  float: right;
+  margin-top: -15px;
+}
+.notification.is-narrow {
+  padding: 0.75rem 1.0rem;
+}
+input.is-narrow {
+  width: 55px;
+}
+.ml-8 {
+  margin-left: 50px;
+}
+.float-right {
+  float: right;
+}
+.action-btn {
+  width: 35px;
+  margin-top: -1px;
+}
+.text-green {
+  color: green;
+}
+.text-violet {
+  color: #659bff;
+}
+.text-bluenavy {
+  color: #003597;
+}
+.text-red {
+  color: red;
 }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -491,19 +491,24 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         if (skipEmptyReassignment && !isDefined(val) && !target.innerHTML) {
           return; // same result, just skip it
         }
-        let sanitizedText = val;
-        if (typeof this._options?.sanitizer === 'function') {
-          sanitizedText = this._options.sanitizer(val || '');
-        } else if (typeof DOMPurify?.sanitize === 'function') {
-          const purifyOptions = (options?.sanitizerOptions ?? this._options.sanitizerOptions ?? { ADD_ATTR: ['level'], RETURN_TRUSTED_TYPE: true }) as DOMPurify.Config;
-          sanitizedText = DOMPurify.sanitize(val || '', purifyOptions) as unknown as string;
-        }
 
-        // apply HTML when enableHtmlRendering is enabled but make sure we do have a value (without a value, it will simply use `textContent` to clear text content)
-        if (this._options.enableHtmlRendering && sanitizedText) {
-          target.innerHTML = sanitizedText;
-        } else {
+        let sanitizedText = val;
+        if (typeof sanitizedText === 'number' || typeof sanitizedText === 'boolean') {
           target.textContent = sanitizedText;
+        } else {
+          if (typeof this._options?.sanitizer === 'function') {
+            sanitizedText = this._options.sanitizer(val);
+          } else if (typeof DOMPurify?.sanitize === 'function') {
+            const purifyOptions = (options?.sanitizerOptions ?? this._options.sanitizerOptions ?? { ADD_ATTR: ['level'], RETURN_TRUSTED_TYPE: true }) as DOMPurify.Config;
+            sanitizedText = DOMPurify.sanitize(val, purifyOptions) as unknown as string;
+          }
+
+          // apply HTML when enableHtmlRendering is enabled but make sure we do have a value (without a value, it will simply use `textContent` to clear text content)
+          if (this._options.enableHtmlRendering && sanitizedText) {
+            target.innerHTML = sanitizedText;
+          } else {
+            target.textContent = sanitizedText;
+          }
         }
       }
     }

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -98,7 +98,7 @@ const mockColumns = [
     id: 'age', name: 'Age', field: 'age', width: 50, sortable: true,
     grouping: {
       getter: 'age', aggregators: [new Aggregators.Avg('age')],
-      formatter: (g) => `Age: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+      formatter: (g) => `Age: ${g.value} <span class="text-green">(${g.count} items)</span>`,
       collapsed: true
     }
   },
@@ -106,7 +106,7 @@ const mockColumns = [
     id: 'medals', name: 'Medals', field: 'medals', width: 50, sortable: true,
     grouping: {
       getter: 'medals', aggregators: [new Aggregators.Sum('medals')],
-      formatter: (g) => `Medals: ${g.value} <span style="color:green">(${g.count} items)</span>`,
+      formatter: (g) => `Medals: ${g.value} <span class="text-green">(${g.count} items)</span>`,
     }
   },
   { name: 'Gender', field: 'gender', width: 75 },

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -754,7 +754,7 @@ describe('ExcelExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -766,7 +766,7 @@ describe('ExcelExportService', () => {
         mockGroup1 = {
           collapsed: 0, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
 
@@ -856,7 +856,7 @@ describe('ExcelExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -868,7 +868,7 @@ describe('ExcelExportService', () => {
         mockGroup1 = {
           collapsed: 0, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
 
@@ -961,7 +961,7 @@ describe('ExcelExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -973,7 +973,7 @@ describe('ExcelExportService', () => {
         mockGroup1 = {
           collapsed: 0, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
 
@@ -1060,7 +1060,7 @@ describe('ExcelExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -1072,25 +1072,25 @@ describe('ExcelExportService', () => {
         mockGroup1 = {
           collapsed: false, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
         mockGroup2 = {
           collapsed: false, count: 2, groupingKey: '10:|:X', groups: null, level: 1, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Last Name: X <span style="color:green">(1 items)</span>`,
+          title: `Last Name: X <span class="text-green">(1 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 10 } },
         };
         mockGroup3 = {
           collapsed: false, count: 2, groupingKey: '10:|:Doe', groups: null, level: 1, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Last Name: Doe <span style="color:green">(1 items)</span>`,
+          title: `Last Name: Doe <span class="text-green">(1 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 10 } },
         };
         mockGroup4 = {
           collapsed: true, count: 0, groupingKey: '10:|:', groups: null, level: 1, selectChecked: false,
           rows: [],
-          title: `Last Name: null <span style="color:green">(0 items)</span>`,
+          title: `Last Name: null <span class="text-green">(0 items)</span>`,
           totals: { value: '0', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 10 } },
         };
 

--- a/packages/graphql/src/services/__tests__/graphql.service.spec.ts
+++ b/packages/graphql/src/services/__tests__/graphql.service.spec.ts
@@ -1237,7 +1237,7 @@ describe('GraphqlService', () => {
     it('should return a query using column name that is an HTML Element', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:Gender, operator:EQ, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const nameElm = document.createElement('div');
-      nameElm.innerHTML = `<span class="red">Gender</span>`;
+      nameElm.innerHTML = `<span class="text-red">Gender</span>`;
       const mockColumn = { id: 'gender', name: nameElm } as unknown as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['female'], operator: 'EQ', type: FieldType.string },

--- a/packages/odata/src/services/__tests__/grid-odata.service.spec.ts
+++ b/packages/odata/src/services/__tests__/grid-odata.service.spec.ts
@@ -939,7 +939,7 @@ describe('GridOdataService', () => {
     it('should return a query using column name that is an HTML Element', () => {
       const expectation = `$top=10&$filter=(Gender eq 'female')`;
       const nameElm = document.createElement('div');
-      nameElm.innerHTML = `<span class="red">Gender</span>`;
+      nameElm.innerHTML = `<span class="text-red">Gender</span>`;
       const mockColumn = { id: 'gender', name: nameElm } as unknown as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['female'], operator: 'EQ', type: FieldType.string },

--- a/packages/text-export/src/textExport.service.spec.ts
+++ b/packages/text-export/src/textExport.service.spec.ts
@@ -586,7 +586,7 @@ describe('ExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -598,7 +598,7 @@ describe('ExportService', () => {
         mockGroup1 = {
           collapsed: 0, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
 
@@ -692,7 +692,7 @@ describe('ExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -704,7 +704,7 @@ describe('ExportService', () => {
         mockGroup1 = {
           collapsed: 0, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
 
@@ -800,7 +800,7 @@ describe('ExportService', () => {
           comparer: (a, b) => SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc),
           compiledAccumulators: [jest.fn(), jest.fn()],
           displayTotalsRow: true,
-          formatter: (g) => `Order:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
+          formatter: (g) => `Order:  ${g.value} <span class="text-green">(${g.count} items)</span>`,
           getter: 'order',
           getterIsAFn: false,
           lazyTotalsCalculation: true,
@@ -812,19 +812,19 @@ describe('ExportService', () => {
         mockGroup1 = {
           collapsed: 0, count: 2, groupingKey: '10', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Order: 20 <span style="color:green">(2 items)</span>`,
+          title: `Order: 20 <span class="text-green">(2 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 20 } },
         };
         mockGroup2 = {
           collapsed: 0, count: 2, groupingKey: '10:|:Z', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Last Name: Z <span style="color:green">(1 items)</span>`,
+          title: `Last Name: Z <span class="text-green">(1 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 10 } },
         };
         mockGroup3 = {
           collapsed: 0, count: 2, groupingKey: '10:|:Doe', groups: null, level: 0, selectChecked: false,
           rows: [mockItem1, mockItem2],
-          title: `Last Name: Doe <span style="color:green">(1 items)</span>`,
+          title: `Last Name: Doe <span class="text-green">(1 items)</span>`,
           totals: { value: '10', __group: true, __groupTotals: true, group: {}, initialized: true, sum: { order: 10 } },
         };
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -489,7 +489,7 @@ export class SlickVanillaGridBundle<TData = any> {
 
     if (!this.customDataView) {
       const dataviewInlineFilters = this._gridOptions?.dataView?.inlineFilters ?? false;
-      let dataViewOptions: Partial<DataViewOption> = { inlineFilters: dataviewInlineFilters };
+      let dataViewOptions: Partial<DataViewOption> = { ...this._gridOptions.dataView, inlineFilters: dataviewInlineFilters };
 
       if (this.gridOptions.draggableGrouping || this.gridOptions.enableGrouping) {
         this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();

--- a/test/cypress/e2e/example13.cy.ts
+++ b/test/cypress/e2e/example13.cy.ts
@@ -50,7 +50,7 @@ describe('Example 13 - Header Button Plugin', () => {
               const numberValue = $cell.text();
               const htmlValue = $cell.html();
               if (+numberValue < 0) {
-                expect(htmlValue).to.eq(`<div style="color:red; font-weight:bold;">${numberValue}</div>`);
+                expect(htmlValue).to.eq(`<div class="text-red text-bold">${numberValue}</div>`);
               } else {
                 expect(htmlValue).to.eq(numberValue);
               }
@@ -244,7 +244,7 @@ describe('Example 13 - Header Button Plugin', () => {
               const numberValue = $cell.text();
               const htmlValue = $cell.html();
               if (+numberValue < 0) {
-                expect(htmlValue).to.eq(`<div style="color:red; font-weight:bold;">${numberValue}</div>`);
+                expect(htmlValue).to.eq(`<div class="text-red text-bold">${numberValue}</div>`);
               } else {
                 expect(htmlValue).to.eq(numberValue);
               }
@@ -477,7 +477,7 @@ describe('Example 13 - Header Button Plugin', () => {
             .each($cell => {
               const numberValue = $cell.text();
               const htmlValue = $cell.html();
-              expect(htmlValue).to.eq(`<div style="color:red; font-weight:bold;">${numberValue}</div>`);
+              expect(htmlValue).to.eq(`<div class="text-red text-bold">${numberValue}</div>`);
             });
         });
     });


### PR DESCRIPTION
- calling `applyHtmlCode()` and having a Formatter returning a number or boolean might not work correctly when passed to sanitizer like DOMPurify. We should simply apply text directly with `.textContent` without passing by the sanitizer
- add basic CSP rules