### PR TITLE
feat: convert CheckSelectColumn plugin to native HTML for CSP safe code

### DIFF
--- a/docs/migrations/migration-to-4.x.md
+++ b/docs/migrations/migration-to-4.x.md
@@ -174,7 +174,7 @@ The previous Formatters implementation were all returning HTML strings (or `Form
 
 **Since all Formatters were rewritten as HTML, you might get unexpected behavior in your UI, you will have to inspect your UI and make changes accordingly**. For example, I had to adjust [Example 12](https://ghiscoding.github.io/slickgrid-universal/#/example12) `customEditableInputFormatter` because it was expecting all Formatters to return an HTML string and I was concatenating them to an HTML string but that code was now resulting in `[object HTMLElement]`, so I had to update the code and detect if Formatter output is a native element then do something or else do something else... Below is the adjustment I had to do to fix my own demo (your use case may vary)
 
-> **Note** some Formatters now return `HTMLElement` or `DocumentFragment`, you can add a condition check with `instanceof HTMLElement` or `instanceof DocumentFragment`, however please also note that a `DocumentFragment` does not have `innerHTML`/`outerHTML` (you can write a simple function for loop to get them, see this [SO](https://stackoverflow.com/a/51017093/1212166) or use `getHTMLFromFragment(elm)` from Slickgrid-Universal)
+> **Note** some Formatters now return `HTMLElement` or `DocumentFragment`, you can add a condition check with `instanceof HTMLElement` or `instanceof DocumentFragment`, however please also note that a `DocumentFragment` does not have `innerHTML`/`outerHTML` (you can write a simple function for loop to get them, see this [SO](https://stackoverflow.com/a/51017093/1212166) or use `getHtmlStringOutput(elm)` from Slickgrid-Universal)
 
 ```diff
 const customEditableInputFormatter: Formatter = (_row, _cell, value, columnDef, dataContext, grid) => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1327,42 +1327,43 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   /**
    * Updates an existing column definition and a corresponding header DOM element with the new title and tooltip.
    * @param {Number|String} columnId Column id.
-   * @param {String} [title] New column name.
+   * @param {string | HTMLElement | DocumentFragment} [title] New column name.
    * @param {String} [toolTip] New column tooltip.
    */
-  updateColumnHeader(columnId: number | string, title?: string | HTMLElement, toolTip?: string) {
-    if (!this.initialized) { return; }
-    const idx = this.getColumnIndex(columnId);
-    if (!isDefined(idx)) {
-      return;
-    }
-
-    const columnDef = this.columns[idx];
-    const header: any = this.getColumnByIndex(idx);
-    if (header) {
-      if (title !== undefined) {
-        this.columns[idx].name = title;
-      }
-      if (toolTip !== undefined) {
-        this.columns[idx].toolTip = toolTip;
+  updateColumnHeader(columnId: number | string, title?: string | HTMLElement | DocumentFragment, toolTip?: string) {
+    if (this.initialized) {
+      const idx = this.getColumnIndex(columnId);
+      if (!isDefined(idx)) {
+        return;
       }
 
-      this.triggerEvent(this.onBeforeHeaderCellDestroy, {
-        node: header,
-        column: columnDef,
-        grid: this
-      });
+      const columnDef = this.columns[idx];
+      const header: HTMLElement | undefined = this.getColumnByIndex(idx);
+      if (header) {
+        if (title !== undefined) {
+          this.columns[idx].name = title;
+        }
+        if (toolTip !== undefined) {
+          this.columns[idx].toolTip = toolTip;
+        }
 
-      header.setAttribute('title', toolTip || '');
-      if (title !== undefined) {
-        this.applyHtmlCode(header.children[0], title);
+        this.triggerEvent(this.onBeforeHeaderCellDestroy, {
+          node: header,
+          column: columnDef,
+          grid: this
+        });
+
+        header.setAttribute('title', toolTip || '');
+        if (title !== undefined) {
+          this.applyHtmlCode(header.children[0] as HTMLElement, title);
+        }
+
+        this.triggerEvent(this.onHeaderCellRendered, {
+          node: header,
+          column: columnDef,
+          grid: this
+        });
       }
-
-      this.triggerEvent(this.onHeaderCellRendered, {
-        node: header,
-        column: columnDef,
-        grid: this
-      });
     }
   }
 

--- a/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
@@ -187,7 +187,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     expect(plugin).toBeTruthy();
     expect(updateColHeaderSpy).toHaveBeenCalledWith(
       '_checkbox_selector',
-      `<input id="header-selector${plugin.selectAllUid}" type="checkbox" aria-checked="false"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      plugin.createCheckboxElement(`header-selector${plugin.selectAllUid}`),
       'Select/Deselect All'
     );
     expect(preventDefaultSpy).toHaveBeenCalled();
@@ -664,7 +664,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     expect(setSelectedRowSpy).not.toHaveBeenCalled();
     expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
       '_checkbox_selector',
-      `<input id="header-selector${plugin.selectAllUid}" type="checkbox" aria-checked="false"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      plugin.createCheckboxElement(`header-selector${plugin.selectAllUid}`),
       'Select/Deselect All'
     );
   });
@@ -690,7 +690,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     expect(setSelectedRowSpy).not.toHaveBeenCalled();
     expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
       '_checkbox_selector',
-      `<input id="header-selector${plugin.selectAllUid}" type="checkbox" aria-checked="false"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      plugin.createCheckboxElement(`header-selector${plugin.selectAllUid}`),
       'Select/Deselect All'
     );
   });
@@ -721,7 +721,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     expect(setSelectedRowSpy).toHaveBeenCalled();
     expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
       '_checkbox_selector',
-      `<input id="header-selector${plugin.selectAllUid}" type="checkbox" checked="checked" aria-checked="true"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      plugin.createCheckboxElement(`header-selector${plugin.selectAllUid}`, true),
       'Select/Deselect All'
     );
   });
