### PR TITLE
chore(tests): latest JSDOM is adding aria attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jest-cli": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^4.0.2",
-    "jsdom": "^23.0.1",
+    "jsdom": "^23.1.0",
     "jsdom-global": "^3.0.2",
     "moment-mini": "^2.29.4",
     "npm-run-all2": "^6.1.1",

--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -297,33 +297,33 @@ describe('CellMenu Plugin', () => {
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-cell-menu slick-menu-level-0 slickgrid12345 dropdown dropleft" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
-            <div class="slick-menu-command-list">
+            <div class="slick-menu-command-list" role="menu">
               <div class="slick-command-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu">×</button>
+                <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
-              <li class="slick-menu-item orange" data-command="command1">
+              <li class="slick-menu-item orange" role="menuitem" data-command="command1">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Command 1</span>
               </li>
-              <li class="slick-menu-item" data-command="command2">
+              <li class="slick-menu-item" role="menuitem" data-command="command2">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Command 2</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class="slick-menu-item red" data-command="delete-row">
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class="slick-menu-item red" role="menuitem" data-command="delete-row">
                 <div class="slick-menu-icon mdi mdi-close"></div>
                 <span class="slick-menu-content bold">Delete Row</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class=\"slick-menu-item slick-submenu-item\" data-command=\"sub-commands\">
-                <div class=\"slick-menu-icon\"></div>
-                <span class=\"slick-menu-content\">Sub Commands</span>
-                <span class=\"sub-item-chevron\">⮞</span>
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class="slick-menu-item slick-submenu-item" role="menuitem" data-command="sub-commands">
+                <div class="slick-menu-icon"></div>
+                <span class="slick-menu-content">Sub Commands</span>
+                <span class="sub-item-chevron">⮞</span>
               </li>
-              <li class=\"slick-menu-item slick-submenu-item\" data-command=\"sub-commands2\">
-                <div class=\"slick-menu-icon\"></div>
-                <span class=\"slick-menu-content\">Sub Commands 2</span>
-                <span class=\"sub-item-chevron\">⮞</span>
+              <li class="slick-menu-item slick-submenu-item" role="menuitem" data-command="sub-commands2">
+                <div class="slick-menu-icon"></div>
+                <span class="slick-menu-content">Sub Commands 2</span>
+                <span class="sub-item-chevron">⮞</span>
               </li>
           </div>
         </div>`));
@@ -785,28 +785,28 @@ describe('CellMenu Plugin', () => {
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-cell-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
-            <div class="slick-menu-option-list">
+            <div class="slick-menu-option-list" role="menu">
               <div class="slick-option-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu">×</button>
+                <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
-              <li class="slick-menu-item purple" data-option="option1">
+              <li class="slick-menu-item purple" role="menuitem" data-option="option1">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Option 1</span>
               </li>
-              <li class="slick-menu-item" data-option="option2">
+              <li class="slick-menu-item" role="menuitem" data-option="option2">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Option 2</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class="slick-menu-item sky" data-option="delete-row">
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class="slick-menu-item sky" role="menuitem" data-option="delete-row">
                 <div class="slick-menu-icon mdi mdi-checked"></div>
                 <span class="slick-menu-content underline">Delete Row</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class=\"slick-menu-item slick-submenu-item\" data-option=\"sub-options\">
-                <div class=\"slick-menu-icon\"></div>
-                <span class=\"slick-menu-content\">Sub Options</span>
-                <span class=\"sub-item-chevron\">⮞</span>
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class="slick-menu-item slick-submenu-item" role="menuitem" data-option="sub-options">
+                <div class="slick-menu-icon"></div>
+                <span class="slick-menu-content">Sub Options</span>
+                <span class="sub-item-chevron">⮞</span>
               </li>
           </div>
         </div>`));

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -323,25 +323,25 @@ describe('ContextMenu Plugin', () => {
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-context-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
-            <div class="slick-menu-command-list">
+            <div class="slick-menu-command-list" role="menu">
               <div class="slick-command-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu">×</button>
+                <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
-              <li class="slick-menu-item orange" data-command="command1">
+              <li class="slick-menu-item orange" role="menuitem" data-command="command1">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Command 1</span>
               </li>
-              <li class="slick-menu-item" data-command="command2">
+              <li class="slick-menu-item" role="menuitem" data-command="command2">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Command 2</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class="slick-menu-item red" data-command="delete-row">
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class="slick-menu-item red" role="menuitem" data-command="delete-row">
                 <div class="slick-menu-icon mdi mdi-close"></div>
                 <span class="slick-menu-content bold">Delete Row</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class=\"slick-menu-item slick-submenu-item\" data-command=\"sub-commands\">
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class=\"slick-menu-item slick-submenu-item\" role="menuitem" data-command=\"sub-commands\">
                 <div class=\"slick-menu-icon\"></div>
                 <span class=\"slick-menu-content\">Sub Commands</span>
                 <span class=\"sub-item-chevron\">⮞</span>
@@ -1336,25 +1336,25 @@ describe('ContextMenu Plugin', () => {
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
           `<div class="slick-context-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
-            <div class="slick-menu-option-list">
+            <div class="slick-menu-option-list" role="menu">
               <div class="slick-option-header no-title with-close">
-                <button class="close" type="button" data-dismiss="slick-menu">×</button>
+                <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>
               </div>
-              <li class="slick-menu-item purple" data-option="option1">
+              <li class="slick-menu-item purple" role="menuitem" data-option="option1">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Option 1</span>
               </li>
-              <li class="slick-menu-item" data-option="option2">
+              <li class="slick-menu-item" role="menuitem" data-option="option2">
                 <div class="slick-menu-icon">◦</div>
                 <span class="slick-menu-content">Option 2</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class="slick-menu-item sky" data-option="delete-row">
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class="slick-menu-item sky" role="menuitem" data-option="delete-row">
                 <div class="slick-menu-icon mdi mdi-checked"></div>
                 <span class="slick-menu-content underline">Delete Row</span>
               </li>
-              <li class="slick-menu-item slick-menu-item-divider"></li>
-              <li class=\"slick-menu-item slick-submenu-item\" data-option=\"sub-options\">
+              <li class="slick-menu-item slick-menu-item-divider" role="menuitem"></li>
+              <li class=\"slick-menu-item slick-submenu-item\" role="menuitem" data-option=\"sub-options\">
                 <div class=\"slick-menu-icon\"></div>
                 <span class=\"slick-menu-content\">Sub Options</span>
                 <span class=\"sub-item-chevron\">⮞</span>

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -129,7 +129,7 @@ describe('GroupItemMetadataProvider Service', () => {
       service.setOptions({ enableExpandCollapse: true });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: 'Some Title' }, gridStub) as DocumentFragment;
       const htmlContent = [].map.call(output.childNodes, x => x.outerHTML).join('');
-      expect(htmlContent).toBe('<span class="slick-group-toggle expanded" style="margin-left: 0px;"></span><span class="slick-group-title" level="0">Some Title</span>');
+      expect(htmlContent).toBe('<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title" level="0">Some Title</span>');
     });
 
     it('should provide HTMLElement and return same Grouping info formatted with a group level 0 without indentation when calling "defaultGroupCellFormatter" with option "enableExpandCollapse" set to True', () => {
@@ -139,7 +139,7 @@ describe('GroupItemMetadataProvider Service', () => {
       spanElm.textContent = 'Another Title';
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: spanElm }, gridStub) as DocumentFragment;
       const htmlContent = getHTMLFromFragment(output, 'outerHTML');
-      expect(htmlContent).toBe('<span class="slick-group-toggle expanded" style="margin-left: 0px;"></span><span class="slick-group-title" level="0"><span>Another Title</span></span>');
+      expect(htmlContent).toBe('<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title" level="0"><span>Another Title</span></span>');
     });
 
     it('should provide a DocumentFragment as header title and return same Grouping info formatted with a group level 0 without indentation when calling "defaultGroupCellFormatter" with option "enableExpandCollapse" set to True', () => {
@@ -149,7 +149,7 @@ describe('GroupItemMetadataProvider Service', () => {
       fragment.textContent = 'Fragment Title';
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: fragment }, gridStub) as DocumentFragment;
       const htmlContent = getHTMLFromFragment(output, 'outerHTML');
-      expect(htmlContent).toBe('<span class="slick-group-toggle expanded" style="margin-left: 0px;"></span><span class="slick-group-title" level="0">Fragment Title</span>');
+      expect(htmlContent).toBe('<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title" level="0">Fragment Title</span>');
     });
 
     it('should return Grouping info formatted with a group level 2 with indentation of 30px when calling "defaultGroupCellFormatter" with option "enableExpandCollapse" set to True and level 2', () => {
@@ -157,7 +157,7 @@ describe('GroupItemMetadataProvider Service', () => {
       service.setOptions({ enableExpandCollapse: true, toggleCssClass: 'groupy-toggle', toggleExpandedCssClass: 'groupy-expanded' });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { level: 2, title: 'Some Title' }, gridStub) as DocumentFragment;
       const htmlContent = getHTMLFromFragment(output, 'outerHTML');
-      expect(htmlContent).toBe('<span class="groupy-toggle groupy-expanded" style="margin-left: 30px;"></span><span class="slick-group-title" level="2">Some Title</span>');
+      expect(htmlContent).toBe('<span class="groupy-toggle groupy-expanded" aria-expanded="true" style="margin-left: 30px;"></span><span class="slick-group-title" level="2">Some Title</span>');
     });
 
     it('should return Grouping info formatted with a group level 2 with indentation of 30px when calling "defaultGroupCellFormatter" with option "enableExpandCollapse" set to True and level 2', () => {
@@ -165,7 +165,7 @@ describe('GroupItemMetadataProvider Service', () => {
       service.setOptions({ enableExpandCollapse: true, toggleCssClass: 'groupy-toggle', toggleCollapsedCssClass: 'groupy-collapsed' });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { collapsed: true, level: 3, title: 'Some Title' }, gridStub) as DocumentFragment;
       const htmlContent = [].map.call(output.childNodes, x => x.outerHTML).join('')
-      expect(htmlContent).toBe('<span class="groupy-toggle groupy-collapsed" style="margin-left: 45px;"></span><span class="slick-group-title" level="3">Some Title</span>');
+      expect(htmlContent).toBe('<span class="groupy-toggle groupy-collapsed" aria-expanded="false" style="margin-left: 45px;"></span><span class="slick-group-title" level="3">Some Title</span>');
     });
   });
 

--- a/packages/common/src/extensions/__tests__/slickHeaderButtons.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderButtons.spec.ts
@@ -129,7 +129,7 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (only 1x)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
 
       gridStub.onBeforeHeaderCellDestroy.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData as any, gridStub);
       expect(headerDiv.innerHTML).toBe('');
@@ -148,7 +148,7 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (only 1x)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
     });
 
     it('should populate 2x Header Buttons when cell is being rendered and a 2nd button item visibility & usability callbacks returns true', () => {
@@ -165,8 +165,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-        <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+        <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
     });
 
     it('should populate 2x Header Buttons and a 2nd button item usability callback returns false and expect button to be disabled', () => {
@@ -183,8 +183,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button slick-header-button-disabled mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-        <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button slick-header-button-disabled mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+        <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
     });
 
     it('should populate 2x Header Buttons and a 2nd button is "disabled" and expect button to be disabled', () => {
@@ -201,8 +201,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button slick-header-button-disabled mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-        <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button slick-header-button-disabled mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+        <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
     });
 
     it('should populate 2x Header Buttons and a 2nd button and property "showOnHover" is enabled and expect button to be hidden until we hover it', () => {
@@ -219,8 +219,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button slick-header-button-hidden mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-        <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button slick-header-button-hidden mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+        <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
     });
 
     it('should populate 2x Header Buttons and a 2nd button and a "handler" callback to be executed when defined', () => {
@@ -238,8 +238,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-          <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+          <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
       expect(handlerMock).toHaveBeenCalled();
     });
 
@@ -258,8 +258,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-          <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+          <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
       expect(actionMock).toHaveBeenCalled();
     });
 
@@ -279,8 +279,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-          <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+          <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
       expect(onCommandMock).toHaveBeenCalled();
       expect(updateColSpy).toHaveBeenCalledWith('field1');
     });
@@ -301,8 +301,8 @@ describe('HeaderButton Plugin', () => {
 
       // add Header Buttons which are visible (2x buttons)
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-header-button mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
-        <li class="slick-header-button mdi mdi-lightbulb-outline" data-command="show-positive-numbers"></li>`));
+        `<li class="slick-header-button mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers."></li>
+        <li class="slick-header-button mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers"></li>`));
     });
   });
 });

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -208,7 +208,7 @@ describe('HeaderMenu Plugin', () => {
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData as any, gridStub);
 
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<div class="slick-header-menu-button mdi mdi-chevron-down"></div>`));
+        `<div class="slick-header-menu-button mdi mdi-chevron-down" aria-label="Header Menu"></div>`));
     });
 
     it('should populate a Header Menu button with extra tooltip title attribute when header menu option "tooltip" and cell is being rendered', () => {
@@ -220,7 +220,7 @@ describe('HeaderMenu Plugin', () => {
       gridStub.onHeaderCellRendered.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData as any, gridStub);
 
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<div class="slick-header-menu-button" title="some tooltip text"></div>`));
+        `<div class="slick-header-menu-button" aria-label="Header Menu" title="some tooltip text"></div>`));
     });
 
     it('should populate a Header Menu when cell is being rendered and a 2nd button item visibility callback returns undefined', () => {
@@ -233,7 +233,7 @@ describe('HeaderMenu Plugin', () => {
 
       // add Header Menu which is visible
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<div class="slick-header-menu-button"></div>`));
+        `<div class="slick-header-menu-button" aria-label="Header Menu"></div>`));
 
       gridStub.onBeforeHeaderCellDestroy.notify({ column: columnsMock[0], node: headerDiv, grid: gridStub }, eventData as any, gridStub);
       expect(headerDiv.innerHTML).toBe('');
@@ -249,7 +249,7 @@ describe('HeaderMenu Plugin', () => {
 
       // add Header Menu which is visible
       expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(
-        `<div class="slick-header-menu-button"></div>`));
+        `<div class="slick-header-menu-button" aria-label="Header Menu"></div>`));
     });
 
     it('should populate a Header Menu when cell is being rendered and a 2nd button item visibility & usability callbacks returns true', () => {
@@ -263,13 +263,13 @@ describe('HeaderMenu Plugin', () => {
       const headerButtonElm = headerDiv.querySelector('.slick-header-menu-button') as HTMLDivElement;
 
       // add Header Menu which is visible
-      expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(`<div class="slick-header-menu-button"></div>`));
+      expect(removeExtraSpaces(headerDiv.innerHTML)).toBe(removeExtraSpaces(`<div class="slick-header-menu-button" aria-label="Header Menu"></div>`));
       headerButtonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
       const commandElm = gridContainerDiv.querySelector('.slick-menu-item') as HTMLDivElement;
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-outline" data-command="show-positive-numbers">
+        `<li class="slick-menu-item mdi mdi-lightbulb-outline" role="menuitem" data-command="show-positive-numbers">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -291,7 +291,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item slick-menu-item-disabled mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item slick-menu-item-disabled mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -315,7 +315,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item slick-menu-item-disabled mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item slick-menu-item-disabled mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -335,7 +335,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item slick-menu-item-hidden mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item slick-menu-item-hidden mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -355,7 +355,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Some Tooltip">
+        `<li class="slick-menu-item mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Some Tooltip">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -377,7 +377,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -403,7 +403,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -432,7 +432,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -459,7 +459,7 @@ describe('HeaderMenu Plugin', () => {
       expect(menuElm.clientWidth).toBe(275);
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`
@@ -514,7 +514,7 @@ describe('HeaderMenu Plugin', () => {
 
       expect(commandElm).toBeTruthy();
       expect(removeExtraSpaces(commandElm.outerHTML)).toBe(removeExtraSpaces(
-        `<li class="slick-menu-item mdi mdi-lightbulb-on" data-command="show-negative-numbers" title="Highlight negative numbers.">
+        `<li class="slick-menu-item mdi mdi-lightbulb-on" role="menuitem" data-command="show-negative-numbers" title="Highlight negative numbers.">
             <div class="slick-menu-icon">◦</div>
             <span class="slick-menu-content"></span>
           </li>`

--- a/packages/common/src/formatters/__tests__/checkmarkFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/checkmarkFormatter.spec.ts
@@ -26,20 +26,20 @@ describe('the Checkmark Formatter', () => {
     const value = 'True';
     const result1 = checkmarkFormatter(0, 0, value.toLowerCase(), {} as Column, {}, {} as any);
     const result2 = checkmarkFormatter(0, 0, value.toUpperCase(), {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
-    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
+    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is True', () => {
     const value = true;
     const result = checkmarkFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
+    expect((result as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is a string even if it start with 0', () => {
     const value = '005A00ABC';
     const result1 = checkmarkFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return an empty string when the string "0" is provided', () => {
@@ -51,13 +51,13 @@ describe('the Checkmark Formatter', () => {
   it('should return the Font Awesome Checkmark icon when input is a number greater than 0', () => {
     const value = 0.000001;
     const result1 = checkmarkFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is a number as a text greater than 0', () => {
     const value = '0.000001';
     const result1 = checkmarkFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return an empty string when input is a number lower or equal to 0', () => {
@@ -92,7 +92,7 @@ describe('the Checkmark Formatter', () => {
     const value2 = 'undefined';
     const result1 = checkmarkFormatter(0, 0, value1, {} as Column, {}, {} as any);
     const result2 = checkmarkFormatter(0, 0, value2, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
-    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
+    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>');
   });
 });

--- a/packages/common/src/formatters/__tests__/checkmarkMaterialFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/checkmarkMaterialFormatter.spec.ts
@@ -26,20 +26,20 @@ describe('the Checkmark Formatter with Material Design Icon', () => {
     const value = 'True';
     const result1 = checkmarkMaterialFormatter(0, 0, value.toLowerCase(), {} as Column, {}, {} as any);
     const result2 = checkmarkMaterialFormatter(0, 0, value.toUpperCase(), {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
-    expect((result2 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
+    expect((result2 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is True', () => {
     const value = true;
     const result = checkmarkMaterialFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
+    expect((result as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is a string even if it start with 0', () => {
     const value = '005A00ABC';
     const result1 = checkmarkMaterialFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return an empty string when the string "0" is provided', () => {
@@ -51,13 +51,13 @@ describe('the Checkmark Formatter with Material Design Icon', () => {
   it('should return the Font Awesome Checkmark icon when input is a number greater than 0', () => {
     const value = 0.000001;
     const result1 = checkmarkMaterialFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is a number as a text greater than 0', () => {
     const value = '0.000001';
     const result1 = checkmarkMaterialFormatter(0, 0, value, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
   });
 
   it('should return an empty string when input is a number lower or equal to 0', () => {
@@ -92,7 +92,7 @@ describe('the Checkmark Formatter with Material Design Icon', () => {
     const value2 = 'undefined';
     const result1 = checkmarkMaterialFormatter(0, 0, value1, {} as Column, {}, {} as any);
     const result2 = checkmarkMaterialFormatter(0, 0, value2, {} as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
-    expect((result2 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
+    expect((result2 as HTMLElement).outerHTML).toBe('<i class="mdi mdi-18px mdi-check checkmark-icon" aria-hidden="true"></i>');
   });
 });

--- a/packages/common/src/formatters/__tests__/dollarColoredBoldFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/dollarColoredBoldFormatter.spec.ts
@@ -20,68 +20,68 @@ describe('the DollarColoredBold Formatter', () => {
   it('should display a green number with dollar symbol formatter when number 0 is provided', () => {
     const input = 0;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green; font-weight: bold;">$0.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green; font-weight: bold;">$0.00</span>`);
   });
 
   it('should display a red number with dollar symbol when value is a negative number', () => {
     const input = -15;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red; font-weight: bold;">-$15.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red; font-weight: bold;">-$15.00</span>`);
   });
 
   it('should display a red number with dollar symbol and thousand separator when value is a negative number', () => {
     const input = -12345678;
     const output = dollarColoredBoldFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red; font-weight: bold;">-$12,345,678.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red; font-weight: bold;">-$12,345,678.00</span>`);
   });
 
   it('should display a green number with dollar symbol when value greater or equal to 70 and is a type string', () => {
     const input = '70';
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green; font-weight: bold;">$70.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green; font-weight: bold;">$70.00</span>`);
   });
 
   it('should display a green number with dollar symbol with percentage of 100% when number is greater than 100 is provided', () => {
     const input = 125;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green; font-weight: bold;">$125.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green; font-weight: bold;">$125.00</span>`);
   });
 
   it('should display a number with dollar sign and use minimum decimal set', () => {
     const input = 99.1;
     const output = dollarColoredBoldFormatter(1, 1, input, { params: { minDecimal: 2 } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green; font-weight: bold;">$99.10</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green; font-weight: bold;">$99.10</span>`);
   });
 
   it('should display a number with dollar sign and use maximum decimal set', () => {
     const input = 88.156789;
     const output = dollarColoredBoldFormatter(1, 1, input, { params: { maxDecimal: 3 } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green; font-weight: bold;">$88.157</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green; font-weight: bold;">$88.157</span>`);
   });
 
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
     const input = -2.4;
     const output = dollarColoredBoldFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red; font-weight: bold;">($2.40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red; font-weight: bold;">($2.40)</span>`);
   });
 
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
     const input = -12345678.4;
     const output = dollarColoredBoldFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red; font-weight: bold;">($12,345,678.40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red; font-weight: bold;">($12,345,678.40)</span>`);
   });
 
   it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions = () => ({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, gridStub);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red; font-weight: bold;">($2.40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red; font-weight: bold;">($2.40)</span>`);
   });
 
   it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
     gridStub.getOptions = () => ({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
     const input = -12345678.4;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, gridStub);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red; font-weight: bold;">($12 345 678,40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red; font-weight: bold;">($12 345 678,40)</span>`);
   });
 });

