### PR TITLE
feat: add `name` option to CheckboxSelectColumn plugin on columDef

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example04.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example04.html
@@ -35,13 +35,17 @@
       <span class="icon mdi mdi-close"></span>
       <span>Remove Frozen Columns</span>
     </button>
-    <button class="button is-small" onclick.delegate="setFrozenColumns(2)" data-test="set-3frozen-columns">
+    <button class="button is-small" data-test="set-3frozen-columns" onclick.delegate="setFrozenColumns(2)">
       <span class="icon mdi mdi-pin-outline"></span>
       <span>Set 3 Frozen Columns</span>
     </button>
-    <button class="button is-small" onclick.delegate="toggleFrozenBottomRows()">
+    <button class="button is-small" data-test="toggle-frozen-bottom" onclick.delegate="toggleFrozenBottomRows()">
       <span class="icon mdi mdi-flip-vertical"></span>
       <span>Toggle Pinned Rows (top/bottom)</span>
+    </button>
+    <button class="button is-small ml-3" data-test="toggle-select-all-row" onclick.delegate="toggleWhichRowToShowSelectAll()">
+      <span class="icon mdi mdi-swap-horizontal mdi-rotate-90"></span>
+      <span>Toggle which row to show "Select All" checkbox</span>
     </button>
   </span>
 </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example04.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example04.ts
@@ -11,6 +11,7 @@ import {
   type GridOption,
   OperatorType,
   type SlickDataView,
+  type SlickCheckboxSelectColumn,
 } from '@slickgrid-universal/common';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
@@ -61,6 +62,8 @@ export default class Example04 {
   frozenRowCount = 3;
   isFrozenBottom = false;
   sgb: SlickVanillaGridBundle;
+  checkboxSelectorInstance: SlickCheckboxSelectColumn;
+  isSelectAllShownAsColumnTitle = false;
 
   constructor() {
     this._bindingEventService = new BindingEventService();
@@ -372,6 +375,12 @@ export default class Example04 {
         selectActiveRow: false
       },
       enableCheckboxSelector: true,
+      checkboxSelector: {
+        hideInColumnTitleRow: !this.isSelectAllShownAsColumnTitle,
+        hideInFilterHeaderRow: this.isSelectAllShownAsColumnTitle,
+        name: 'Sel', // column name will only show when `hideInColumnTitleRow` is true
+        onExtensionRegistered: (instance) => this.checkboxSelectorInstance = instance,
+      },
       enableRowSelection: true,
       frozenColumn: this.frozenColumnCount,
       frozenRow: this.frozenRowCount,
@@ -544,6 +553,14 @@ export default class Example04 {
       });
       this.isFrozenBottom = !this.isFrozenBottom; // toggle the variable
     }
