### PR TITLE
perf(plugins): decrease number of calls to translate all extensions only once

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/translate.service.ts
+++ b/examples/vite-demo-vanilla-bundle/src/translate.service.ts
@@ -13,7 +13,7 @@ interface TranslateOptions {
 export class TranslateService implements TranslaterService {
   eventName = 'onLanguageChange' as TranslateServiceEventName;
   protected _currentLanguage = 'en';
-  protected _locales: { [language: string]: Locales } = {};
+  protected _locales: { [language: string]: Locales; } = {};
   protected _pubSubServices: PubSubService[] = [];
   protected _options;
   protected templateMatcher = /{{\s?([^{}\s]*)\s?}}/g;
@@ -82,17 +82,22 @@ export class TranslateService implements TranslaterService {
   }
 
   async use(newLang: string): Promise<Locales> {
+    const hasLangChanged = this._currentLanguage !== newLang;
     this._currentLanguage = newLang;
 
     // if it's already loaded in the cache, then resolve the locale set, else fetch it
     if (this._locales?.hasOwnProperty(newLang)) {
-      this.publishLanguageChangeEvent(newLang);
+      if (hasLangChanged) {
+        this.publishLanguageChangeEvent(newLang);
+      }
       return Promise.resolve(this._locales[newLang]);
     }
 
     const path = this._options.loadPath.replace(/{{lang}}/gi, newLang);
     const localeSet = await this.fetchLocales(path, newLang);
-    this.publishLanguageChangeEvent(newLang);
+    if (hasLangChanged) {
+      this.publishLanguageChangeEvent(newLang);
+    }
 
     return localeSet;
   }

--- a/packages/common/src/extensions/extensionUtility.ts
+++ b/packages/common/src/extensions/extensionUtility.ts
@@ -19,7 +19,7 @@ export class ExtensionUtility {
    * 3- else if nothing is provided use text defined as constants
    */
   getPickerTitleOutputString(propName: string, pickerName: 'gridMenu' | 'columnPicker') {
-    if (this.sharedService.gridOptions && this.sharedService.gridOptions.enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
+    if (this.sharedService.gridOptions?.enableTranslate && (!this.translaterService?.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
 

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -28,15 +28,6 @@ import {
 jest.mock('flatpickr', () => { });
 const GRID_UID = 'slickgrid_12345';
 
-const extensionUtilityStub = {
-  getPickerTitleOutputString: jest.fn(),
-  refreshBackendDataset: jest.fn(),
-  sortItems: jest.fn(),
-  translateItems: jest.fn(),
-  translateMenuItemsFromTitleKey: jest.fn(),
-  translateWhenEnabledAndServiceExist: jest.fn(),
-} as unknown as ExtensionUtility;
-
 const mockCellSelectionModel = {
   pluginName: 'CellSelectionModel',
   constructor: jest.fn(),
@@ -172,6 +163,7 @@ const extensionColumnPickerStub = {
 };
 
 describe('ExtensionService', () => {
+  let extensionUtility: ExtensionUtility;
   let sharedService: SharedService;
   let service: ExtensionService;
   let translateService: TranslateServiceStub;
@@ -181,9 +173,10 @@ describe('ExtensionService', () => {
       sharedService = new SharedService();
       translateService = new TranslateServiceStub();
       translateService.use('fr');
+      extensionUtility = new ExtensionUtility(sharedService, undefined, translateService);
 
       service = new ExtensionService(
-        extensionUtilityStub,
+        extensionUtility,
         filterServiceStub,
         pubSubServiceStub,
         sharedService,
@@ -351,7 +344,7 @@ describe('ExtensionService', () => {
         const extSpy = jest.spyOn(SlickRowBasedEdit.prototype, 'init').mockImplementation();
 
         service = new ExtensionService(
-          extensionUtilityStub,
+          extensionUtility,
           filterServiceStub,
           pubSubServiceStub,
           sharedService,
@@ -672,7 +665,7 @@ describe('ExtensionService', () => {
 
     it('should call the refreshBackendDataset method on the GridMenu Extension when service with same method name is called', () => {
       const gridOptionsMock = { enableGridMenu: true } as GridOption;
-      const extSpy = jest.spyOn(extensionUtilityStub, 'refreshBackendDataset');
+      const extSpy = jest.spyOn(extensionUtility, 'refreshBackendDataset');
       jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
 
       service.refreshBackendDataset();
@@ -917,8 +910,9 @@ describe('ExtensionService', () => {
   describe('without Translate Service', () => {
     beforeEach(() => {
       translateService = undefined as any;
+      extensionUtility = new ExtensionUtility(sharedService, undefined, translateService);
       service = new ExtensionService(
-        extensionUtilityStub,
+        extensionUtility,
         filterServiceStub,
         pubSubServiceStub,
         sharedService,

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -686,9 +686,7 @@ describe('ExtensionService', () => {
       const cellMenuSpy = jest.spyOn(service, 'translateCellMenu');
       const contextMenuSpy = jest.spyOn(service, 'translateContextMenu');
       const colHeaderSpy = jest.spyOn(service, 'translateColumnHeaders');
-      const colPickerSpy = jest.spyOn(service, 'translateColumnPicker');
       const contextSpy = jest.spyOn(service, 'translateContextMenu');
-      const gridMenuSpy = jest.spyOn(service, 'translateGridMenu');
       const headerMenuSpy = jest.spyOn(service, 'translateHeaderMenu');
 
       service.translateAllExtensions();
@@ -696,9 +694,7 @@ describe('ExtensionService', () => {
       expect(cellMenuSpy).toHaveBeenCalled();
       expect(contextMenuSpy).toHaveBeenCalled();
       expect(colHeaderSpy).toHaveBeenCalled();
-      expect(colPickerSpy).toHaveBeenCalled();
       expect(contextSpy).toHaveBeenCalled();
-      expect(gridMenuSpy).toHaveBeenCalled();
       expect(headerMenuSpy).toHaveBeenCalled();
     });
 

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -383,6 +383,7 @@ export class ExtensionService {
     this.translateRowEditPlugin();
 
     // translating column headers will also indirectly translate ColumnPicker & GridMenu since headers are updated
+    // also make this the last call since it will also indirectly call `grid.invalidate()` which we want to do at the end only
     this.translateColumnHeaders(lang);
   }
 
@@ -444,13 +445,11 @@ export class ExtensionService {
 
     // translate all column headers & header column group when defined
     this.translateItems(columnDefinitions, 'nameKey', 'name');
-    this.extensionUtility.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
-    this.extensionUtility.translateItems(this.sharedService.allColumns, 'columnGroupKey', 'columnGroup');
+    this.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
+    this.translateItems(this.sharedService.allColumns, 'columnGroupKey', 'columnGroup');
 
-    // re-render the column headers & then re-translate ColumnPicker/GridMenu
+    // re-render the column headers which will indirectly re-translate ColumnPicker/GridMenu
     this.renderColumnHeaders(columnDefinitions, Array.isArray(newColumnDefinitions));
-    this.translateColumnPicker();
-    this.translateGridMenu();
   }
 
   /**

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -461,7 +461,7 @@ export class ExtensionService {
     if (!collection) {
       collection = this.sharedService.columnDefinitions;
     }
-    if (Array.isArray(collection) && this.sharedService.slickGrid && this.sharedService.slickGrid.setColumns) {
+    if (Array.isArray(collection) && this.sharedService.slickGrid?.setColumns) {
       if (collection.length > this.sharedService.allColumns.length || forceColumnDefinitionsOverwrite) {
         this.sharedService.allColumns = collection;
       }
@@ -477,6 +477,7 @@ export class ExtensionService {
     // replace the Grid Menu columns array list
     if (this.gridOptions.enableGridMenu && this._gridMenuControl) {
       this._gridMenuControl.columns = this.sharedService.allColumns ?? [];
+      this._gridMenuControl.recreateGridMenu();
       this._gridMenuControl.translateGridMenu();
     }
   }
@@ -512,12 +513,6 @@ export class ExtensionService {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
 
-    if (Array.isArray(items)) {
-      items.forEach(item => {
-        if (item[inputKey]) {
-          item[outputKey] = this.translaterService?.translate(item[inputKey]);
-        }
-      });
-    }
+    this.extensionUtility.translateItems(items, inputKey, outputKey);
   }
 }

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -471,12 +471,13 @@ export class ExtensionService {
     // replace Column Picker columns with newer data which includes new translations
     if (this.gridOptions.enableColumnPicker && this._columnPickerControl) {
       this._columnPickerControl.columns = this.sharedService.allColumns;
+      this._columnPickerControl.translateColumnPicker();
     }
 
     // replace the Grid Menu columns array list
     if (this.gridOptions.enableGridMenu && this._gridMenuControl) {
       this._gridMenuControl.columns = this.sharedService.allColumns ?? [];
-      this._gridMenuControl.recreateGridMenu();
+      this._gridMenuControl.translateGridMenu();
     }
   }
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -737,17 +737,13 @@ export class SlickVanillaGridBundle<TData = any> {
     // translate them all on first load, then on each language change
     if (gridOptions.enableTranslate) {
       this.extensionService.translateAllExtensions();
-      this.translateColumnHeaderTitleKeys();
-      this.translateColumnGroupKeys();
     }
 
     // on locale change, we have to manually translate the Headers, GridMenu
     this.subscriptions.push(
-      this._eventPubSubService.subscribe('onLanguageChange', () => {
+      this._eventPubSubService.subscribe('onLanguageChange', (args: { language: string; }) => {
         if (gridOptions.enableTranslate) {
-          this.extensionService.translateAllExtensions();
-          this.translateColumnHeaderTitleKeys();
-          this.translateColumnGroupKeys();
+          this.extensionService.translateAllExtensions(args.language);
           if (gridOptions.createPreHeaderPanel && !gridOptions.enableDraggableGrouping) {
             this.groupingService.translateGroupingAndColSpan();
           }
@@ -1040,7 +1036,7 @@ export class SlickVanillaGridBundle<TData = any> {
       }
 
       if (this._gridOptions.enableTranslate) {
-        this.extensionService.translateColumnHeaders(false, newColumnDefinitions);
+        this.extensionService.translateColumnHeaders(undefined, newColumnDefinitions);
       } else {
         this.extensionService.renderColumnHeaders(newColumnDefinitions, true);
       }
@@ -1445,16 +1441,6 @@ export class SlickVanillaGridBundle<TData = any> {
 
       return { ...column, editor: columnEditor?.model, internalColumnEditor: { ...columnEditor } };
     });
-  }
-
-  /** translate all columns (including hidden columns) */
-  protected translateColumnHeaderTitleKeys() {
-    this.extensionUtility.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
-  }
-
-  /** translate all column groups (including hidden columns) */
-  protected translateColumnGroupKeys() {
-    this.extensionUtility.translateItems(this.sharedService.allColumns, 'columnGroupKey', 'columnGroup');
   }
 
   /**


### PR DESCRIPTION
found a couple of places in the code where it was translating the same things more than once
- `translateAllExtensions()` is calling translate on all extensions including a call to `translateColumnHeaders()` but that one was also calling GridMenu translates which was already translated, instead we can expect that `translateColumnHeaders()` should also indirectly translate both ColumnPicker/GridMenu only once inside `renderColumnHeaders()` when reassigning translated `columns`
- also `translateColumnHeaders()` will indirectly call a `grid.invalidate()` so I think this call should be made last in `translateAllExtensions()` so that everything else had a chance to be translated prior to reaching the invalidate
- `onLanguageChange` is calling `translateAllExtensions()` but was also calling `translateColumnHeaderTitleKeys()` and `translateColumnGroupKeys()`, however these last 2 were already covered by `translateColumnHeaders()` so they can be removed
- also a rare but potential infinite loop could happen if `translateColumnHeaders()` is provided with a lang, which then triggers a `onLanguageChange` which then calls back `translateColumnHeaders()` which could become infinite, so we should make sure that we only trigger a lang change event only when we see the lang being different
- another small perf improvement, there's no need to check if the translateXYZ methods exists on each extensions because we already know it exists (that code was put in place when we were using the external `6pac/SlickGrid` dependency, but now everything is internal and we know all these methods already exists since it must follow the interface), e.g.
```diff
translateGridMenu() {
-    this._gridMenuControl?.translateGridMenu?.();
+    this._gridMenuControl?.translateGridMenu();
}
```