### PR TITLE
fix: SlickEmptyWarningComponent should accept native HTML

### DIFF
--- a/packages/common/src/interfaces/emptyWarning.interface.ts
+++ b/packages/common/src/interfaces/emptyWarning.interface.ts
@@ -1,6 +1,6 @@
 export interface EmptyWarning {
   /** Empty data warning message, defaults to "No data to display." */
-  message: string;
+  message: string | HTMLElement | DocumentFragment;
 
   /** Empty data warning message translation key, defaults to "EMPTY_DATA_WARNING_MESSAGE" */
   messageKey?: string;

--- a/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
+++ b/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
@@ -1,5 +1,10 @@
-import type { GridOption } from '@slickgrid-universal/common';
+import { createDomElement, type GridOption } from '@slickgrid-universal/common';
 import { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
+
+// create empty warning message as Document Fragment to be CSP safe
+const emptyWarningElm = new DocumentFragment();
+emptyWarningElm.appendChild(createDomElement('span', { className: 'mdi mdi-alert color-warning' }));
+emptyWarningElm.appendChild(document.createTextNode(' No data to display.'));
 
 /** Global Grid Options Defaults for Salesforce */
 export const SalesforceGlobalGridOptions = {
@@ -20,7 +25,7 @@ export const SalesforceGlobalGridOptions = {
   },
   datasetIdPropertyName: 'Id',
   emptyDataWarning: {
-    message: `<span class="mdi mdi-alert color-warning"></span> No data to display.`,
+    message: emptyWarningElm
   },
   enableDeepCopyDatasetOnPageLoad: true,
   enableTextExport: true,


### PR DESCRIPTION
- we should be able to pass `HTMLElement`/`DocumentFragment` to empty warning `message` option