+  }
+
+  toggleWhichRowToShowSelectAll() {
+    this.isSelectAllShownAsColumnTitle = !this.isSelectAllShownAsColumnTitle;
+    this.checkboxSelectorInstance.setOptions({
+      hideInColumnTitleRow: !this.isSelectAllShownAsColumnTitle,
+      hideInFilterHeaderRow: this.isSelectAllShownAsColumnTitle,
+    });
   }
 
   executeCommand(_e, args) {

--- a/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
@@ -64,14 +64,6 @@ const gridStub = {
   onSelectedRowsChanged: new SlickEvent(),
 } as unknown as SlickGrid;
 
-const mockAddon = jest.fn().mockImplementation(() => ({
-  init: jest.fn(),
-  dispose: jest.fn(),
-  getColumnDefinition: jest.fn(),
-  onBeforeMoveRows: new SlickEvent(),
-  onMoveRows: new SlickEvent(),
-}));
-
 const mockRowSelectionModel = {
   constructor: jest.fn(),
   init: jest.fn(),
@@ -121,6 +113,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       cssClass: null,
       field: '_checkbox_selector',
       hideSelectAllCheckbox: false,
+      name: '',
       toolTip: 'Select/Deselect All',
       width: 30,
       hideInColumnTitleRow: false,
@@ -144,6 +137,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       cssClass: 'some-class',
       field: '_checkbox_selector',
       hideSelectAllCheckbox: true,
+      name: '',
       toolTip: 'Select/Deselect All',
       width: 30,
       hideInColumnTitleRow: true,
@@ -160,6 +154,17 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
 
     expect(plugin).toBeTruthy();
     expect(updateColHeaderSpy).toHaveBeenCalledWith('_checkbox_selector', '', '');
+  });
+
+  it('should create the plugin and call "setOptions" and expect options changed and call grid "updateColumnHeader()" when setting "hideInColumnTitleRow: true" and a column "name"', () => {
+    const colName = 'Selection';
+    const updateColHeaderSpy = jest.spyOn(gridStub, 'updateColumnHeader');
+
+    plugin.init(gridStub);
+    plugin.setOptions({ hideInColumnTitleRow: true, hideSelectAllCheckbox: false, cssClass: 'some-class', name: colName });
+
+    expect(plugin).toBeTruthy();
+    expect(updateColHeaderSpy).toHaveBeenCalledWith('_checkbox_selector', colName, '');
   });
 
   it('should create the plugin and call "setOptions" and expect options changed and render the Select All toggle when "hideInColumnTitleRow: false"', () => {
@@ -459,6 +464,30 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       resizable: false,
       sortable: false,
       toolTip: 'Select/Deselect All',
+      width: 30,
+    });
+  });
+
+  it('should add a "name" and "hideSelectAllCheckbox: true" and call the "create" method and expect plugin to be created with a column name and without a checkbox', () => {
+    const colName = 'Selection';
+    plugin.create(mockColumns, { checkboxSelector: { columnIndexPosition: 1, name: colName, hideSelectAllCheckbox: true } });
+
+    expect(plugin).toBeTruthy();
+    expect(mockColumns[1]).toEqual({
+      cssClass: null,
+      excludeFromColumnPicker: true,
+      excludeFromExport: true,
+      excludeFromGridMenu: true,
+      excludeFromHeaderMenu: true,
+      excludeFromQuery: true,
+      field: '_checkbox_selector',
+      formatter: expect.toBeFunction(),
+      hideSelectAllCheckbox: true,
+      id: '_checkbox_selector',
+      name: colName,
+      resizable: false,
+      sortable: false,
+      toolTip: '',
       width: 30,
     });
   });

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -14,6 +14,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     cssClass: null,
     field: '_checkbox_selector',
     hideSelectAllCheckbox: false,
+    name: '',
     toolTip: 'Select/Deselect All',
     width: 30,
     applySelectOnAllPages: true, // when that is enabled the "Select All" will be applied to all pages (when using Pagination)
