### PR TITLE
feat: introduce devMode to support nodejs based unit testing

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -19,8 +19,8 @@ describe('SlickGrid core file', () => {
 
   it('should be able to instantiate SlickGrid without DataView', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
-    const options = { enableCellNavigation: true } as GridOption;
-    grid = new SlickGrid<any, Column>('#myGrid', [], columns, options, undefined, true);
+    const options = { enableCellNavigation: true, devMode: { ownerNodeIndex: 0 } } as GridOption;
+    grid = new SlickGrid<any, Column>('#myGrid', [], columns, options);
     grid.init();
 
     expect(grid).toBeTruthy();
@@ -29,9 +29,9 @@ describe('SlickGrid core file', () => {
 
   it('should be able to instantiate SlickGrid with a DataView', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
-    const options = { enableCellNavigation: true } as GridOption;
+    const options = { enableCellNavigation: true, devMode: { ownerNodeIndex: 0 } } as GridOption;
     const dv = new SlickDataView({});
-    grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options, undefined, true);
+    grid = new SlickGrid<any, Column>('#myGrid', dv, columns, options);
     grid.init();
 
     expect(grid).toBeTruthy();

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -176,7 +176,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected canvas: HTMLCanvasElement | null = null;
   protected canvas_context: CanvasRenderingContext2D | null = null;
-  protected _devMode = false;
 
   // settings
   protected _options!: O;
@@ -454,7 +453,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Array<C>} columns - An array of column definitions.
    * @param {Object} [options] - Grid this._options.
    **/
-  constructor(protected container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], protected options: Partial<O>, protected externalPubSub?: BasePubSub, protected devMode = false) {
+  constructor(protected container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], protected options: Partial<O>, protected externalPubSub?: BasePubSub) {
     this.onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>('onActiveCellChanged', externalPubSub);
     this.onActiveCellPositionChanged = new SlickEvent<SlickGridEventData>('onActiveCellPositionChanged', externalPubSub);
     this.onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>('onAddNewRow', externalPubSub);
@@ -2417,9 +2416,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     let i: number;
     if (!this.stylesheet) {
       const sheets: any = (this._options.shadowRoot || document).styleSheets;
+
+      if (typeof this.options.devMode?.ownerNodeIndex === 'number' && this.options.devMode.ownerNodeIndex >= 0) {
+        sheets[this.options.devMode.ownerNodeIndex].ownerNode = this._style;
+      }
+
       for (i = 0; i < sheets.length; i++) {
         const sheet = sheets[i];
-        if ((sheet.ownerNode || sheet.owningElement) === this._style || this.devMode) {
+        if ((sheet.ownerNode || sheet.owningElement) === this._style) {
           this.stylesheet = sheet;
           break;
         }
@@ -3745,7 +3749,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   getViewportWidth() {
-    this.viewportW = parseFloat(getInnerSize(this._container, 'width') as unknown as string);
+    this.viewportW = parseFloat(getInnerSize(this._container, 'width') as unknown as string) || this.options.devMode?.containerClientWidth || 0;
     return this.viewportW;
   }
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -259,6 +259,9 @@ export interface GridOption<C extends Column = Column> {
   /** Default cell Formatter that will be used by the grid */
   defaultFormatter?: Formatter;
 
+  /** Escape hatch geared towards testing Slickgrid in jsdom based environments to circumvent the lack of stylesheet.ownerNode and clientWidth calculations */
+  devMode?: false & { ownerNodeIndex?: number; containerClientWidth?: number; };
+
   /** Do we have paging enabled? */
   doPaging?: boolean;
 


### PR DESCRIPTION
- copies implementation made in 6pac/SlickGrid repo at https://github.com/6pac/SlickGrid/pull/946
> as the title suggests this is meant to make unit/integration tests, e.g with testing-library, possible for apps using Slickgrid. In my specific case I'm making use of angular-slickgrid and would like to be able to test my app using angular-testing-library.
>
> The introduced devMode workarounds are in order to work around the following jsdom issues:
>
> [jsdom/jsdom#2310](https://github.com/jsdom/jsdom/issues/2310) (missing clientWidth) [jsdom/jsdom#992](https://github.com/jsdom/jsdom/issues/992) (missing ownerNode, even with a nice reference to Slickgrid ;) ) For additional conversations about this topic please refer to [ghiscoding/Angular-Slickgrid#1319](https://github.com/ghiscoding/Angular-Slickgrid/discussions/1319)