@@ -729,10 +729,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
   it('should trigger "onSelectedRowIdsChanged" event and invalidate row and render to be called also with "setSelectedRows" when checkSelectableOverride returns False and input select checkbox is all checked', () => {
     const nodeElm = document.createElement('div');
     nodeElm.className = 'slick-headerrow-column';
-    const invalidateRowSpy = jest.spyOn(gridStub, 'invalidateRow');
-    const renderSpy = jest.spyOn(gridStub, 'render');
     const updateColumnHeaderSpy = jest.spyOn(gridStub, 'updateColumnHeader');
-    const setSelectedRowSpy = jest.spyOn(gridStub, 'setSelectedRows');
     jest.spyOn(dataViewStub, 'getAllSelectedFilteredIds').mockReturnValueOnce([1, 2]);
     jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit').mockReturnValue(true);
     jest.spyOn(dataViewStub, 'getFilteredItems').mockReturnValueOnce([{ id: 22, firstName: 'John', lastName: 'Doe', age: 30 }]);
@@ -753,7 +750,7 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     expect(plugin).toBeTruthy();
     expect(updateColumnHeaderSpy).toHaveBeenCalledWith(
       '_checkbox_selector',
-      `<input id="header-selector${plugin.selectAllUid}" type="checkbox" checked="checked" aria-checked="true"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      plugin.createCheckboxElement(`header-selector${plugin.selectAllUid}`, true),
       'Select/Deselect All'
     );
   });

--- a/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
@@ -5,6 +5,7 @@ import { SlickCheckboxSelectColumn } from '../slickCheckboxSelectColumn';
 import type { Column, OnSelectedRowsChangedEventArgs } from '../../interfaces/index';
 import { SlickRowSelectionModel } from '../../extensions/slickRowSelectionModel';
 import { SlickEvent, SlickGrid } from '../../core/index';
+import { getHtmlStringOutput } from '@slickgrid-universal/utils';
 
 const addVanillaEventPropagation = function (event, commandKey = '', keyName = '', target?: HTMLElement, which: string | number = '') {
   Object.defineProperty(event, 'isPropagationStopped', { writable: true, configurable: true, value: jest.fn() });
@@ -382,10 +383,10 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
   it('should create a new row selection column definition', () => {
     plugin = new SlickCheckboxSelectColumn(pubSubServiceStub);
     plugin.init(gridStub);
+    const nameHtmlOutput = getHtmlStringOutput(plugin.getColumnDefinition()?.name || '', 'outerHTML');
 
     expect(plugin.getColumnDefinition()).toEqual({
       id: '_checkbox_selector',
-      name: `<input id="header-selector${plugin.selectAllUid}" type="checkbox"><label for="header-selector${plugin.selectAllUid}"></label>`,
       toolTip: 'Select/Deselect All',
       field: '_checkbox_selector',
       cssClass: null,
@@ -398,8 +399,10 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       resizable: false,
       sortable: false,
       width: 30,
+      name: expect.any(DocumentFragment),
       formatter: expect.toBeFunction(),
     });
+    expect(nameHtmlOutput).toBe(`<input id="header-selector${plugin.selectAllUid}" type="checkbox" aria-checked="false"><label for="header-selector${plugin.selectAllUid}"></label>`);
   });
 
   it('should create the plugin and add the Toggle All checkbox in the filter header row and expect toggle all to work when clicked', () => {
@@ -431,7 +434,6 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       field: 'chk-id',
       hideSelectAllCheckbox: false,
       id: 'chk-id',
-      name: `<input id="header-selector${plugin.selectAllUid}" type="checkbox"><label for="header-selector${plugin.selectAllUid}"></label>`,
       resizable: false,
       sortable: false,
       toolTip: 'Select/Deselect All',
@@ -439,14 +441,21 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     };
 
     plugin.create(mockColumns, { checkboxSelector: { columnId: 'chk-id' } });
+    const nameHtmlOutput = getHtmlStringOutput(mockColumns[0]?.name || '', 'outerHTML');
 
-    expect(pubSubSpy).toHaveBeenCalledWith('onPluginColumnsChanged', { columns: expect.arrayContaining([{ ...checkboxColumnMock, formatter: expect.toBeFunction() }]), pluginName: 'CheckboxSelectColumn' });
+    expect(pubSubSpy).toHaveBeenCalledWith('onPluginColumnsChanged', {
+      columns: expect.arrayContaining([{ ...checkboxColumnMock, name: expect.any(DocumentFragment), formatter: expect.toBeFunction() }]),
+      pluginName: 'CheckboxSelectColumn'
+    });
     expect(plugin).toBeTruthy();
     expect(mockColumns[0]).toEqual(expect.objectContaining({ ...checkboxColumnMock, formatter: expect.toBeFunction() }));
+    expect(nameHtmlOutput).toBe(`<input id="header-selector${plugin.selectAllUid}" type="checkbox" aria-checked="false"><label for="header-selector${plugin.selectAllUid}"></label>`);
   });
+
 
   it('should call the "create" method and expect plugin to be created at position 1 when defined', () => {
     plugin.create(mockColumns, { checkboxSelector: { columnIndexPosition: 1 } });
+    const nameHtmlOutput = getHtmlStringOutput(mockColumns[1]?.name || '', 'outerHTML');
 
     expect(plugin).toBeTruthy();
     expect(mockColumns[1]).toEqual({
@@ -460,12 +469,13 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
       formatter: expect.toBeFunction(),
       hideSelectAllCheckbox: false,
       id: '_checkbox_selector',
-      name: `<input id="header-selector${plugin.selectAllUid}" type="checkbox"><label for="header-selector${plugin.selectAllUid}"></label>`,
+      name: expect.any(DocumentFragment),
       resizable: false,
       sortable: false,
       toolTip: 'Select/Deselect All',
       width: 30,
     });
+    expect(nameHtmlOutput).toBe(`<input id="header-selector${plugin.selectAllUid}" type="checkbox" aria-checked="false"><label for="header-selector${plugin.selectAllUid}"></label>`);
   });
 
   it('should add a "name" and "hideSelectAllCheckbox: true" and call the "create" method and expect plugin to be created with a column name and without a checkbox', () => {
@@ -504,11 +514,11 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
   it('should process the "checkboxSelectionFormatter" and expect necessary Formatter to return null when selectableOverride is returning False', () => {
     plugin.init(gridStub);
     plugin.selectableOverride(() => true);
-    const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: 'checkbox_selector', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub);
+    const output = plugin.getColumnDefinition().formatter!(0, 0, null, { id: 'checkbox_selector', field: '' } as Column, { firstName: 'John', lastName: 'Doe', age: 33 }, gridStub) as DocumentFragment;
 
     expect(plugin).toBeTruthy();
-    expect(output).toContain(`<input id="selector`);
-    expect(output).toContain(`<label for="selector`);
+    expect(output.querySelector('input')?.id).toMatch(/^selector.*/);
+    expect(output.querySelector('label')?.htmlFor).toMatch(/^selector.*/);
   });
 
   it('should trigger "onClick" event and expect toggleRowSelection to be called', () => {

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -2,7 +2,7 @@ import 'jest-extended';
 import type { Column, GridOption, GroupItemMetadataProviderOption } from '../../interfaces';
 import { SlickGroupItemMetadataProvider } from '../slickGroupItemMetadataProvider';
 import { type SlickDataView, SlickEvent, SlickGrid, SlickGroup } from '../../core/index';
-import { getHTMLFromFragment } from '@slickgrid-universal/utils';
+import { getHtmlStringOutput } from '@slickgrid-universal/utils';
 
 const gridOptionMock = {
   enablePagination: true,
@@ -138,7 +138,7 @@ describe('GroupItemMetadataProvider Service', () => {
       const spanElm = document.createElement('span');
       spanElm.textContent = 'Another Title';
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: spanElm }, gridStub) as DocumentFragment;
-      const htmlContent = getHTMLFromFragment(output, 'outerHTML');
+      const htmlContent = getHtmlStringOutput(output, 'outerHTML');
       expect(htmlContent).toBe('<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title" level="0"><span>Another Title</span></span>');
     });
 
@@ -148,7 +148,7 @@ describe('GroupItemMetadataProvider Service', () => {
       const fragment = document.createDocumentFragment();
       fragment.textContent = 'Fragment Title';
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: fragment }, gridStub) as DocumentFragment;
-      const htmlContent = getHTMLFromFragment(output, 'outerHTML');
+      const htmlContent = getHtmlStringOutput(output, 'outerHTML');
       expect(htmlContent).toBe('<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title" level="0">Fragment Title</span>');
     });
 
