### PR TITLE
fix(styling): ms-select filter should use same color as other filters

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/material-styles.scss
+++ b/examples/vite-demo-vanilla-bundle/src/material-styles.scss
@@ -99,8 +99,8 @@
         font-weight: bold;
       }
       .search-filter.filled .ms-choice {
-        box-shadow: inset 0 0 0 1px #55B876;
-        border: 1px solid #ccc;
+        box-shadow: none;
+        border: 1px solid #55B876;
         span {
           font-weight: normal;
           color: #555;

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -783,6 +783,7 @@ $slick-multiselect-select-all-text-color:                   darken($slick-primar
 $slick-multiselect-select-all-text-hover-color:             transparent !default;
 
 // override some multiple-select SASS variables
+$ms-choice-border:                                          $slick-multiselect-input-filter-border;
 $ms-drop-list-padding:                                      $slick-multiselect-dropdown-list-padding;
 $ms-drop-list-item-align-items:                             center;
 $ms-drop-list-item-display:                                 flex;


### PR DESCRIPTION
- this is a very small border color difference (`#aaa` instead of `#ccc` for all other filters, so ms-select were standing out because their border were slightly darker). The filled ms-select filter(s) also had a background gray color that was merging with the primary box shadow color (green below) which was not a pure color, now it's all good.

#### Before

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/93422c38-7ab6-425a-9fd7-709026c2c6fd)


#### After

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/1d4320a9-9094-49fb-9eff-43446a00c405)
