### PR TITLE
fix(styling): remove different bg-color on unorderable column

### DIFF
--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -35,7 +35,7 @@ $slick-container-border-left:                               0 none !default;
 $slick-grid-border-color:                                   fade(black, 3%) !default;
 $slick-grid-border-style:                                   solid !default;
 $slick-grid-header-background:                              rgba(255, 255, 255, .6) !default;
-$slick-grid-header-unorderable-bg-color:                    darken($slick-grid-header-background, 4%) !default;
+$slick-grid-header-unorderable-bg-color:                    $slick-grid-header-background !default;
 $slick-grid-cell-color:                                     rgb(255, 255, 255) !default;
 $slick-gray-dark:              			                        #333 !default;
 $slick-link-color:        				                          #08c !default;


### PR DESCRIPTION
It looks a little weird that the locked (unorderable) columns have different background-color especially when our grid doesn't have any borders around the headers. So I think it's better to remove it and fix the styling discrepancy by using the same bg-color for all column headers but keeping the SASS variable in case the user still want to change it

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/8b3a7027-a48c-4ec9-8f0f-4ce0d15246cc)
