### PR TITLE
chore(tests): fix more broken tests after update to JSDOM 23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jest-cli": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^4.0.2",
-    "jsdom": "^23.1.0",
+    "jsdom": "^23.2.0",
     "jsdom-global": "^3.0.2",
     "moment-mini": "^2.29.4",
     "npm-run-all2": "^6.1.1",

--- a/packages/common/src/formatters/__tests__/progressBarFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/progressBarFormatter.spec.ts
@@ -17,7 +17,7 @@ describe('the Progress Bar Formatter', () => {
     const barType = 'danger';
     const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLDivElement;
-    const innerDiv = output.querySelector('div') as HTMLDivElement;
+    const innerDiv = output.querySelector('div.progress-bar') as HTMLDivElement;
 
     expect(output.outerHTML).toBe(template.trim());
     expect(innerDiv.className).toBe(`progress-bar progress-bar-${barType} bg-${barType}`);
@@ -32,7 +32,7 @@ describe('the Progress Bar Formatter', () => {
     const barType = 'danger';
     const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLDivElement;
-    const innerDiv = output.querySelector('div') as HTMLDivElement;
+    const innerDiv = output.querySelector('div.progress-bar') as HTMLDivElement;
 
     expect(output.outerHTML).toBe(template.trim());
     expect(innerDiv.className).toBe(`progress-bar progress-bar-${barType} bg-${barType}`);
@@ -51,8 +51,8 @@ describe('the Progress Bar Formatter', () => {
 
     const output1 = progressBarFormatter(1, 1, inputValue1, {} as Column, {}, {} as any) as HTMLDivElement;
     const output2 = progressBarFormatter(1, 1, inputValue2, {} as Column, {}, {} as any) as HTMLDivElement;
-    const innerDiv1 = output1.querySelector('div') as HTMLDivElement;
-    const innerDiv2 = output2.querySelector('div') as HTMLDivElement;
+    const innerDiv1 = output1.querySelector('div.progress-bar') as HTMLDivElement;
+    const innerDiv2 = output2.querySelector('div.progress-bar') as HTMLDivElement;
 
     expect(output1.outerHTML).toBe(template1.trim());
     expect(innerDiv1.className).toBe(`progress-bar progress-bar-${barType} bg-${barType}`);
@@ -74,7 +74,7 @@ describe('the Progress Bar Formatter', () => {
     const barType = 'success';
     const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="${inputValue}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputValue}%;">${inputValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLDivElement;
-    const innerDiv = output.querySelector('div') as HTMLDivElement;
+    const innerDiv = output.querySelector('div.progress-bar') as HTMLDivElement;
 
     expect(output.outerHTML).toBe(template.trim());
     expect(innerDiv.className).toBe(`progress-bar progress-bar-${barType} bg-${barType}`);
@@ -90,7 +90,7 @@ describe('the Progress Bar Formatter', () => {
     const barType = 'success';
     const template = `<div class="progress"><div class="progress-bar progress-bar-${barType} bg-${barType}" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: ${inputMaxValue}%;">${inputMaxValue}%</div></div>`;
     const output = progressBarFormatter(1, 1, inputValue, {} as Column, {}, {} as any) as HTMLElement;
-    const innerDiv = output.querySelector('div') as HTMLDivElement;
+    const innerDiv = output.querySelector('div.progress-bar') as HTMLDivElement;
 
     expect(output.outerHTML).toBe(template.trim());
     expect(innerDiv.className).toBe(`progress-bar progress-bar-${barType} bg-${barType}`);

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -101,7 +101,7 @@ describe('Resizer Service', () => {
       resizeByContentOptions: {},
     } as GridOption;
     jest.spyOn(gridStub, 'getOptions').mockReturnValue(mockGridOptions);
-    jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(divContainer.querySelector(`#${GRID_ID}`) as HTMLDivElement);
+    jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(divContainer.querySelector(`.${GRID_UID}`) as HTMLDivElement);
   });
 
   afterEach(() => {
@@ -120,7 +120,7 @@ describe('Resizer Service', () => {
 
     it('should call "bindAutoResizeDataGrid" when autoResize is enabled', () => {
       mockGridOptions.enableAutoResize = true;
-      jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(null as any);
+      jest.spyOn(gridStub, 'getContainerNode').mockReturnValueOnce(null as any);
       const bindAutoResizeDataGridSpy = jest.spyOn(service, 'bindAutoResizeDataGrid').mockImplementation();
 
       service.init(gridStub, divContainer);
@@ -130,7 +130,7 @@ describe('Resizer Service', () => {
 
     it('should not call "bindAutoResizeDataGrid" when autoResize is not enabled', () => {
       mockGridOptions.enableAutoResize = false;
-      jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(null as any);
+      jest.spyOn(gridStub, 'getContainerNode').mockReturnValueOnce(null as any);
       const bindAutoResizeDataGridSpy = jest.spyOn(service, 'bindAutoResizeDataGrid').mockImplementation();
 
       service.init(gridStub, divContainer);
@@ -233,7 +233,7 @@ describe('Resizer Service', () => {
     });
 
     it('should return null when calling "bindAutoResizeDataGrid" method with a gridId that is not found in the DOM', () => {
-      jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(null as any);
+      jest.spyOn(gridStub, 'getContainerNode').mockReturnValueOnce(null as any);
       service.init(gridStub, divContainer);
       const output = service.bindAutoResizeDataGrid();
 
@@ -242,7 +242,7 @@ describe('Resizer Service', () => {
     });
 
     it('should return null when calling "calculateGridNewDimensions" method with a gridId that is not found in the DOM', () => {
-      jest.spyOn(gridStub, 'getContainerNode').mockReturnValue(null as any);
+      jest.spyOn(gridStub, 'getContainerNode').mockReturnValueOnce(null as any);
       service.init(gridStub, divContainer);
       const output = service.calculateGridNewDimensions(mockGridOptions);
       expect(output).toBe(null as any);

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -112,7 +112,7 @@ export class ResizerService {
       gridParentContainerElm.style.width = typeof fixedGridSizes.width === 'string' ? fixedGridSizes.width : `${fixedGridSizes.width}px`;
     }
 
-    this._gridDomElm = grid?.getContainerNode() as HTMLDivElement;
+    this._gridDomElm = grid.getContainerNode() as HTMLDivElement;
 
     if (typeof this._autoResizeOptions.container === 'string') {
       this._pageContainerElm = typeof this._autoResizeOptions.container === 'string' ? document.querySelector(this._autoResizeOptions.container) as HTMLElement : this._autoResizeOptions.container;
@@ -120,13 +120,12 @@ export class ResizerService {
       this._pageContainerElm = this._autoResizeOptions.container!;
     }
 
-
     if (fixedGridSizes) {
       this._fixedHeight = fixedGridSizes.height;
       this._fixedWidth = fixedGridSizes.width;
     }
 
-    if (this.gridOptions && this.gridOptions.enableAutoResize) {
+    if (this.gridOptions.enableAutoResize) {
       this.bindAutoResizeDataGrid();
     }
 
@@ -140,7 +139,7 @@ export class ResizerService {
 
     // on double-click resize, should we resize the cell by its cell content?
     // the same action can be called from a double-click and/or from column header menu
-    if (this.gridOptions?.enableColumnResizeOnDoubleClick) {
+    if (this.gridOptions.enableColumnResizeOnDoubleClick) {
       this._subscriptions.push(
         this.pubSubService.subscribe('onHeaderMenuColumnResizeByContent', (data => {
           this.handleSingleColumnResizeByContent(data.columnId);
@@ -647,10 +646,10 @@ export class ResizerService {
         const headerTitleRowHeight = 44; // this one is set by SASS/CSS so let's hard code it
         const headerPos = getOffset(headerElm);
         let headerOffsetTop = headerPos?.top ?? 0;
-        if (this.gridOptions && this.gridOptions.enableFiltering && this.gridOptions.headerRowHeight) {
+        if (this.gridOptions?.enableFiltering && this.gridOptions.headerRowHeight) {
           headerOffsetTop += this.gridOptions.headerRowHeight; // filter row height
         }
-        if (this.gridOptions && this.gridOptions.createPreHeaderPanel && this.gridOptions.showPreHeaderPanel && this.gridOptions.preHeaderPanelHeight) {
+        if (this.gridOptions?.createPreHeaderPanel && this.gridOptions.showPreHeaderPanel && this.gridOptions.preHeaderPanelHeight) {
           headerOffsetTop += this.gridOptions.preHeaderPanelHeight; // header grouping titles row height
         }
         headerOffsetTop += headerTitleRowHeight; // header title row height

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,11 +75,11 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2(jest@29.7.0)
       jsdom:
-        specifier: ^23.1.0
-        version: 23.1.0
+        specifier: ^23.2.0
+        version: 23.2.0
       jsdom-global:
         specifier: ^3.0.2
-        version: 3.0.2(jsdom@23.1.0)
+        version: 3.0.2(jsdom@23.2.0)
       moment-mini:
         specifier: ^2.29.4
         version: 2.29.4
@@ -643,6 +643,14 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
+    dev: true
+
+  /@asamuzakjp/dom-selector@2.0.1:
+    resolution: {integrity: sha512-QJAJffmCiymkv6YyQ7voyQb5caCth6jzZsQncYCpHXrJ7RqdYG5y43+is8mnFcYubdOkr7cn1+na9BdFMxqw7w==}
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 2.3.1
+      is-potential-custom-element-name: 1.0.1
     dev: true
 
   /@babel/code-frame@7.22.13:
@@ -3259,6 +3267,12 @@ packages:
 
   /before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+    dev: true
+
+  /bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+    dependencies:
+      require-from-string: 2.0.2
     dev: true
 
   /bin-links@4.0.3:
@@ -6397,12 +6411,12 @@ packages:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
     dev: true
 
-  /jsdom-global@3.0.2(jsdom@23.1.0):
+  /jsdom-global@3.0.2(jsdom@23.2.0):
     resolution: {integrity: sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==}
     peerDependencies:
       jsdom: '>=10.0.0'
     dependencies:
-      jsdom: 23.1.0
+      jsdom: 23.2.0
     dev: true
 
   /jsdom@20.0.3:
@@ -6446,8 +6460,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jsdom@23.1.0:
-    resolution: {integrity: sha512-wRscu8dBFxi7O65Cvi0jFRDv0Qa7XEHPix8Qg/vlXHLAMQsRWV1EDeQHBermzXf4Dt7JtFgBLbva3iTcBZDXEQ==}
+  /jsdom@23.2.0:
+    resolution: {integrity: sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==}
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^2.11.2
@@ -6455,6 +6469,7 @@ packages:
       canvas:
         optional: true
     dependencies:
+      '@asamuzakjp/dom-selector': 2.0.1
       cssstyle: 4.0.1
       data-urls: 5.0.0
       decimal.js: 10.4.3
@@ -6463,7 +6478,6 @@ packages:
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.7
       parse5: 7.1.2
       rrweb-cssom: 0.6.0
       saxes: 6.0.0
@@ -8179,6 +8193,11 @@ packages:
 
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
     dev: true
 


### PR DESCRIPTION
- the latest JSDOM 23.2  switched their CSS selector engine from nwsapi to @asamuzakjp/dom-selector but that also broke some of my unit tests