### PR TITLE
feat: datasetIdPropertyName respected in newRowCreator

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellExcelCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExcelCopyManager.spec.ts
@@ -305,6 +305,21 @@ describe('CellExcelCopyManager', () => {
       expect(addItemSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'newRow_1' }));
     });
 
+    it('should respect datasetIdPropertyName when calling "newRowCreator" callback', () => {
+      const expectedColumnName = 'mySuperSpecialId';
+      gridOptionsMock.datasetIdPropertyName = expectedColumnName;
+      plugin.init(gridStub);
+      const mockGetData = { addItem: jest.fn() };
+      const getDataSpy = jest.spyOn(gridStub, 'getData').mockReturnValue(mockGetData as any);
+      const addItemSpy = jest.spyOn(mockGetData, 'addItem');
+
+      plugin.addonOptions!.newRowCreator!(2);
+
+      expect(getDataSpy).toHaveBeenCalled();
+      expect(addItemSpy).toHaveBeenCalledWith(expect.objectContaining({ [expectedColumnName]: 'newRow_0' }));
+      expect(addItemSpy).toHaveBeenCalledWith(expect.objectContaining({ [expectedColumnName]: 'newRow_1' }));
+    });
+
     it('should expect a formatted output after calling "dataItemColumnValueExtractor" callback', () => {
       plugin.init(gridStub);
       const output = plugin.addonOptions!.dataItemColumnValueExtractor!({ firstName: 'John', lastName: 'Doe' }, { id: 'firstName', field: 'firstName', exportWithFormatter: true, formatter: myBoldFormatter });

--- a/packages/common/src/extensions/slickCellExcelCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExcelCopyManager.ts
@@ -166,7 +166,7 @@ export class SlickCellExcelCopyManager {
       includeHeaderWhenCopying: false,
       newRowCreator: (count: number) => {
         for (let i = 0; i < count; i++) {
-          this._grid.getData<SlickDataView>().addItem({ id: `newRow_${newRowIds++}` });
+          this._grid.getData<SlickDataView>().addItem({ [this.gridOptions.datasetIdPropertyName || 'id']: `newRow_${newRowIds++}` });
         }
       }
     };


### PR DESCRIPTION
Hey ho, when playing around with the Excel Copy Buffer I noticed that in my sample when copying and pasting multiple rows which overflow, new row creation failed with

`[SlickGrid DataView] Each data element must implement a unique 'id' property`

My example was using the OData Backend hence with a custom id column, set via `datasetIdPropertyName`.

It took me quite a while to figure out that this can be solved by overriding the following property in the options:

```
excelCopyBufferOptions: {
     newRowCreator: (count) => { ... }
}
```

so I thought adding this feature to respect the `datasetIdPropertyName` should make it work out of the box.

See the added unit test for better clarification :)