--- a/packages/common/src/formatters/__tests__/dollarColoredFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/dollarColoredFormatter.spec.ts
@@ -20,67 +20,67 @@ describe('the DollarColored Formatter', () => {
   it('should display a green number with dollar symbol formatter when number 0 is provided', () => {
     const input = 0;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green;">$0.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green;">$0.00</span>`);
   });
 
   it('should display a red number with dollar symbol when value is a negative number', () => {
     const input = -15;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red;">-$15.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red;">-$15.00</span>`);
   });
 
   it('should display a red number with dollar symbol and thousand separator when value is a negative number', () => {
     const input = -12345678;
     const output = dollarColoredFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red;">-$12,345,678.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red;">-$12,345,678.00</span>`);
   });
 
   it('should display a green number with dollar symbol when value greater or equal to 70 and is a type string', () => {
     const input = '70';
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green;">$70.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green;">$70.00</span>`);
   });
 
   it('should display a green number with dollar symbol with percentage of 100% when number is greater than 100 is provided', () => {
     const input = 125;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green;">$125.00</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green;">$125.00</span>`);
   });
 
   it('should display a number with dollar sign and use minimum decimal set', () => {
     const input = 99.1;
     const output = dollarColoredFormatter(1, 1, input, { params: { minDecimal: 2 } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green;">$99.10</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green;">$99.10</span>`);
   });
 
   it('should display a number with dollar sign and use maximum decimal set', () => {
     const input = 88.156789;
     const output = dollarColoredFormatter(1, 1, input, { params: { maxDecimal: 3 } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: green;">$88.157</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: green;">$88.157</span>`);
   });
 
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
     const input = -2.4;
     const output = dollarColoredFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red;">($2.40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red;">($2.40)</span>`);
   });
 
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
     const input = -12345678.4;
     const output = dollarColoredFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {}, {} as any);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red;">($12,345,678.40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red;">($12,345,678.40)</span>`);
   });
 
   it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions = () => ({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, gridStub);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red;">($2.40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red;">($2.40)</span>`);
   });
   it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
     gridStub.getOptions = () => ({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
     const input = -12345678.4;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, gridStub);
-    expect((output as HTMLElement).outerHTML).toBe(`<span style="color: red;">($12 345 678,40)</span>`);
+    expect((output as HTMLElement).outerHTML).toBe(`<span aria-hidden="true" style="color: red;">($12 345 678,40)</span>`);
   });
 });

