### PR TITLE
chore: remove `getCellFromPoint()` unreachable code

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4962,9 +4962,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (row < -1) {
       row = -1;
     }
-    if (cell < -1) {
-      cell = -1;
-    }
 
     return { row, cell };
   }


### PR DESCRIPTION
- since we always assign `cell = 0` at the start, the `cell < -1` is technically unreachable, so there's no need to keep it