@@ -156,7 +156,7 @@ describe('GroupItemMetadataProvider Service', () => {
       service.init(gridStub);
       service.setOptions({ enableExpandCollapse: true, toggleCssClass: 'groupy-toggle', toggleExpandedCssClass: 'groupy-expanded' });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { level: 2, title: 'Some Title' }, gridStub) as DocumentFragment;
-      const htmlContent = getHTMLFromFragment(output, 'outerHTML');
+      const htmlContent = getHtmlStringOutput(output, 'outerHTML');
       expect(htmlContent).toBe('<span class="groupy-toggle groupy-expanded" aria-expanded="true" style="margin-left: 30px;"></span><span class="slick-group-title" level="2">Some Title</span>');
     });
 
@@ -164,7 +164,7 @@ describe('GroupItemMetadataProvider Service', () => {
       service.init(gridStub);
       service.setOptions({ enableExpandCollapse: true, toggleCssClass: 'groupy-toggle', toggleCollapsedCssClass: 'groupy-collapsed' });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { collapsed: true, level: 3, title: 'Some Title' }, gridStub) as DocumentFragment;
-      const htmlContent = [].map.call(output.childNodes, x => x.outerHTML).join('')
+      const htmlContent = [].map.call(output.childNodes, x => x.outerHTML).join('');
       expect(htmlContent).toBe('<span class="groupy-toggle groupy-collapsed" aria-expanded="false" style="margin-left: 45px;"></span><span class="slick-group-title" level="3">Some Title</span>');
     });
   });

--- a/packages/common/src/extensions/slickAutoTooltip.ts
+++ b/packages/common/src/extensions/slickAutoTooltip.ts
@@ -1,5 +1,5 @@
 
-import { stripTags } from '@slickgrid-universal/utils';
+import { getHtmlStringOutput, stripTags } from '@slickgrid-universal/utils';
 
 import type { AutoTooltipOption, Column } from '../interfaces/index';
 import { SlickEventHandler, type SlickEventData, type SlickGrid } from '../core/index';
@@ -101,7 +101,7 @@ export class SlickAutoTooltip {
       node = targetElm.closest<HTMLDivElement>('.slick-header-column');
       if (node && !(column?.toolTip)) {
         const titleVal = (targetElm.clientWidth < node.clientWidth) ? column?.name ?? '' : '';
-        node.title = titleVal instanceof HTMLElement ? stripTags(titleVal.innerHTML) : titleVal;
+        node.title = stripTags(getHtmlStringOutput(titleVal, 'innerHTML'));
       }
     }
     node = null;

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -1,4 +1,4 @@
-import { createDomElement, stripTags } from '@slickgrid-universal/utils';
+import { createDomElement, getHtmlStringOutput, stripTags } from '@slickgrid-universal/utils';
 
 import type { Column, ExcelCopyBufferOption, ExternalCopyClipCommand, OnEventArgs } from '../interfaces/index';
 import { SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, SlickRange, SlickDataView, Utils as SlickUtils } from '../core/index';
