### PR TITLE
chore: remove unused code related to Column Reorder & SortableJS

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1798,7 +1798,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const scrollColumnsRight = () => this._viewportScrollContainerX.scrollLeft += 10;
     const scrollColumnsLeft = () => this._viewportScrollContainerX.scrollLeft -= 10;
 
-    let canDragScroll;
+    let canDragScroll = false;
     const sortableOptions = {
       animation: 50,
       direction: 'horizontal',
@@ -1826,12 +1826,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         }
       },
       onEnd: (e: SortableEvent) => {
-        const cancel = false;
         clearInterval(columnScrollTimer);
         columnScrollTimer = null;
-        let limit;
 
-        if (cancel || !this.getEditorLock()?.commitCurrentEdit()) {
+        if (!this.getEditorLock()?.commitCurrentEdit()) {
           return;
         }
 
@@ -1844,7 +1842,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         }
         this.setColumns(reorderedColumns);
 
-        this.triggerEvent(this.onColumnsReordered, { impactedColumns: this.getImpactedColumns(limit) });
+        this.triggerEvent(this.onColumnsReordered, { impactedColumns: this.columns });
         e.stopPropagation();
         this.setupColumnResize();
         if (this.activeCellNode) {
@@ -1863,26 +1861,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return a.concat(b) as HTMLElement[];
   }
 
-  protected getImpactedColumns(limit?: { start: number; end: number; }) {
-    let impactedColumns: C[] = [];
-
-    if (limit) {
-      for (let i = limit.start; i <= limit.end; i++) {
-        impactedColumns.push(this.columns[i]);
-      }
-    } else {
-      impactedColumns = this.columns;
-    }
-
-    return impactedColumns;
-  }
-
   protected handleResizeableHandleDoubleClick(evt: MouseEvent & { target: HTMLDivElement; }) {
     const triggeredByColumn = evt.target.parentElement!.id.replace(this.uid, '');
     this.triggerEvent(this.onColumnsResizeDblClick, { triggeredByColumn });
   }
 
   protected setupColumnResize() {
+    /* istanbul ignore if */
     if (typeof Resizable === 'undefined') {
       throw new Error(`SlickResizable is undefined, make sure to import "slick.interactions.js"`);
     }


### PR DESCRIPTION
- when we added SortableJS, we previously had code that is longer required since SortableJS already takes care of the order validation and such, there is also code related to Tree Column Depth that should have been removed.