### PR TITLE
fix(common): Select All checkbox shouldn't disappear w/Dark Mode toggle

### DIFF
--- a/docs/events/Available-Events.md
+++ b/docs/events/Available-Events.md
@@ -112,6 +112,7 @@ handleOnHeaderMenuCommand(e) {
   - `onActiveCellChanged`
   - `onActiveCellPositionChanged`
   - `onAddNewRow`
+  - `onAfterSetColumns`
   - `onAutosizeColumns`
   - `onBeforeAppendCell`
   - `onBeforeCellEditorDestroy`

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -51,6 +51,7 @@ import type {
   OnActivateChangedOptionsEventArgs,
   OnActiveCellChangedEventArgs,
   OnAddNewRowEventArgs,
+  OnAfterSetColumnsEventArgs,
   OnAutosizeColumnsEventArgs,
   OnBeforeAppendCellEventArgs,
   OnBeforeCellEditorDestroyEventArgs,
@@ -129,6 +130,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onActiveCellChanged: SlickEvent<OnActiveCellChangedEventArgs>;
   onActiveCellPositionChanged: SlickEvent<{ grid: SlickGrid; }>;
   onAddNewRow: SlickEvent<OnAddNewRowEventArgs>;
+  onAfterSetColumns: SlickEvent<OnAfterSetColumnsEventArgs>;
   onAutosizeColumns: SlickEvent<OnAutosizeColumnsEventArgs>;
   onBeforeAppendCell: SlickEvent<OnBeforeAppendCellEventArgs>;
   onBeforeCellEditorDestroy: SlickEvent<OnBeforeCellEditorDestroyEventArgs>;
@@ -488,6 +490,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onActiveCellChanged = new SlickEvent<OnActiveCellChangedEventArgs>('onActiveCellChanged', externalPubSub);
     this.onActiveCellPositionChanged = new SlickEvent<{ grid: SlickGrid; }>('onActiveCellPositionChanged', externalPubSub);
     this.onAddNewRow = new SlickEvent<OnAddNewRowEventArgs>('onAddNewRow', externalPubSub);
+    this.onAfterSetColumns = new SlickEvent<OnAfterSetColumnsEventArgs>('onAfterSetColumns', externalPubSub);
     this.onAutosizeColumns = new SlickEvent<OnAutosizeColumnsEventArgs>('onAutosizeColumns', externalPubSub);
     this.onBeforeAppendCell = new SlickEvent<OnBeforeAppendCellEventArgs>('onBeforeAppendCell', externalPubSub);
     this.onBeforeCellEditorDestroy = new SlickEvent<OnBeforeCellEditorDestroyEventArgs>('onBeforeCellEditorDestroy', externalPubSub);
@@ -2923,6 +2926,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onBeforeSetColumns, { previousColumns: this.columns, newColumns: columnDefinitions, grid: this });
     this.columns = columnDefinitions;
     this.updateColumnsInternal();
+    this.triggerEvent(this.onAfterSetColumns, { newColumns: columnDefinitions, grid: this });
   }
 
   /** Update columns for when a hidden property has changed but the column list itself has not changed. */

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -83,10 +83,15 @@ export class SlickCheckboxSelectColumn<T = any> {
       .subscribe(grid.onClick, this.handleClick.bind(this))
       .subscribe(grid.onKeyDown, this.handleKeyDown.bind(this));
 
-    if (this._isUsingDataView && this._dataView && this._addonOptions.applySelectOnAllPages) {
-      this._eventHandler
-        .subscribe(this._dataView.onSelectedRowIdsChanged, this.handleDataViewSelectedIdsChanged.bind(this))
-        .subscribe(this._dataView.onPagingInfoChanged, this.handleDataViewSelectedIdsChanged.bind(this));
+    if (this._isUsingDataView && this._dataView) {
+      // whenever columns changed, we need to rerender Select All, we can call handler to simulate that
+      this._eventHandler.subscribe(grid.onAfterSetColumns, this.handleDataViewSelectedIdsChanged.bind(this));
+
+      if (this._addonOptions.applySelectOnAllPages) {
+        this._eventHandler
+          .subscribe(this._dataView.onSelectedRowIdsChanged, this.handleDataViewSelectedIdsChanged.bind(this))
+          .subscribe(this._dataView.onPagingInfoChanged, this.handleDataViewSelectedIdsChanged.bind(this));
+      }
     }
 
     if (!this._addonOptions.hideInFilterHeaderRow) {

--- a/packages/common/src/interfaces/gridEvents.interface.ts
+++ b/packages/common/src/interfaces/gridEvents.interface.ts
@@ -4,6 +4,7 @@ import type { SlickGrid } from '../core/index';
 export interface SlickGridArg { grid: SlickGrid; }
 export interface OnActiveCellChangedEventArgs extends SlickGridArg { cell: number; row: number; }
 export interface OnAddNewRowEventArgs extends SlickGridArg { item: any; column: Column; }
+export interface OnAfterSetColumnsEventArgs extends SlickGridArg { newColumns: Column[]; }
 export interface OnAutosizeColumnsEventArgs extends SlickGridArg { columns: Column[]; }
 export interface OnBeforeUpdateColumnsEventArgs extends SlickGridArg { columns: Column[]; }
 export interface OnBeforeAppendCellEventArgs extends SlickGridArg { row: number; cell: number; value: any; dataContext: any; }


### PR DESCRIPTION
- when using Row Selections grid option, the Select All checkbox was disappearing after toggling Dark Mode, that was caused by the fact that calling `grid.setOptions()` is recreating the header columns and the Select All itself is not being recreated
- also the same issue happened whenever reordering a column to another position because again it called the grid set columns and that again rerendered all column headers without the Select All
- to fix both issue, I added a new `onAfterSetColumns` SlickEvent which we subscribe to inside the SlickCheckboxSelectColumn plugin, and whenever triggered, we reevaluate the Select All which in term recreates it

below are the 2 problems identified that were fixed by this PR

![brave_hYRDIxVdpU](https://github.com/ghiscoding/slickgrid-universal/assets/643976/574c1e57-fb2e-46d7-90b0-901041493278)
![brave_ynYb7ao5e3](https://github.com/ghiscoding/slickgrid-universal/assets/643976/2f84be3e-c98c-42ba-bdd3-0de8f9dce0de)
