### PR TITLE
fix(plugin): the RowMove plugin cell should be selectable

### DIFF
--- a/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowMoveManager.spec.ts
@@ -152,7 +152,6 @@ describe('SlickRowMoveManager Plugin', () => {
       behavior: 'selectAndMove',
       reorderable: false,
       resizable: false,
-      selectable: false,
       width: 40,
     };
 
@@ -201,7 +200,6 @@ describe('SlickRowMoveManager Plugin', () => {
       name: '',
       reorderable: false,
       resizable: false,
-      selectable: false,
       width: 40,
     });
   });

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -139,7 +139,6 @@ export class SlickRowMoveManager {
       field: columnId,
       reorderable: this._addonOptions.reorderable,
       resizable: false,
-      selectable: false,
       width: this._addonOptions.width || 40,
       formatter: this.moveIconFormatter.bind(this),
     };


### PR DESCRIPTION
- cell that aren't selectable are not styled with bg-color when selecting full row