### PR TITLE
perf: decrease calls to setItems & grid invalidate

### DIFF
--- a/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
@@ -108,7 +108,7 @@ describe('AutocompleterEditor', () => {
       gridOptionMock.translater = translateService;
       gridOptionMock.enableTranslate = true;
       const mockCollection = ['male', 'female'];
-      const promise = new Promise(resolve => resolve(mockCollection));
+      const promise = Promise.resolve(mockCollection);
       (mockColumn.internalColumnEditor as ColumnEditor).collection = null as any;
       (mockColumn.internalColumnEditor as ColumnEditor).collectionAsync = promise;
 

--- a/packages/common/src/editors/__tests__/selectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/selectEditor.spec.ts
@@ -155,7 +155,7 @@ describe('SelectEditor', () => {
 
     it('should initialize the editor with element being disabled in the DOM when passing a collectionAsync and an empty collection property', () => {
       const mockCollection = ['male', 'female'];
-      const promise = new Promise(resolve => resolve(mockCollection));
+      const promise = Promise.resolve(mockCollection);
       (mockColumn.internalColumnEditor as ColumnEditor).collection = null as any;
       (mockColumn.internalColumnEditor as ColumnEditor).collectionAsync = promise;
       gridOptionMock.translater = translateService;

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -1673,13 +1673,11 @@ describe('Grid Service', () => {
   describe('renderGrid method', () => {
     it('should invalidate the grid and call render after', () => {
       const invalidateSpy = jest.spyOn(gridStub, 'invalidate');
-      const renderSpy = jest.spyOn(gridStub, 'render');
 
       service.renderGrid();
 
       expect(invalidateSpy).toHaveBeenCalled();
-      expect(renderSpy).toHaveBeenCalled();
-      expect(gridStub.invalidate).toHaveBeenCalledBefore(gridStub.render as any);
+      expect(gridStub.invalidate).toHaveBeenCalled();
     });
   });
 

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -290,9 +290,8 @@ export class GridService {
 
   /** Re-Render the Grid */
   renderGrid() {
-    if (this._grid && typeof this._grid.invalidate === 'function') {
+    if (typeof this._grid?.invalidate === 'function') {
       this._grid.invalidate();
-      this._grid.render();
     }
   }
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1064,6 +1064,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const refreshSpy = jest.spyOn(component, 'refreshGridData');
 
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
+        jest.spyOn(mockDataView, 'getItems').mockReturnValueOnce(mockData);
         component.gridOptions = {
           enablePagination: true,
           presets: { pagination: { pageSize: 2, pageNumber: expectedPageNumber } }
@@ -1904,7 +1905,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       });
 
       it('should have custom footer with metrics when the DataView "onSetItemsCalled" event is triggered', () => {
-        const invalidateSpy = jest.spyOn(mockGrid, 'invalidate');
         const expectation = {
           startTime: expect.toBeDate(),
           endTime: expect.toBeDate(),
@@ -1918,7 +1918,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const footerSpy = jest.spyOn(component.slickFooter!, 'metrics', 'set');
         mockDataView.onSetItemsCalled.notify({ idProperty: 'id', itemCount: 0 });
 
-        expect(invalidateSpy).toHaveBeenCalled();
         expect(component.metrics).toEqual(expectation);
         expect(footerSpy).toHaveBeenCalledWith(expectation);
       });
@@ -2119,6 +2118,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file', initialSort: { columndId: 'file', direction: 'ASC' } } } as unknown as GridOption;
         component.datasetHierarchical = mockHierarchical;
         component.eventPubSubService = new EventPubSubService(divContainer);
+        component.isDatasetHierarchicalInitialized = true;
         component.initialization(divContainer, slickEventHandler);
 
         expect(hierarchicalSpy).toHaveBeenCalledWith(mockHierarchical);

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -714,7 +714,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should be able to load async editors with a regular Promise', (done) => {
         const mockCollection = ['male', 'female'];
-        const promise = new Promise(resolve => resolve(mockCollection));
+        const promise = Promise.resolve(mockCollection);
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
 
         component.columnDefinitions = mockColDefs;
@@ -730,7 +730,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should be able to load collectionAsync and expect Editor to be destroyed and re-render when receiving new collection from await', (done) => {
         const mockCollection = ['male', 'female'];
-        const promise = new Promise(resolve => resolve(mockCollection));
+        const promise = Promise.resolve(mockCollection);
         const mockEditor = {
           disable: jest.fn(),
           destroy: jest.fn(),
@@ -758,7 +758,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should be able to load async editors with as a Promise with content to simulate http-client', (done) => {
         const mockCollection = ['male', 'female'];
-        const promise = new Promise(resolve => resolve({ content: mockCollection }));
+        const promise = Promise.resolve({ content: mockCollection });
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
 
         component.columnDefinitions = mockColDefs;
@@ -1530,7 +1530,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
             service: mockGraphqlService2,
             options: mockGraphqlOptions,
             preProcess: () => jest.fn(),
-            process: () => new Promise(resolve => resolve({ data: { users: { nodes: [], totalCount: 100 } } })),
+            process: () => Promise.resolve({ data: { users: { nodes: [], totalCount: 100 } } }),
           } as GraphqlServiceApi,
           pagination: mockPagination,
         } as unknown as GridOption;
@@ -1548,7 +1548,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           backendServiceApi: {
             service: mockGraphqlService,
             preProcess: () => jest.fn(),
-            process: () => new Promise(resolve => resolve('process resolved')),
+            process: () => Promise.resolve('process resolved'),
           }
         } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
@@ -1565,7 +1565,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
             service: mockGraphqlService,
             useLocalSorting: true,
             preProcess: () => jest.fn(),
-            process: () => new Promise(resolve => resolve('process resolved')),
+            process: () => Promise.resolve('process resolved'),
           }
         } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
@@ -1595,7 +1595,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
             service: mockGraphqlService,
             useLocalFiltering: true,
             preProcess: () => jest.fn(),
-            process: () => new Promise(resolve => resolve('process resolved')),
+            process: () => Promise.resolve('process resolved'),
           }
         } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
@@ -1613,7 +1613,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           backendServiceApi: {
             service: mockGraphqlService,
             preProcess: () => jest.fn(),
-            process: () => new Promise(resolve => resolve('process resolved')),
+            process: () => Promise.resolve('process resolved'),
           }
         } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -555,6 +555,7 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
         const refreshSpy = jest.spyOn(component, 'refreshGridData');
 
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
+        jest.spyOn(mockDataView, 'getItems').mockReturnValueOnce(mockData);
         component.gridOptions = {
           enablePagination: true,
           presets: { pagination: { pageSize: 2, pageNumber: expectedPageNumber } }

--- a/test/cypress/e2e/example17.cy.ts
+++ b/test/cypress/e2e/example17.cy.ts
@@ -200,8 +200,8 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
     cy.get(`.grid17-2 [style="top: ${CELL_HEIGHT * 0}px;"]`).should('have.length', 2 * 2);
     cy.get(`.grid17-1 .grid-canvas-left > [style="top: ${CELL_HEIGHT * 0}px;"]`).children().should('have.length', 2 * 2);
     cy.get(`.grid17-2 .grid-canvas-left > [style="top: ${CELL_HEIGHT * 0}px;"]`).children().should('have.length', 2 * 2);
-    cy.get('.grid17-1 .grid-canvas-top').children().should('have.length', 3 * 2 + 1); // +1 for "Empty Data" div
-    cy.get('.grid17-2 .grid-canvas-top').children().should('have.length', 3 * 2 + 1);
+    cy.get('.grid17-1 .grid-canvas-top').children().should('have.length', 3 * 2);
+    cy.get('.grid17-2 .grid-canvas-top').children().should('have.length', 3 * 2);
   });
 
   function resetScrollInFrozen() {

--- a/test/translateServiceStub.ts
+++ b/test/translateServiceStub.ts
@@ -103,6 +103,6 @@ export class TranslateServiceStub implements TranslaterService {
   }
 
   use(locale: string) {
-    return new Promise(resolve => resolve(this._locale = locale));
+    return Promise.resolve(this._locale = locale);
   }
 }


### PR DESCRIPTION
- with the previous implementation when dataset was provided through the constructor, it was internally calling `dataView.setItems(data)` twice, this PR will now only call it once and is much closer to the other repos implementation which didn't have this issue (like Angular-Slickgrid is fine, or actually it's calling twice but the first time is always empty so it doesn't have any impact)
- remove unnecessary calls to `grid.invalidate()`
- remove unnecessary calls to `grid.render()` when `grid.invalidate()` is called just before, it is unnecessary since that the invalidate already calls the render internally, so no need to do the same thing twice