### PR TITLE
fix: when `onResizeStart` return false it should stop

### DIFF
--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -230,18 +230,20 @@ export function Resizable(options: ResizableOption) {
 
   function executeResizeCallbackWhenDefined(callback?: (e: MouseEvent | TouchEvent, resizeElms: { resizeableElement: HTMLElement; resizeableHandleElement: HTMLElement; }) => boolean | void, e?: MouseEvent | TouchEvent | Touch) {
     if (typeof callback === 'function') {
-      callback(e as any, { resizeableElement, resizeableHandleElement });
+      return callback(e as any, { resizeableElement, resizeableHandleElement });
     }
   }
 
   function resizeStartHandler(e: MouseEvent | TouchEvent) {
     e.preventDefault();
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
-    executeResizeCallbackWhenDefined(onResizeStart, event);
-    document.body.addEventListener('mousemove', resizingHandler);
-    document.body.addEventListener('mouseup', resizeEndHandler);
-    document.body.addEventListener('touchmove', resizingHandler);
-    document.body.addEventListener('touchend', resizeEndHandler);
+    const result = executeResizeCallbackWhenDefined(onResizeStart, event);
+    if (result !== false) {
+      document.body.addEventListener('mousemove', resizingHandler);
+      document.body.addEventListener('mouseup', resizeEndHandler);
+      document.body.addEventListener('touchmove', resizingHandler);
+      document.body.addEventListener('touchend', resizeEndHandler);
+    }
   }
 
   function resizingHandler(e: MouseEvent | TouchEvent) {


### PR DESCRIPTION
- when `onResizeStart` returns `false`, for example when editor `commitCurrentEdit()` fails, then the column resize shouldn't be allowed

https://github.com/ghiscoding/slickgrid-universal/blob/bc4402a1ee53de0e4333a8900e95207ec9b39cde/packages/common/src/core/slickGrid.ts#L1906-L1910

![brave_I40YFJ1bdv](https://github.com/ghiscoding/slickgrid-universal/assets/643976/9a88dfc0-3f8f-49e3-b500-9fb16373309f)