@@ -105,14 +105,14 @@ export class SlickCellExternalCopyManager {
     this._grid.removeCellCssStyles(this._copiedCellStyleLayerKey);
   }
 
-  getHeaderValueForColumn(columnDef: Column) {
+  getHeaderValueForColumn(columnDef: Column): string {
     if (typeof this._addonOptions.headerColumnValueExtractor === 'function') {
-      const val = this._addonOptions.headerColumnValueExtractor(columnDef);
+      const val = getHtmlStringOutput(this._addonOptions.headerColumnValueExtractor(columnDef), 'innerHTML');
       if (val) {
-        return (val instanceof HTMLElement) ? stripTags(val.innerHTML) : val;
+        return stripTags(val);
       }
     }
-    return columnDef.name instanceof HTMLElement ? stripTags(columnDef.name.innerHTML) : columnDef.name;
+    return getHtmlStringOutput(columnDef.name || '', 'innerHTML');
   }
 
   getDataItemValueForColumn(item: any, columnDef: Column, event: SlickEventData) {

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -202,6 +202,25 @@ export class SlickCheckboxSelectColumn<T = any> {
     this._grid.setSelectedRows(newSelectedRows);
   }
 
+  /**
+   * use a DocumentFragment to return a fragment including an <input> then a <label> as siblings,
+   * the label is using `for` to link it to the input `id`
+   * @param {String} inputId - id to link the label
+   * @param {Boolean} checked - is the input checkbox checked?
+   * @returns
+   */
+  createCheckboxElement(inputId: string, checked = false) {
+    const fragmentElm = new DocumentFragment();
+    fragmentElm.appendChild(
+      createDomElement('input', { id: inputId, type: 'checkbox', checked, ariaChecked: String(checked) })
+    );
+    fragmentElm.appendChild(
+      createDomElement('label', { htmlFor: inputId })
+    );
+
+    return fragmentElm;
+  }
+
   getColumnDefinition(): Column {
     const columnId = String(this._addonOptions?.columnId ?? this._defaults.columnId);
 
@@ -321,25 +340,6 @@ export class SlickCheckboxSelectColumn<T = any> {
       return this._selectableOverride(row, dataContext, grid);
     }
     return true;
-  }
-
-  /**
-   * use a DocumentFragment to return a fragment including an <input> then a <label> as siblings,
-   * the label is using `for` to link it to the input `id`
-   * @param {String} inputId - id to link the label
-   * @param {Boolean} checked - is the input checkbox checked?
-   * @returns
-   */
-  protected createCheckboxElement(inputId: string, checked = false) {
-    const fragmentElm = new DocumentFragment();
-    fragmentElm.appendChild(
-      createDomElement('input', { id: inputId, type: 'checkbox', checked, ariaChecked: String(checked) })
-    );
-    fragmentElm.appendChild(
-      createDomElement('label', { htmlFor: inputId })
-    );
-
-    return fragmentElm;
   }
 
   protected createUID(): number {

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -209,7 +209,7 @@ export class SlickCheckboxSelectColumn<T = any> {
       id: columnId,
       name: (this._addonOptions.hideSelectAllCheckbox || this._addonOptions.hideInColumnTitleRow)
         ? this._addonOptions.name || ''
-        : `<input id="header-selector${this._selectAll_UID}" type="checkbox"><label for="header-selector${this._selectAll_UID}"></label>`,
+        : this.createCheckboxElement(`header-selector${this._selectAll_UID}`),
       toolTip: (this._addonOptions.hideSelectAllCheckbox || this._addonOptions.hideInColumnTitleRow) ? '' : this._addonOptions.toolTip,
       field: columnId,
       cssClass: this._addonOptions.cssClass,
@@ -311,7 +311,7 @@ export class SlickCheckboxSelectColumn<T = any> {
   protected checkboxSelectionFormatter(row: number, _cell: number, _val: any, _columnDef: Column, dataContext: any, grid: SlickGrid) {
     if (dataContext && this.checkSelectableOverride(row, dataContext, grid)) {
       const UID = this.createUID() + row;
-      return `<input id="selector${UID}" type="checkbox" ${this._selectedRowsLookup[row] ? `checked="checked" aria-checked="true"` : 'aria-checked="false"'}><label for="selector${UID}"></label>`;
+      return this.createCheckboxElement(`selector${UID}`, !!this._selectedRowsLookup[row]);
     }
     return null;
   }
@@ -321,6 +321,25 @@ export class SlickCheckboxSelectColumn<T = any> {
       return this._selectableOverride(row, dataContext, grid);
     }
     return true;
+  }
+
+  /**
+   * use a DocumentFragment to return a fragment including an <input> then a <label> as siblings,
+   * the label is using `for` to link it to the input `id`
+   * @param {String} inputId - id to link the label
+   * @param {Boolean} checked - is the input checkbox checked?
+   * @returns
+   */
+  protected createCheckboxElement(inputId: string, checked = false) {
+    const fragmentElm = new DocumentFragment();
+    fragmentElm.appendChild(
+      createDomElement('input', { id: inputId, type: 'checkbox', checked, ariaChecked: String(checked) })
+    );
+    fragmentElm.appendChild(
+      createDomElement('label', { htmlFor: inputId })
+    );
+
+    return fragmentElm;
   }
 
   protected createUID(): number {

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -553,10 +553,9 @@ export class SlickCheckboxSelectColumn<T = any> {
   }
 
   protected renderSelectAllCheckbox(isSelectAllChecked: boolean) {
-    const checkedStr = isSelectAllChecked ? ` checked="checked" aria-checked="true"` : ' aria-checked="false"';
     this._grid.updateColumnHeader(
       this._addonOptions.columnId || '',
-      `<input id="header-selector${this._selectAll_UID}" type="checkbox"${checkedStr}><label for="header-selector${this._selectAll_UID}"></label>`,
+      this.createCheckboxElement(`header-selector${this._selectAll_UID}`, !!isSelectAllChecked),
       this._addonOptions.toolTip
     );
   }

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -1,6 +1,6 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
 import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import { createDomElement, emptyElement, findWidthOrDefault } from '@slickgrid-universal/utils';
+import { createDomElement, emptyElement, findWidthOrDefault, getHtmlStringOutput } from '@slickgrid-universal/utils';
 
 import type { Column, ColumnPickerOption, DOMMouseOrTouchEvent, GridOption, OnColumnsChangedArgs } from '../interfaces/index';
 import type { ExtensionUtility } from '../extensions/extensionUtility';
@@ -46,7 +46,7 @@ export class SlickColumnPicker {
     forceFitTitle: 'Force fit columns',
     minHeight: 200,
     syncResizeTitle: 'Synchronous resize',
-    headerColumnValueExtractor: (columnDef: Column) => columnDef.name
+    headerColumnValueExtractor: (columnDef: Column) => getHtmlStringOutput(columnDef.name || '', 'innerHTML')
   } as ColumnPickerOption;
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -1,5 +1,5 @@
 import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import { calculateAvailableSpace, createDomElement, emptyElement, findWidthOrDefault, getOffset, classNameToList, } from '@slickgrid-universal/utils';
+import { calculateAvailableSpace, createDomElement, emptyElement, findWidthOrDefault, getOffset, classNameToList, getHtmlStringOutput, } from '@slickgrid-universal/utils';
 
 import type {
   Column,
@@ -70,7 +70,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     resizeOnShowHeaderRow: false,
     syncResizeTitle: 'Synchronous resize',
     subMenuOpenByEvent: 'mouseover',
-    headerColumnValueExtractor: (columnDef: Column) => columnDef.name
+    headerColumnValueExtractor: (columnDef: Column) => getHtmlStringOutput(columnDef.name || '', 'innerHTML')
   } as GridMenuOption;
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -1,4 +1,4 @@
-import { getHTMLFromFragment } from '@slickgrid-universal/utils';
+import { getHtmlStringOutput } from '@slickgrid-universal/utils';
 
 import { Column, FormatterResultWithHtml, GridOption } from '../../interfaces/index';
 import { treeFormatter } from '../treeFormatter';
@@ -54,7 +54,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span>`);
   });
 
@@ -71,7 +71,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, dataset[6]['firstName'], {} as Column, dataset[6], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-1');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="1">Bobby</span>`);
   });
 
@@ -79,7 +79,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, dataset[5]['firstName'], {} as Column, dataset[5], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-3');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 45px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="3">Sponge</span>`);
   });
 
