### PR TITLE
fix(demo): Unsaved Cell CSS Styling follow sort/filter/pagination

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -136,8 +136,7 @@ export default class Example12 {
     this._bindingEventService.bind(this.gridContainerElm, 'ongridstatechanged', this.handleOnGridStateChanged.bind(this));
     this._bindingEventService.bind(this.gridContainerElm, 'ondblclick', () => this.openCompositeModal('edit', 50));
     this._bindingEventService.bind(this.gridContainerElm, 'oncompositeeditorchange', this.handleOnCompositeEditorChange.bind(this));
-    this._bindingEventService.bind(this.gridContainerElm, 'onpaginationchanged', this.handleReRenderUnsavedStyling.bind(this));
-    this._bindingEventService.bind(this.gridContainerElm, 'onfilterchanged', this.handleReRenderUnsavedStyling.bind(this));
+    this._bindingEventService.bind(this.gridContainerElm, 'onrowsorcountchanged', this.handleReRenderUnsavedStyling.bind(this));
     this._bindingEventService.bind(this.gridContainerElm, 'onselectedrowidschanged', this.handleOnSelectedRowIdsChanged.bind(this));
   }
 


### PR DESCRIPTION
- so it turns out that instead of subscribing to multiple events like (`onPaginationChanged`, `onSort`, `onFilterChanged`, ....), they all can be replaced with 1 event `onRowsOrCountChanged` from DataView which is triggered for all of these cases because that is the 1 event that tell the UI to rerender when anything changes

![brave_eNPJ0vxffu](https://github.com/ghiscoding/slickgrid-universal/assets/643976/3ac2df45-1870-4aef-9a5e-dd8b4d851a3a)
