### PR TITLE
fix(core): EventHandler subscribed event should be SlickEventData type

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -79,7 +79,7 @@ jobs:
           wait-on: 'http://localhost:8888'
           config-file: test/cypress.config.ts
           browser: chrome
-          record: false
+          record: true
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/packages/common/src/core/__tests__/slickCore.spec.ts
+++ b/packages/common/src/core/__tests__/slickCore.spec.ts
@@ -39,10 +39,12 @@ describe('SlickCore file', () => {
     it('should call isDefaultPrevented() and expect truthy when event propagation is stopped by calling preventDefault()', () => {
       const ed = new SlickEventData();
 
+      expect(ed.defaultPrevented).toBeFalsy();
       expect(ed.isDefaultPrevented()).toBeFalsy();
 
       ed.preventDefault();
 
+      expect(ed.defaultPrevented).toBeTruthy();
       expect(ed.isDefaultPrevented()).toBeTruthy();
     });
 
@@ -59,6 +61,7 @@ describe('SlickCore file', () => {
       const evtSpy = jest.spyOn(evt, 'preventDefault');
       const ed = new SlickEventData(evt);
 
+      expect(ed.defaultPrevented).toBeFalsy();
       expect(ed.isDefaultPrevented()).toBeFalsy();
 
       ed.preventDefault();
@@ -364,7 +367,7 @@ describe('SlickCore file', () => {
       const elock = new SlickEditorLock();
       elock.activate(ec);
 
-      expect(() => elock.activate(ec2)).toThrow(`SlickEditorLock.activate: an editController is still active, can't activate another editController`)
+      expect(() => elock.activate(ec2)).toThrow(`SlickEditorLock.activate: an editController is still active, can't activate another editController`);
     });
 
     it('should throw when trying to call activate() with an EditController that forgot to implement commitCurrentEdit() method', () => {
@@ -372,7 +375,7 @@ describe('SlickCore file', () => {
       const ec = { cancelCurrentEdit: cancelSpy, } as any;
 
       const elock = new SlickEditorLock();
-      expect(() => elock.activate(ec)).toThrow(`SlickEditorLock.activate: editController must implement .commitCurrentEdit()`)
+      expect(() => elock.activate(ec)).toThrow(`SlickEditorLock.activate: editController must implement .commitCurrentEdit()`);
     });
 
     it('should throw when trying to call activate() with an EditController that forgot to implement cancelCurrentEdit() method', () => {
@@ -380,7 +383,7 @@ describe('SlickCore file', () => {
       const ec = { commitCurrentEdit: commitSpy, } as any;
 
       const elock = new SlickEditorLock();
-      expect(() => elock.activate(ec)).toThrow(`SlickEditorLock.activate: editController must implement .cancelCurrentEdit()`)
+      expect(() => elock.activate(ec)).toThrow(`SlickEditorLock.activate: editController must implement .cancelCurrentEdit()`);
     });
 
     it('should deactivate an EditController and expect isActive() to be falsy', () => {
@@ -408,7 +411,7 @@ describe('SlickCore file', () => {
       const elock = new SlickEditorLock();
       elock.activate(ec);
 
-      expect(() => elock.deactivate(ec2)).toThrow(`SlickEditorLock.deactivate: specified editController is not the currently active one`)
+      expect(() => elock.deactivate(ec2)).toThrow(`SlickEditorLock.deactivate: specified editController is not the currently active one`);
     });
 
     it('should expect active EditController.commitCurrentEdit() being called when calling commitCurrentEdit() after it was activated', () => {

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -10,7 +10,7 @@
 import { MergeTypes } from '../enums/index';
 import type { CSSStyleDeclarationWritable, EditController } from '../interfaces';
 
-export type Handler<ArgType = any> = (e: any, args: ArgType) => void;
+export type Handler<ArgType = any> = (e: SlickEventData, args: ArgType) => void;
 
 export interface BasePubSub {
   publish<ArgType = any>(_eventName: string | any, _data?: ArgType): any;
@@ -30,7 +30,32 @@ export class SlickEventData<ArgType = any> {
   protected _isDefaultPrevented = false;
   protected nativeEvent?: Event | null;
   protected returnValue: any = undefined;
-  protected target?: EventTarget | null;
+  protected _eventTarget?: EventTarget | null;
+
+  // public props that can be optionally pulled from the provided Event in constructor
+  // they are all optional props because it really depends on the type of Event provided (KeyboardEvent, MouseEvent, ...)
+  readonly altKey?: boolean;
+  readonly ctrlKey?: boolean;
+  readonly metaKey?: boolean;
+  readonly shiftKey?: boolean;
+  readonly key?: string;
+  readonly keyCode?: number;
+  readonly clientX?: number;
+  readonly clientY?: number;
+  readonly offsetX?: number;
+  readonly offsetY?: number;
+  readonly pageX?: number;
+  readonly pageY?: number;
+  readonly bubbles?: boolean;
+  readonly target?: HTMLElement;
+  readonly type?: string;
+  readonly which?: number;
+  readonly x?: number;
+  readonly y?: number;
+
+  get defaultPrevented() {
+    return this._isDefaultPrevented;
+  }
 
   constructor(protected event?: Event | null, protected args?: ArgType) {
     this.nativeEvent = event;
@@ -42,10 +67,10 @@ export class SlickEventData<ArgType = any> {
       [
         'altKey', 'ctrlKey', 'metaKey', 'shiftKey', 'key', 'keyCode',
         'clientX', 'clientY', 'offsetX', 'offsetY', 'pageX', 'pageY',
-        'bubbles', 'type', 'which', 'x', 'y'
+        'bubbles', 'target', 'type', 'which', 'x', 'y'
       ].forEach(key => (this as any)[key] = event[key as keyof Event]);
     }
-    this.target = this.nativeEvent ? this.nativeEvent.target : undefined;
+    this._eventTarget = this.nativeEvent ? this.nativeEvent.target : undefined;
   }
 
   /**
@@ -186,13 +211,13 @@ export class SlickEvent<ArgType = any> {
     scope = scope || this;
 
     for (let i = 0; i < this._handlers.length && !(sed.isPropagationStopped() || sed.isImmediatePropagationStopped()); i++) {
-      const returnValue = this._handlers[i].call(scope, sed as SlickEvent | SlickEventData, args);
+      const returnValue = this._handlers[i].call(scope, sed, args);
       sed.addReturnValue(returnValue);
     }
 
     // user can optionally add a global PubSub Service which makes it easy to publish/subscribe to events
     if (typeof this._pubSubService?.publish === 'function' && this.eventName) {
-      const ret = this._pubSubService.publish<{ args: ArgType; eventData?: Event | SlickEventData; nativeEvent?: Event; }>(this.eventName, { args, eventData: sed });
+      const ret = this._pubSubService.publish<{ args: ArgType; eventData?: SlickEventData; nativeEvent?: Event; }>(this.eventName, { args, eventData: sed });
       sed.addReturnValue(ret);
     }
     return sed;

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -71,10 +71,10 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected items: TData[] = [];            // data by index
   protected rows: TData[] = [];             // data by row
   protected idxById = new Map<DataIdType, number>();   // indexes by id
-  protected rowsById: { [id: DataIdType]: number } | undefined = undefined;       // rows by id; lazy-calculated
+  protected rowsById: { [id: DataIdType]: number; } | undefined = undefined;       // rows by id; lazy-calculated
   protected filter: FilterFn<TData> | null = null;         // filter function
   protected filterCSPSafe: FilterFn<TData> | null = null;         // filter function
-  protected updated: ({ [id: DataIdType]: boolean }) | null = null;        // updated item ids
+  protected updated: ({ [id: DataIdType]: boolean; }) | null = null;        // updated item ids
   protected suspend = false;            // suspends the recalculation
   protected isBulkSuspend = false;      // delays protectedious operations like the
   // index update and delete to efficient
@@ -107,7 +107,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     displayTotalsRow: true,
     lazyTotalsCalculation: false
   };
-  protected groupingInfos: Array<Grouping & { aggregators: Aggregator[]; getterIsAFn?: boolean; compiledAccumulators: any[]; getter: GroupGetterFn | string }> = [];
+  protected groupingInfos: Array<Grouping & { aggregators: Aggregator[]; getterIsAFn?: boolean; compiledAccumulators: any[]; getter: GroupGetterFn | string; }> = [];
   protected groups: SlickGroup[] = [];
   protected toggledGroupsByLevel: any[] = [];
   protected groupingDelimiter = ':|:';
@@ -752,7 +752,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
     // overrides for totals rows
     if ((item as SlickGroupTotals).__groupTotals) {
-      return this._options.groupItemMetadataProvider!.getTotalsRowMetadata(item as { group: GroupingFormatterItem });
+      return this._options.groupItemMetadataProvider!.getTotalsRowMetadata(item as { group: GroupingFormatterItem; });
     }
 
     return null;
@@ -1409,7 +1409,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       }
     };
 
-    grid.onSelectedRowsChanged.subscribe((_e: Event, args: { rows: number[]; }) => {
+    grid.onSelectedRowsChanged.subscribe((_e: SlickEventData, args: { rows: number[]; }) => {
       if (!inHandler) {
         const newSelectedRowIds = this.mapRowsToIds(args.rows);
         const selectedRowsChangedArgs = {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -87,7 +87,6 @@ import type {
   PagingInfo,
   SingleColumnSort,
   SlickPlugin,
-  SlickGridEventData,
 } from '../interfaces';
 import type { SlickDataView } from './slickDataview';
 
@@ -128,13 +127,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // Events
   onActiveCellChanged: SlickEvent<OnActiveCellChangedEventArgs>;
-  onActiveCellPositionChanged: SlickEvent<SlickGridEventData>;
+  onActiveCellPositionChanged: SlickEvent<{ grid: SlickGrid; }>;
   onAddNewRow: SlickEvent<OnAddNewRowEventArgs>;
   onAutosizeColumns: SlickEvent<OnAutosizeColumnsEventArgs>;
   onBeforeAppendCell: SlickEvent<OnBeforeAppendCellEventArgs>;
   onBeforeCellEditorDestroy: SlickEvent<OnBeforeCellEditorDestroyEventArgs>;
   onBeforeColumnsResize: SlickEvent<OnBeforeColumnsResizeEventArgs>;
-  onBeforeDestroy: SlickEvent<SlickGridEventData>;
+  onBeforeDestroy: SlickEvent<{ grid: SlickGrid; }>;
   onBeforeEditCell: SlickEvent<OnBeforeEditCellEventArgs>;
   onBeforeFooterRowCellDestroy: SlickEvent<OnBeforeFooterRowCellDestroyEventArgs>;
   onBeforeHeaderCellDestroy: SlickEvent<OnBeforeHeaderCellDestroyEventArgs>;
@@ -150,7 +149,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onColumnsResized: SlickEvent<OnColumnsResizedEventArgs>;
   onColumnsResizeDblClick: SlickEvent<OnColumnsResizeDblClickEventArgs>;
   onCompositeEditorChange: SlickEvent<OnCompositeEditorChangeEventArgs>;
-  onContextMenu: SlickEvent<SlickGridEventData>;
+  onContextMenu: SlickEvent<{ grid: SlickGrid; }>;
   onDrag: SlickEvent<DragRowMove>;
   onDblClick: SlickEvent<OnDblClickEventArgs>;
   onDragInit: SlickEvent<DragRowMove>;
@@ -177,7 +176,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onActivateChangedOptions: SlickEvent<OnActivateChangedOptionsEventArgs>;
   onSort: SlickEvent<SingleColumnSort | MultiColumnSort>;
   onValidationError: SlickEvent<OnValidationErrorEventArgs>;
-  onViewportChanged: SlickEvent<SlickGridEventData>;
+  onViewportChanged: SlickEvent<{ grid: SlickGrid; }>;
 
   // ---
   // protected variables
@@ -485,13 +484,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this._pubSubService = externalPubSub;
     this.onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>('onActiveCellChanged', externalPubSub);
-    this.onActiveCellPositionChanged = new SlickEvent<SlickGridEventData>('onActiveCellPositionChanged', externalPubSub);
+    this.onActiveCellPositionChanged = new SlickEvent<{ grid: SlickGrid; }>('onActiveCellPositionChanged', externalPubSub);
     this.onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>('onAddNewRow', externalPubSub);
     this.onAutosizeColumns = new SlickEvent<OnAutosizeColumnsEventArgs>('onAutosizeColumns', externalPubSub);
     this.onBeforeAppendCell = new SlickEvent<OnBeforeAppendCellEventArgs>('onBeforeAppendCell', externalPubSub);
     this.onBeforeCellEditorDestroy = new SlickEvent<OnBeforeCellEditorDestroyEventArgs>('onBeforeCellEditorDestroy', externalPubSub);
     this.onBeforeColumnsResize = new SlickEvent<OnBeforeColumnsResizeEventArgs>('onBeforeColumnsResize', externalPubSub);
-    this.onBeforeDestroy = new SlickEvent<SlickGridEventData>('onBeforeDestroy', externalPubSub);
+    this.onBeforeDestroy = new SlickEvent<{ grid: SlickGrid; }>('onBeforeDestroy', externalPubSub);
     this.onBeforeEditCell = new SlickEvent<OnBeforeEditCellEventArgs>('onBeforeEditCell', externalPubSub);
     this.onBeforeFooterRowCellDestroy = new SlickEvent<OnBeforeFooterRowCellDestroyEventArgs>('onBeforeFooterRowCellDestroy', externalPubSub);
     this.onBeforeHeaderCellDestroy = new SlickEvent<OnBeforeHeaderCellDestroyEventArgs>('onBeforeHeaderCellDestroy', externalPubSub);
@@ -507,7 +506,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onColumnsResized = new SlickEvent<OnColumnsResizedEventArgs>('onColumnsResized', externalPubSub);
     this.onColumnsResizeDblClick = new SlickEvent<OnColumnsResizeDblClickEventArgs>('onColumnsResizeDblClick', externalPubSub);
     this.onCompositeEditorChange = new SlickEvent<OnCompositeEditorChangeEventArgs>('onCompositeEditorChange', externalPubSub);
-    this.onContextMenu = new SlickEvent<SlickGridEventData>('onContextMenu', externalPubSub);
+    this.onContextMenu = new SlickEvent<{ grid: SlickGrid; }>('onContextMenu', externalPubSub);
     this.onDrag = new SlickEvent<DragRowMove>('onDrag', externalPubSub);
     this.onDblClick = new SlickEvent<OnDblClickEventArgs>('onDblClick', externalPubSub);
     this.onDragInit = new SlickEvent<DragRowMove>('onDragInit', externalPubSub);
@@ -534,7 +533,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onActivateChangedOptions = new SlickEvent<OnActivateChangedOptionsEventArgs>('onActivateChangedOptions', externalPubSub);
     this.onSort = new SlickEvent<SingleColumnSort | MultiColumnSort>('onSort', externalPubSub);
     this.onValidationError = new SlickEvent<OnValidationErrorEventArgs>('onValidationError', externalPubSub);
-    this.onViewportChanged = new SlickEvent<SlickGridEventData>('onViewportChanged', externalPubSub);
+    this.onViewportChanged = new SlickEvent<{ grid: SlickGrid; }>('onViewportChanged', externalPubSub);
 
     this.initialize(options);
   }

--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -296,7 +296,7 @@ describe('CellMenu Plugin', () => {
         expect(commandListElm.querySelectorAll('.slick-menu-item').length).toBe(7);
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
-          `<div class="slick-cell-menu slick-menu-level-0 slickgrid12345 dropdown dropleft" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
+          `<div class="slick-cell-menu slick-menu-level-0 slickgrid12345 dropdown dropleft" style="top: 0px; display: block; left: 0px;" aria-expanded="true">
             <div class="slick-menu-command-list" role="menu">
               <div class="slick-command-header no-title with-close">
                 <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>
@@ -784,7 +784,7 @@ describe('CellMenu Plugin', () => {
         expect(optionListElm.querySelectorAll('.slick-menu-item').length).toBe(6);
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
-          `<div class="slick-cell-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
+          `<div class="slick-cell-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="top: 0px; display: block; left: 0px;" aria-expanded="true">
             <div class="slick-menu-option-list" role="menu">
               <div class="slick-option-header no-title with-close">
                 <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -322,7 +322,7 @@ describe('ContextMenu Plugin', () => {
         expect(commandListElm.querySelectorAll('.slick-menu-item').length).toBe(6);
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
-          `<div class="slick-context-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
+          `<div class="slick-context-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="top: 0px; display: block; left: 0px;" aria-expanded="true">
             <div class="slick-menu-command-list" role="menu">
               <div class="slick-command-header no-title with-close">
                 <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>
@@ -1335,7 +1335,7 @@ describe('ContextMenu Plugin', () => {
         expect(optionListElm.querySelectorAll('.slick-menu-item').length).toBe(6);
         expect(document.body.querySelector('button.close')!.ariaLabel).toBe('Close'); // JSDOM doesn't support ariaLabel, but we can test attribute this way
         expect(removeExtraSpaces(document.body.innerHTML)).toBe(removeExtraSpaces(
-          `<div class="slick-context-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="display: block; top: 0px; left: 0px;" aria-expanded="true">
+          `<div class="slick-context-menu slick-menu-level-0 slickgrid12345 dropdown dropright" style="top: 0px; display: block; left: 0px;" aria-expanded="true">
             <div class="slick-menu-option-list" role="menu">
               <div class="slick-option-header no-title with-close">
                 <button aria-label="Close" class="close" type="button" data-dismiss="slick-menu">×</button>

--- a/packages/common/src/extensions/slickAutoTooltip.ts
+++ b/packages/common/src/extensions/slickAutoTooltip.ts
@@ -2,7 +2,7 @@
 import { stripTags } from '@slickgrid-universal/utils';
 
 import type { AutoTooltipOption, Column } from '../interfaces/index';
-import { SlickEventHandler, type SlickGrid } from '../core/index';
+import { SlickEventHandler, type SlickEventData, type SlickGrid } from '../core/index';
 
 /**
  * AutoTooltips plugin to show/hide tooltips when columns are too narrow to fit content.
@@ -65,9 +65,9 @@ export class SlickAutoTooltip {
 
   /**
    * Handle mouse entering grid cell to add/remove tooltip.
-   * @param {Object} event - The event
+   * @param {SlickEventData} event - The event
    */
-  protected handleMouseEnter(event: MouseEvent) {
+  protected handleMouseEnter(event: SlickEventData) {
     const cell = this._grid.getCellFromEvent(event);
     if (cell) {
       let node: HTMLElement | null = this._grid.getCellNode(cell.row, cell.cell);
@@ -89,10 +89,10 @@ export class SlickAutoTooltip {
 
   /**
    * Handle mouse entering header cell to add/remove tooltip.
-   * @param {Object} event - The event
+   * @param {SlickEventData} event - The event
    * @param {Object} args.column - The column definition
    */
-  protected handleHeaderMouseEnter(event: MouseEvent, args: { column: Column; }) {
+  protected handleHeaderMouseEnter(event: SlickEventData, args: { column: Column; }) {
     const column = args.column;
     let node: HTMLDivElement | null;
     const targetElm = (event.target as HTMLDivElement);

--- a/packages/common/src/extensions/slickCellExcelCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExcelCopyManager.ts
@@ -139,7 +139,7 @@ export class SlickCellExcelCopyManager {
     let newRowIds = 0;
 
     return {
-      clipboardCommandHandler: (editCommand: any) => {
+      clipboardCommandHandler: (editCommand: EditCommand) => {
         this._undoRedoBuffer.queueAndExecuteCommand.call(this._undoRedoBuffer, editCommand);
       },
       dataItemColumnValueExtractor: (item: any, columnDef: Column) => {

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -115,7 +115,7 @@ export class SlickCellExternalCopyManager {
     return columnDef.name instanceof HTMLElement ? stripTags(columnDef.name.innerHTML) : columnDef.name;
   }
 
-  getDataItemValueForColumn(item: any, columnDef: Column, event: Event) {
+  getDataItemValueForColumn(item: any, columnDef: Column, event: SlickEventData) {
     if (typeof this._addonOptions.dataItemColumnValueExtractor === 'function') {
       const val = this._addonOptions.dataItemColumnValueExtractor(item, columnDef) as string | HTMLElement;
       if (val) {
@@ -287,7 +287,7 @@ export class SlickCellExternalCopyManager {
               const dt = this._grid.getDataItem(desty);
 
               if (this._grid.triggerEvent(this.onBeforePasteCell, { row: desty, cell: destx, dt, column: columns[destx], target: 'grid' }).getReturnValue() === false) {
-                 continue;
+                continue;
               }
 
               clipCommand.oldValues[y][x] = dt[columns[destx]['field']];
@@ -377,7 +377,7 @@ export class SlickCellExternalCopyManager {
     }
   }
 
-  protected handleKeyDown(e: any): boolean | void {
+  protected handleKeyDown(e: SlickEventData): boolean | void {
     let ranges: SlickRange[];
     if (!this._grid.getEditorLock().isActive() || this._grid.getOptions().autoEdit) {
       if (e.key === 'Escape') {

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -8,10 +8,12 @@ import type {
   MenuCommandItem,
   MenuCommandItemCallbackArgs,
   MenuOptionItem,
+  OnClickEventArgs,
 } from '../interfaces/index';
 import type { ExtensionUtility } from '../extensions/extensionUtility';
 import type { SharedService } from '../services/shared.service';
 import { MenuFromCellBaseClass } from './menuFromCellBaseClass';
+import type { SlickEventData } from '../core';
 
 /**
  * A plugin to add Menu on a Cell click (click on the cell that has the cellMenu object defined)
@@ -63,10 +65,10 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
     // sort all menu items by their position order when defined
     this.sortMenuItems(this.sharedService.allColumns);
 
-    this._eventHandler.subscribe(this.grid.onClick, this.handleCellClick.bind(this) as EventListener);
+    this._eventHandler.subscribe(this.grid.onClick, this.handleCellClick.bind(this));
 
     if (this._addonOptions.hideMenuOnScroll) {
-      this._eventHandler.subscribe(this.grid.onScroll, this.closeMenu.bind(this) as EventListener);
+      this._eventHandler.subscribe(this.grid.onScroll, this.closeMenu.bind(this));
     }
   }
 
@@ -102,7 +104,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
   // event handlers
   // ------------------
 
-  protected handleCellClick(event: DOMMouseOrTouchEvent<HTMLDivElement>, args: MenuCommandItemCallbackArgs) {
+  protected handleCellClick(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: OnClickEventArgs) {
     this.disposeAllMenus(); // make there's only 1 parent menu opened at a time
     const cell = this.grid.getCellFromEvent(event);
 
@@ -119,11 +121,11 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
       this._addonOptions = { ...this._addonOptions, ...columnDef.cellMenu };
 
       // run the override function (when defined), if the result is false it won't go further
-      args = args || {};
-      args.column = columnDef;
-      args.dataContext = dataContext;
-      args.grid = this.grid;
-      if (!this.extensionUtility.runOverrideFunctionWhenExists(this._addonOptions.menuUsabilityOverride, args)) {
+      const menuArgs = (args || {}) as MenuCommandItemCallbackArgs;
+      menuArgs.column = columnDef;
+      menuArgs.dataContext = dataContext;
+      menuArgs.grid = this.grid;
+      if (!this.extensionUtility.runOverrideFunctionWhenExists(this._addonOptions.menuUsabilityOverride, menuArgs)) {
         return;
       }
 

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -2,7 +2,6 @@ import { deepMerge, emptyElement, getOffset, } from '@slickgrid-universal/utils'
 
 import type {
   CellRangeSelectorOption,
-  DOMMouseOrTouchEvent,
   DragPosition,
   DragRange,
   DragRowMove,
@@ -316,7 +315,7 @@ export class SlickCellRangeSelector {
     }
   }
 
-  protected handleDragInit(e: Event) {
+  protected handleDragInit(e: SlickEventData) {
     // Set the active canvas node because the decorator needs to append its
     // box to the correct canvas
     this._activeCanvas = this._grid.getActiveCanvasNode(e);
@@ -354,7 +353,7 @@ export class SlickCellRangeSelector {
     }
   }
 
-  protected handleDragStart(e: DOMMouseOrTouchEvent<HTMLDivElement>, dd: DragRowMove) {
+  protected handleDragStart(e: SlickEventData, dd: DragRowMove) {
     const cellObj = this._grid.getCellFromEvent(e);
     if (cellObj && this.onBeforeCellRangeSelected.notify(cellObj).getReturnValue() !== false && this._grid.canCellBeSelected(cellObj.row, cellObj.cell)) {
       this._dragging = true;
@@ -384,7 +383,7 @@ export class SlickCellRangeSelector {
     return this._decorator.show(new SlickRange(start.row, start.cell));
   }
 
-  protected handleScroll(_e: DOMMouseOrTouchEvent<HTMLDivElement>, args: OnScrollEventArgs) {
+  protected handleScroll(_e: SlickEventData, args: OnScrollEventArgs) {
     this._scrollTop = args.scrollTop;
     this._scrollLeft = args.scrollLeft;
   }

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -148,7 +148,7 @@ export class SlickCellSelectionModel implements SelectionModel {
   // protected functions
   // ---------------------
 
-  protected handleActiveCellChange(_e: Event, args: OnActiveCellChangedEventArgs) {
+  protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs) {
     this._prevSelectedRow = undefined;
     const isCellDefined = isDefined(args.cell);
     const isRowDefined = isDefined(args.row);
@@ -161,14 +161,14 @@ export class SlickCellSelectionModel implements SelectionModel {
     }
   }
 
-  protected handleBeforeCellRangeSelected(e: any): boolean | void {
+  protected handleBeforeCellRangeSelected(e: SlickEventData): boolean | void {
     if (this._grid.getEditorLock().isActive()) {
       e.stopPropagation();
       return false;
     }
   }
 
-  protected handleCellRangeSelected(_e: any, args: { range: SlickRange; }) {
+  protected handleCellRangeSelected(_e: SlickEventData, args: { range: SlickRange; }) {
     this._grid.setActiveCell(args.range.fromRow, args.range.fromCell, false, false, true);
     this.setSelectedRanges([args.range]);
   }
@@ -177,7 +177,7 @@ export class SlickCellSelectionModel implements SelectionModel {
     return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End'].some(k => k === key);
   }
 
-  protected handleKeyDown(e: KeyboardEvent) {
+  protected handleKeyDown(e: SlickEventData) {
     let ranges: SlickRange[];
     let last: SlickRange;
     const colLn = this._grid.getColumns().length;
@@ -190,7 +190,7 @@ export class SlickCellSelectionModel implements SelectionModel {
       dataLn = this._grid.getDataLength();
     }
 
-    if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key)) {
+    if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key as string)) {
       ranges = this.getSelectedRanges().slice();
       if (!ranges.length) {
         ranges.push(new SlickRange(active.row, active.cell));
@@ -209,7 +209,7 @@ export class SlickCellSelectionModel implements SelectionModel {
         // walking direction
         const dirRow = active.row === last.fromRow ? 1 : -1;
         const dirCell = active.cell === last.fromCell ? 1 : -1;
-        const isSingleKeyMove = e.key.startsWith('Arrow');
+        const isSingleKeyMove = e.key!.startsWith('Arrow');
         let toCell: undefined | number;
         let toRow = 0;
 
@@ -285,7 +285,7 @@ export class SlickCellSelectionModel implements SelectionModel {
 
         e.preventDefault();
         e.stopPropagation();
-        this._prevKeyDown = e.key;
+        this._prevKeyDown = e.key as string;
       }
     }
   }

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -2,7 +2,7 @@ import { BindingEventService } from '@slickgrid-universal/binding';
 import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { createDomElement, emptyElement } from '@slickgrid-universal/utils';
 
-import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
+import { type SlickDataView, type SlickEventData, SlickEventHandler, type SlickGrid } from '../core/index';
 import type { CheckboxSelectorOption, Column, DOMMouseOrTouchEvent, GridOption, OnHeaderClickEventArgs, SelectableOverrideCallback } from '../interfaces/index';
 import { SlickRowSelectionModel } from './slickRowSelectionModel';
 import { SelectionModel } from '../enums/index';
@@ -155,7 +155,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     } else {
       if (!this._addonOptions.hideInColumnTitleRow) {
         this.renderSelectAllCheckbox(this._isSelectAllChecked);
-        this._eventHandler.subscribe(this._grid.onHeaderClick, this.handleHeaderClick.bind(this) as EventListener);
+        this._eventHandler.subscribe(this._grid.onHeaderClick, this.handleHeaderClick.bind(this));
       } else {
         this.hideSelectAllFromColumnHeaderTitleRow();
       }
@@ -245,7 +245,7 @@ export class SlickCheckboxSelectColumn<T = any> {
    * @param {Number} row - grid row number to toggle
    * @returns
    */
-  toggleRowSelectionWithEvent(event: Event | null, row: number) {
+  toggleRowSelectionWithEvent(event: SlickEventData | null, row: number) {
     const dataContext = this._grid.getDataItem(row);
     if (!this.checkSelectableOverride(row, dataContext, this._grid)) {
       return;
@@ -365,10 +365,10 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleClick(e: DOMMouseOrTouchEvent<HTMLInputElement>, args: { row: number; cell: number; grid: SlickGrid; }) {
+  protected handleClick(e: SlickEventData, args: { row: number; cell: number; grid: SlickGrid; }) {
     // clicking on a row select checkbox
-    if (this._grid.getColumns()[args.cell].id === this._addonOptions.columnId && e.target.type === 'checkbox') {
-      e.target.ariaChecked = String(e.target.checked);
+    if (this._grid.getColumns()[args.cell].id === this._addonOptions.columnId && (e.target as HTMLInputElement).type === 'checkbox') {
+      (e.target as HTMLInputElement).ariaChecked = String((e.target as HTMLInputElement).checked);
 
       // if editing, try to commit
       if (this._grid.getEditorLock().isActive() && !this._grid.getEditorLock().commitCurrentEdit()) {
@@ -383,9 +383,9 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleHeaderClick(e: DOMMouseOrTouchEvent<HTMLInputElement>, args: OnHeaderClickEventArgs) {
-    if (args.column.id === this._addonOptions.columnId && e.target.type === 'checkbox') {
-      e.target.ariaChecked = String(e.target.checked);
+  protected handleHeaderClick(e: DOMMouseOrTouchEvent<HTMLInputElement> | SlickEventData, args: OnHeaderClickEventArgs) {
+    if (args.column.id === this._addonOptions.columnId && (e.target as HTMLInputElement).type === 'checkbox') {
+      (e.target as HTMLInputElement).ariaChecked = String((e.target as HTMLInputElement).checked);
 
       // if editing, try to commit
       if (this._grid.getEditorLock().isActive() && !this._grid.getEditorLock().commitCurrentEdit()) {
@@ -395,7 +395,7 @@ export class SlickCheckboxSelectColumn<T = any> {
       }
 
       // who called the selection?
-      let isAllSelected = e.target.checked;
+      let isAllSelected = (e.target as HTMLInputElement).checked;
       const caller = isAllSelected ? 'click.selectAll' : 'click.unselectAll';
 
       // trigger event before the real selection so that we have an event before & the next one after the change
@@ -446,7 +446,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleKeyDown(e: KeyboardEvent, args: any) {
+  protected handleKeyDown(e: SlickEventData, args: any) {
     if (e.key === ' ') {
       if (this._grid.getColumns()[args.cell].id === this._addonOptions.columnId) {
         // if editing, try to commit

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -12,7 +12,7 @@ import {
   populateColumnPicker,
   updateColumnPickerOrder
 } from '../extensions/extensionCommonUtils';
-import { SlickEvent, SlickEventHandler, type SlickGrid } from '../core/index';
+import { SlickEvent, type SlickEventData, SlickEventHandler, type SlickGrid } from '../core/index';
 
 /**
  * A control to add a Column Picker (right+click on any column header to reveal the column picker)
@@ -190,7 +190,7 @@ export class SlickColumnPicker {
   }
 
   /** Mouse header context handler when doing a right+click on any of the header column title */
-  protected handleHeaderContextMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected handleHeaderContextMenu(e: SlickEventData) {
     e.preventDefault();
     emptyElement(this._listElm);
     this._columnCheckboxes = [];
@@ -204,7 +204,7 @@ export class SlickColumnPicker {
     this.repositionMenu(e);
   }
 
-  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData) {
     const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
     if (this._menuElm) {
       this._menuElm.style.top = `${targetEvent.pageY - 10}px`;

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -3,12 +3,12 @@ import type {
   ContextMenu,
   ContextMenuOption,
   Column,
-  DOMMouseOrTouchEvent,
   MenuCallbackArgs,
   MenuCommandItem,
   MenuCommandItemCallbackArgs,
   MenuOptionItem,
 } from '../interfaces/index';
+import type { SlickEventData, SlickGrid } from '../core';
 import { DelimiterType, FileType } from '../enums/index';
 import { type ExcelExportService, getCellValueFromQueryFieldGetter, getTranslationPrefix, type TextExportService } from '../services/index';
 import { exportWithFormatterWhenDefined } from '../formatters/formatterUtilities';
@@ -74,10 +74,10 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
     // sort all menu items by their position order when defined
     this.sortMenuItems();
 
-    this._eventHandler.subscribe(this.grid.onContextMenu, this.handleOnContextMenu.bind(this) as EventListener);
+    this._eventHandler.subscribe(this.grid.onContextMenu, this.handleOnContextMenu.bind(this));
 
     if (this._addonOptions.hideMenuOnScroll) {
-      this._eventHandler.subscribe(this.grid.onScroll, this.closeMenu.bind(this) as EventListener);
+      this._eventHandler.subscribe(this.grid.onScroll, this.closeMenu.bind(this));
     }
   }
 
@@ -109,7 +109,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
   // event handlers
   // ------------------
 
-  protected handleOnContextMenu(event: DOMMouseOrTouchEvent<HTMLDivElement>, args: MenuCommandItemCallbackArgs) {
+  protected handleOnContextMenu(event: SlickEventData, args: { grid: SlickGrid; }) {
     this.disposeAllMenus(); // make there's only 1 parent menu opened at a time
     const cell = this.grid.getCellFromEvent(event);
 
@@ -118,13 +118,13 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
       const columnDef = this.grid.getColumns()[cell.cell];
 
       // run the override function (when defined), if the result is false it won't go further
-      args = args || {};
-      args.cell = cell.cell;
-      args.row = cell.row;
-      args.column = columnDef;
-      args.dataContext = dataContext;
-      args.grid = this.grid;
-      if (!this.extensionUtility.runOverrideFunctionWhenExists(this._addonOptions.menuUsabilityOverride, args)) {
+      const menuArgs = (args || {}) as MenuCommandItemCallbackArgs;
+      menuArgs.cell = cell.cell;
+      menuArgs.row = cell.row;
+      menuArgs.column = columnDef;
+      menuArgs.dataContext = dataContext;
+      menuArgs.grid = this.grid;
+      if (!this.extensionUtility.runOverrideFunctionWhenExists(this._addonOptions.menuUsabilityOverride, menuArgs)) {
         return;
       }
 

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -1,9 +1,8 @@
 import { createDomElement, extend } from '@slickgrid-universal/utils';
 
-import { SlickEventHandler, type SlickDataView, SlickGroup, type SlickGrid } from '../core/index';
+import { SlickEventHandler, type SlickDataView, SlickGroup, type SlickGrid, type SlickEventData } from '../core/index';
 import type {
   Column,
-  DOMEvent,
   GridOption,
   GroupingFormatterItem,
   GroupItemMetadataProviderOption,
@@ -101,7 +100,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     };
   }
 
-  getTotalsRowMetadata(item: { group: GroupingFormatterItem }) {
+  getTotalsRowMetadata(item: { group: GroupingFormatterItem; }) {
     return {
       selectable: false,
       focusable: this._options.totalsFocusable,
@@ -151,8 +150,8 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
   }
 
   /** Handle a grid cell clicked, it could be a Group that is being collapsed/expanded or do nothing when it's not */
-  protected handleGridClick(e: DOMEvent<HTMLDivElement>, args: OnClickEventArgs) {
-    const target = e.target;
+  protected handleGridClick(e: SlickEventData, args: OnClickEventArgs) {
+    const target = e.target as HTMLElement;
     const item = this._grid?.getDataItem(args.row);
     if (item instanceof SlickGroup && target.classList.contains(this._options.toggleCssClass || '')) {
       this.handleDataViewExpandOrCollapse(item);
@@ -165,7 +164,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
    * Handle a keyboard down event on a grouping cell.
    * TODO:  add -/+ handling
    */
-  protected handleGridKeyDown(e: KeyboardEvent) {
+  protected handleGridKeyDown(e: SlickEventData) {
     if (this._options.enableExpandCollapse && (e.key === ' ')) {
       const activeCell = this._grid?.getActiveCell();
       if (activeCell) {

--- a/packages/common/src/extensions/slickHeaderButtons.ts
+++ b/packages/common/src/extensions/slickHeaderButtons.ts
@@ -14,7 +14,7 @@ import type {
 import type { ExtensionUtility } from '../extensions/extensionUtility';
 import type { SharedService } from '../services/shared.service';
 import { type ExtendableItemTypes, type ExtractMenuType, MenuBaseClass, type MenuType } from './menuBaseClass';
-import { SlickEventHandler, type SlickGrid } from '../core/index';
+import { SlickEventHandler, type SlickEventData, type SlickGrid } from '../core/index';
 
 /**
  * A plugin to add custom buttons to column headers.
@@ -84,7 +84,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
    * @param {Object} event - The event
    * @param {Object} args - object arguments
    */
-  protected handleHeaderCellRendered(_e: Event, args: OnHeaderCellRenderedEventArgs) {
+  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs) {
     const column = args.column;
 
     if (column.header?.buttons && Array.isArray(column.header.buttons)) {
@@ -112,7 +112,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
    * @param {Object} event - The event
    * @param {Object} args.column - The column definition
    */
-  protected handleBeforeHeaderCellDestroy(_e: Event, args: { column: Column; node: HTMLElement; }) {
+  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }) {
     const column = args.column;
 
     if (column.header?.buttons && this._addonOptions?.buttonCssClass) {

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -16,6 +16,7 @@ import type {
   MultiColumnSort,
   OnHeaderCellRenderedEventArgs,
 } from '../interfaces/index';
+import type { SlickEventData } from '../core';
 import { getTranslationPrefix } from '../services/index';
 import type { ExtensionUtility } from '../extensions/extensionUtility';
 import type { FilterService } from '../services/filter.service';
@@ -124,18 +125,18 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     this._activeHeaderColumnElm?.classList.remove('slick-header-column-active');
   }
 
-  repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement>, item: MenuCommandItem, level: number, columnDef: Column) {
+  repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, item: MenuCommandItem, level: number, columnDef: Column) {
     // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
     const subMenuElm = this.createCommandMenu(item.commandItems || [], columnDef, level + 1, item);
     document.body.appendChild(subMenuElm);
     this.repositionMenu(e, subMenuElm);
   }
 
-  repositionMenu(e: DOMMouseOrTouchEvent<HTMLElement>, menuElm: HTMLDivElement) {
+  repositionMenu(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, menuElm: HTMLDivElement) {
     const buttonElm = e.target as HTMLDivElement; // get header button createElement
     const isSubMenu = menuElm.classList.contains('slick-submenu');
     const parentElm = isSubMenu
-      ? e.target.closest('.slick-menu-item') as HTMLDivElement
+      ? (e.target as HTMLElement).closest('.slick-menu-item') as HTMLDivElement
       : buttonElm as HTMLElement;
 
     const relativePos = getOffsetRelativeToParent(this.sharedService.gridContainerElement, buttonElm);
@@ -216,7 +217,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
    * @param {Object} event - The event
    * @param {Object} args - object arguments
    */
-  protected handleHeaderCellRendered(_e: Event, args: OnHeaderCellRenderedEventArgs) {
+  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs) {
     const column = args.column;
     const menu = column.header?.menu as HeaderMenuItems;
 
@@ -249,7 +250,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
    * @param {Object} event - The event
    * @param {Object} args.column - The column definition
    */
-  protected handleBeforeHeaderCellDestroy(_e: Event, args: { column: Column; node: HTMLElement; }) {
+  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }) {
     const column = args.column;
 
     if (column.header?.menu) {
@@ -277,7 +278,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     }
   }
 
-  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column): boolean | void {
+  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column): boolean | void {
     if (item !== 'divider' && !item.disabled && !(item as MenuCommandItem).divider) {
       const command = (item as MenuCommandItem).command || '';
 
@@ -316,7 +317,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     }
   }
 
-  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column) {
+  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column) {
     if (item !== 'divider' && !item.disabled && !(item as MenuCommandItem).divider) {
       if ((item as MenuCommandItem).commandItems) {
         this.repositionSubMenu(e, item as MenuCommandItem, level, columnDef as Column);
@@ -455,21 +456,21 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Clear the Filter on the current column (if it's actually filtered) */
-  protected clearColumnFilter(event: Event, args: MenuCommandItemCallbackArgs) {
+  protected clearColumnFilter(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs) {
     if (args?.column) {
       this.filterService.clearFilterByColumnId(event, args.column.id);
     }
   }
 
   /** Clear the Sort on the current column (if it's actually sorted) */
-  protected clearColumnSort(event: Event, args: MenuCommandItemCallbackArgs) {
+  protected clearColumnSort(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs) {
     if (args?.column && this.sharedService) {
       this.sortService.clearSortByColumnId(event, args.column.id);
     }
   }
 
   /** Execute the Header Menu Commands that was triggered by the onCommand subscribe */
-  protected executeHeaderMenuInternalCommands(event: Event, args: MenuCommandItemCallbackArgs) {
+  protected executeHeaderMenuInternalCommands(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs) {
     if (args?.command) {
       switch (args.command) {
         case 'hide-column':
@@ -643,7 +644,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Sort the current column */
-  protected sortColumn(event: Event, args: MenuCommandItemCallbackArgs, isSortingAsc = true) {
+  protected sortColumn(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs, isSortingAsc = true) {
     if (args?.column) {
       // get previously sorted columns
       const columnDef = args.column;

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -160,12 +160,12 @@ export class SlickRowMoveManager {
   // protected functions
   // ------------------
 
-  protected handleDragInit(e: MouseEvent) {
+  protected handleDragInit(e: SlickEventData) {
     // prevent the grid from cancelling drag'n'drop by default
     e.stopImmediatePropagation();
   }
 
-  protected handleDragEnd(e: MouseEvent, dd: DragRowMove) {
+  protected handleDragEnd(e: SlickEventData, dd: DragRowMove) {
     if (!this._dragging) {
       return;
     }
@@ -184,7 +184,7 @@ export class SlickRowMoveManager {
       };
       // TODO:  this._grid.remapCellCssClasses ?
       if (typeof this._addonOptions.onMoveRows === 'function') {
-        this._addonOptions.onMoveRows(e, eventData);
+        this._addonOptions.onMoveRows(e instanceof SlickEventData ? e.getNativeEvent() : e, eventData);
       }
       this.onMoveRows.notify(eventData);
     }

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -163,7 +163,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     }
   }
 
-  protected handleClick(e: MouseEvent): boolean | void {
+  protected handleClick(e: SlickEventData): boolean | void {
     const cell = this._grid.getCellFromEvent(e);
     if (!cell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
       return false;
@@ -204,7 +204,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     return true;
   }
 
-  protected handleKeyDown(e: KeyboardEvent) {
+  protected handleKeyDown(e: SlickEventData) {
     const activeRow = this._grid.getActiveCell();
 
     if (this.gridOptions.multiSelect && activeRow &&

--- a/packages/common/src/interfaces/cellMenu.interface.ts
+++ b/packages/common/src/interfaces/cellMenu.interface.ts
@@ -5,6 +5,7 @@ import type {
   MenuOptionItemCallbackArgs,
 } from './index';
 import type { SlickCellMenu } from '../extensions/slickCellMenu';
+import type { SlickEventData } from '../core';
 
 export interface CellMenu extends CellMenuOption {
 
@@ -15,17 +16,17 @@ export interface CellMenu extends CellMenuOption {
   onExtensionRegistered?: (plugin: SlickCellMenu) => void;
 
   /** SlickGrid Event fired After the menu is shown. */
-  onAfterMenuShow?: (e: Event, args: MenuFromCellCallbackArgs) => boolean | void;
+  onAfterMenuShow?: (e: Event | SlickEventData, args: MenuFromCellCallbackArgs) => boolean | void;
 
   /** SlickGrid Event fired Before the menu is shown. */
-  onBeforeMenuShow?: (e: Event, args: MenuFromCellCallbackArgs) => boolean | void;
+  onBeforeMenuShow?: (e: Event | SlickEventData, args: MenuFromCellCallbackArgs) => boolean | void;
 
   /** SlickGrid Event fired when the menu is closing. */
-  onBeforeMenuClose?: (e: Event, args: MenuFromCellCallbackArgs) => boolean | void;
+  onBeforeMenuClose?: (e: Event | SlickEventData, args: MenuFromCellCallbackArgs) => boolean | void;
 
   /** SlickGrid Event fired on menu option clicked from the Command items list */
-  onCommand?: (e: Event, args: MenuCommandItemCallbackArgs) => void;
+  onCommand?: (e: Event | SlickEventData, args: MenuCommandItemCallbackArgs) => void;
 
   /** SlickGrid Event fired on menu option selected from the Option items list. */
-  onOptionSelected?: (e: Event, args: MenuOptionItemCallbackArgs) => void;
+  onOptionSelected?: (e: Event | SlickEventData, args: MenuOptionItemCallbackArgs) => void;
 }

--- a/packages/common/src/interfaces/checkboxSelectorOption.interface.ts
+++ b/packages/common/src/interfaces/checkboxSelectorOption.interface.ts
@@ -1,3 +1,4 @@
+import type { SlickEventData } from '../core';
 import type { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
 
 export interface CheckboxSelectorOption {
@@ -42,17 +43,17 @@ export interface CheckboxSelectorOption {
   selectableOverride?: UsabilityOverrideFn;
 
   /** Optional callback method to be executed when the row checkbox gets clicked but prior to the actual toggling itself. */
-  onRowToggleStart?: (e: Event | null, args: { row: number; previousSelectedRows: number[]; }) => void;
+  onRowToggleStart?: (e: SlickEventData | Event | null, args: { row: number; previousSelectedRows: number[]; }) => void;
 
   /** Optional callback method to be executed after the row checkbox toggle is completed. */
-  onRowToggleEnd?: (e: Event | null, args: { row: number; previousSelectedRows: number[]; }) => void;
+  onRowToggleEnd?: (e: SlickEventData | Event | null, args: { row: number; previousSelectedRows: number[]; }) => void;
 
   /**
    * Optional callback method to be executed when the "Select All" gets clicked but prior to the actual toggling itself.
    * For example we could expand all Groups or Tree prior to the selection so that we also have the chance to even include Group/Tree children in the selection.
    */
-  onSelectAllToggleStart?: (e: Event | null, args: { previousSelectedRows: number[]; caller: 'click.selectAll' | 'click.unselectAll'; }) => void;
+  onSelectAllToggleStart?: (e: SlickEventData | Event | null, args: { previousSelectedRows: number[]; caller: 'click.selectAll' | 'click.unselectAll'; }) => void;
 
   /** Optional callback method to be executed when the "Select All" toggled action is completed. */
-  onSelectAllToggleEnd?: (e: Event | null, args: { rows: number[]; previousSelectedRows: number[]; caller: 'click.selectAll' | 'click.unselectAll'; }) => void;
+  onSelectAllToggleEnd?: (e: SlickEventData | Event | null, args: { rows: number[]; previousSelectedRows: number[]; caller: 'click.selectAll' | 'click.unselectAll'; }) => void;
 }

--- a/packages/common/src/interfaces/contextMenu.interface.ts
+++ b/packages/common/src/interfaces/contextMenu.interface.ts
@@ -1,3 +1,4 @@
+import type { SlickEventData } from '../core';
 import type { SlickContextMenu } from '../extensions/slickContextMenu';
 import type {
   ContextMenuOption,
@@ -14,17 +15,17 @@ export interface ContextMenu extends ContextMenuOption {
   onExtensionRegistered?: (plugin: SlickContextMenu) => void;
 
   /** SlickGrid Event fired After the menu is shown. */
-  onAfterMenuShow?: (e: Event, args: MenuFromCellCallbackArgs) => boolean | void;
+  onAfterMenuShow?: (e: Event | SlickEventData, args: MenuFromCellCallbackArgs) => boolean | void;
 
   /** SlickGrid Event fired Before the menu is shown. */
-  onBeforeMenuShow?: (e: Event, args: MenuFromCellCallbackArgs) => boolean | void;
+  onBeforeMenuShow?: (e: Event | SlickEventData, args: MenuFromCellCallbackArgs) => boolean | void;
 
   /** SlickGrid Event fired when the menu is closing. */
-  onBeforeMenuClose?: (e: Event, args: MenuFromCellCallbackArgs) => boolean | void;
+  onBeforeMenuClose?: (e: Event | SlickEventData, args: MenuFromCellCallbackArgs) => boolean | void;
 
   /** SlickGrid Event fired on menu option clicked from the Command items list */
-  onCommand?: (e: Event, args: MenuCommandItemCallbackArgs) => void;
+  onCommand?: (e: Event | SlickEventData, args: MenuCommandItemCallbackArgs) => void;
 
   /** SlickGrid Event fired on menu option selected from the Option items list. */
-  onOptionSelected?: (e: Event, args: MenuOptionItemCallbackArgs) => void;
+  onOptionSelected?: (e: Event | SlickEventData, args: MenuOptionItemCallbackArgs) => void;
 }

--- a/packages/common/src/interfaces/gridEvents.interface.ts
+++ b/packages/common/src/interfaces/gridEvents.interface.ts
@@ -1,44 +1,44 @@
 import type { Column, CompositeEditorOption, CssStyleHash, Editor, EditorValidationResult, GridOption } from './index';
 import type { SlickGrid } from '../core/index';
 
-export interface SlickGridEventData { grid: SlickGrid; }
-export interface OnActiveCellChangedEventArgs extends SlickGridEventData { cell: number; row: number; }
-export interface OnAddNewRowEventArgs extends SlickGridEventData { item: any; column: Column; }
-export interface OnAutosizeColumnsEventArgs extends SlickGridEventData { columns: Column[]; }
-export interface OnBeforeUpdateColumnsEventArgs extends SlickGridEventData { columns: Column[]; }
-export interface OnBeforeAppendCellEventArgs extends SlickGridEventData { row: number; cell: number; value: any; dataContext: any; }
-export interface OnBeforeCellEditorDestroyEventArgs extends SlickGridEventData { editor: Editor; }
-export interface OnBeforeColumnsResizeEventArgs extends SlickGridEventData { triggeredByColumn: string; }
-export interface OnBeforeEditCellEventArgs extends SlickGridEventData { row?: number; cell?: number; item: any; column: Column; target?: 'grid' | 'composite'; compositeEditorOptions?: CompositeEditorOption; }
-export interface OnBeforeHeaderCellDestroyEventArgs extends SlickGridEventData { node: HTMLElement; column: Column; }
-export interface OnBeforeHeaderRowCellDestroyEventArgs extends SlickGridEventData { node: HTMLElement; column: Column; }
-export interface OnBeforeFooterRowCellDestroyEventArgs extends SlickGridEventData { node: HTMLElement; column: Column; }
-export interface OnBeforeSetColumnsEventArgs extends SlickGridEventData { previousColumns: Column[]; newColumns: Column[]; }
-export interface OnCellChangeEventArgs extends SlickGridEventData { row: number; cell: number; item: any; column: Column; }
-export interface OnCellCssStylesChangedEventArgs extends SlickGridEventData { key: string; hash: CssStyleHash; }
-export interface OnColumnsDragEventArgs extends SlickGridEventData { triggeredByColumn: string; resizeHandle: HTMLDivElement; }
-export interface OnColumnsReorderedEventArgs extends SlickGridEventData { impactedColumns: Column[]; }
-export interface OnColumnsResizedEventArgs extends SlickGridEventData { triggeredByColumn: string; }
-export interface OnColumnsResizeDblClickEventArgs extends SlickGridEventData { triggeredByColumn: string; }
-export interface OnCompositeEditorChangeEventArgs extends SlickGridEventData { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor; }; triggeredBy?: 'user' | 'system'; }
-export interface OnClickEventArgs extends SlickGridEventData { row: number; cell: number; }
-export interface OnDblClickEventArgs extends SlickGridEventData { row: number; cell: number; }
-export interface OnFooterContextMenuEventArgs extends SlickGridEventData { column: Column; }
-export interface OnFooterRowCellRenderedEventArgs extends SlickGridEventData { node: HTMLDivElement; column: Column; }
-export interface OnHeaderCellRenderedEventArgs extends SlickGridEventData { node: HTMLDivElement; column: Column; }
-export interface OnFooterClickEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderClickEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderContextMenuEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderMouseEventArgs extends SlickGridEventData { column: Column; }
-export interface OnHeaderRowCellRenderedEventArgs extends SlickGridEventData { node: HTMLDivElement; column: Column; }
-export interface OnKeyDownEventArgs extends SlickGridEventData { row: number; cell: number; }
-export interface OnValidationErrorEventArgs extends SlickGridEventData { row: number; cell: number; validationResults: EditorValidationResult; column: Column; editor: Editor; cellNode: HTMLDivElement; }
-export interface OnRenderedEventArgs extends SlickGridEventData { startRow: number; endRow: number; }
-export interface OnSelectedRowsChangedEventArgs extends SlickGridEventData { rows: number[]; previousSelectedRows: number[]; changedSelectedRows: number[]; changedUnselectedRows: number[]; caller: string; }
-export interface OnSetOptionsEventArgs extends SlickGridEventData { optionsBefore: GridOption; optionsAfter: GridOption; }
-export interface OnActivateChangedOptionsEventArgs extends SlickGridEventData { options: GridOption; }
-export interface OnScrollEventArgs extends SlickGridEventData { scrollLeft: number; scrollTop: number; }
-export interface OnDragEventArgs extends SlickGridEventData {
+export interface SlickGridArg { grid: SlickGrid; }
+export interface OnActiveCellChangedEventArgs extends SlickGridArg { cell: number; row: number; }
+export interface OnAddNewRowEventArgs extends SlickGridArg { item: any; column: Column; }
+export interface OnAutosizeColumnsEventArgs extends SlickGridArg { columns: Column[]; }
+export interface OnBeforeUpdateColumnsEventArgs extends SlickGridArg { columns: Column[]; }
+export interface OnBeforeAppendCellEventArgs extends SlickGridArg { row: number; cell: number; value: any; dataContext: any; }
+export interface OnBeforeCellEditorDestroyEventArgs extends SlickGridArg { editor: Editor; }
+export interface OnBeforeColumnsResizeEventArgs extends SlickGridArg { triggeredByColumn: string; }
+export interface OnBeforeEditCellEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; target?: 'grid' | 'composite'; compositeEditorOptions?: CompositeEditorOption; }
+export interface OnBeforeHeaderCellDestroyEventArgs extends SlickGridArg { node: HTMLElement; column: Column; }
+export interface OnBeforeHeaderRowCellDestroyEventArgs extends SlickGridArg { node: HTMLElement; column: Column; }
+export interface OnBeforeFooterRowCellDestroyEventArgs extends SlickGridArg { node: HTMLElement; column: Column; }
+export interface OnBeforeSetColumnsEventArgs extends SlickGridArg { previousColumns: Column[]; newColumns: Column[]; }
+export interface OnCellChangeEventArgs extends SlickGridArg { row: number; cell: number; item: any; column: Column; }
+export interface OnCellCssStylesChangedEventArgs extends SlickGridArg { key: string; hash: CssStyleHash; }
+export interface OnColumnsDragEventArgs extends SlickGridArg { triggeredByColumn: string; resizeHandle: HTMLDivElement; }
+export interface OnColumnsReorderedEventArgs extends SlickGridArg { impactedColumns: Column[]; }
+export interface OnColumnsResizedEventArgs extends SlickGridArg { triggeredByColumn: string; }
+export interface OnColumnsResizeDblClickEventArgs extends SlickGridArg { triggeredByColumn: string; }
+export interface OnCompositeEditorChangeEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor; }; triggeredBy?: 'user' | 'system'; }
+export interface OnClickEventArgs extends SlickGridArg { row: number; cell: number; }
+export interface OnDblClickEventArgs extends SlickGridArg { row: number; cell: number; }
+export interface OnFooterContextMenuEventArgs extends SlickGridArg { column: Column; }
+export interface OnFooterRowCellRenderedEventArgs extends SlickGridArg { node: HTMLDivElement; column: Column; }
+export interface OnHeaderCellRenderedEventArgs extends SlickGridArg { node: HTMLDivElement; column: Column; }
+export interface OnFooterClickEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderClickEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderContextMenuEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderMouseEventArgs extends SlickGridArg { column: Column; }
+export interface OnHeaderRowCellRenderedEventArgs extends SlickGridArg { node: HTMLDivElement; column: Column; }
+export interface OnKeyDownEventArgs extends SlickGridArg { row: number; cell: number; }
+export interface OnValidationErrorEventArgs extends SlickGridArg { row: number; cell: number; validationResults: EditorValidationResult; column: Column; editor: Editor; cellNode: HTMLDivElement; }
+export interface OnRenderedEventArgs extends SlickGridArg { startRow: number; endRow: number; }
+export interface OnSelectedRowsChangedEventArgs extends SlickGridArg { rows: number[]; previousSelectedRows: number[]; changedSelectedRows: number[]; changedUnselectedRows: number[]; caller: string; }
+export interface OnSetOptionsEventArgs extends SlickGridArg { optionsBefore: GridOption; optionsAfter: GridOption; }
+export interface OnActivateChangedOptionsEventArgs extends SlickGridArg { options: GridOption; }
+export interface OnScrollEventArgs extends SlickGridArg { scrollLeft: number; scrollTop: number; }
+export interface OnDragEventArgs extends SlickGridArg {
   count: number; deltaX: number; deltaY: number; offsetX: number; offsetY: number; originalX: number; originalY: number;
   available: HTMLDivElement | HTMLDivElement[]; drag: HTMLDivElement; drop: HTMLDivElement | HTMLDivElement[]; helper: HTMLDivElement;
   proxy: HTMLDivElement; target: HTMLDivElement; mode: string;

--- a/packages/common/src/interfaces/headerMenu.interface.ts
+++ b/packages/common/src/interfaces/headerMenu.interface.ts
@@ -5,7 +5,7 @@ import type {
   MenuCommandItem,
   MenuCommandItemCallbackArgs,
 } from './index';
-import { SlickGrid } from '../core/index';
+import { SlickGrid, type SlickEventData } from '../core/index';
 
 export interface HeaderMenuCommandItemCallbackArgs {
   /** Column definition */
@@ -27,11 +27,11 @@ export interface HeaderMenu extends HeaderMenuOption {
   onExtensionRegistered?: (plugin: SlickHeaderMenu) => void;
 
   /** Fired After the header menu shows up. */
-  onAfterMenuShow?: (e: Event, args: HeaderMenuCommandItemCallbackArgs) => boolean | void;
+  onAfterMenuShow?: (e: Event | SlickEventData, args: HeaderMenuCommandItemCallbackArgs) => boolean | void;
 
   /** Fired Before the header menu shows up. */
-  onBeforeMenuShow?: (e: Event, args: HeaderMenuCommandItemCallbackArgs) => boolean | void;
+  onBeforeMenuShow?: (e: Event | SlickEventData, args: HeaderMenuCommandItemCallbackArgs) => boolean | void;
 
   /** Fired when a command is clicked */
-  onCommand?: (e: Event, args: MenuCommandItemCallbackArgs) => void;
+  onCommand?: (e: Event | SlickEventData, args: MenuCommandItemCallbackArgs) => void;
 }

--- a/packages/common/src/services/__tests__/gridEvent.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridEvent.service.spec.ts
@@ -56,7 +56,7 @@ describe('GridEventService', () => {
       const spyGetCols = jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn]);
 
       service.bindOnBeforeEditCell(gridStub);
-      gridStub.onBeforeEditCell.notify({ cell: undefined as any, row: undefined as any, grid: gridStub, column: {} as Column, item: {} }, new SlickEventData(), gridStub);
+      gridStub.onBeforeEditCell.notify({ cell: undefined as any, row: undefined as any, grid: gridStub, column: {} as Column, item: {} }, new SlickEventData(new Event('click')), gridStub);
 
       expect(spyGetCols).not.toHaveBeenCalled();
     });
@@ -67,11 +67,11 @@ describe('GridEventService', () => {
       const spyOnChange = jest.spyOn(mockColumn, 'onBeforeEditCell');
 
       service.bindOnBeforeEditCell(gridStub);
-      gridStub.onBeforeEditCell.notify({ cell: 0, row: 0, grid: gridStub, column: {} as Column, item: {}, target: 'grid' }, new SlickEventData(), gridStub);
+      gridStub.onBeforeEditCell.notify({ cell: 0, row: 0, grid: gridStub, column: {} as Column, item: {}, target: 'grid' }, new SlickEventData(new Event('click')), gridStub);
 
       expect(spyGetCols).toHaveBeenCalled();
       expect(spyGetData).toHaveBeenCalled();
-      expect(spyOnChange).toHaveBeenCalledWith(expect.anything(), {
+      expect(spyOnChange).toHaveBeenCalledWith(expect.any(Event), {
         row: 0,
         cell: 0,
         dataView: dataViewStub,
@@ -104,7 +104,7 @@ describe('GridEventService', () => {
       const spyGetCols = jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn]);
 
       service.bindOnCellChange(gridStub);
-      gridStub.onCellChange.notify({ cell: undefined as any, row: undefined as any, grid: gridStub, item: {}, column: {} as Column }, new SlickEventData(), gridStub);
+      gridStub.onCellChange.notify({ cell: undefined as any, row: undefined as any, grid: gridStub, item: {}, column: {} as Column }, new SlickEventData(new Event('click')), gridStub);
 
       expect(spyGetCols).not.toHaveBeenCalled();
     });
@@ -115,11 +115,11 @@ describe('GridEventService', () => {
       const spyOnChange = jest.spyOn(mockColumn, 'onCellChange');
 
       service.bindOnCellChange(gridStub);
-      gridStub.onCellChange.notify({ cell: 0, row: 0, grid: gridStub, item: {}, column: {} as Column }, new SlickEventData(), gridStub);
+      gridStub.onCellChange.notify({ cell: 0, row: 0, grid: gridStub, item: {}, column: {} as Column }, new SlickEventData(new Event('click')), gridStub);
 
       expect(spyGetCols).toHaveBeenCalled();
       expect(spyGetData).toHaveBeenCalled();
-      expect(spyOnChange).toHaveBeenCalledWith(expect.anything(), {
+      expect(spyOnChange).toHaveBeenCalledWith(expect.any(Event), {
         row: 0,
         cell: 0,
         dataView: dataViewStub,
@@ -152,7 +152,7 @@ describe('GridEventService', () => {
       const spyGetCols = jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn]);
 
       service.bindOnClick(gridStub);
-      gridStub.onClick.notify({ cell: undefined as any, row: undefined as any, grid: gridStub, }, new SlickEventData(), gridStub);
+      gridStub.onClick.notify({ cell: undefined as any, row: undefined as any, grid: gridStub, }, new SlickEventData(new Event('click')), gridStub);
 
       expect(spyGetCols).not.toHaveBeenCalled();
     });
@@ -164,11 +164,11 @@ describe('GridEventService', () => {
       const spyOnChange = jest.spyOn(mockColumn, 'onCellClick');
 
       service.bindOnClick(gridStub);
-      gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, new SlickEventData(), gridStub);
+      gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, new SlickEventData(new Event('click')), gridStub);
 
       expect(spyGetCols).toHaveBeenCalled();
       expect(spyGetData).toHaveBeenCalled();
-      expect(spyOnChange).toHaveBeenCalledWith(expect.anything(), {
+      expect(spyOnChange).toHaveBeenCalledWith(expect.any(Event), {
         row: 0,
         cell: 0,
         dataView: dataViewStub,

--- a/packages/common/src/services/gridEvent.service.ts
+++ b/packages/common/src/services/gridEvent.service.ts
@@ -1,4 +1,4 @@
-import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
+import { type SlickDataView, SlickEventHandler, type SlickGrid, SlickEventData } from '../core/index';
 import type { Column, OnEventArgs } from './../interfaces/index';
 
 export class GridEventService {
@@ -40,7 +40,7 @@ export class GridEventService {
         };
 
         // finally call up the Slick column.onBeforeEditCells.... function
-        column.onBeforeEditCell(e, returnedArgs);
+        column.onBeforeEditCell(e instanceof SlickEventData ? e.getNativeEvent() : e, returnedArgs);
       }
     });
   }
@@ -69,7 +69,7 @@ export class GridEventService {
         };
 
         // finally call up the Slick column.onCellChanges.... function
-        column.onCellChange(e, returnedArgs);
+        column.onCellChange(e instanceof SlickEventData ? e.getNativeEvent() : e, returnedArgs);
       }
     });
   }
@@ -97,7 +97,7 @@ export class GridEventService {
         };
 
         // finally call up the Slick column.onCellClick.... function
-        column.onCellClick(e, returnedArgs);
+        column.onCellClick(e instanceof SlickEventData ? e.getNativeEvent() : e, returnedArgs);
       }
     });
   }

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -7,6 +7,7 @@ import type {
   MultiColumnSort,
   SingleColumnSort,
   TreeDataOption,
+  DOMMouseOrTouchEvent,
 } from '../interfaces/index';
 import { EmitterType, FieldType, SortDirection, SortDirectionNumber, type SortDirectionString, } from '../enums/index';
 import type { BackendUtilityService } from './backendUtility.service';
@@ -72,7 +73,7 @@ export class SortService {
     this._dataView = grid?.getData<SlickDataView>();
 
     // subscribe to the SlickGrid event and call the backend execution
-    this._eventHandler.subscribe(grid.onSort, this.onBackendSortChanged.bind(this) as EventListener);
+    this._eventHandler.subscribe(grid.onSort, this.onBackendSortChanged.bind(this));
   }
 
   /**
@@ -118,7 +119,7 @@ export class SortService {
     this.emitSortChanged(EmitterType.local);
   }
 
-  clearSortByColumnId(event: Event | undefined, columnId: string | number) {
+  clearSortByColumnId(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData | undefined, columnId: string | number) {
     // get previously sorted columns
     const allSortedCols = this.getCurrentColumnSorts() as ColumnSort[];
     const sortedColsWithoutCurrent = this.getCurrentColumnSorts(`${columnId}`) as ColumnSort[];
@@ -350,7 +351,7 @@ export class SortService {
    * @param args - sort event arguments
    * @returns - False since we'll apply the sort icon(s) manually only after server responded
    */
-  onBackendSortChanged(event: Event | undefined, args: MultiColumnSort & { clearSortTriggered?: boolean; }) {
+  onBackendSortChanged(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData | undefined, args: (SingleColumnSort | MultiColumnSort) & { clearSortTriggered?: boolean; }) {
     if (!args || !args.grid) {
       throw new Error('Something went wrong when trying to bind the "onBackendSortChanged(event, args)" function, it seems that "args" is not populated correctly');
     }
@@ -369,7 +370,7 @@ export class SortService {
     }
 
     // query backend
-    const query = backendApi.service.processOnSortChanged(event, args);
+    const query = backendApi.service.processOnSortChanged(event as Event, args);
     const totalItems = gridOptions?.pagination?.totalItems || 0;
     this.backendUtilities?.executeBackendCallback(backendApi, query, args, startTime, totalItems, {
       emitActionChangedCallback: this.emitSortChanged.bind(this),

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -18,7 +18,7 @@ import {
 } from './utilities';
 import type { SharedService } from './shared.service';
 import type { SortService } from './sort.service';
-import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
+import { type SlickDataView, SlickEventHandler, type SlickGrid, type SlickEventData } from '../core/index';
 
 export class TreeDataService {
   protected _lastToggleStateChange!: Omit<TreeToggleStateChange, 'fromItemId'>;
@@ -287,7 +287,7 @@ export class TreeDataService {
    * @param {Object} gridOptions - grid options
    * @returns {Array<Object>} - tree dataset
    */
-  convertFlatParentChildToTreeDatasetAndSort<P, T extends P & { [childrenPropName: string]: T[] }>(flatDataset: P[], columnDefinitions: Column[], gridOptions: GridOption) {
+  convertFlatParentChildToTreeDatasetAndSort<P, T extends P & { [childrenPropName: string]: T[]; }>(flatDataset: P[], columnDefinitions: Column[], gridOptions: GridOption) {
     // 1- convert the flat array into a hierarchical array
     const datasetHierarchical = this.convertFlatParentChildToTreeDataset(flatDataset, gridOptions);
 
@@ -308,7 +308,7 @@ export class TreeDataService {
    * @param {Object} gridOptions - grid options
    * @returns {Array<Object>} - tree dataset
    */
-  convertFlatParentChildToTreeDataset<P, T extends P & { [childrenPropName: string]: P[] }>(flatDataset: P[], gridOptions: GridOption): T[] {
+  convertFlatParentChildToTreeDataset<P, T extends P & { [childrenPropName: string]: P[]; }>(flatDataset: P[], gridOptions: GridOption): T[] {
     const dataViewIdIdentifier = gridOptions?.datasetIdPropertyName ?? 'id';
     const treeDataOpt: TreeDataOption = gridOptions?.treeDataOptions ?? { columnId: 'id' };
     const treeDataOptions = {
@@ -408,7 +408,7 @@ export class TreeDataService {
   // protected functions
   // ------------------
 
-  protected handleOnCellClick(event: MouseEvent, args: OnClickEventArgs) {
+  protected handleOnCellClick(event: SlickEventData, args: OnClickEventArgs) {
     if (event && args) {
       const targetElm: any = event.target || {};
       const idPropName = this.gridOptions.datasetIdPropertyName ?? 'id';

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -18,6 +18,7 @@ import type {
   OnErrorOption,
   PlainFunc,
   SlickDataView,
+  SlickEventData,
   SlickGrid,
   TranslaterService,
 } from '@slickgrid-universal/common';
@@ -874,7 +875,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Anytime an input of the Composite Editor form changes, we'll add/remove a "modified" CSS className for styling purposes */
-  protected handleOnCompositeEditorChange(_e: Event, args: OnCompositeEditorChangeEventArgs) {
+  protected handleOnCompositeEditorChange(_e: SlickEventData, args: OnCompositeEditorChangeEventArgs) {
     const columnId = args.column?.id ?? '';
     this._formValues = { ...this._formValues, ...args.formValues };
     const editor = this._editors?.[columnId] as Editor;

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -4,7 +4,6 @@ import type {
   ContainerService,
   CustomDataView,
   CustomTooltipOption,
-  DOMEvent,
   Formatter,
   FormatterResultWithHtml,
   FormatterResultWithText,
@@ -12,6 +11,7 @@ import type {
   Observable,
   RxJsFacade,
   SharedService,
+  SlickEventData,
   SlickGrid,
   Subscription,
 } from '@slickgrid-universal/common';
@@ -127,12 +127,12 @@ export class SlickCustomTooltip {
     this._sharedService = containerService.get<SharedService>('SharedService');
     this._addonOptions = { ...this._defaultOptions, ...(this._sharedService?.gridOptions?.customTooltip) } as CustomTooltipOption;
     this._eventHandler
-      .subscribe(grid.onMouseEnter, this.handleOnMouseEnter.bind(this) as unknown as EventListener)
+      .subscribe(grid.onMouseEnter, this.handleOnMouseEnter.bind(this))
       .subscribe(grid.onHeaderMouseEnter, (e, args) => this.handleOnHeaderMouseEnterByType(e, args, 'slick-header-column'))
       .subscribe(grid.onHeaderRowMouseEnter, (e, args) => this.handleOnHeaderMouseEnterByType(e, args, 'slick-headerrow-column'))
-      .subscribe(grid.onMouseLeave, this.hideTooltip.bind(this) as unknown as EventListener)
-      .subscribe(grid.onHeaderMouseLeave, this.hideTooltip.bind(this) as unknown as EventListener)
-      .subscribe(grid.onHeaderRowMouseLeave, this.hideTooltip.bind(this) as unknown as EventListener);
+      .subscribe(grid.onMouseLeave, this.hideTooltip.bind(this))
+      .subscribe(grid.onHeaderMouseLeave, this.hideTooltip.bind(this))
+      .subscribe(grid.onHeaderRowMouseLeave, this.hideTooltip.bind(this));
   }
 
   dispose() {
@@ -169,7 +169,7 @@ export class SlickCustomTooltip {
    * Async process callback will hide any prior tooltip & then merge the new result with the item `dataContext` under a `__params` property
    * (unless a new prop name is provided) to provice as dataContext object to the asyncPostFormatter.
    */
-  protected asyncProcessCallback(asyncResult: any, cell: { row: number, cell: number }, value: any, columnDef: Column, dataContext: any) {
+  protected asyncProcessCallback(asyncResult: any, cell: { row: number, cell: number; }, value: any, columnDef: Column, dataContext: any) {
     this.hideTooltip();
     const itemWithAsyncData = { ...dataContext, [this.addonOptions?.asyncParamsPropName ?? '__params']: asyncResult };
     if (this._cellAddonOptions?.useRegularTooltip) {
@@ -180,7 +180,7 @@ export class SlickCustomTooltip {
   }
 
   /** depending on the selector type, execute the necessary handler code */
-  protected handleOnHeaderMouseEnterByType(event: DOMEvent<HTMLDivElement>, args: any, selector: CellType) {
+  protected handleOnHeaderMouseEnterByType(event: SlickEventData, args: any, selector: CellType) {
     this._cellType = selector;
 
     // before doing anything, let's remove any previous tooltip before
@@ -221,7 +221,7 @@ export class SlickCustomTooltip {
     }
   }
 
-  protected async handleOnMouseEnter(event: DOMEvent<HTMLDivElement>) {
+  protected async handleOnMouseEnter(event: SlickEventData) {
     this._cellType = 'slick-cell';
 
     // before doing anything, let's remove any previous tooltip before

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -1,7 +1,6 @@
 import { createDomElement, SlickEvent, SlickEventHandler, Utils as SlickUtils } from '@slickgrid-universal/common';
 import type {
   Column,
-  DOMMouseOrTouchEvent,
   ExternalResource,
   FormatterResultWithHtml,
   GridOption,
@@ -152,9 +151,9 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     this.gridOptions.minRowBuffer = this._addonOptions.panelRows + 3;
 
     this._eventHandler
-      .subscribe(this._grid.onClick, this.handleClick.bind(this) as EventListener)
+      .subscribe(this._grid.onClick, this.handleClick.bind(this))
       .subscribe(this._grid.onBeforeEditCell, () => this.collapseAll())
-      .subscribe(this._grid.onScroll, this.handleScroll.bind(this) as EventListener);
+      .subscribe(this._grid.onScroll, this.handleScroll.bind(this));
 
     // Sort will, by default, Collapse all of the open items (unless user implements his own onSort which deals with open row and padding)
     if (this._addonOptions.collapseAllOnSort) {
@@ -335,7 +334,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
    * subscribe to the onAsyncResponse so that the plugin knows when the user server side calls finished
    * the response has to be as "args.item" (or "args.itemDetail") with it's data back
    */
-  handleOnAsyncResponse(_e: Event, args: { item: any; itemDetail: any; detailView?: any; }) {
+  handleOnAsyncResponse(_e: SlickEventData, args: { item: any; itemDetail: any; detailView?: any; }) {
     if (!args || (!args.item && !args.itemDetail)) {
       console.error('SlickRowDetailView plugin requires the onAsyncResponse() to supply "args.item" property.');
       return;
@@ -684,13 +683,13 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Handle mouse click event */
-  protected handleClick(e: DOMMouseOrTouchEvent<HTMLDivElement>, args: { row: number; cell: number; }) {
+  protected handleClick(e: SlickEventData, args: { row: number; cell: number; }) {
     const dataContext = this._grid.getDataItem(args.row);
 
     if (this.checkExpandableOverride(args.row, dataContext, this._grid)) {
       // clicking on a row select checkbox
       const columnDef = this._grid.getColumns()[args.cell];
-      if (this._addonOptions.useRowClick || (columnDef.id === this._addonOptions.columnId && e.target.classList.contains(this._addonOptions.cssClass || ''))) {
+      if (this._addonOptions.useRowClick || (columnDef.id === this._addonOptions.columnId && e.target!.classList.contains(this._addonOptions.cssClass || ''))) {
         // if editing, try to commit
         if (this._grid.getEditorLock().isActive() && !this._grid.getEditorLock().commitCurrentEdit()) {
           e.preventDefault();


### PR DESCRIPTION
- previously the 1st argument event was typed as `any` but in practical it will always be of type `SlickEventData` because a SlickEvent `.notify()` method always passes a `SlickEventData` instance as 1st argument

![image](https://github.com/6pac/SlickGrid/assets/643976/e0b3104a-c8dc-4ae1-b2de-fc315063fb05)
![image](https://github.com/6pac/SlickGrid/assets/643976/a1f273b7-72a4-4661-95d8-6a8433983547)
