### PR TITLE
feat(common): upgrade `multiple-select-vanilla` to v2

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -29,7 +29,7 @@
     "fetch-jsonp": "^1.3.0",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^1.2.5",
+    "multiple-select-vanilla": "^2.0.1",
     "rxjs": "^7.8.1",
     "whatwg-fetch": "^3.6.20"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -83,7 +83,7 @@
     "excel-builder-vanilla": "3.0.1",
     "flatpickr": "^4.6.13",
     "moment-mini": "^2.29.4",
-    "multiple-select-vanilla": "^1.2.5",
+    "multiple-select-vanilla": "^2.0.1",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12"
   },

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -754,6 +754,7 @@ $slick-multiselect-icon-radio-width:                        $slick-multiselect-i
 $slick-multiselect-icon-search-margin-right:                8px !default;
 $slick-multiselect-item-height:                             26px !default;
 $slick-multiselect-item-border:                             1px solid transparent !default;
+$slick-multiselect-item-hover-bg-color:                     transparent !default;
 $slick-multiselect-item-hover-border:                       1px solid #d5d5d5 !default;
 $slick-multiselect-item-line-height:                        calc(#{$slick-multiselect-icon-font-size} + 2px) !default;
 $slick-multiselect-item-padding:                            2px 4px !default;
@@ -772,6 +773,8 @@ $slick-multiselect-ok-button-text-hover-color:              darken($slick-primar
 $slick-multiselect-ok-button-height:                        26px !default;
 $slick-multiselect-ok-button-width:                         100% !default;
 $slick-multiselect-ok-button-text-align:                    center !default;
+$slick-multiselect-option-highlight-bg-color:               rgba(#3a3a3a, 0.01) !default;
+$slick-multiselect-option-highlight-border:                 1px solid #c9c9c9 !default;
 $slick-multiselect-select-all-border-bottom:                1px solid #ddd !default;
 $slick-multiselect-select-all-label-border:                 $slick-multiselect-item-border !default;
 $slick-multiselect-select-all-label-hover-border:           $slick-multiselect-item-hover-border !default;
@@ -788,12 +791,14 @@ $ms-drop-list-padding:                                      $slick-multiselect-d
 $ms-drop-list-item-align-items:                             center;
 $ms-drop-list-item-display:                                 flex;
 $ms-drop-list-item-padding:                                 $slick-multiselect-item-padding;
+$ms-drop-hide-radio-hover-bgcolor:                          $slick-multiselect-item-hover-bg-color;
 $ms-drop-hide-radio-selected-color:                         unset;
 $ms-drop-hide-radio-selected-bgcolor:                       unset;
 $ms-label-padding:                                          $slick-multiselect-item-padding;
 $ms-ok-button-bg-hover-color:                               $slick-multiselect-ok-button-bg-hover-color;
 $ms-ok-button-text-color:                                   $slick-multiselect-ok-button-text-color;
 $ms-ok-button-text-hover-color:                             $slick-multiselect-ok-button-text-hover-color;
+$ms-option-highlight-bg-color:                                       $slick-multiselect-option-highlight-bg-color;
 $ms-select-all-label-hover-border:                          $slick-multiselect-select-all-label-hover-border;
 $ms-select-all-label-padding:                               $slick-multiselect-select-all-padding;
 $ms-select-all-label-span-padding:                          $slick-multiselect-select-all-label-padding;

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -708,6 +708,10 @@ li.hidden {
       border: var(--slick-multiselect-item-hover-border, $slick-multiselect-item-hover-border);
       background-color: var(--slick-multiselect-checkbox-hover-bg-color, $slick-multiselect-checkbox-hover-bg-color);
     }
+    &.highlighted {
+      border: var(--slick-multiselect-option-highlight-border, $slick-multiselect-option-highlight-border);
+      background-color: var(--slick-multiselect-option-highlight-bg-color, $slick-multiselect-option-highlight-bg-color);
+    }
   }
 
   label {
@@ -727,6 +731,10 @@ li.hidden {
     line-height: var(--slick-multiselect-select-all-line-height, $slick-multiselect-select-all-line-height);
     &:hover {
       background-color: var(--slick-multiselect-select-all-text-hover-color, $slick-multiselect-select-all-text-hover-color);
+    }
+    &.highlighted label {
+      border: var(--slick-multiselect-option-highlight-border, $slick-multiselect-option-highlight-border);
+      background-color: var(--slick-multiselect-option-highlight-bg-color, $slick-multiselect-option-highlight-bg-color);
     }
 
     label {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^2.0.1
+        version: 2.0.1
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -250,8 +250,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       multiple-select-vanilla:
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^2.0.1
+        version: 2.0.1
       sortablejs:
         specifier: ^1.15.2
         version: 1.15.2
@@ -7080,8 +7080,8 @@ packages:
       minimatch: 9.0.3
     dev: true
 
-  /multiple-select-vanilla@1.2.5:
-    resolution: {integrity: sha512-1LSwRIBWlzNucZD5uI9ksz2mXKteC0ld4I7b5G5LC5iCbDbOwopU5Gt7wfA8XTetKQ1/e1vJlKfhxsJP42SmCA==}
+  /multiple-select-vanilla@2.0.1:
+    resolution: {integrity: sha512-4sFy7UqOOzRxRaOr1TQcVzweKKcfZLMtceVQ3+sl2R/2i1z/K5KMx9TeHbb9wuhuUL5RgCB2H5puROE0ay7SCQ==}
     dependencies:
       '@types/trusted-types': 2.0.7
     dev: false

--- a/test/jest-global-mocks.ts
+++ b/test/jest-global-mocks.ts
@@ -8,6 +8,8 @@ const mock = () => {
   };
 };
 
+window.HTMLElement.prototype.scrollIntoView = () => { };
+
 Object.defineProperty(window, 'localStorage', { value: mock() });
 Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(window, 'getComputedStyle', {


### PR DESCRIPTION
- see `multiple-select-vanilla` [v2](https://github.com/ghiscoding/multiple-select-vanilla/releases/tag/v2.0.0) release for more info.
- the main difference is mostly a UX change that switches from `tabIndex` to arrow navigation highlight. Except the UX changes, the upgrade is mainly transparent for most users.