@@ -158,6 +159,9 @@ export class SlickCheckboxSelectColumn<T = any> {
         this._eventHandler.subscribe(this._grid.onHeaderClick, this.handleHeaderClick.bind(this));
       } else {
         this.hideSelectAllFromColumnHeaderTitleRow();
+        if (this._addonOptions.name) {
+          this._grid.updateColumnHeader(this._addonOptions.columnId || '', this._addonOptions.name, '');
+        }
       }
 
       if (!this._addonOptions.hideInFilterHeaderRow) {
@@ -203,7 +207,9 @@ export class SlickCheckboxSelectColumn<T = any> {
 
     return {
       id: columnId,
-      name: (this._addonOptions.hideSelectAllCheckbox || this._addonOptions.hideInColumnTitleRow) ? '' : `<input id="header-selector${this._selectAll_UID}" type="checkbox"><label for="header-selector${this._selectAll_UID}"></label>`,
+      name: (this._addonOptions.hideSelectAllCheckbox || this._addonOptions.hideInColumnTitleRow)
+        ? this._addonOptions.name || ''
+        : `<input id="header-selector${this._selectAll_UID}" type="checkbox"><label for="header-selector${this._selectAll_UID}"></label>`,
       toolTip: (this._addonOptions.hideSelectAllCheckbox || this._addonOptions.hideInColumnTitleRow) ? '' : this._addonOptions.toolTip,
       field: columnId,
       cssClass: this._addonOptions.cssClass,
@@ -221,7 +227,7 @@ export class SlickCheckboxSelectColumn<T = any> {
   }
 
   hideSelectAllFromColumnHeaderTitleRow() {
-    this._grid.updateColumnHeader(this._addonOptions.columnId || '', '', '');
+    this._grid.updateColumnHeader(this._addonOptions.columnId || '', this._addonOptions.name || '', '');
   }
 
   hideSelectAllFromColumnHeaderFilterRow() {

--- a/packages/common/src/interfaces/checkboxSelectorOption.interface.ts
+++ b/packages/common/src/interfaces/checkboxSelectorOption.interface.ts
@@ -1,5 +1,6 @@
 import type { SlickEventData } from '../core';
 import type { UsabilityOverrideFn } from '../enums/usabilityOverrideFn.type';
+import type { SlickCheckboxSelectColumn } from '../extensions/slickCheckboxSelectColumn';
 
 export interface CheckboxSelectorOption {
   /**
@@ -33,6 +34,12 @@ export interface CheckboxSelectorOption {
   /** defaults to true, do we want to hide the "Select All" checkbox from the Column Header Filter Row? */
   hideInFilterHeaderRow?: boolean;
 
+  /**
+   * defaults to empty string, column name.
+   * This will only work when the "Select All" checkbox is NOT shown in the column header row (`hideInColumnTitleRow: true`)
+   */
+  name?: string;
+
   /** Defaults to "Select/Deselect All", provide a tooltip that will be shown over the "Select All" checkbox */
   toolTip?: string;
 
@@ -41,6 +48,12 @@ export interface CheckboxSelectorOption {
 
   /** Override the logic for showing (or not) the expand icon (use case example: only every 2nd row is expandable) */
   selectableOverride?: UsabilityOverrideFn;
+
+  // --
+  // Events
+
+  /** Fired after extension is registered by SlickGrid */
+  onExtensionRegistered?: (plugin: SlickCheckboxSelectColumn) => void;
 
   /** Optional callback method to be executed when the row checkbox gets clicked but prior to the actual toggling itself. */
   onRowToggleStart?: (e: SlickEventData | Event | null, args: { row: number; previousSelectedRows: number[]; }) => void;

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -311,7 +311,7 @@ describe('ExtensionService', () => {
 
       it('should register the ColumnPicker addon when "enableColumnPicker" is set in the grid options', () => {
         const gridOptionsMock = { enableColumnPicker: true } as GridOption;
-        jest.spyOn(extensionColumnPickerStub, 'register').mockReturnValue(instanceMock);
+        jest.spyOn(extensionColumnPickerStub, 'register').mockReturnValueOnce(instanceMock);
         const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
 
         service.bindDifferentExtensions();
@@ -382,7 +382,7 @@ describe('ExtensionService', () => {
       it('should register the CheckboxSelector addon when "enableCheckboxSelector" is set in the grid options', () => {
         const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
         const gridOptionsMock = { enableCheckboxSelector: true } as GridOption;
-        const extCreateSpy = jest.spyOn(mockCheckboxSelectColumn, 'create').mockReturnValue(mockCheckboxSelectColumn);
+        const extCreateSpy = jest.spyOn(mockCheckboxSelectColumn, 'create').mockReturnValueOnce(mockCheckboxSelectColumn);
         const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         const rowSelectionSpy = jest.spyOn(SlickRowSelectionModel.prototype, 'constructor' as any);
 
@@ -396,6 +396,32 @@ describe('ExtensionService', () => {
         expect(rowSelectionInstance).not.toBeNull();
         expect(rowSelectionSpy).toHaveBeenCalledWith({});
         expect(output).toEqual({ name: ExtensionName.checkboxSelector, instance: mockCheckboxSelectColumn as unknown } as ExtensionModel<any>);
+      });
+
+      it('should call "onExtensionRegistered" when defined in grid option and the CheckboxSelectColumn plugin gets created', () => {
+        const onRegisteredMock = jest.fn();
+        const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
+        const gridOptionsMock = {
+          enableCheckboxSelector: true,
+          checkboxSelector: {
+            onExtensionRegistered: onRegisteredMock
+          }
+        } as GridOption;
+        const extCreateSpy = jest.spyOn(mockCheckboxSelectColumn, 'create').mockReturnValueOnce(mockCheckboxSelectColumn);
+        const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
+        const rowSelectionSpy = jest.spyOn(SlickRowSelectionModel.prototype, 'constructor' as any);
+
+        service.createExtensionsBeforeGridCreation(columnsMock, gridOptionsMock);
+        service.bindDifferentExtensions();
+        const rowSelectionInstance = service.getExtensionByName(ExtensionName.rowSelection);
+        const output = service.getExtensionByName(ExtensionName.checkboxSelector);
+
+        expect(gridSpy).toHaveBeenCalled();
+        expect(extCreateSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
+        expect(rowSelectionInstance).not.toBeNull();
+        expect(rowSelectionSpy).toHaveBeenCalledWith({});
+        expect(output).toEqual({ name: ExtensionName.checkboxSelector, instance: mockCheckboxSelectColumn as unknown } as ExtensionModel<any>);
+        expect(onRegisteredMock).toHaveBeenCalledWith(expect.any(Object));
       });
 
       it('should register the RowMoveManager addon when "enableRowMoveManager" is set in the grid options', () => {
@@ -538,7 +564,7 @@ describe('ExtensionService', () => {
 
         service.createExtensionsBeforeGridCreation(columnsMock, gridOptionsMock);
         const instance = service.getCreatedExtensionByName<SlickDraggableGrouping>(ExtensionName.draggableGrouping);
-        service.addExtensionToList(ExtensionName.draggableGrouping, { name: ExtensionName.draggableGrouping, instance })
+        service.addExtensionToList(ExtensionName.draggableGrouping, { name: ExtensionName.draggableGrouping, instance });
         const instance2 = service.getCreatedExtensionByName(ExtensionName.draggableGrouping);
 
         expect(instance).toBeTruthy();
@@ -794,7 +820,7 @@ describe('ExtensionService', () => {
         ] as Column[];
         const instanceMock = { translateColumnPicker: jest.fn() };
         const gridOptionsMock = { enableColumnPicker: true } as GridOption;
-        jest.spyOn(extensionColumnPickerStub, 'register').mockReturnValue(instanceMock);
+        jest.spyOn(extensionColumnPickerStub, 'register').mockReturnValueOnce(instanceMock);
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
@@ -813,7 +839,7 @@ describe('ExtensionService', () => {
         ] as Column[];
         const instanceMock = { translateGridMenu: jest.fn() };
         const gridOptionsMock = { enableGridMenu: true } as GridOption;
-        jest.spyOn(extensionGridMenuStub, 'register').mockReturnValue(instanceMock);
+        jest.spyOn(extensionGridMenuStub, 'register').mockReturnValueOnce(instanceMock);
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -207,8 +207,11 @@ export class ExtensionService {
         this._checkboxSelectColumn = this._checkboxSelectColumn || new SlickCheckboxSelectColumn(this.pubSubService, this.gridOptions.checkboxSelector);
         this._checkboxSelectColumn.init(this.sharedService.slickGrid);
         const createdExtension = this.getCreatedExtensionByName(ExtensionName.checkboxSelector); // get the instance from when it was really created earlier
-        const instance = createdExtension && createdExtension.instance;
+        const instance = createdExtension?.instance;
         if (instance) {
+          if (this.gridOptions.checkboxSelector?.onExtensionRegistered) {
+            this.gridOptions.checkboxSelector.onExtensionRegistered(instance);
+          }
           this._extensionList[ExtensionName.checkboxSelector] = { name: ExtensionName.checkboxSelector, instance: this._checkboxSelectColumn };
         }
       }

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -1,7 +1,8 @@
 describe('Example 04 - Frozen Grid', () => {
   // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
 
-  const fullTitles = ['', 'Title', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
+  const withTitleRowTitles = ['Sel', 'Title', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
+  const withoutTitleRowTitles = ['', 'Title', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
   const GRID_ROW_HEIGHT = 45;
 
   it('should display Example title', () => {
@@ -13,14 +14,14 @@ describe('Example 04 - Frozen Grid', () => {
     cy.get('.grid4')
       .find('.slick-header-columns')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
   });
 
   it('should have exact Column Header Titles in the grid', () => {
     cy.get('.grid4')
       .find('.slick-header-columns:nth(0)')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
   });
 
   it('should have a frozen grid with 4 containers on page load with 3 columns on the left and 6 columns on the right', () => {
@@ -36,7 +37,7 @@ describe('Example 04 - Frozen Grid', () => {
   });
 
   it('should hide "Title" column from Grid Menu and expect last frozen column to be "% Complete"', () => {
-    const newColumnList = ['', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
+    const newColumnList = ['Sel', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
 
     cy.get('.grid4')
       .find('button.slick-grid-menu-button')
@@ -81,7 +82,7 @@ describe('Example 04 - Frozen Grid', () => {
     cy.get('.grid4')
       .find('.slick-header-columns')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
 
     cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 3 * 2);
     cy.get('.grid-canvas-right > [style="top: 0px;"]').children().should('have.length', 6 * 2);
@@ -94,7 +95,7 @@ describe('Example 04 - Frozen Grid', () => {
   });
 
   it('should hide "Title" column from Header Menu and expect last frozen column to be "% Complete"', () => {
-    const newColumnList = ['', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
+    const newColumnList = ['Sel', '% Complete', 'Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
 
     cy.get('.grid4')
       .find('.slick-header-column:nth(1)')
@@ -146,7 +147,7 @@ describe('Example 04 - Frozen Grid', () => {
     cy.get('.grid4')
       .find('.slick-header-columns')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
 
     cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 3 * 2);
     cy.get('.grid-canvas-right > [style="top: 0px;"]').children().should('have.length', 6 * 2);
@@ -176,7 +177,7 @@ describe('Example 04 - Frozen Grid', () => {
     cy.get('.grid4')
       .find('.slick-header-columns:nth(0)')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
   });
 
   it('should click on the "Set 3 Frozen Columns" button to switch frozen columns grid and expect 3 frozen columns on the left and 4 columns on the right', () => {
@@ -198,7 +199,7 @@ describe('Example 04 - Frozen Grid', () => {
     cy.get('.grid4')
       .find('.slick-header-columns:nth(0)')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
   });
 
   it('should click on the Grid Menu command "Unfreeze Columns/Rows" to switch to a regular grid without frozen columns/rows', () => {
@@ -514,6 +515,46 @@ describe('Example 04 - Frozen Grid', () => {
       .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: contact-chat'));
 
     cy.get('.slick-submenu').should('have.length', 0);
+  });
+
+  it('should toggle Select All checkbox and expect back "Sel" column title to show when Select All checkbox is shown in the header row', () => {
+    cy.get('.slick-header-column:nth(0)')
+      .find('.slick-column-name')
+      .should('contain', 'Sel');
+    cy.get('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
+
+    cy.get('[data-test="toggle-select-all-row"]').click();
+
+    cy.get('.slick-header-column:nth(0)')
+      .find('.slick-column-name')
+      .should('not.contain', 'Sel');
+
+    cy.get('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(withoutTitleRowTitles[index]));
+  });
+
+  it('should toggle back Select All checkbox and expect back "Sel" column title to show when Select All checkbox is shown in the header row', () => {
+    cy.get('[data-test="toggle-select-all-row"]').click();
+
+    cy.get('.slick-header-column:nth(0)')
+      .find('.slick-column-name')
+      .should('contain', 'Sel');
+    cy.get('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(withTitleRowTitles[index]));
+
+    cy.get('[data-test="toggle-select-all-row"]').click();
+
+    cy.get('.slick-header-column:nth(0)')
+      .find('.slick-column-name')
+      .should('not.contain', 'Sel');
+
+    cy.get('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(withoutTitleRowTitles[index]));
   });
 
   describe('Test UI rendering after Scrolling with large columns', () => {


### PR DESCRIPTION
- this will only work when the "Select All" checkbox is NOT shown in the column header titles row (`hideInColumnTitleRow: true`)

![msedge_9E3z18EJQD](https://github.com/ghiscoding/slickgrid-universal/assets/643976/0cda51b8-0666-43f4-a743-396b979627c0)
