### PR TITLE
chore: `highlightRow()` should always have default duration

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4751,21 +4751,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /**
    * Highlight a row for a certain duration (ms) of time.
-   * If the duration is set to null/undefined, then the row will remain highlighted indifinitely.
    * @param {Number} row - grid row number
-   * @param {Number} duration - duration (ms)
+   * @param {Number} [duration] - duration (ms), defaults to 500ms
    */
-  highlightRow(row: number, duration?: number) {
+  highlightRow(row: number, duration = 500) {
     const rowCache = this.rowsCache[row];
 
     if (Array.isArray(rowCache?.rowNode) && this._options.rowHighlightCssClass) {
       rowCache.rowNode.forEach(node => node.classList.add(this._options.rowHighlightCssClass || ''));
-      if (typeof duration === 'number') {
-        clearTimeout(this._highlightRowTimer);
-        this._highlightRowTimer = setTimeout(() => {
-          rowCache.rowNode?.forEach(node => node.classList.remove(this._options.rowHighlightCssClass || ''));
-        }, duration);
-      }
+      clearTimeout(this._highlightRowTimer);
+      this._highlightRowTimer = setTimeout(() => {
+        rowCache.rowNode?.forEach(node => node.classList.remove(this._options.rowHighlightCssClass || ''));
+      }, duration);
     }
   }
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -630,8 +630,8 @@ export interface GridOption<C extends Column = Column> {
 
   /**
    * Defaults to "highlight-animate", a CSS class name used to simulate row highlight with an optional duration (e.g. after insert).
-   * The default class is "highlight-animate" but you could also use "highlight" if you don't plan on using duration neither animation.
-   * Note: when having a duration, make sure that it's always lower than the duration defined in the CSS/SASS variable `$slick-row-highlight-fade-animation`
+   * Note: make sure that the duration is always lower than the duration defined in the CSS/SASS variable `$slick-row-highlight-fade-animation`.
+   * Also note that the highlight is temporary and will also disappear as soon as the user starts scrolling or a `render()` is being called
    */
   rowHighlightCssClass?: string;
 

--- a/packages/common/src/styles/slick-bootstrap.scss
+++ b/packages/common/src/styles/slick-bootstrap.scss
@@ -97,7 +97,7 @@
         background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
       }
       &.highlight-animate {
-        background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color);
+        background: var(--slick-row-highlight-background-color, $slick-row-highlight-background-color) !important;
         animation: fade var(--slick-row-highlight-fade-animation, $slick-row-highlight-fade-animation);
       }
       &.slick-group-totals {


### PR DESCRIPTION
- the idea of having a permanent highlight is irrealistic since the highlight is applied to a temp slick-row, in other word this highlight would disappear as soon as we call any of: scroll, render, invalidate