--- a/packages/common/src/formatters/__tests__/iconBooleanFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/iconBooleanFormatter.spec.ts
@@ -35,22 +35,22 @@ describe('the Checkmark Formatter', () => {
     const cssClass = 'fa fa-check';
     const result1 = iconBooleanFormatter(0, 0, value.toLowerCase(), { field: 'user', params: { cssClass } } as Column, {}, {} as any);
     const result2 = iconBooleanFormatter(0, 0, value.toUpperCase(), { field: 'user', params: { cssClass } } as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
-    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
+    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is True', () => {
     const value = true;
     const cssClass = 'fa fa-check';
     const result = iconBooleanFormatter(0, 0, value, { field: 'user', params: { cssClass } } as Column, {}, {} as any);
-    expect((result as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
+    expect((result as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is a string even if it start with 0', () => {
     const value = '005A00ABC';
     const cssClass = 'fa fa-check';
     const result1 = iconBooleanFormatter(0, 0, value, { field: 'user', params: { cssClass } } as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
   });
 
   it('should return an empty string when the string "0" is provided', () => {
@@ -64,14 +64,14 @@ describe('the Checkmark Formatter', () => {
     const value = 0.000001;
     const cssClass = 'fa fa-check';
     const result1 = iconBooleanFormatter(0, 0, value, { field: 'user', params: { cssClass } } as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
   });
 
   it('should return the Font Awesome Checkmark icon when input is a number as a text greater than 0', () => {
     const value = '0.000001';
     const cssClass = 'fa fa-check';
     const result1 = iconBooleanFormatter(0, 0, value, { field: 'user', params: { cssClass } } as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
   });
 
   it('should return an empty string when input is a number lower or equal to 0', () => {
@@ -110,7 +110,7 @@ describe('the Checkmark Formatter', () => {
     const cssClass = 'fa fa-check';
     const result1 = iconBooleanFormatter(0, 0, value1, { field: 'user', params: { cssClass } } as Column, {}, {} as any);
     const result2 = iconBooleanFormatter(0, 0, value2, { field: 'user', params: { cssClass } } as Column, {}, {} as any);
-    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
-    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check"></i>');
+    expect((result1 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
+    expect((result2 as HTMLElement).outerHTML).toBe('<i class="fa fa-check" aria-hidden="true"></i>');
   });
 });

--- a/packages/common/src/formatters/__tests__/iconFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/iconFormatter.spec.ts
@@ -13,21 +13,21 @@ describe('the Icon Formatter', () => {
     const input = null;
     const icon = 'fa fa-search';
     const result = iconFormatter(0, 0, input, { field: 'user', params: { icon } } as Column, {}, {} as any);
-    expect((result as HTMLElement).outerHTML).toBe(`<i class="${icon}"></i>`);
+    expect((result as HTMLElement).outerHTML).toBe(`<i class="${icon}" aria-hidden="true"></i>`);
   });
 
   it('should always return a <i> with the icon class name provided in the "formatterIcon" property from "params"', () => {
     const input = null;
     const icon = 'fa fa-search';
     const result = iconFormatter(0, 0, input, { field: 'user', params: { formatterIcon: icon } } as Column, {}, {} as any);
-    expect((result as HTMLElement).outerHTML).toBe(`<i class="${icon}"></i>`);
+    expect((result as HTMLElement).outerHTML).toBe(`<i class="${icon}" aria-hidden="true"></i>`);
   });
 
   it('should show console warning when using deprecated icon/formatterIcon params', () => {
     const input = null;
     const icon = 'fa fa-search';
     const result = iconFormatter(0, 0, input, { field: 'user', params: { icon } } as Column, {}, {} as any);
-    expect((result as HTMLElement).outerHTML).toBe(`<i class="${icon}"></i>`);
+    expect((result as HTMLElement).outerHTML).toBe(`<i class="${icon}" aria-hidden="true"></i>`);
     expect(consoleWarnSpy).toHaveBeenCalledWith('[Slickgrid-Universal] deprecated params.icon or params.formatterIcon are deprecated when using `Formatters.icon` in favor of params.iconCssClass. (e.g.: `{ formatter: Formatters.icon, params: { iconCssClass: "fa fa-search" }}`');
   });
 });

--- a/packages/common/src/formatters/__tests__/progressBarFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/progressBarFormatter.spec.ts
@@ -15,7 +15,7 @@ describe('the Progress Bar Formatter', () => {
   it('should display a red color bar formatter when number 0 is provided', () => {
     const inputValue = 0;
     const barType = 'danger';
-    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
+    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLDivElement;
     const innerDiv = output.querySelector('div') as HTMLDivElement;
 
@@ -30,7 +30,7 @@ describe('the Progress Bar Formatter', () => {
   it('should display a red color bar when value is a negative number', () => {
     const inputValue = -15;
     const barType = 'danger';
-    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
+    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLDivElement;
     const innerDiv = output.querySelector('div') as HTMLDivElement;
 
@@ -46,8 +46,8 @@ describe('the Progress Bar Formatter', () => {
     const inputValue1 = 30;
     const inputValue2 = 69;
     const barType = 'warning';
-    const template1 = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" style="min-width: 2em; width: ${inputValue1}%;">${inputValue1}%</div></div>`;
-    const template2 = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" style="min-width: 2em; width: ${inputValue2}%;">${inputValue2}%</div></div>`;
+    const template1 = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue1}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue1}%;">${inputValue1}%</div></div>`;
+    const template2 = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue2}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue2}%;">${inputValue2}%</div></div>`;
 
     const output1 = progressBarFormatter(1, 1, inputValue1, {} as Column, {}, {} as any) as HTMLDivElement;
     const output2 = progressBarFormatter(1, 1, inputValue2, {} as Column, {}, {} as any) as HTMLDivElement;
@@ -72,7 +72,7 @@ describe('the Progress Bar Formatter', () => {
   it('should display a green color bar when value greater or equal to 70 and is a type string', () => {
     const inputValue = '70';
     const barType = 'success';
-    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
+    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLDivElement;
     const innerDiv = output.querySelector('div') as HTMLDivElement;
 
@@ -88,7 +88,7 @@ describe('the Progress Bar Formatter', () => {
     const inputValue = 125;
     const inputMaxValue = 100;
     const barType = 'success';
-    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" style="min-width: 2em; width: ${inputMaxValue}%;">${inputMaxValue}%</div></div>`;
+    const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputMaxValue}%;">${inputMaxValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLElement;
     const innerDiv = output.querySelector('div') as HTMLDivElement;
 

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -55,7 +55,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="0">Barbara</span>`);
+      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span>`);
   });
 
   it('should return the Tree content wrapped inside a span HTML element when "allowDocumentFragmentUsage" grid option is disabled', () => {
@@ -64,7 +64,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect((output.html as HTMLElement).outerHTML)
-      .toEqual(`<span><span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="0">Barbara</span></span>`);
+      .toEqual(`<span><span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span></span>`);
   });
 
   it('should return a span without any toggle icon and have a 15px indentation with tree level 3', () => {
@@ -72,7 +72,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-1');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="1">Bobby</span>`);
+      .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="1">Bobby</span>`);
   });
 
   it('should return a span without any toggle icon and have a 45px indentation of a tree level 3', () => {
@@ -80,7 +80,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-3');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 45px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="3">Sponge</span>`);
+      .toEqual(`<span style="display: inline-block; width: 45px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="3">Sponge</span>`);
   });
 
   it('should return a span with expanded icon and 15px indentation when item is a parent and is not collapsed', () => {
@@ -88,7 +88,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-1');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded"></div><span class="slick-tree-title" level="1">Jane</span>`);
+      .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1">Jane</span>`);
   });
 
   it('should return a span with collapsed icon and 0px indentation of a tree level 0 when item is a parent and is collapsed', () => {
@@ -96,7 +96,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed"></div><span class="slick-tree-title" level="0">Anonymous</span>`);
+      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous</span>`);
   });
 
   it('should return a span with expanded icon and 15px indentation of a tree level 1 with a value prefix when provided', () => {
@@ -112,7 +112,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-1');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded"></div><span class="slick-tree-title" level="1"><span class="mdi mdi-subdirectory-arrow-right"></span>Jane</span>`);
+      .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1"><span class="mdi mdi-subdirectory-arrow-right"></span>Jane</span>`);
   });
 
   it('should execute "queryFieldNameGetterFn" callback to get field name to use when it is defined', () => {
@@ -121,7 +121,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="0">Barbara Cane</span>`);
+      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara Cane</span>`);
   });
 
   it('should execute "queryFieldNameGetterFn" callback to get field name and also apply html encoding when output value includes a character that should be encoded', () => {
@@ -130,7 +130,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed"></div><span class="slick-tree-title" level="0">Anonymous &lt; Doe</span>`);
+      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous &lt; Doe</span>`);
   });
 
   it('should execute "queryFieldNameGetterFn" callback to get field name, which has (.) dot notation reprensenting complex object', () => {
@@ -139,6 +139,6 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
-      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle"></div><span class="slick-tree-title" level="0">444444</span>`);
+      .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">444444</span>`);
   });
 });

--- a/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
@@ -108,8 +108,8 @@ describe('Slick-Pagination Component', () => {
       expect(pageInfoFromTo.querySelector('span.item-from')!.ariaLabel).toBe('Page Item From'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
       expect(pageInfoFromTo.querySelector('span.item-to')!.ariaLabel).toBe('Page Item To');
       expect(pageInfoTotalItems.querySelector('span.total-items')!.ariaLabel).toBe('Total Items');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" data-test="item-from">10</span>-<span class="item-to" data-test="item-to">15</span> <span class="text-of">of</span> ');
-      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" data-test="total-items">95</span> <span class="text-items">items</span> ');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" aria-label="Page Item From" data-test="item-from">10</span>-<span class="item-to" aria-label="Page Item To" data-test="item-to">15</span> <span class="text-of">of</span> ');
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" aria-label="Total Items" data-test="total-items">95</span> <span class="text-items">items</span> ');
       component.dispose();
     });
   });

--- a/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
@@ -126,8 +126,8 @@ describe('Slick-Pagination Component', () => {
         expect(pageInfoFromTo.querySelector('span.item-from')!.ariaLabel).toBe('Page Item From'); // JSDom doesn't support ariaLabel, but we can test attribute this way
         expect(pageInfoFromTo.querySelector('span.item-to')!.ariaLabel).toBe('Page Item To');
         expect(pageInfoTotalItems.querySelector('span.total-items')!.ariaLabel).toBe('Total Items');
-        expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" data-test="item-from">10</span>-<span class="item-to" data-test="item-to">15</span> <span class="text-of">of</span> ');
-        expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" data-test="total-items">95</span> <span class="text-items">items</span> ');
+        expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span class="item-from" aria-label="Page Item From" data-test="item-from">10</span>-<span class="item-to" aria-label="Page Item To" data-test="item-to">15</span> <span class="text-of">of</span> ');
+        expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span class="total-items" aria-label="Total Items" data-test="total-items">95</span> <span class="text-items">items</span> ');
         expect(itemsPerPage.selectedOptions[0].value).toBe('5');
       });
 
@@ -344,8 +344,8 @@ describe('with different i18n locale', () => {
       expect(pageInfoFromTo.querySelector('span.item-from')!.ariaLabel).toBe('Page Item From'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
       expect(pageInfoFromTo.querySelector('span.item-to')!.ariaLabel).toBe('Page Item To');
       expect(pageInfoTotalItems.querySelector('span.total-items')!.ariaLabel).toBe('Total Items');
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span class="item-from" data-test="item-from">10</span>-<span class="item-to" data-test="item-to">15</span> <span class="text-of">de</span> `);
-      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe(`<span class="total-items" data-test="total-items">95</span> <span class="text-items">éléments</span> `);
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span class="item-from" aria-label="Page Item From" data-test="item-from">10</span>-<span class="item-to" aria-label="Page Item To" data-test="item-to">15</span> <span class="text-of">de</span> `);
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe(`<span class="total-items" aria-label="Total Items" data-test="total-items">95</span> <span class="text-items">éléments</span> `);
       done();
     }, 50);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,11 +75,11 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2(jest@29.7.0)
       jsdom:
-        specifier: ^23.0.1
-        version: 23.0.1
+        specifier: ^23.1.0
+        version: 23.1.0
       jsdom-global:
         specifier: ^3.0.2
-        version: 3.0.2(jsdom@23.0.1)
+        version: 3.0.2(jsdom@23.1.0)
       moment-mini:
         specifier: ^2.29.4
         version: 2.29.4
@@ -3991,9 +3991,9 @@ packages:
       cssom: 0.3.8
     dev: true
 
-  /cssstyle@3.0.0:
-    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
-    engines: {node: '>=14'}
+  /cssstyle@4.0.1:
+    resolution: {integrity: sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==}
+    engines: {node: '>=18'}
     dependencies:
       rrweb-cssom: 0.6.0
     dev: true
@@ -6400,12 +6400,12 @@ packages:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
     dev: true
 
-  /jsdom-global@3.0.2(jsdom@23.0.1):
+  /jsdom-global@3.0.2(jsdom@23.1.0):
     resolution: {integrity: sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==}
     peerDependencies:
       jsdom: '>=10.0.0'
     dependencies:
-      jsdom: 23.0.1
+      jsdom: 23.1.0
     dev: true
 
   /jsdom@20.0.3:
@@ -6449,8 +6449,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jsdom@23.0.1:
-    resolution: {integrity: sha512-2i27vgvlUsGEBO9+/kJQRbtqtm+191b5zAZrU/UezVmnC2dlDAFLgDYJvAEi94T4kjsRKkezEtLQTgsNEsW2lQ==}
+  /jsdom@23.1.0:
+    resolution: {integrity: sha512-wRscu8dBFxi7O65Cvi0jFRDv0Qa7XEHPix8Qg/vlXHLAMQsRWV1EDeQHBermzXf4Dt7JtFgBLbva3iTcBZDXEQ==}
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^2.11.2
@@ -6458,7 +6458,7 @@ packages:
       canvas:
         optional: true
     dependencies:
-      cssstyle: 3.0.0
+      cssstyle: 4.0.1
       data-urls: 5.0.0
       decimal.js: 10.4.3
       form-data: 4.0.0
@@ -6477,7 +6477,7 @@ packages:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-      ws: 8.14.2
+      ws: 8.16.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -9534,6 +9534,19 @@ packages:
 
   /ws@8.14.2:
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
- previous JSDOM version didn't include `aria` attributes, however it does now so all tests comparing HTML strings started failing