@@ -87,7 +87,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, dataset[1]['firstName'], {} as Column, dataset[1], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-1');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1">Jane</span>`);
   });
 
@@ -95,7 +95,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, dataset[4]['firstName'], {} as Column, dataset[4], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous</span>`);
   });
 
@@ -111,7 +111,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, { ...dataset[1]['firstName'], indent: 1 }, { field: 'firstName' } as Column, dataset[1], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-1');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1"><span class="mdi mdi-subdirectory-arrow-right"></span>Jane</span>`);
   });
 
@@ -120,7 +120,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, null, mockColumn as Column, dataset[3], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara Cane</span>`);
   });
 
@@ -129,7 +129,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, null, mockColumn as Column, dataset[4], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous &lt; Doe</span>`);
   });
 
@@ -138,7 +138,7 @@ describe('Tree Formatter', () => {
     const output = treeFormatter(1, 1, null, mockColumn as Column, dataset[3], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');
-    expect(getHTMLFromFragment(output.html as DocumentFragment, 'outerHTML'))
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML'))
       .toEqual(`<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">444444</span>`);
   });
 });

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -1,4 +1,4 @@
-import { getHTMLFromFragment, isPrimitiveOrHTML, stripTags } from '@slickgrid-universal/utils';
+import { getHtmlStringOutput, isPrimitiveOrHTML, stripTags } from '@slickgrid-universal/utils';
 import moment from 'moment-mini';
 
 import { FieldType } from '../enums/fieldType.enum';
