### PR TITLE
feat(core): add `rowHighlightCssClass` & `highlightRow()` to SlickGrid

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2,6 +2,8 @@ import { Column, FormatterResultWithHtml, FormatterResultWithText, GridOption } 
 import { SlickDataView } from '../slickDataview';
 import { SlickGrid } from '../slickGrid';
 
+jest.useFakeTimers();
+
 describe('SlickGrid core file', () => {
   let container: HTMLElement;
   let grid: SlickGrid;
@@ -188,6 +190,41 @@ describe('SlickGrid core file', () => {
       grid.applyFormatResultToCellNode(formatterResult, cellNodeElm);
 
       expect(cellNodeElm.outerHTML).toBe('<div class="some-class" title="some tooltip">some content</div>');
+    });
+  });
+
+  describe('highlightRow() method', () => {
+    const columns = [
+      { id: 'firstName', field: 'firstName', name: 'First Name' },
+      { id: 'lastName', field: 'lastName', name: 'Last Name' },
+      { id: 'age', field: 'age', name: 'Age' },
+    ] as Column[];
+    const options = { enableCellNavigation: true, devMode: { ownerNodeIndex: 0 } } as GridOption;
+    const dv = new SlickDataView({});
+
+    it('should call the method and expect the highlight to happen for a certain duration', () => {
+      const mockItems = [{ id: 0, firstName: 'John', lastName: 'Doe', age: 30 }, { id: 0, firstName: 'Jane', lastName: 'Doe', age: 28 }];
+
+      grid = new SlickGrid<any, Column>(container, dv, columns, options);
+      dv.addItems(mockItems);
+      grid.init();
+      grid.render();
+
+      grid.highlightRow(0, 10);
+      expect(grid).toBeTruthy();
+      expect(grid.getDataLength()).toBe(2);
+
+      let slickRowElms = container.querySelectorAll<HTMLDivElement>('.slick-row');
+      expect(slickRowElms.length).toBe(2);
+      expect(slickRowElms[0].classList.contains('highlight-animate')).toBeTruthy(); // only 1st row is highlighted
+      expect(slickRowElms[1].classList.contains('highlight-animate')).toBeFalsy();
+
+      jest.runAllTimers(); // fast-forward timer
+
+      slickRowElms = container.querySelectorAll<HTMLDivElement>('.slick-row');
+      expect(slickRowElms.length).toBe(2);
+      expect(slickRowElms[0].classList.contains('highlight-animate')).toBeFalsy();
+      expect(slickRowElms[1].classList.contains('highlight-animate')).toBeFalsy();
     });
   });
 });

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -628,6 +628,13 @@ export interface GridOption<C extends Column = Column> {
   /** Grid row height in pixels (only type the number). Row of cell values. */
   rowHeight?: number;
 
+  /**
+   * Defaults to "highlight-animate", a CSS class name used to simulate row highlight with an optional duration (e.g. after insert).
+   * The default class is "highlight-animate" but you could also use "highlight" if you don't plan on using duration neither animation.
+   * Note: when having a duration, make sure that it's always lower than the duration defined in the CSS/SASS variable `$slick-row-highlight-fade-animation`
+   */
+  rowHighlightCssClass?: string;
+
   /** Row Move Manager Plugin options & events */
   rowMoveManager?: RowMoveManager;
 

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -71,8 +71,7 @@ $slick-row-mouse-hover-box-shadow:                          none !default;
 $slick-row-mouse-hover-z-index:                             5 !default;
 $slick-row-selected-color:                                  #dae8f1 !default;
 $slick-row-highlight-background-color:                      darken($slick-row-selected-color, 5%) !default;
-$slick-row-highlight-fade-animation:                        1.5s ease 1 !default;
-$slick-row-highlight-fade-out-animation:                    0.3s ease 1 !default;
+$slick-row-highlight-fade-animation:                        1s linear !default;
 $slick-row-checkbox-selector-background:                    inherit !default;
 $slick-row-checkbox-selector-border:                        none !default;
 

--- a/packages/common/src/styles/slick-bootstrap.scss
+++ b/packages/common/src/styles/slick-bootstrap.scss
@@ -1,24 +1,9 @@
 /* Mixins for SlickGrid */
 @import './variables';
 
-@-webkit-keyframes highlight-start {
-  to { background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color); }
-  from { background: none; }
-}
-
-@keyframes highlight-start {
-  to { background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color); }
-  from { background: none; }
-}
-
-@-webkit-keyframes highlight-end {
-  from { background: var(--slick-row-highlight-fade-out-animation, $slick-row-highlight-fade-out-animation); }
-  to { background: none; }
-}
-
-@keyframes highlight-end {
-  from { background: var(--slick-row-highlight-fade-out-animation, $slick-row-highlight-fade-out-animation); }
-  to { background: none; }
+@keyframes fade {
+  0%, 100% { background: none }
+  50% { background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color) }
 }
 
 .slickgrid-container {
@@ -72,34 +57,6 @@
       &.active {
         padding: var(--slick-cell-padding, $slick-cell-padding);
       }
-      &.highlight {
-        background-color: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
-        animation: highlight-start $slick-row-highlight-fade-animation;
-        .slick-cell {
-          &.copied {
-            background: var(--slick-copied-cell-bg-color-transition, $slick-copied-cell-bg-color-transition);
-            transition: var(--slick-copied-cell-transition, $slick-copied-cell-transition);
-          }
-        }
-        &.odd {
-          background-color: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
-          animation: highlight-start #{var(--slick-row-highlight-fade-animation, $slick-row-highlight-fade-animation)};
-        }
-        &.odd .slick-cell {
-          &.copied {
-            background: var(--slick-copied-cell-bg-color-transition, $slick-copied-cell-bg-color-transition);
-            transition: var(--slick-copied-cell-transition, $slick-copied-cell-transition);
-          }
-        }
-      }
-      &.highlight-end {
-        background-color: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
-        animation: highlight-end #{var(--slick-row-highlight-fade-animation, $slick-row-highlight-fade-animation)};
-        &.odd {
-          background-color: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
-          animation: highlight-end #{var(--slick-row-highlight-fade-animation, $slick-row-highlight-fade-animation)};
-        }
-      }
       &.highlighter {
         background: orange !important;
         transition-property: background;
@@ -135,6 +92,13 @@
           transition: var(--slick-copied-cell-transition, $slick-copied-cell-transition);
         }
         background: inherit;
+      }
+      &.highlight {
+        background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
+      }
+      &.highlight-animate {
+        background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
+        animation: fade var(--slick-row-highlight-fade-animation, $slick-row-highlight-fade-animation);
       }
       &.slick-group-totals {
         color: var(--slick-group-totals-formatter-color, $slick-group-totals-formatter-color);

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -501,7 +501,6 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         // when adding a new row to the grid, we need to invalidate that row and re-render the grid
         this._eventHandler.subscribe(this.grid.onAddNewRow, (_e, args) => {
           this._originalDataContext = this.insertNewItemInDataView(args.item); // this becomes the new data context
-          // this.disposeComponent();
         });
       }
       return this;


### PR DESCRIPTION
- remove previous `highlightRowByMetadata()` method in GridService, we can avoid using ItemMetaData altogether by adding a simple `highlightRow()` method directly in the SlickGrid core lib and also add `rowHighlightCssClass` grid option which will be animated by default but user could also disable the animation and/or even disable the fade out (remain highlighted)
- this new approach simplifies the code a lot and doesn't require the use of ItemMetadata and calling multiple `updateItem()` and `render()` which is much better for performance
- also fixes an issue that was previously happening when inserting multiple items before the highlight timer had time to finish, that was leaving multiple row highlighted when they shouldn't. 
- also fix potential mem leak found on some `setTimeout` not having any `clearTimeout` assigned which could cause potential mem leaks
- fixes opened Angular-Slickgrid issue https://github.com/ghiscoding/Angular-Slickgrid/issues/1332

![msedge_9JHSBZbK2A](https://github.com/ghiscoding/slickgrid-universal/assets/643976/915d2f73-df03-4ccb-83d9-36e8ee1d6bea)
