### PR TITLE
fix(ci): disable Husky when pushing new release

### DIFF
--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -105,6 +105,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -127,6 +128,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           pnpm exec lerna publish from-package --force-publish --yes --otp ${{ steps.wait-for-secrets.outputs.OTP }}
 

--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -67,15 +67,6 @@ jobs:
       - name: Build Library
         run: pnpm bundle
 
-      # - name: Archive common build artifacts
-      #   if: ${{ inputs.dryrun != true }}
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: dist-common
-      #     path: |
-      #       packages/common/dist
-      #     retention-days: 5
-
       - name: Lerna Version (build query)
         shell: bash
         run: |

--- a/.github/workflows/publish-npm-prerelease.yml
+++ b/.github/workflows/publish-npm-prerelease.yml
@@ -96,6 +96,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -108,6 +109,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -120,6 +122,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           pnpm exec lerna publish from-package --force-publish --dist-tag ${{ inputs.tag }} --yes --dry-run
 
@@ -129,6 +132,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -141,6 +145,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -163,5 +168,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           pnpm exec lerna publish from-package --force-publish --dist-tag ${{ inputs.tag }} --yes --otp ${{ steps.wait-for-secrets.outputs.OTP }}

--- a/.github/workflows/publish-npm-prompt.yml
+++ b/.github/workflows/publish-npm-prompt.yml
@@ -96,6 +96,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -116,6 +117,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          HUSKY: 0
         run: |
           pnpm exec lerna publish from-package --force-publish --yes --otp ${{ steps.wait-for-secrets.outputs.OTP }}
 


### PR DESCRIPTION
- as per issue identified in this [comment](https://github.com/ghiscoding/slickgrid-universal/pull/1385#issuecomment-1940388130)
- Husky that was added recently and caused an issue with the last release, the typical `chore(release)` commit was completely missing in today's release, possibly because of a racing condition or a prompt that cannot be answered in a CI environment
- as per Husky [docs](https://typicode.github.io/husky/how-to.html#ci-server-and-docker) we can disable Husky via 
```sh
env:
  HUSKY: 0
```