### PR TITLE
fix: `column.editor` and `gridOptions.editorFactory` type changed

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5345,44 +5345,42 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // editor was null and columnMetadata and editorFactory returned null or undefined
     // the editor must be constructable. Also makes sure that useEditor is of type EditorConstructor
-    if (!useEditor || typeof useEditor !== 'function') {
-      return;
-    }
-
-    // don't clear the cell if a custom editor is passed through
-    if (!editor && !useEditor.suppressClearOnEdit) {
-      emptyElement(this.activeCellNode);
-    }
-
-    let metadata = (this.data as CustomDataView<TData>)?.getItemMetadata?.(this.activeRow);
-    metadata = metadata?.columns as any;
-    const columnMetaData = metadata && (metadata[columnDef.id as keyof ItemMetadata] || (metadata as any)[this.activeCell]);
-
-    const editorArgs: EditorArguments<TData, C, O> = {
-      grid: this,
-      gridPosition: this.absBox(this._container),
-      position: this.absBox(this.activeCellNode),
-      container: this.activeCellNode,
-      column: columnDef,
-      columnMetaData,
-      item: item || {},
-      event: e as Event,
-      commitChanges: this.commitEditAndSetFocus.bind(this),
-      cancelChanges: this.cancelEditAndSetFocus.bind(this)
-    };
-    this.currentEditor = new useEditor(editorArgs);
-
-    if (item && this.currentEditor) {
-      this.currentEditor.loadValue(item);
-      if (preClickModeOn && typeof this.currentEditor?.preClick === 'function') {
-        this.currentEditor.preClick();
+    if (typeof useEditor === 'function') {
+      // don't clear the cell if a custom editor is passed through
+      if (!editor && !useEditor.suppressClearOnEdit) {
+        emptyElement(this.activeCellNode);
       }
-    }
 
-    this.serializedEditorValue = this.currentEditor?.serializeValue();
+      let metadata = (this.data as CustomDataView<TData>)?.getItemMetadata?.(this.activeRow);
+      metadata = metadata?.columns as any;
+      const columnMetaData = metadata && (metadata[columnDef.id as keyof ItemMetadata] || (metadata as any)[this.activeCell]);
 
-    if (this.currentEditor?.position) {
-      this.handleActiveCellPositionChange();
+      const editorArgs: EditorArguments<TData, C, O> = {
+        grid: this,
+        gridPosition: this.absBox(this._container),
+        position: this.absBox(this.activeCellNode),
+        container: this.activeCellNode,
+        column: columnDef,
+        columnMetaData,
+        item: item || {},
+        event: e as Event,
+        commitChanges: this.commitEditAndSetFocus.bind(this),
+        cancelChanges: this.cancelEditAndSetFocus.bind(this)
+      };
+      this.currentEditor = new useEditor(editorArgs);
+
+      if (item && this.currentEditor) {
+        this.currentEditor.loadValue(item);
+        if (preClickModeOn && typeof this.currentEditor?.preClick === 'function') {
+          this.currentEditor.preClick();
+        }
+      }
+
+      this.serializedEditorValue = this.currentEditor?.serializeValue();
+
+      if (this.currentEditor?.position) {
+        this.handleActiveCellPositionChange();
+      }
     }
   }
 

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -5,7 +5,6 @@ import type {
   ColumnExcelExportOption,
   ColumnFilter,
   CustomTooltipOption,
-  EditorConstructor,
   EditorValidator,
   Formatter,
   Grouping,

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -92,7 +92,7 @@ export interface Column<T = any> {
   disableTooltip?: boolean;
 
   /** Any inline editor function that implements Editor for the cell value or ColumnEditor */
-  editor?: ColumnEditor | EditorConstructor | null;
+  editor?: any;
 
   /** Editor number fixed decimal places */
   editorFixedDecimalPlaces?: number;

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -5,6 +5,7 @@ import type {
   ColumnExcelExportOption,
   ColumnFilter,
   CustomTooltipOption,
+  EditorConstructor,
   EditorValidator,
   Formatter,
   Grouping,
@@ -21,7 +22,7 @@ export type PathsToStringProps<T> = T extends string | number | boolean | Date ?
 
 type AllowedJoinTypes = string | number | boolean;
 
-export type Join<T extends (AllowedJoinTypes | unknown )[], D extends string> =
+export type Join<T extends (AllowedJoinTypes | unknown)[], D extends string> =
   T extends [] ? never :
   T extends [infer F] ? F :
   T extends [infer F, ...infer R] ?
@@ -91,7 +92,7 @@ export interface Column<T = any> {
   disableTooltip?: boolean;
 
   /** Any inline editor function that implements Editor for the cell value or ColumnEditor */
-  editor?: ColumnEditor | null;
+  editor?: ColumnEditor | EditorConstructor | null;
 
   /** Editor number fixed decimal places */
   editorFixedDecimalPlaces?: number;

--- a/packages/common/src/interfaces/editor.interface.ts
+++ b/packages/common/src/interfaces/editor.interface.ts
@@ -1,4 +1,4 @@
-import type { EditorArguments, EditorValidationResult } from './index';
+import type { Column, EditorArguments, EditorValidationResult, GridOption } from './index';
 
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo
@@ -121,3 +121,10 @@ export interface Editor {
    */
   validate: (targetElm?: HTMLElement, options?: any) => EditorValidationResult;
 }
+
+export type EditorConstructor = {
+  new <TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>>(args?: EditorArguments<TData, C, O>): Editor;
+
+  /** Static flag used in makeActiveCellEditable. */
+  suppressClearOnEdit?: boolean;
+};

--- a/packages/common/src/interfaces/editorArguments.interface.ts
+++ b/packages/common/src/interfaces/editorArguments.interface.ts
@@ -1,8 +1,8 @@
-import type { Column, CompositeEditorOption, ElementPosition } from './index';
+import type { Column, CompositeEditorOption, ElementPosition, GridOption } from './index';
 import type { PositionMethod } from '../enums/positionMethod.type';
 import type { SlickDataView, SlickGrid } from '../core/index';
 
-export interface EditorArguments {
+export interface EditorArguments<TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>> {
   /** Column Definition */
   column: Column;
 
@@ -13,13 +13,13 @@ export interface EditorArguments {
   container: HTMLDivElement;
 
   /** Slick DataView */
-  dataView: SlickDataView;
+  dataView?: SlickDataView;
 
   /** Event that was triggered */
   event: Event;
 
   /** Slick Grid object */
-  grid: SlickGrid;
+  grid: SlickGrid<TData, C, O>;
 
   /** Grid Position */
   gridPosition: ElementPosition;

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -14,6 +14,7 @@ import type {
   CustomTooltipOption,
   DraggableGrouping,
   EditCommand,
+  EditorConstructor,
   EmptyWarning,
   ExcelCopyBufferOption,
   ExcelExportOption,
@@ -55,7 +56,7 @@ export interface CustomDataView<T = any> {
 }
 
 export interface CssStyleHash {
-  [prop: number | string]: { [columnId: number | string]: any; }
+  [prop: number | string]: { [columnId: number | string]: any; };
 }
 
 /** Escape hatch geared towards testing Slickgrid in JSDOM based environments to circumvent the lack of stylesheet.ownerNode and clientWidth calculations */
@@ -293,7 +294,7 @@ export interface GridOption<C extends Column = Column> {
   editCommandHandler?: (item: any, column: C, command: EditCommand) => void;
 
   /** Editor classes factory */
-  editorFactory?: any;
+  editorFactory?: null | { getEditor: (col: C) => EditorConstructor; };
 
   /** a global singleton editor lock. */
   editorLock?: SlickEditorLock;


### PR DESCRIPTION
as per SlickGrid [PR 995](https://github.com/6pac/SlickGrid/pull/995)
> editor and editor factory do not return an Editor Object but a typeof Editor to be constructed with new (...) Otherwise it is impossible to implement an Editor Factory in TypeScript