@@ -185,11 +185,7 @@ export function parseFormatterWhenExist<T = any>(formatter: Formatter<T> | undef
   if (typeof formatter === 'function') {
     const formattedData = formatter(row, col, cellValue, columnDef, dataContext, grid);
     const cellResult = isPrimitiveOrHTML(formattedData) ? formattedData : (formattedData as FormatterResultWithHtml).html || (formattedData as FormatterResultWithText).text;
-    if (cellResult instanceof DocumentFragment) {
-      output = getHTMLFromFragment(cellResult);
-    } else {
-      output = (cellResult instanceof HTMLElement) ? cellResult.innerHTML : cellResult as string;
-    }
+    output = getHtmlStringOutput(cellResult as string | HTMLElement | DocumentFragment);
   } else {
     output = ((!dataContext?.hasOwnProperty(fieldProperty as keyof T)) ? '' : cellValue) as string;
   }

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -222,7 +222,7 @@ export interface Column<T = any> {
   originalWidth?: number;
 
   /** Column Title Name to be displayed in the Grid (UI) */
-  name?: string | HTMLElement;
+  name?: string | HTMLElement | DocumentFragment;
 
   /** Alternative Column Title Name that could be used by the Composite Editor Modal, it has precedence over the column "name" property. */
   nameCompositeEditor?: string;

--- a/packages/common/src/interfaces/columnPicker.interface.ts
+++ b/packages/common/src/interfaces/columnPicker.interface.ts
@@ -43,7 +43,7 @@ export interface ColumnPickerOption {
   syncResizeTitle?: string;
 
   /** Callback method to override the column name output used by the ColumnPicker/GridMenu. */
-  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string | HTMLElement;
+  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string | HTMLElement | DocumentFragment;
 }
 
 export interface OnColumnsChangedArgs {

--- a/packages/common/src/interfaces/excelCopyBufferOption.interface.ts
+++ b/packages/common/src/interfaces/excelCopyBufferOption.interface.ts
@@ -44,7 +44,7 @@ export interface ExcelCopyBufferOption<T = any> {
   readOnlyMode?: boolean;
 
   /** option to specify a custom column header value extractor function */
-  headerColumnValueExtractor?: (columnDef: Column<T>) => any;
+  headerColumnValueExtractor?: (columnDef: Column<T>) => string | HTMLElement | DocumentFragment;
 
   // --
   // Events

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -158,7 +158,7 @@ export interface GridMenuOption {
   // action/override callbacks
 
   /** Callback method to override the column name output used by the ColumnPicker/GridMenu. */
-  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string | HTMLElement;
+  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string | HTMLElement | DocumentFragment;
 
   /** Callback method that user can override the default behavior of enabling/disabling an item from the list. */
   menuUsabilityOverride?: (args: MenuCallbackArgs<any>) => boolean;

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -1,5 +1,5 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { deepCopy, deepMerge, emptyObject, setDeepValue, classNameToList } from '@slickgrid-universal/utils';
+import { deepCopy, deepMerge, emptyObject, setDeepValue, classNameToList, getHtmlStringOutput } from '@slickgrid-universal/utils';
 import type {
   Column,
   CompositeEditorLabel,
@@ -814,7 +814,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     }
 
     const columnLabel = columnGroup ? `${columnGroup}${columnGroupSeparator}${columnName}` : columnName;
-    return columnLabel instanceof HTMLElement ? columnLabel.innerHTML : columnLabel || '';
+    return getHtmlStringOutput(columnLabel, 'innerHTML');
   }
 
   /** Get the correct label text depending, if we use a Translater Service then translate the text when possible else use default text */

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -28,7 +28,7 @@ import {
   getTranslationPrefix,
   isColumnDateType,
 } from '@slickgrid-universal/common';
-import { addWhiteSpaces, deepCopy, stripTags, titleCase } from '@slickgrid-universal/utils';
+import { addWhiteSpaces, deepCopy, getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
 
 import { ExcelCellFormat, ExcelMetadata, ExcelStylesheet, } from './interfaces/index';
 import {
@@ -439,7 +439,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
         if ((columnDef.nameKey || columnDef.nameKey) && this._gridOptions.enableTranslate && this._translaterService?.translate) {
           headerTitle = this._translaterService.translate((columnDef.nameKey || columnDef.nameKey));
         } else {
-          headerTitle = (columnDef.name instanceof HTMLElement ? columnDef.name.innerHTML : columnDef.name) || titleCase(columnDef.field);
+          headerTitle = getHtmlStringOutput(columnDef.name || '', 'innerHTML') || titleCase(columnDef.field);
         }
         const skippedField = columnDef.excludeFromExport || false;
 

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -27,7 +27,7 @@ import {
   OperatorType,
   SortDirection,
 } from '@slickgrid-universal/common';
-import { stripTags } from '@slickgrid-universal/utils';
+import { getHtmlStringOutput, stripTags } from '@slickgrid-universal/utils';
 
 import {
   GraphqlCursorPaginationOption,
@@ -417,7 +417,7 @@ export class GraphqlService implements BackendService {
         }
 
         if (this.options?.useVerbatimSearchTerms || columnFilter.verbatimSearchTerms) {
-          searchByArray.push({ field: fieldName, operator: columnFilter.operator, value: JSON.stringify(columnFilter.searchTerms) });
+          searchByArray.push({ field: getHtmlStringOutput(fieldName), operator: columnFilter.operator, value: JSON.stringify(columnFilter.searchTerms) });
           continue;
         }
 
@@ -488,8 +488,8 @@ export class GraphqlService implements BackendService {
         if (searchTerms && searchTerms.length > 1 && (operator === 'IN' || operator === 'NIN' || operator === 'NOT_IN')) {
           searchValue = searchTerms.join(',');
         } else if (searchTerms && searchTerms.length === 2 && (operator === OperatorType.rangeExclusive || operator === OperatorType.rangeInclusive)) {
-          searchByArray.push({ field: fieldName, operator: (operator === OperatorType.rangeInclusive ? 'GE' : 'GT'), value: searchTerms[0] });
-          searchByArray.push({ field: fieldName, operator: (operator === OperatorType.rangeInclusive ? 'LE' : 'LT'), value: searchTerms[1] });
+          searchByArray.push({ field: getHtmlStringOutput(fieldName), operator: (operator === OperatorType.rangeInclusive ? 'GE' : 'GT'), value: searchTerms[0] });
+          searchByArray.push({ field: getHtmlStringOutput(fieldName), operator: (operator === OperatorType.rangeInclusive ? 'LE' : 'LT'), value: searchTerms[1] });
           continue;
         }
 
@@ -499,7 +499,7 @@ export class GraphqlService implements BackendService {
         }
 
         // build the search array
-        searchByArray.push({ field: fieldName, operator: mapOperatorType(operator), value: searchValue });
+        searchByArray.push({ field: getHtmlStringOutput(fieldName), operator: mapOperatorType(operator), value: searchValue });
       }
     }
 

--- a/packages/odata/src/services/grid-odata.service.ts
+++ b/packages/odata/src/services/grid-odata.service.ts
@@ -28,7 +28,7 @@ import {
   parseUtcDate,
   SortDirection,
 } from '@slickgrid-universal/common';
-import { stripTags, titleCase } from '@slickgrid-universal/utils';
+import { getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
 import { OdataQueryBuilderService } from './odataQueryBuilder.service';
 import { OdataOption, OdataSortingOption } from '../interfaces/index';
 
@@ -353,7 +353,7 @@ export class GridOdataService implements BackendService {
 
         // no need to query if search value is empty
         if (fieldName && searchValue === '' && searchTerms.length <= 1) {
-          this.removeColumnFilter(fieldName);
+          this.removeColumnFilter(getHtmlStringOutput(fieldName));
           continue;
         }
 
@@ -399,7 +399,7 @@ export class GridOdataService implements BackendService {
         if (bypassOdataQuery) {
           // push to our temp array and also trim white spaces
           if (fieldName) {
-            this.saveColumnFilter(fieldName, fieldSearchValue, searchTerms);
+            this.saveColumnFilter(getHtmlStringOutput(fieldName), fieldSearchValue, searchTerms);
           }
         } else {
           // Normalize all search values
@@ -414,7 +414,7 @@ export class GridOdataService implements BackendService {
 
           // titleCase the fieldName so that it matches the WebApi names
           if (this._odataService.options.caseType === CaseType.pascalCase) {
-            fieldName = titleCase(fieldName || '');
+            fieldName = titleCase(getHtmlStringOutput(fieldName || ''));
           }
 
           if (searchTerms && searchTerms.length > 1 && (operator === 'IN' || operator === 'NIN' || operator === 'NOTIN' || operator === 'NOT IN' || operator === 'NOT_IN')) {
@@ -441,7 +441,7 @@ export class GridOdataService implements BackendService {
             searchBy = (operator === '*' || operator === '*z' || operator === OperatorType.endsWith) ? `endswith(${fieldName}, ${searchValue})` : `startswith(${fieldName}, ${searchValue})`;
           } else if (operator === OperatorType.rangeExclusive || operator === OperatorType.rangeInclusive) {
             // example:: (Name >= 'Bob' and Name <= 'Jane')
-            searchBy = this.filterBySearchTermRange(fieldName, operator, searchTerms);
+            searchBy = this.filterBySearchTermRange(getHtmlStringOutput(fieldName), operator, searchTerms);
           } else if ((operator === '' || operator === OperatorType.contains || operator === OperatorType.notContains) &&
             (fieldType === FieldType.string || fieldType === FieldType.text || fieldType === FieldType.readonly)) {
             searchBy = odataVersion >= 4 ? `contains(${fieldName}, ${searchValue})` : `substringof(${searchValue}, ${fieldName})`;
@@ -456,7 +456,7 @@ export class GridOdataService implements BackendService {
           // push to our temp array and also trim white spaces
           if (searchBy !== '') {
             searchByArray.push(searchBy.trim());
-            this.saveColumnFilter(fieldName || '', fieldSearchValue, searchValue);
+            this.saveColumnFilter(getHtmlStringOutput(fieldName || ''), fieldSearchValue, searchValue);
           }
         }
       }

--- a/packages/text-export/src/textExport.service.ts
+++ b/packages/text-export/src/textExport.service.ts
@@ -22,7 +22,7 @@ import {
   getTranslationPrefix,
   htmlEntityDecode,
 } from '@slickgrid-universal/common';
-import { addWhiteSpaces, deepCopy, stripTags, titleCase } from '@slickgrid-universal/utils';
+import { addWhiteSpaces, deepCopy, getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
 
 const DEFAULT_EXPORT_OPTIONS: TextExportOption = {
   delimiter: DelimiterType.comma,
@@ -314,7 +314,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
         if ((columnDef.nameKey || columnDef.nameKey) && this._gridOptions.enableTranslate && this._translaterService?.translate && this._translaterService?.getCurrentLanguage?.()) {
           headerTitle = this._translaterService.translate((columnDef.nameKey || columnDef.nameKey));
         } else {
-          headerTitle = (columnDef.name instanceof HTMLElement ? columnDef.name.innerHTML : columnDef.name) || titleCase(columnDef.field);
+          headerTitle = getHtmlStringOutput(columnDef.name || '', 'innerHTML') || titleCase(columnDef.field);
         }
         const skippedField = columnDef.excludeFromExport || false;
 

--- a/packages/utils/src/__tests__/domUtils.spec.ts
+++ b/packages/utils/src/__tests__/domUtils.spec.ts
@@ -9,6 +9,7 @@ import {
   findFirstAttribute,
   findWidthOrDefault,
   getHTMLFromFragment,
+  getHtmlStringOutput,
   getOffsetRelativeToParent,
   getStyleProp,
   getOffset,
@@ -104,8 +105,8 @@ describe('Service/domUtilies', () => {
       destroyAllElementProps(obj);
 
       expect(obj).toEqual({ age: 20, elm: null, elms: [null] });
-    })
-  })
+    });
+  });
 
   describe('emptyElement() method', () => {
     const div = document.createElement('div');
@@ -154,7 +155,7 @@ describe('Service/domUtilies', () => {
     });
   });
 
-  describe('getHTMLFromFragment() method', () => {
+  describe('getHtmlStringOutput() method', () => {
     it('should return innerHTML from fragment', () => {
       const div = document.createElement('div');
       const span = document.createElement('span');
@@ -163,9 +164,11 @@ describe('Service/domUtilies', () => {
       div.appendChild(span);
       fragment.appendChild(div);
 
-      const result = getHTMLFromFragment(fragment);
+      const result1 = getHTMLFromFragment(fragment); // deprecated
+      const result2 = getHtmlStringOutput(fragment);
 
-      expect(result).toBe('<span>some text</span>');
+      expect(result1).toBe('<span>some text</span>');
+      expect(result2).toBe('<span>some text</span>');
     });
 
     it('should return outerHTML from fragment', () => {
@@ -176,18 +179,18 @@ describe('Service/domUtilies', () => {
       div.appendChild(span);
       fragment.appendChild(div);
 
-      const result = getHTMLFromFragment(fragment, 'outerHTML');
+      const result = getHtmlStringOutput(fragment, 'outerHTML');
 
       expect(result).toBe('<div><span>some text</span></div>');
     });
 
-    it('should return same input when it is not an instance of DocumentFragment', () => {
+    it('should return innerHTML of input div when input is a div and no argument type is provided, defaults to innerHTML', () => {
       const div = document.createElement('div');
       const span = document.createElement('span');
       span.textContent = 'some text';
       div.appendChild(span);
 
-      expect(getHTMLFromFragment(div as any)).toEqual(div);
+      expect(getHtmlStringOutput(div as any)).toEqual('<span>some text</span>');
     });
   });
 

--- a/packages/utils/src/__tests__/domUtils.spec.ts
+++ b/packages/utils/src/__tests__/domUtils.spec.ts
@@ -192,6 +192,12 @@ describe('Service/domUtilies', () => {
 
       expect(getHtmlStringOutput(div as any)).toEqual('<span>some text</span>');
     });
+
+    it('should return same string when input is already an HTML string', () => {
+      const input = '<span>some text</span>';
+
+      expect(getHtmlStringOutput(input)).toEqual(input);
+    });
   });
 
   describe('getElementOffsetRelativeToParent() method', () => {

--- a/packages/utils/src/domUtils.ts
+++ b/packages/utils/src/domUtils.ts
@@ -98,14 +98,29 @@ export function emptyElement<T extends Element = Element>(element?: T | null): T
 }
 
 /**
- * From a DocumentFragment, get the innerHTML or outerHTML of all child elements.
- * We can get the HTML by looping through all fragment `childNodes`
+ * @deprecated @see `getHtmlStringOutput()`
+ * This function is now deprecated and is an alias to the new `getHtmlStringOutput()`, so please use this new function instead which works with various type of inputs.
  */
-export function getHTMLFromFragment(input: DocumentFragment, type: 'innerHTML' | 'outerHTML' = 'innerHTML'): string {
+export function getHTMLFromFragment(input: DocumentFragment | HTMLElement | string | number, type: 'innerHTML' | 'outerHTML' = 'innerHTML'): string {
+  return getHtmlStringOutput(input, type);
+}
+
+/**
+ * From any input provided, return the HTML string (when a string is provided, it will be returned "as is" but when it's a number it will be converted to string)
+ * When detecting HTMLElement/DocumentFragment, we can also specify which HTML type to retrieve innerHTML or outerHTML.
+ * We can get the HTML by looping through all fragment `childNodes`
+ * @param {DocumentFragment | HTMLElement | string | number} input
+ * @param {'innerHTML' | 'outerHTML'} [type] - when the input is a DocumentFragment or HTMLElement, which type of HTML do you want to return? 'innerHTML' or 'outerHTML'
+ * @returns {String}
+ */
+export function getHtmlStringOutput(input: DocumentFragment | HTMLElement | string | number, type: 'innerHTML' | 'outerHTML' = 'innerHTML'): string {
   if (input instanceof DocumentFragment) {
+    // a DocumentFragment doesn't have innerHTML/outerHTML, but we can loop through all children and concatenate them all to an HTML string
     return [].map.call(input.childNodes, (x: HTMLElement) => x[type]).join('') || input.textContent || '';
+  } else if (input instanceof HTMLElement) {
+    return input[type];
   }
-  return input;
+  return String(input ?? ''); // reaching this line means it's already a string (or number) so just return it as string
 }
 
 /** Get offset of HTML element relative to a parent element */

--- a/packages/utils/src/stripTagsUtil.ts
+++ b/packages/utils/src/stripTagsUtil.ts
@@ -1,12 +1,13 @@
 /**
- * This stripTags function is a lib that already existed
- * but was not TypeScript and ESM friendly.
- * So I ported the code into the project and removed any old code like IE11 that we don't need for our project.
- * I also accept more input types without throwing, the code below accepts `string | number | boolean | HTMLElement` while original code only accepted string.
+ * This stripTags function is a lib that already existed on NPM
+ * but was not written as TypeScript and was not ESM friendly.
+ * So I ported the code into the project and removed any legacy browser code that we don't need for our project since we dropped IE browsers support.
+ * The function also accept more input types without throwing like the original one does,
+ * the code below accepts `string | number | boolean | HTMLElement` while original code only accepted string.
  *
  * The previous lib can be found here at this Github link:
  *     https://github.com/ericnorris/striptags/
- * With an MIT licence that and can be found at
+ * With an MIT licence that and can be found at this link:
  *     https://github.com/ericnorris/striptags/blob/main/LICENSE
  */
 


### PR DESCRIPTION
- change Column interface `name` to also accept `DocumentFragment`
- change `headerColumnValueExtractor` to also accept `DocumentFragment`
- add `getHtmlStringOutput()` util to get HTML from any type of input (string, number, HTMLElement or DocumentFragment), which is especially useful with `DocumentFragment` which doesn't return HTML by default

I think (hope) this is the last piece to convert to native element for CSP safe approach