### PR TITLE
feat: use PubSub Service singleton to subscribe to any SlickEvent

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -20,7 +20,7 @@ describe('SlickGrid core file', () => {
   it('should be able to instantiate SlickGrid without DataView', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
     const options = { enableCellNavigation: true } as GridOption;
-    grid = new SlickGrid<any, Column>('#myGrid', [], columns, options, true);
+    grid = new SlickGrid<any, Column>('#myGrid', [], columns, options, undefined, true);
     grid.init();
 
     expect(grid).toBeTruthy();
@@ -31,7 +31,7 @@ describe('SlickGrid core file', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
     const options = { enableCellNavigation: true } as GridOption;
     const dv = new SlickDataView({});
-    grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options, true);
+    grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options, undefined, true);
     grid.init();
 
     expect(grid).toBeTruthy();

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -14,6 +14,11 @@ import type { CSSStyleDeclarationWritable, EditController } from '../interfaces'
 
 export type Handler<ArgType = any> = (e: any, args: ArgType) => void;
 
+export interface BasePubSub {
+  publish<ArgType = any>(_eventName: string | any, _data?: ArgType): any;
+  subscribe<ArgType = any>(_eventName: string | Function, _callback: (data: ArgType) => void): any;
+}
+
 /**
  * An event object for passing data to event handlers and letting them control propagation.
  * <p>This is pretty much identical to how W3C and jQuery implement events.</p>
@@ -125,10 +130,20 @@ export class SlickEventData<ArgType = any> {
  * @constructor
  */
 export class SlickEvent<ArgType = any> {
-  protected handlers: Handler<ArgType>[] = [];
+  protected _handlers: Handler<ArgType>[] = [];
+  protected _pubSubService?: BasePubSub;
 
   get subscriberCount() {
-    return this.handlers.length;
+    return this._handlers.length;
+  }
+
+  /**
+   * Constructor
+   * @param {String} [eventName] - event name that could be used for dispatching CustomEvent (when enabled)
+   * @param {BasePubSub} [pubSubService] - event name that could be used for dispatching CustomEvent (when enabled)
+   */
+  constructor(protected readonly eventName?: string, protected readonly pubSub?: BasePubSub) {
+    this._pubSubService = pubSub;
   }
 
   /**
@@ -136,21 +151,21 @@ export class SlickEvent<ArgType = any> {
    * <p>Event handler will receive two arguments - an <code>EventData</code> and the <code>data</code>
    * object the event was fired with.<p>
    * @method subscribe
-   * @param fn {Function} Event handler.
+   * @param {Function} fn - Event handler.
    */
   subscribe(fn: Handler<ArgType>) {
-    this.handlers.push(fn);
+    this._handlers.push(fn);
   }
 
   /**
    * Removes an event handler added with <code>subscribe(fn)</code>.
    * @method unsubscribe
-   * @param fn {Function} Event handler to be removed.
+   * @param {Function} [fn] - Event handler to be removed.
    */
   unsubscribe(fn?: Handler<ArgType>) {
-    for (let i = this.handlers.length - 1; i >= 0; i--) {
-      if (this.handlers[i] === fn) {
-        this.handlers.splice(i, 1);
+    for (let i = this._handlers.length - 1; i >= 0; i--) {
+      if (this._handlers[i] === fn) {
+        this._handlers.splice(i, 1);
       }
     }
   }
@@ -158,26 +173,31 @@ export class SlickEvent<ArgType = any> {
   /**
    * Fires an event notifying all subscribers.
    * @method notify
-   * @param args {Object} Additional data object to be passed to all handlers.
-   * @param e {EventData}
-   *      Optional.
-   *      An <code>EventData</code> object to be passed to all handlers.
+   * @param {Object} args Additional data object to be passed to all handlers.
+   * @param {EventData} [event] - An <code>EventData</code> object to be passed to all handlers.
    *      For DOM events, an existing W3C event object can be passed in.
-   * @param scope {Object}
-   *      Optional.
-   *      The scope ("this") within which the handler will be executed.
+   * @param {Object} [scope] - The scope ("this") within which the handler will be executed.
    *      If not specified, the scope will be set to the <code>Event</code> instance.
    */
   notify(args: ArgType, evt?: SlickEventData | Event | MergeTypes<SlickEventData, Event> | null, scope?: any) {
     const sed = evt instanceof SlickEventData ? evt : new SlickEventData(evt, args);
     scope = scope || this;
 
-    for (let i = 0; i < this.handlers.length && !(sed.isPropagationStopped() || sed.isImmediatePropagationStopped()); i++) {
-      const returnValue = this.handlers[i].call(scope, sed as SlickEvent | SlickEventData, args);
+    for (let i = 0; i < this._handlers.length && !(sed.isPropagationStopped() || sed.isImmediatePropagationStopped()); i++) {
+      const returnValue = this._handlers[i].call(scope, sed as SlickEvent | SlickEventData, args);
       sed.addReturnValue(returnValue);
     }
 
+    // user can optionally add a global PubSub Service which makes it easy to publish/subscribe to events
+    if (typeof this._pubSubService?.publish === 'function' && this.eventName) {
+      const ret = this._pubSubService.publish<{ args: ArgType; eventData?: Event | SlickEventData; nativeEvent?: Event; }>(this.eventName, { args, eventData: sed });
+      sed.addReturnValue(ret);
+    }
     return sed;
+  }
+
+  setPubSubService(pubSub: BasePubSub) {
+    this._pubSubService = pubSub;
   }
 }
 
@@ -727,6 +747,22 @@ export class Utils {
     for (const key in srcObj) {
       if (srcObj.hasOwnProperty(key) && !targetObj.hasOwnProperty(key)) {
         targetObj[key] = srcObj[key];
+      }
+    }
+  }
+
+  /**
+   * User could optionally add PubSub Service to SlickEvent
+   * When it is defined then a SlickEvent `notify()` call will also dispatch it by using the PubSub publish() method
+   * @param {BasePubSub} [pubSubService]
+   * @param {*} scope
+   */
+  public static addSlickEventPubSubWhenDefined<T = any>(pubSub?: BasePubSub, scope?: T) {
+    if (pubSub) {
+      for (const prop in scope) {
+        if (scope[prop] instanceof SlickEvent && typeof (scope[prop] as SlickEvent).setPubSubService === 'function') {
+          (scope[prop] as SlickEvent).setPubSubService(pubSub);
+        }
       }
     }
   }

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -19,6 +19,7 @@ import type {
 } from '../interfaces';
 import { CssStyleHash, CustomDataView } from '../interfaces/gridOption.interface';
 import {
+  type BasePubSub,
   SlickEvent,
   SlickEventData,
   SlickGroup,
@@ -114,17 +115,27 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected _options: DataViewOption;
 
   // public events
-  onBeforePagingInfoChanged = new SlickEvent<PagingInfo>();
-  onGroupExpanded = new SlickEvent<OnGroupExpandedEventArgs>();
-  onGroupCollapsed = new SlickEvent<OnGroupCollapsedEventArgs>();
-  onPagingInfoChanged = new SlickEvent<PagingInfo>();
-  onRowCountChanged = new SlickEvent<OnRowCountChangedEventArgs>();
-  onRowsChanged = new SlickEvent<OnRowsChangedEventArgs>();
-  onRowsOrCountChanged = new SlickEvent<OnRowsOrCountChangedEventArgs>();
-  onSelectedRowIdsChanged = new SlickEvent<OnSelectedRowIdsChangedEventArgs>();
-  onSetItemsCalled = new SlickEvent<OnSetItemsCalledEventArgs>();
+  onBeforePagingInfoChanged: SlickEvent<PagingInfo>;
+  onGroupExpanded: SlickEvent<OnGroupExpandedEventArgs>;
+  onGroupCollapsed: SlickEvent<OnGroupCollapsedEventArgs>;
+  onPagingInfoChanged: SlickEvent<PagingInfo>;
+  onRowCountChanged: SlickEvent<OnRowCountChangedEventArgs>;
+  onRowsChanged: SlickEvent<OnRowsChangedEventArgs>;
+  onRowsOrCountChanged: SlickEvent<OnRowsOrCountChangedEventArgs>;
+  onSelectedRowIdsChanged: SlickEvent<OnSelectedRowIdsChangedEventArgs>;
+  onSetItemsCalled: SlickEvent<OnSetItemsCalledEventArgs>;
 
-  constructor(options: Partial<DataViewOption>) {
+  constructor(options: Partial<DataViewOption>, protected externalPubSub?: BasePubSub) {
+    this.onBeforePagingInfoChanged = new SlickEvent<PagingInfo>('onBeforePagingInfoChanged', externalPubSub);
+    this.onGroupExpanded = new SlickEvent<OnGroupExpandedEventArgs>('onGroupExpanded', externalPubSub);
+    this.onGroupCollapsed = new SlickEvent<OnGroupCollapsedEventArgs>('onGroupCollapsed', externalPubSub);
+    this.onPagingInfoChanged = new SlickEvent<PagingInfo>('onPagingInfoChanged', externalPubSub);
+    this.onRowCountChanged = new SlickEvent<OnRowCountChangedEventArgs>('onRowCountChanged', externalPubSub);
+    this.onRowsChanged = new SlickEvent<OnRowsChangedEventArgs>('onRowsChanged', externalPubSub);
+    this.onRowsOrCountChanged = new SlickEvent<OnRowsOrCountChangedEventArgs>('onRowsOrCountChanged', externalPubSub);
+    this.onSelectedRowIdsChanged = new SlickEvent<OnSelectedRowIdsChangedEventArgs>('onSelectedRowIdsChanged', externalPubSub);
+    this.onSetItemsCalled = new SlickEvent<OnSetItemsCalledEventArgs>('onSetItemsCalled', externalPubSub);
+
     this._options = Utils.extend(true, {}, this.defaults, options);
   }
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5,6 +5,7 @@ import { BindingEventService } from '@slickgrid-universal/binding';
 import { isDefined, isPrimitiveOrHTML } from '@slickgrid-universal/utils';
 
 import {
+  type BasePubSub,
   preClickClassName,
   type SlickEditorLock,
   SlickGlobalEditorLock,
@@ -114,57 +115,57 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   cid = '';
 
   // Events
-  onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>();
-  onActiveCellPositionChanged = new SlickEvent<SlickGridEventData>();
-  onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>();
-  onAutosizeColumns = new SlickEvent<OnAutosizeColumnsEventArgs>();
-  onBeforeAppendCell = new SlickEvent<OnBeforeAppendCellEventArgs>();
-  onBeforeCellEditorDestroy = new SlickEvent<OnBeforeCellEditorDestroyEventArgs>();
-  onBeforeColumnsResize = new SlickEvent<OnBeforeColumnsResizeEventArgs>();
-  onBeforeDestroy = new SlickEvent<SlickGridEventData>();
-  onBeforeEditCell = new SlickEvent<OnBeforeEditCellEventArgs>();
-  onBeforeFooterRowCellDestroy = new SlickEvent<OnBeforeFooterRowCellDestroyEventArgs>();
-  onBeforeHeaderCellDestroy = new SlickEvent<OnBeforeHeaderCellDestroyEventArgs>();
-  onBeforeHeaderRowCellDestroy = new SlickEvent<OnBeforeHeaderRowCellDestroyEventArgs>();
-  onBeforeSetColumns = new SlickEvent<OnBeforeSetColumnsEventArgs>();
-  onBeforeSort = new SlickEvent<SingleColumnSort | MultiColumnSort>();
-  onBeforeUpdateColumns = new SlickEvent<OnBeforeUpdateColumnsEventArgs>();
-  onCellChange = new SlickEvent<OnCellChangeEventArgs>();
-  onCellCssStylesChanged = new SlickEvent<OnCellCssStylesChangedEventArgs>();
-  onClick = new SlickEvent<OnClickEventArgs>();
-  onColumnsReordered = new SlickEvent<OnColumnsReorderedEventArgs>();
-  onColumnsDrag = new SlickEvent<OnColumnsDragEventArgs>();
-  onColumnsResized = new SlickEvent<OnColumnsResizedEventArgs>();
-  onColumnsResizeDblClick = new SlickEvent<OnColumnsResizeDblClickEventArgs>();
-  onCompositeEditorChange = new SlickEvent<OnCompositeEditorChangeEventArgs>();
-  onContextMenu = new SlickEvent<SlickGridEventData>();
-  onDrag = new SlickEvent<DragRowMove>();
-  onDblClick = new SlickEvent<OnDblClickEventArgs>();
-  onDragInit = new SlickEvent<DragRowMove>();
-  onDragStart = new SlickEvent<DragRowMove>();
-  onDragEnd = new SlickEvent<DragRowMove>();
-  onFooterClick = new SlickEvent<OnFooterClickEventArgs>();
-  onFooterContextMenu = new SlickEvent<OnFooterContextMenuEventArgs>();
-  onFooterRowCellRendered = new SlickEvent<OnFooterRowCellRenderedEventArgs>();
-  onHeaderCellRendered = new SlickEvent<OnHeaderCellRenderedEventArgs>();
-  onHeaderClick = new SlickEvent<OnHeaderClickEventArgs>();
-  onHeaderContextMenu = new SlickEvent<OnHeaderContextMenuEventArgs>();
-  onHeaderMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>();
-  onHeaderMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>();
-  onHeaderRowCellRendered = new SlickEvent<OnHeaderRowCellRenderedEventArgs>();
-  onHeaderRowMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>();
-  onHeaderRowMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>();
-  onKeyDown = new SlickEvent<OnKeyDownEventArgs>();
-  onMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>();
-  onMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>();
-  onRendered = new SlickEvent<OnRenderedEventArgs>();
-  onScroll = new SlickEvent<OnScrollEventArgs>();
-  onSelectedRowsChanged = new SlickEvent<OnSelectedRowsChangedEventArgs>();
-  onSetOptions = new SlickEvent<OnSetOptionsEventArgs>();
-  onActivateChangedOptions = new SlickEvent<OnActivateChangedOptionsEventArgs>();
-  onSort = new SlickEvent<SingleColumnSort | MultiColumnSort>();
-  onValidationError = new SlickEvent<OnValidationErrorEventArgs>();
-  onViewportChanged = new SlickEvent<SlickGridEventData>();
+  onActiveCellChanged: SlickEvent<OnActiveCellChangedEventArgs>;
+  onActiveCellPositionChanged: SlickEvent<SlickGridEventData>;
+  onAddNewRow: SlickEvent<OnAddNewRowEventArgs>;
+  onAutosizeColumns: SlickEvent<OnAutosizeColumnsEventArgs>;
+  onBeforeAppendCell: SlickEvent<OnBeforeAppendCellEventArgs>;
+  onBeforeCellEditorDestroy: SlickEvent<OnBeforeCellEditorDestroyEventArgs>;
+  onBeforeColumnsResize: SlickEvent<OnBeforeColumnsResizeEventArgs>;
+  onBeforeDestroy: SlickEvent<SlickGridEventData>;
+  onBeforeEditCell: SlickEvent<OnBeforeEditCellEventArgs>;
+  onBeforeFooterRowCellDestroy: SlickEvent<OnBeforeFooterRowCellDestroyEventArgs>;
+  onBeforeHeaderCellDestroy: SlickEvent<OnBeforeHeaderCellDestroyEventArgs>;
+  onBeforeHeaderRowCellDestroy: SlickEvent<OnBeforeHeaderRowCellDestroyEventArgs>;
+  onBeforeSetColumns: SlickEvent<OnBeforeSetColumnsEventArgs>;
+  onBeforeSort: SlickEvent<SingleColumnSort | MultiColumnSort>;
+  onBeforeUpdateColumns: SlickEvent<OnBeforeUpdateColumnsEventArgs>;
+  onCellChange: SlickEvent<OnCellChangeEventArgs>;
+  onCellCssStylesChanged: SlickEvent<OnCellCssStylesChangedEventArgs>;
+  onClick: SlickEvent<OnClickEventArgs>;
+  onColumnsReordered: SlickEvent<OnColumnsReorderedEventArgs>;
+  onColumnsDrag: SlickEvent<OnColumnsDragEventArgs>;
+  onColumnsResized: SlickEvent<OnColumnsResizedEventArgs>;
+  onColumnsResizeDblClick: SlickEvent<OnColumnsResizeDblClickEventArgs>;
+  onCompositeEditorChange: SlickEvent<OnCompositeEditorChangeEventArgs>;
+  onContextMenu: SlickEvent<SlickGridEventData>;
+  onDrag: SlickEvent<DragRowMove>;
+  onDblClick: SlickEvent<OnDblClickEventArgs>;
+  onDragInit: SlickEvent<DragRowMove>;
+  onDragStart: SlickEvent<DragRowMove>;
+  onDragEnd: SlickEvent<DragRowMove>;
+  onFooterClick: SlickEvent<OnFooterClickEventArgs>;
+  onFooterContextMenu: SlickEvent<OnFooterContextMenuEventArgs>;
+  onFooterRowCellRendered: SlickEvent<OnFooterRowCellRenderedEventArgs>;
+  onHeaderCellRendered: SlickEvent<OnHeaderCellRenderedEventArgs>;
+  onHeaderClick: SlickEvent<OnHeaderClickEventArgs>;
+  onHeaderContextMenu: SlickEvent<OnHeaderContextMenuEventArgs>;
+  onHeaderMouseEnter: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderMouseLeave: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderRowCellRendered: SlickEvent<OnHeaderRowCellRenderedEventArgs>;
+  onHeaderRowMouseEnter: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderRowMouseLeave: SlickEvent<OnHeaderMouseEventArgs>;
+  onKeyDown: SlickEvent<OnKeyDownEventArgs>;
+  onMouseEnter: SlickEvent<OnHeaderMouseEventArgs>;
+  onMouseLeave: SlickEvent<OnHeaderMouseEventArgs>;
+  onRendered: SlickEvent<OnRenderedEventArgs>;
+  onScroll: SlickEvent<OnScrollEventArgs>;
+  onSelectedRowsChanged: SlickEvent<OnSelectedRowsChangedEventArgs>;
+  onSetOptions: SlickEvent<OnSetOptionsEventArgs>;
+  onActivateChangedOptions: SlickEvent<OnActivateChangedOptionsEventArgs>;
+  onSort: SlickEvent<SingleColumnSort | MultiColumnSort>;
+  onValidationError: SlickEvent<OnValidationErrorEventArgs>;
+  onViewportChanged: SlickEvent<SlickGridEventData>;
 
   // ---
   // protected variables
@@ -453,7 +454,59 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Array<C>} columns - An array of column definitions.
    * @param {Object} [options] - Grid this._options.
    **/
-  constructor(protected container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], protected options: Partial<O>, protected devMode = false) {
+  constructor(protected container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], protected options: Partial<O>, protected externalPubSub?: BasePubSub, protected devMode = false) {
+    this.onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>('onActiveCellChanged', externalPubSub);
+    this.onActiveCellPositionChanged = new SlickEvent<SlickGridEventData>('onActiveCellPositionChanged', externalPubSub);
+    this.onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>('onAddNewRow', externalPubSub);
+    this.onAutosizeColumns = new SlickEvent<OnAutosizeColumnsEventArgs>('onAutosizeColumns', externalPubSub);
+    this.onBeforeAppendCell = new SlickEvent<OnBeforeAppendCellEventArgs>('onBeforeAppendCell', externalPubSub);
+    this.onBeforeCellEditorDestroy = new SlickEvent<OnBeforeCellEditorDestroyEventArgs>('onBeforeCellEditorDestroy', externalPubSub);
+    this.onBeforeColumnsResize = new SlickEvent<OnBeforeColumnsResizeEventArgs>('onBeforeColumnsResize', externalPubSub);
+    this.onBeforeDestroy = new SlickEvent<SlickGridEventData>('onBeforeDestroy', externalPubSub);
+    this.onBeforeEditCell = new SlickEvent<OnBeforeEditCellEventArgs>('onBeforeEditCell', externalPubSub);
+    this.onBeforeFooterRowCellDestroy = new SlickEvent<OnBeforeFooterRowCellDestroyEventArgs>('onBeforeFooterRowCellDestroy', externalPubSub);
+    this.onBeforeHeaderCellDestroy = new SlickEvent<OnBeforeHeaderCellDestroyEventArgs>('onBeforeHeaderCellDestroy', externalPubSub);
+    this.onBeforeHeaderRowCellDestroy = new SlickEvent<OnBeforeHeaderRowCellDestroyEventArgs>('onBeforeHeaderRowCellDestroy', externalPubSub);
+    this.onBeforeSetColumns = new SlickEvent<OnBeforeSetColumnsEventArgs>('onBeforeSetColumns', externalPubSub);
+    this.onBeforeSort = new SlickEvent<SingleColumnSort | MultiColumnSort>('onBeforeSort', externalPubSub);
+    this.onBeforeUpdateColumns = new SlickEvent<OnBeforeUpdateColumnsEventArgs>('onBeforeUpdateColumns', externalPubSub);
+    this.onCellChange = new SlickEvent<OnCellChangeEventArgs>('onCellChange', externalPubSub);
+    this.onCellCssStylesChanged = new SlickEvent<OnCellCssStylesChangedEventArgs>('onCellCssStylesChanged', externalPubSub);
+    this.onClick = new SlickEvent<OnClickEventArgs>('onClick', externalPubSub);
+    this.onColumnsReordered = new SlickEvent<OnColumnsReorderedEventArgs>('onColumnsReordered', externalPubSub);
+    this.onColumnsDrag = new SlickEvent<OnColumnsDragEventArgs>('onColumnsDrag', externalPubSub);
+    this.onColumnsResized = new SlickEvent<OnColumnsResizedEventArgs>('onColumnsResized', externalPubSub);
+    this.onColumnsResizeDblClick = new SlickEvent<OnColumnsResizeDblClickEventArgs>('onColumnsResizeDblClick', externalPubSub);
+    this.onCompositeEditorChange = new SlickEvent<OnCompositeEditorChangeEventArgs>('onCompositeEditorChange', externalPubSub);
+    this.onContextMenu = new SlickEvent<SlickGridEventData>('onContextMenu', externalPubSub);
+    this.onDrag = new SlickEvent<DragRowMove>('onDrag', externalPubSub);
+    this.onDblClick = new SlickEvent<OnDblClickEventArgs>('onDblClick', externalPubSub);
+    this.onDragInit = new SlickEvent<DragRowMove>('onDragInit', externalPubSub);
+    this.onDragStart = new SlickEvent<DragRowMove>('onDragStart', externalPubSub);
+    this.onDragEnd = new SlickEvent<DragRowMove>('onDragEnd', externalPubSub);
+    this.onFooterClick = new SlickEvent<OnFooterClickEventArgs>('onFooterClick', externalPubSub);
+    this.onFooterContextMenu = new SlickEvent<OnFooterContextMenuEventArgs>('onFooterContextMenu', externalPubSub);
+    this.onFooterRowCellRendered = new SlickEvent<OnFooterRowCellRenderedEventArgs>('onFooterRowCellRendered', externalPubSub);
+    this.onHeaderCellRendered = new SlickEvent<OnHeaderCellRenderedEventArgs>('onHeaderCellRendered', externalPubSub);
+    this.onHeaderClick = new SlickEvent<OnHeaderClickEventArgs>('onHeaderClick', externalPubSub);
+    this.onHeaderContextMenu = new SlickEvent<OnHeaderContextMenuEventArgs>('onHeaderContextMenu', externalPubSub);
+    this.onHeaderMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderMouseEnter', externalPubSub);
+    this.onHeaderMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderMouseLeave', externalPubSub);
+    this.onHeaderRowCellRendered = new SlickEvent<OnHeaderRowCellRenderedEventArgs>('onHeaderRowCellRendered', externalPubSub);
+    this.onHeaderRowMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderRowMouseEnter', externalPubSub);
+    this.onHeaderRowMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderRowMouseLeave', externalPubSub);
+    this.onKeyDown = new SlickEvent<OnKeyDownEventArgs>('onKeyDown', externalPubSub);
+    this.onMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>('onMouseEnter', externalPubSub);
+    this.onMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>('onMouseLeave', externalPubSub);
+    this.onRendered = new SlickEvent<OnRenderedEventArgs>('onRendered', externalPubSub);
+    this.onScroll = new SlickEvent<OnScrollEventArgs>('onScroll', externalPubSub);
+    this.onSelectedRowsChanged = new SlickEvent<OnSelectedRowsChangedEventArgs>('onSelectedRowsChanged', externalPubSub);
+    this.onSetOptions = new SlickEvent<OnSetOptionsEventArgs>('onSetOptions', externalPubSub);
+    this.onActivateChangedOptions = new SlickEvent<OnActivateChangedOptionsEventArgs>('onActivateChangedOptions', externalPubSub);
+    this.onSort = new SlickEvent<SingleColumnSort | MultiColumnSort>('onSort', externalPubSub);
+    this.onValidationError = new SlickEvent<OnValidationErrorEventArgs>('onValidationError', externalPubSub);
+    this.onViewportChanged = new SlickEvent<SlickGridEventData>('onViewportChanged', externalPubSub);
+
     this.initialize();
   }
 
@@ -2988,21 +3041,21 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Boolean} [suppressColumnSet] - do we want to supress the columns set, via "setColumns()" method? (defaults to false)
    * @param {Boolean} [suppressSetOverflow] - do we want to suppress the call to `setOverflow`
    */
-  setOptions(args: Partial<O>, suppressRender?: boolean, suppressColumnSet?: boolean, suppressSetOverflow?: boolean): void {
+  setOptions(newOptions: Partial<O>, suppressRender?: boolean, suppressColumnSet?: boolean, suppressSetOverflow?: boolean): void {
     this.prepareForOptionsChange();
 
-    if (this._options.enableAddRow !== args.enableAddRow) {
+    if (this._options.enableAddRow !== newOptions.enableAddRow) {
       this.invalidateRow(this.getDataLength());
     }
 
     // before applying column freeze, we need our viewports to be scrolled back to left to avoid misaligned column headers
-    if (args.frozenColumn) {
+    if (newOptions.frozenColumn) {
       this.getViewports().forEach(vp => vp.scrollLeft = 0);
       this.handleScroll(); // trigger scroll to realign column headers as well
     }
 
     const originalOptions = Utils.extend(true, {}, this._options);
-    this._options = Utils.extend(this._options, args);
+    this._options = Utils.extend(this._options, newOptions);
     this.trigger(this.onSetOptions, { optionsBefore: originalOptions, optionsAfter: this._options });
 
     this.internal_setOptions(suppressRender, suppressColumnSet, suppressSetOverflow);

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -113,8 +113,6 @@ export const GlobalGridOptions: Partial<GridOption> = {
   defaultFilterPlaceholder: '🔎︎',
   defaultFilterRangeOperator: OperatorType.rangeInclusive,
   defaultColumnSortFieldId: 'id',
-  defaultComponentEventPrefix: '',
-  defaultSlickgridEventPrefix: '',
   draggableGrouping: {
     hideToggleAllButton: false,
     toggleAllButtonText: '',

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -247,9 +247,6 @@ export interface GridOption<C extends Column = Column> {
   /** Default column width, is set to 80 when null */
   defaultColumnWidth?: number;
 
-  /** Default prefix for Component Event names (events created in the Web Component) */
-  defaultComponentEventPrefix?: string;
-
   /** The default filter model to use when none is specified */
   defaultFilter?: any;
 
@@ -261,9 +258,6 @@ export interface GridOption<C extends Column = Column> {
 
   /** Default cell Formatter that will be used by the grid */
   defaultFormatter?: Formatter;
-
-  /** Default prefix for SlickGrid Event names (events created in the SlickGrid and/or DataView objects) */
-  defaultSlickgridEventPrefix?: string;
 
   /** Do we have paging enabled? */
   doPaging?: boolean;

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -101,6 +101,7 @@ export class EventPubSubService implements BasePubSubService {
 
     if (delay) {
       return new Promise(resolve => {
+        clearTimeout(this._timer);
         this._timer = setTimeout(() => resolve(this.dispatchCustomEvent<T>(eventNameByConvention, data, true, true)), delay);
       });
     } else {

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -799,7 +799,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const extensions = component.extensions as ExtensionList<any>;
 
         expect(Object.keys(extensions).length).toBe(1);
-        expect(dataviewSpy).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() });
+        expect(dataviewSpy).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() }, eventPubSubService);
         expect(sharedService.groupItemMetadataProvider instanceof SlickGroupItemMetadataProvider).toBeTruthy();
         expect(sharedMetaSpy).toHaveBeenCalledWith(expect.toBeObject());
         expect(mockGrid.registerPlugin).toHaveBeenCalled();
@@ -814,7 +814,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.gridOptions = { enableGrouping: true };
         component.initialization(divContainer, slickEventHandler);
 
-        expect(dataviewSpy).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() });
+        expect(dataviewSpy).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() }, eventPubSubService);
         expect(sharedMetaSpy).toHaveBeenCalledWith(expect.toBeObject());
         expect(sharedService.groupItemMetadataProvider instanceof SlickGroupItemMetadataProvider).toBeTruthy();
         expect(mockGrid.registerPlugin).toHaveBeenCalled();
@@ -1626,20 +1626,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(component.eventHandler).toEqual(slickEventHandler);
         expect(renderSpy).toHaveBeenCalled();
         expect(updateRowSpy).toHaveBeenCalledTimes(3);
-      });
-
-      it('should call "dispatchCustomEvent" when event gets trigger', () => {
-        const dispatchSpy = jest.spyOn(eventPubSubService, 'dispatchCustomEvent');
-        const callback = jest.fn();
-
-        component.gridOptions = { enableFiltering: true };
-        component.initialization(divContainer, slickEventHandler);
-
-        component.eventHandler.subscribe(mockEventPubSub as any, callback);
-        mockGrid.onClick.notify({ rows: [1, 2, 3] } as any);
-
-        // callback(new CustomEvent('onDblClick'), {});
-        expect(dispatchSpy).toHaveBeenCalledWith('onclick', { eventData: undefined, args: { rows: [1, 2, 3] } });
       });
     });
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -496,7 +496,7 @@ export class SlickVanillaGridBundle<TData = any> {
         this.sharedService.groupItemMetadataProvider = this.groupItemMetadataProvider;
         dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: this.groupItemMetadataProvider };
       }
-      this.dataView = new SlickDataView<TData>(dataViewOptions as Partial<DataViewOption>);
+      this.dataView = new SlickDataView<TData>(dataViewOptions as Partial<DataViewOption>, this._eventPubSubService);
       this._eventPubSubService.publish('onDataviewCreated', this.dataView);
     }
 
@@ -537,7 +537,7 @@ export class SlickVanillaGridBundle<TData = any> {
       this.gridOptions = { ...this.gridOptions, ...this.gridOptions.presets.pinning };
     }
 
-    this.slickGrid = new SlickGrid<TData, Column<TData>, GridOption<Column<TData>>>(gridContainerElm, this.dataView as SlickDataView<TData>, this._columnDefinitions, this._gridOptions);
+    this.slickGrid = new SlickGrid<TData, Column<TData>, GridOption<Column<TData>>>(gridContainerElm, this.dataView as SlickDataView<TData>, this._columnDefinitions, this._gridOptions, this._eventPubSubService);
     this.sharedService.dataView = this.dataView as SlickDataView;
     this.sharedService.slickGrid = this.slickGrid as SlickGrid;
     this.sharedService.gridContainerElement = this._gridContainerElm;
@@ -762,26 +762,6 @@ export class SlickVanillaGridBundle<TData = any> {
     }
 
     if (dataView && grid) {
-      // expose all Slick Grid Events through dispatch
-      for (const prop in grid) {
-        if (grid.hasOwnProperty(prop) && prop.startsWith('on')) {
-          this._eventHandler.subscribe((grid as any)[prop], (event, args) => {
-            const gridEventName = this._eventPubSubService.getEventNameByNamingConvention(prop, this._gridOptions?.defaultSlickgridEventPrefix ?? '');
-            return this._eventPubSubService.dispatchCustomEvent(gridEventName, { eventData: event, args });
-          });
-        }
-      }
-
-      // expose all Slick DataView Events through dispatch
-      for (const prop in dataView) {
-        if (dataView.hasOwnProperty(prop) && prop.startsWith('on')) {
-          this._eventHandler.subscribe((dataView as any)[prop], (event, args) => {
-            const dataViewEventName = this._eventPubSubService.getEventNameByNamingConvention(prop, this._gridOptions?.defaultSlickgridEventPrefix ?? '');
-            return this._eventPubSubService.dispatchCustomEvent(dataViewEventName, { eventData: event, args });
-          });
-        }
-      }
-
       // after all events are exposed
       // we can bind external filter (backend) when available or default onFilter (dataView)
       if (gridOptions.enableFiltering) {


### PR DESCRIPTION
- by modifying the SlickEvent class to also publish an event when a PubSub Service is provided to a SlickEvent, we can avoid having our previous monkey patch of subscribing to **all** SlickGrid/DataView events to then dispatch event, this acted like a middleware, we can avoid all of that middleware with this new approach and publish right away via the PubSub when provided
- also removed `defaultComponentEventPrefix`, `defaultSlickgridEventPrefix` grid options since they will not be used anymore
- more info below

With this PR, we merged the `SlickEvent` with our own PubSub Service (which uses a `CustomEvent`), this makes it easier to maintain and requires less monkey patch code. The reason we use our own PubSub is because it makes it easier to communicate with Component based frameworks (used in Angular-Slickgrid, Slickgrid-React, ...). Note that this only applies to SlickGrid/DataView events since all other extensions (plugins/controls) were already using the PubSub through grid options or extension configurations. Note that you can still use SlickGrid `.subscribe` on SlickEvent but please remember to `.unsubscribe` each of them if you use that approach (which is not needed with a PubSub since you only have to do that once at a global level).

Also note that our PubSub Service is a JS [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) based, so all the data is only available through the `.eventDetail` property of a CustomEvent. We use our PubSub to publish all events in the project, however the SlickGrid/DataView are the only events following this structure `{ eventData: SlickEventData; args: any; }`, while all other extensions also publish events but the arguments are directly in the root (`args`).

_What was the monkey patch anyway? The previous patch required to loop through all SlickGrid/DataView events (`SlickEvent`), we were then subscribing to each of them and whenever they were dispatching an event (through SlickEvent notify), we were then using our own PubSub Service to publish the event (similar to a middleware would do). As you can see, that was quite a monkey patch, the new approach simply adds an optional PubSub Service reference to the SlickEvent, allowing us to publish right away without the monkey patch or middleware._