### PR TITLE
perf(resizer): `autosizeColumns` is called too many times on page load

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1,11 +1,12 @@
 import { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
+import { createDomElement } from '@slickgrid-universal/utils';
+
 import { CheckboxEditor, InputEditor, LongTextEditor } from '../../editors';
 import { SlickCellSelectionModel, SlickRowSelectionModel } from '../../extensions';
 import { Column, Editor, FormatterResultWithHtml, FormatterResultWithText, GridOption, type EditCommand } from '../../interfaces';
 import { SlickEventData, SlickGlobalEditorLock } from '../slickCore';
 import { SlickDataView } from '../slickDataview';
 import { SlickGrid } from '../slickGrid';
-import { createDomElement } from '@slickgrid-universal/utils';
 
 jest.useFakeTimers();
 

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -348,10 +348,13 @@ export class ResizerService {
       }
 
       // also call the grid auto-size columns so that it takes available space when going bigger
-      if (this.gridOptions?.enableAutoSizeColumns && this._grid.autosizeColumns) {
+      if (this._grid && this.gridOptions?.enableAutoSizeColumns) {
         // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree) to avoid SlickGrid error "missing stylesheet"
         if (this.gridUid && document.querySelector(this.gridUidSelector)) {
-          this._grid.autosizeColumns();
+          // don't call autosize unless dimension really changed
+          if (!this._lastDimensions || this._lastDimensions.height !== newHeight || this._lastDimensions.width !== newWidth) {
+            this._grid.autosizeColumns();
+          }
         }
       } else if (this.gridOptions.enableAutoResizeColumnsByCellContent && (!this._lastDimensions?.width || newWidth !== this._lastDimensions?.width)) {
         // we can call our resize by content here (when enabled)

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -518,7 +518,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
-        expect(autosizeSpy).toHaveBeenCalledTimes(3); // 1x by datasetChanged and 2x by bindResizeHook
+        expect(autosizeSpy).toHaveBeenCalledTimes(1); // 1x by datasetChanged and 2x by bindResizeHook
         expect(refreshSpy).toHaveBeenCalledWith(mockData);
       });
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -508,6 +508,20 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         sharedService.slickGrid = mockGrid as unknown as SlickGrid;
       });
 
+      it('should expect "autosizeColumns" being called when "autoFitColumnsOnFirstLoad" is set we udpated the dataset', () => {
+        const autosizeSpy = jest.spyOn(mockGrid, 'autosizeColumns');
+        const refreshSpy = jest.spyOn(component, 'refreshGridData');
+        const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
+        jest.spyOn(mockDataView, 'getLength').mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValueOnce(mockData.length);
+
+        component.gridOptions = { autoFitColumnsOnFirstLoad: true };
+        component.initialization(divContainer, slickEventHandler);
+        component.setData(mockData, true); // manually force an autoresize
+
+        expect(autosizeSpy).toHaveBeenCalledTimes(2); // 1x by datasetChanged and 1x by bindResizeHook
+        expect(refreshSpy).toHaveBeenCalledWith(mockData);
+      });
+
       it('should expect "autosizeColumns" being called when "autoFitColumnsOnFirstLoad" is set and we are on first page load', () => {
         const autosizeSpy = jest.spyOn(mockGrid, 'autosizeColumns');
         const refreshSpy = jest.spyOn(component, 'refreshGridData');
@@ -518,7 +532,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
         component.dataset = mockData;
 
-        expect(autosizeSpy).toHaveBeenCalledTimes(1); // 1x by datasetChanged and 2x by bindResizeHook
+        expect(autosizeSpy).toHaveBeenCalledTimes(1);
         expect(refreshSpy).toHaveBeenCalledWith(mockData);
       });
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1067,6 +1067,7 @@ export class SlickVanillaGridBundle<TData = any> {
   setData(data: TData[], shouldAutosizeColumns = false) {
     if (shouldAutosizeColumns) {
       this._isAutosizeColsCalled = false;
+      this._currentDatasetLength = 0;
     }
     this.dataset = data || [];
   }

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -383,7 +383,7 @@ export class SlickVanillaGridBundle<TData = any> {
 
     this.initialization(this._gridContainerElm, eventHandler);
     if (!hierarchicalDataset && !this.gridOptions.backendServiceApi) {
-      this.dataset = dataset || [];
+      this.setData(dataset || []);
       this._currentDatasetLength = this.dataset.length;
     }
   }
@@ -1062,6 +1062,13 @@ export class SlickVanillaGridBundle<TData = any> {
       this.slickGrid.setColumns(this.columnDefinitions);
     }
     return showing;
+  }
+
+  setData(data: TData[], shouldAutosizeColumns = false) {
+    if (shouldAutosizeColumns) {
+      this._isAutosizeColsCalled = false;
+    }
+    this.dataset = data || [];
   }
 
   /**


### PR DESCRIPTION
- when loading a new grid, we are calling `grid.autosizeColumns()` to resize the columns and while adding tests for that method I incidently discovered that it was being called multiple times on a page load (up to 6-8x times) but in reality there is no need to call it more than once or twice.
- there is also no need to call the `autosizeColumns` if the grid dimension calculated by the Resizer Service are the same as the previously calculated dimensions
- the updated code will never call `autosizeColumns` more than twice on a page load, however note that the method will always be called whenever the grid dimensions or columns get updated