### PR TITLE
fix(core): remove editor keydown keyCaptureList duplicate code

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4767,12 +4767,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
     if (!handled) {
       if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
-        // editor may specify an array of keys to bubble
-        if (this._options.editable && this.currentEditor?.keyCaptureList) {
-          if (this.currentEditor.keyCaptureList.indexOf(String(e.which)) > -1) {
-            return;
-          }
-        }
         if (e.key === 'Escape') {
           if (!this.getEditorLock()?.isActive()) {
             return; // no editing mode to cancel, allow bubbling and default processing (exit without cancelling the event)


### PR DESCRIPTION
duplicate code exist at line shown below, so there's no need to keep keydown keyCaptureList duplicate code. I found this duplicate code while adding unit tests and the piece of code that I'm removing seems unreachable, hence why I'm removing it

https://github.com/ghiscoding/slickgrid-universal/blob/801bd4ca62edc218b51b10602f0cfd4fd5483a4f/packages/common/src/core/slickGrid.ts#L4754-L4760

so we can remove duplicate code appearing with a slight different if condition

https://github.com/ghiscoding/slickgrid-universal/blob/801bd4ca62edc218b51b10602f0cfd4fd5483a4f/packages/common/src/core/slickGrid.ts#L4769-L4775