### PR TITLE
chore(tests): add more rows to dataset to fix Cypress flakiness

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -74,7 +74,7 @@ export default class Example11 {
   isGridEditable = true;
   dropdownDeleteViewClass = 'dropdown-item dropdown-item-disabled';
   dropdownUpdateViewClass = 'dropdown-item dropdown-item-disabled';
-  editQueue: Array<{ item: any; column: Column; editCommand: EditCommand }> = [];
+  editQueue: Array<{ item: any; column: Column; editCommand: EditCommand; }> = [];
   editedItems = {};
   sgb: SlickVanillaGridBundle;
   gridContainerElm: HTMLDivElement;
@@ -116,7 +116,7 @@ export default class Example11 {
 
   attached() {
     this.initializeGrid();
-    this.dataset = this.loadData(500);
+    this.dataset = this.loadData(1000);
     this.gridContainerElm = document.querySelector(`.grid11`) as HTMLDivElement;
     this.viewSelectElm = document.querySelector('.selected-view') as HTMLSelectElement;
 
@@ -473,7 +473,7 @@ export default class Example11 {
     }
   }
 
-  remoteCallbackFn(args: { item: any, selectedIds: string[], updateType: 'selection' | 'mass' }) {
+  remoteCallbackFn(args: { item: any, selectedIds: string[], updateType: 'selection' | 'mass'; }) {
     const fields: Array<{ fieldName: string; value: any; }> = [];
     for (const key in args.item) {
       if (args.item.hasOwnProperty(key)) {

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -826,7 +826,7 @@ describe('Example 11 - Batch Editing', () => {
       .find('.slick-custom-footer')
       .find('.right-footer .item-count')
       .should($span => {
-        expect(Number($span.text())).to.eq(50);
+        expect(Number($span.text())).to.eq(100);
       });
   });
 });


### PR DESCRIPTION
- there was a condition check in the Cypress tests to assume that the first few rows have their value greater than x, but with a limited dataset that test was flaky and failing from time to time, doublding the dataset size will remove the flakiness