### PR TITLE
feat(core): rename SG `editorClass` & deprecate `internalColumnEditor`

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -611,16 +611,9 @@ export default class Example07 {
     this.sgb.columnDefinitions.pop();
     this.sgb.columnDefinitions = this.sgb.columnDefinitions.slice();
 
-    // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
-    // you MUST use the code below, first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
-    // in other words, SlickGrid is not using the same as Slickgrid-Universal uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
     const allColumns = this.slickerGridInstance.gridService.getAllColumnDefinitions();
-    const allOriginalColumns = allColumns.map((column) => {
-      column.editor = column.internalColumnEditor;
-      return column;
-    });
-    // remove your column the full set of columns
+    // remove your column from the full set of columns
     // and use slice or spread [...] to trigger a dirty change
     allOriginalColumns.pop();
     this.sgb.columnDefinitions = allOriginalColumns.slice();

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -439,7 +439,7 @@ export default class Example11 {
         this.sgb.slickGrid?.getSelectedRows() || [];
         const modalContainerElm = document.querySelector('.modal-container') as HTMLDivElement;
         const columnDefinitionsClone = deepCopy(this.columnDefinitions);
-        const massUpdateColumnDefinitions = columnDefinitionsClone?.filter((col: Column) => col.editor?.massUpdate || col.internalColumnEditor?.massUpdate) || [];
+        const massUpdateColumnDefinitions = columnDefinitionsClone?.filter((col: Column) => col.editor?.massUpdate) || [];
         const selectedItems = this.sgb.gridService.getSelectedRowsDataItem();
         const selectedIds = selectedItems.map(selectedItem => selectedItem.id);
         loadComponent(modalContainerElm, exampleModal, Example11Modal, { columnDefinitions: massUpdateColumnDefinitions, selectedIds, remoteCallback: this.remoteCallbackFn.bind(this) });

--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -915,7 +915,7 @@ describe('SlickDatView core file', () => {
         columns: {
           0: {
             colspan: '*',
-            editor: null,
+            editorClass: null,
             formatter: expect.anything(),
           },
         },
@@ -968,7 +968,7 @@ describe('SlickDatView core file', () => {
       });
       expect(dv.getItemMetadata(3)).toEqual({
         cssClasses: 'slick-group-totals slick-group-level-1',
-        editor: null,
+        editorClass: null,
         focusable: false,
         formatter: expect.anything(),
         selectable: false,
@@ -1058,7 +1058,7 @@ describe('SlickDatView core file', () => {
         columns: {
           0: {
             colspan: '*',
-            editor: null,
+            editorClass: null,
             formatter: expect.anything(),
           },
         },

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1732,7 +1732,7 @@ describe('SlickGrid core file', () => {
       const dv = new SlickDataView();
       dv.setItems(items);
       grid = new SlickGrid<any, Column>(container, dv, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, asyncEditorLoading: true });
-      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { age: { colspan: '*', editorClass: InputEditor } } } as any);
+      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { age: { colspan: '*', editor: InputEditor } } } as any);
       grid.setActiveCell(0, 1);
 
       jest.advanceTimersByTime(2);

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3,7 +3,7 @@ import { createDomElement } from '@slickgrid-universal/utils';
 
 import { CheckboxEditor, InputEditor, LongTextEditor } from '../../editors';
 import { SlickCellSelectionModel, SlickRowSelectionModel } from '../../extensions';
-import { Column, Editor, FormatterResultWithHtml, FormatterResultWithText, GridOption, type EditCommand } from '../../interfaces';
+import type { Column, Editor, FormatterResultWithHtml, FormatterResultWithText, GridOption, EditCommand, EditorConstructor } from '../../interfaces';
 import { SlickEventData, SlickGlobalEditorLock } from '../slickCore';
 import { SlickDataView } from '../slickDataview';
 import { SlickGrid } from '../slickGrid';
@@ -226,7 +226,7 @@ describe('SlickGrid core file', () => {
   });
 
   it('should be able to edit when editable grid option is enabled and invalidate some rows', () => {
-    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', editor: InputEditor }] as Column[];
+    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', editorClass: InputEditor }] as Column[];
     const data = [{ id: 0, firstName: 'John' }, { id: 1, firstName: 'Jane' }];
 
     grid = new SlickGrid<any, Column>('#myGrid', [], columns, { ...defaultOptions, editable: true, enableAsyncPostRenderCleanup: true, asyncPostRenderCleanupDelay: 0 });
@@ -242,7 +242,7 @@ describe('SlickGrid core file', () => {
   });
 
   it('should be able to edit when editable grid option is enabled and invalidate all rows', () => {
-    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', editor: InputEditor }] as Column[];
+    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', editorClass: InputEditor }] as Column[];
     const data = [{ id: 0, firstName: 'John' }, { id: 1, firstName: 'Jane' }];
 
     grid = new SlickGrid<any, Column>('#myGrid', [], columns, { ...defaultOptions, editable: true });
@@ -1640,7 +1640,7 @@ describe('SlickGrid core file', () => {
   });
 
   describe('Editors', () => {
-    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', editor: LongTextEditor }] as Column[];
+    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', editorClass: LongTextEditor }] as Column[];
     let items: Array<{ id: number; name: string; age: number; active?: boolean; }> = [];
 
     beforeEach(() => {
@@ -1672,7 +1672,7 @@ describe('SlickGrid core file', () => {
     });
 
     it('should return undefined editor when getDataItem() did not find any associated cell item', () => {
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
       jest.spyOn(grid, 'getDataItem').mockReturnValue(null);
       grid.setActiveCell(0, 1);
@@ -1684,7 +1684,7 @@ describe('SlickGrid core file', () => {
     });
 
     it('should return undefined editor when trying to add a new row item and "cannotTriggerInsert" is set', () => {
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', cannotTriggerInsert: true, editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', cannotTriggerInsert: true, editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, autoEditNewRow: false });
       const onBeforeEditCellSpy = jest.spyOn(grid.onBeforeEditCell, 'notify');
       grid.setActiveCell(0, 1);
@@ -1695,7 +1695,7 @@ describe('SlickGrid core file', () => {
     });
 
     it('should return undefined editor when onBeforeEditCell returns false', () => {
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', cannotTriggerInsert: true, editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', cannotTriggerInsert: true, editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, autoEditNewRow: false });
       const sed = new SlickEventData();
       jest.spyOn(sed, 'getReturnValue').mockReturnValue(false);
@@ -1709,7 +1709,7 @@ describe('SlickGrid core file', () => {
 
     it('should do nothing when trying to commit unchanged Age field Editor', () => {
       (navigator as any).__defineGetter__('userAgent', () => 'msie'); // this will call clearTextSelection() & window.getSelection()
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
       grid.setActiveCell(0, 1);
       grid.editActiveCell(InputEditor as any, true);
@@ -1728,11 +1728,11 @@ describe('SlickGrid core file', () => {
       (navigator as any).__defineGetter__('userAgent', () => 'msie'); // this will call clearTextSelection() & document.selection.empty()
       Object.defineProperty(document, 'selection', { writable: true, value: { empty: () => { } } });
       const newValue = 33;
-      const columns = [{ id: 'name', field: 'name', name: 'Name', colspan: '*', }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name', colspan: '*', }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
       const dv = new SlickDataView();
       dv.setItems(items);
       grid = new SlickGrid<any, Column>(container, dv, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, asyncEditorLoading: true });
-      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { age: { colspan: '*', editor: InputEditor } } } as any);
+      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { age: { colspan: '*', editorClass: InputEditor } } } as any);
       grid.setActiveCell(0, 1);
 
       jest.advanceTimersByTime(2);
@@ -1761,7 +1761,7 @@ describe('SlickGrid core file', () => {
     it('should commit Name field Editor via an Editor defined as ItemMetadata by column id & asyncEditorLoading enabled and expect it to call execute() command and triggering onCellChange() notify', () => {
       (navigator as any).__defineGetter__('userAgent', () => 'Firefox');
       const newValue = 33;
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', colspan: '2', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', colspan: '2', editorClass: InputEditor }] as Column[];
       const dv = new SlickDataView();
       dv.setItems(items);
       grid = new SlickGrid<any, Column>(container, dv, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, asyncEditorLoading: true });
@@ -1793,7 +1793,7 @@ describe('SlickGrid core file', () => {
 
     it('should commit Age field Editor by calling execute() command and triggering onCellChange() notify', () => {
       const newValue = 33;
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: LongTextEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: LongTextEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
       const onPositionSpy = jest.spyOn(grid.onActiveCellPositionChanged, 'notify');
       grid.setActiveCell(0, 1);
@@ -1830,7 +1830,7 @@ describe('SlickGrid core file', () => {
       const newValue = false;
       const columns = [
         { id: 'name', field: 'name', name: 'Name' },
-        { id: 'age', field: 'age', name: 'Age', type: 'number', editor: CheckboxEditor },
+        { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: CheckboxEditor },
         { id: 'active', field: 'active', name: 'Active', type: 'boolean' }
       ] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
@@ -1872,7 +1872,7 @@ describe('SlickGrid core file', () => {
           editCommand.execute();
         }
       };
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
 
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, editCommandHandler });
       grid.setActiveCell(0, 1);
@@ -1905,7 +1905,7 @@ describe('SlickGrid core file', () => {
 
     it('should commit Age field Editor by applying new values and triggering onAddNewRow() notify', () => {
       const newValue = 77;
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, enableAddRow: true, editable: true });
 
       grid.setActiveCell(1, 1);
@@ -1929,7 +1929,7 @@ describe('SlickGrid core file', () => {
 
     it('should commit Age field Editor by applying new values and triggering onAddNewRow() notify with autoHeight enabled and expect different viewport height', () => {
       const newValue = 77;
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, autoHeight: true, enableCellNavigation: true, enableAddRow: true, editable: true });
       const prevHeight = grid.getViewportHeight();
       grid.onAddNewRow.subscribe((e, args) => {
@@ -1959,7 +1959,7 @@ describe('SlickGrid core file', () => {
 
     it('should not commit Age field Editor returns invalid result, expect triggering onValidationError() notify', () => {
       const invalidResult = { valid: false, msg: 'invalid value' };
-      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editor: InputEditor }] as Column[];
+      const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', type: 'number', editorClass: InputEditor }] as Column[];
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
       grid.setActiveCell(0, 1);
       grid.editActiveCell(InputEditor as any, true);
@@ -4504,7 +4504,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should change an item from an Editor then call updateCell() and expect it call the editor loadValue() method', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         let items = [{ id: 0, name: 'Avery', age: 44 }, { id: 1, name: 'Bob', age: 20 }, { id: 2, name: 'Rachel', age: 46 },];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
@@ -4615,7 +4615,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should change an item from an Editor then call updateRow() and expect it call the editor loadValue() method', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         grid.setActiveCell(0, 1);
@@ -4651,7 +4651,7 @@ describe('SlickGrid core file', () => {
 
     describe('setActiveRow() method', () => {
       it('should do nothing when row to activate is greater than data length or cell is greater than available column length', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollViewSpy = jest.spyOn(grid, 'scrollCellIntoView');
         grid.setActiveRow(99, 1);
@@ -4661,7 +4661,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should do nothing when row or cell is a negative number', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollViewSpy = jest.spyOn(grid, 'scrollCellIntoView');
@@ -4672,7 +4672,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should do nothing when row to activate is greater than data length', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollViewSpy = jest.spyOn(grid, 'scrollCellIntoView');
@@ -4684,7 +4684,7 @@ describe('SlickGrid core file', () => {
 
     describe('gotoCell() method', () => {
       it('should call gotoCell() and expect it to scroll to the cell', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollCellSpy = jest.spyOn(grid, 'scrollCellIntoView');
@@ -4694,7 +4694,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call gotoCell() with invalid cell and expect to NOT scroll to the cell', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollCellSpy = jest.spyOn(grid, 'scrollCellIntoView');
@@ -4704,7 +4704,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call gotoCell() with commitCurrentEdit() returning false and expect to NOT scroll to the cell', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
 
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollCellSpy = jest.spyOn(grid, 'scrollCellIntoView');
@@ -4893,7 +4893,7 @@ describe('SlickGrid core file', () => {
 
     describe('Cell Click', () => {
       test('double-click event triggered on header resize handle should call "onColumnsResizeDblClick" notify', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onColumnsResizeDblClickSpy = jest.spyOn(grid.onColumnsResizeDblClick, 'notify');
         const columnElms = container.querySelectorAll('.slick-header-column');
@@ -4906,7 +4906,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should not scroll or do anything when getCellFromEvent() returns null', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         jest.spyOn(grid, 'getCellFromEvent').mockReturnValue(null);
         const scrollViewSpy = jest.spyOn(grid, 'scrollRowIntoView');
@@ -4919,7 +4919,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should goto cell or do anything when event default is prevented', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const scrollViewSpy = jest.spyOn(grid, 'scrollRowIntoView');
         const secondRowSlickCells = container.querySelectorAll('.slick-row:nth-child(2) .slick-cell');
@@ -4932,7 +4932,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should scroll to cell when clicking on cell', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onClickSpy = jest.spyOn(grid.onClick, 'notify');
         const scrollViewSpy = jest.spyOn(grid, 'scrollRowIntoView');
@@ -4952,7 +4952,7 @@ describe('SlickGrid core file', () => {
           .mockReturnValueOnce({ rangeCount: 2, getRangeAt: () => items[1].name } as any)
           .mockReturnValueOnce({ removeAllRanges: removeRangeMock, addRange: addRangeMock } as any);
 
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onClickSpy = jest.spyOn(grid.onClick, 'notify');
         const scrollViewSpy = jest.spyOn(grid, 'scrollRowIntoView');
@@ -4970,7 +4970,7 @@ describe('SlickGrid core file', () => {
 
     describe('Cell Double-Click', () => {
       it('should goto cell or do anything when getCellFromEvent() returns null', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         jest.spyOn(grid, 'getCellFromEvent').mockReturnValue(null);
         const gotoCellSpy = jest.spyOn(grid, 'gotoCell');
@@ -4983,7 +4983,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should goto cell or do anything when event default is prevented', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const gotoCellSpy = jest.spyOn(grid, 'gotoCell');
         const secondRowSlickCells = container.querySelectorAll('.slick-row:nth-child(2) .slick-cell');
@@ -4996,7 +4996,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should scroll to cell when clicking on cell', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const gotoCellSpy = jest.spyOn(grid, 'gotoCell');
         const secondRowSlickCells = container.querySelectorAll('.slick-row:nth-child(2) .slick-cell');
@@ -5010,7 +5010,7 @@ describe('SlickGrid core file', () => {
 
     describe('Cell Context Menu', () => {
       it('should not trigger onContextMenu event when cannot find closest slick-cell', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onContextMenuSpy = jest.spyOn(grid.onContextMenu, 'notify');
         const secondRowSlickCells = container.querySelectorAll('.slick-row:nth-child(2)');
@@ -5022,7 +5022,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should not trigger onContextMenu event when current cell is active and is editable', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         grid.setActiveCell(1, 1);
         const onContextMenuSpy = jest.spyOn(grid.onContextMenu, 'notify');
@@ -5036,7 +5036,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should trigger onContextMenu event when current cell is not active and not editable', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onContextMenuSpy = jest.spyOn(grid.onContextMenu, 'notify');
         const secondRowSlickCells = container.querySelectorAll('.slick-row:nth-child(2) .slick-cell');
@@ -5072,7 +5072,7 @@ describe('SlickGrid core file', () => {
       // TODO: need to add another test when "columnResizeDragging"
 
       it('should trigger onHeaderClick notify when not column resizing', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         jest.spyOn(grid, 'getCellFromEvent').mockReturnValue(null);
         const onHeaderClickSpy = jest.spyOn(grid.onHeaderClick, 'notify');
@@ -5087,7 +5087,7 @@ describe('SlickGrid core file', () => {
 
     describe('Header Context Menu', () => {
       it('should trigger onHeaderClick notify grid context menu event is triggered', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onContextSpy = jest.spyOn(grid.onHeaderContextMenu, 'notify');
         const headerColumns = container.querySelectorAll('.slick-header-column');
@@ -5253,7 +5253,7 @@ describe('SlickGrid core file', () => {
 
     describe('Keydown Events', () => {
       it('should call navigateRowStart() when triggering Home key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateRowStartSpy = jest.spyOn(grid, 'navigateRowStart');
@@ -5266,7 +5266,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateTop() when triggering Ctrl+Home key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateTopSpy = jest.spyOn(grid, 'navigateTop');
@@ -5280,7 +5280,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateRowEnd() when triggering End key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateRowEndSpy = jest.spyOn(grid, 'navigateRowEnd');
@@ -5293,7 +5293,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateBottom() when triggering Ctrl+End key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateBottomSpy = jest.spyOn(grid, 'navigateBottom');
@@ -5307,7 +5307,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigatePageDown() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigatePageDownSpy = jest.spyOn(grid, 'navigatePageDown');
@@ -5320,7 +5320,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigatePageUp() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigatePageUpSpy = jest.spyOn(grid, 'navigatePageUp');
@@ -5333,7 +5333,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateLeft() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateLeftSpy = jest.spyOn(grid, 'navigateLeft');
@@ -5346,7 +5346,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateRight() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateRightSpy = jest.spyOn(grid, 'navigateRight');
@@ -5359,7 +5359,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateUp() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateUpSpy = jest.spyOn(grid, 'navigateUp');
@@ -5372,7 +5372,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateDown() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateDownSpy = jest.spyOn(grid, 'navigateDown');
@@ -5385,7 +5385,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateNext() when triggering PageDown key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigateNextSpy = jest.spyOn(grid, 'navigateNext');
@@ -5398,7 +5398,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigatePrev() when triggering Enter key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const navigatePrevSpy = jest.spyOn(grid, 'navigatePrev');
@@ -5412,7 +5412,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should do nothing when triggering Escape key without any editor to cancel', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const event = new CustomEvent('keydown');
@@ -5425,7 +5425,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should cancel opened editor when triggering Escape key and editor is active', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const event = new CustomEvent('keydown');
@@ -5439,7 +5439,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should call navigateDown() when triggering Enter key', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const event = new CustomEvent('keydown');
@@ -5450,7 +5450,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should commit editor & set focus to next down cell when triggering Enter key with an active Editor', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         jest.spyOn(grid.getEditorLock(), 'commitCurrentEdit').mockReturnValueOnce(true);
         grid.setActiveCell(0, 1);
@@ -5466,7 +5466,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should navigateDown() when triggering Enter key with an active Editor that is considered a new row', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         grid.setActiveCell(0, 1);
         grid.editActiveCell(InputEditor as any, true);
@@ -5484,7 +5484,7 @@ describe('SlickGrid core file', () => {
       });
 
       it('should do nothing when active Editor has multiple keyCaptureList and event is triggered is part of that list', () => {
-        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editor: InputEditor }] as Column[];
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         grid.setActiveCell(0, 1);
         grid.editActiveCell(InputEditor as any, true);

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1732,7 +1732,7 @@ describe('SlickGrid core file', () => {
       const dv = new SlickDataView();
       dv.setItems(items);
       grid = new SlickGrid<any, Column>(container, dv, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, asyncEditorLoading: true });
-      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { age: { colspan: '*', editor: InputEditor } } } as any);
+      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { age: { colspan: '*', editorClass: InputEditor } } } as any);
       grid.setActiveCell(0, 1);
 
       jest.advanceTimersByTime(2);
@@ -1765,7 +1765,7 @@ describe('SlickGrid core file', () => {
       const dv = new SlickDataView();
       dv.setItems(items);
       grid = new SlickGrid<any, Column>(container, dv, columns, { ...defaultOptions, enableCellNavigation: true, editable: true, asyncEditorLoading: true });
-      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { 1: { editor: InputEditor } } as any });
+      jest.spyOn(dv, 'getItemMetadata').mockReturnValue({ columns: { 1: { editorClass: InputEditor } } as any });
       grid.setActiveCell(0, 1);
 
       jest.advanceTimersByTime(2);

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3257,13 +3257,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const columnMetadata = rowMetadata?.columns;
 
     if (columnMetadata?.[column.id]?.editor !== undefined) {
-      return columnMetadata[column.id].editor as Editor | EditorConstructor;
+      return columnMetadata[column.id].editor;
     }
     if (columnMetadata?.[cell]?.editor !== undefined) {
-      return columnMetadata[cell].editor as Editor | EditorConstructor;
+      return columnMetadata[cell].editor;
     }
 
-    return (column.editor || (this._options?.editorFactory?.getEditor(column))) as Editor | EditorConstructor;
+    return (column.editorClass || (this._options?.editorFactory?.getEditor(column)));
   }
 
   protected getDataItemValueForColumn(item: TData, columnDef: C) {
@@ -4845,7 +4845,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
         const preClickModeOn = ((e as DOMEvent<HTMLDivElement>).target?.className === preClickClassName);
         const column = this.columns[cell.cell];
-        const suppressActiveCellChangedEvent = !!(this._options.editable && column?.editor && this._options.suppressActiveCellChangeOnEdit);
+        const suppressActiveCellChangedEvent = !!(this._options.editable && column?.editorClass && this._options.suppressActiveCellChangeOnEdit);
         this.setActiveCellInternal(this.getCellNode(cell.row, cell.cell), null, preClickModeOn, suppressActiveCellChangedEvent, (e as DOMEvent<HTMLDivElement>));
       }
     }
@@ -5311,11 +5311,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
 
-  editActiveCell(editor: EditorConstructor, preClickModeOn?: boolean | null, e?: Event) {
+  editActiveCell(editor: Editor | EditorConstructor, preClickModeOn?: boolean | null, e?: Event) {
     this.makeActiveCellEditable(editor, preClickModeOn, e);
   }
 
-  protected makeActiveCellEditable(editor?: EditorConstructor, preClickModeOn?: boolean | null, e?: Event | SlickEvent) {
+  protected makeActiveCellEditable(editor?: Editor | EditorConstructor, preClickModeOn?: boolean | null, e?: Event | SlickEvent) {
     if (!this.activeCellNode) {
       return;
     }
@@ -5355,8 +5355,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       metadata = metadata?.columns as any;
       const columnMetaData = metadata && (metadata[columnDef.id as keyof ItemMetadata] || (metadata as any)[this.activeCell]);
 
-      const editorArgs: EditorArguments<TData, C, O> = {
-        grid: this,
+      const editorArgs: EditorArguments = {
+        grid: this as any,
         gridPosition: this.absBox(this._container),
         position: this.absBox(this.activeCellNode),
         container: this.activeCellNode,
@@ -6131,7 +6131,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // if selecting the 'add new' row, start editing right away
     const column = this.columns[cell];
-    const suppressActiveCellChangedEvent = !!(this._options.editable && column?.editor && this._options.suppressActiveCellChangeOnEdit);
+    const suppressActiveCellChangedEvent = !!(this._options.editable && column?.editorClass && this._options.suppressActiveCellChangeOnEdit);
     this.setActiveCellInternal(newCell, (forceEdit || (row === this.getDataLength()) || this._options.autoEdit), null, suppressActiveCellChangedEvent, e);
 
     // if no editor was created, set the focus back on the grid

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3256,11 +3256,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const rowMetadata = (this.data as CustomDataView<TData>)?.getItemMetadata?.(row);
     const columnMetadata = rowMetadata?.columns;
 
-    if (columnMetadata?.[column.id]?.editor !== undefined) {
-      return columnMetadata[column.id].editor;
+    if (columnMetadata?.[column.id]?.editorClass !== undefined) {
+      return columnMetadata[column.id].editorClass;
     }
-    if (columnMetadata?.[cell]?.editor !== undefined) {
-      return columnMetadata[cell].editor;
+    if (columnMetadata?.[cell]?.editorClass !== undefined) {
+      return columnMetadata[cell].editorClass;
     }
 
     return (column.editorClass || (this._options?.editorFactory?.getEditor(column)));

--- a/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
@@ -3,7 +3,7 @@ import 'jest-extended';
 import { Editors } from '../index';
 import { AutocompleterEditor } from '../autocompleterEditor';
 import { FieldType } from '../../enums/index';
-import { AutocompleterOption, Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { AutocompleterOption, Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
 import { SlickDataView, SlickEvent, type SlickGrid } from '../../core/index';
 
@@ -54,7 +54,7 @@ describe('AutocompleterEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.autocompleter }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.autocompleter }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -85,8 +85,8 @@ describe('AutocompleterEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 123, gender: 'male', isActive: true };
-      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.autocompleter }, internalColumnEditor: {} } as Column;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.autocompleter }, editorClass: {} as Editor } as Column;
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -109,8 +109,8 @@ describe('AutocompleterEditor', () => {
       gridOptionMock.enableTranslate = true;
       const mockCollection = ['male', 'female'];
       const promise = Promise.resolve(mockCollection);
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = null as any;
-      (mockColumn.internalColumnEditor as ColumnEditor).collectionAsync = promise;
+      mockColumn.editor!.collection = null as any;
+      mockColumn.editor!.collectionAsync = promise;
 
       editor = new AutocompleterEditor(editorArguments);
       const disableSpy = jest.spyOn(editor, 'disable');
@@ -123,7 +123,7 @@ describe('AutocompleterEditor', () => {
     });
 
     it('should initialize the editor even when user define his own editor options', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+      mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
       editor = new AutocompleterEditor(editorArguments);
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-gender').length;
 
@@ -132,7 +132,7 @@ describe('AutocompleterEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new AutocompleterEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-gender') as HTMLInputElement;
@@ -142,7 +142,7 @@ describe('AutocompleterEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new AutocompleterEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-gender') as HTMLInputElement;
@@ -209,8 +209,8 @@ describe('AutocompleterEditor', () => {
     });
 
     it('should render the DOM element with different key/value pair when user provide its own customStructure', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ option: 'male', text: 'Male' }, { option: 'female', text: 'Female' }];
-      (mockColumn.internalColumnEditor as ColumnEditor).customStructure = { value: 'option', label: 'text' };
+      mockColumn.editor!.collection = [{ option: 'male', text: 'Male' }, { option: 'female', text: 'Female' }];
+      mockColumn.editor!.customStructure = { value: 'option', label: 'text' };
       const event = new (window.window as any).KeyboardEvent('keydown', { key: 'm', bubbles: true, cancelable: true });
 
       editor = new AutocompleterEditor(editorArguments);
@@ -250,7 +250,7 @@ describe('AutocompleterEditor', () => {
 
     it('should return True when calling "isValueChanged()" method with previously dispatched keyboard event as ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
       const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-      (mockColumn.internalColumnEditor as ColumnEditor).alwaysSaveOnEnterKey = true;
+      mockColumn.editor!.alwaysSaveOnEnterKey = true;
 
       editor = new AutocompleterEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-gender') as HTMLInputElement;
@@ -273,7 +273,7 @@ describe('AutocompleterEditor', () => {
 
     describe('collectionOverride callback option', () => {
       it('should create the editor and expect a different collection outputed when using the override', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: [{ value: 'other', label: 'Other' }, { value: 'male', label: 'Male' }, { value: 'female', label: 'Female' }],
           collectionOverride: (inputCollection) => inputCollection.filter(item => item.value !== 'other')
         };
@@ -290,7 +290,7 @@ describe('AutocompleterEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the gender property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 123, gender: 'female', isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -300,7 +300,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should apply the value to the gender property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'user.gender';
         mockItemData = { id: 1, user: { gender: 'female' }, isActive: true };
 
@@ -311,8 +311,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return override the item data as a string found from the collection that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = ['male', 'female'];
+        mockColumn.editor!.validator = null as any;
+        mockColumn.editor!.collection = ['male', 'female'];
         mockItemData = { id: 123, gender: 'female', isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -322,7 +322,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return item data with an empty string in its value when calling "applyValue" which fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.label.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -339,7 +339,7 @@ describe('AutocompleterEditor', () => {
 
     describe('forceUserInput flag', () => {
       it('should return DOM element value when "forceUserInput" is enabled and loaded value length is greater then minLength defined when calling "serializeValue"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { forceUserInput: true, };
+        mockColumn.editor!.editorOptions = { forceUserInput: true, };
         mockItemData = { id: 123, gender: { value: 'male', label: 'Male' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -351,7 +351,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return DOM element value when "forceUserInput" is enabled and loaded value length is greater then custom minLength defined when calling "serializeValue"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { forceUserInput: true, minLength: 2 } as AutocompleterOption;
+        mockColumn.editor!.editorOptions = { forceUserInput: true, minLength: 2 } as AutocompleterOption;
         mockItemData = { id: 123, gender: { value: 'male', label: 'Male' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -363,7 +363,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return loaded value when "forceUserInput" is enabled and loaded value length is lower than minLength defined when calling "serializeValue"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { forceUserInput: true, } as AutocompleterOption;
+        mockColumn.editor!.editorOptions = { forceUserInput: true, } as AutocompleterOption;
         mockItemData = { id: 123, gender: { value: 'male', label: 'Male' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -377,8 +377,8 @@ describe('AutocompleterEditor', () => {
 
     describe('serializeValue method', () => {
       it('should return correct object value even when defining a "customStructure" when calling "serializeValue"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ option: 'male', text: 'Male' }, { option: 'female', text: 'Female' }];
-        (mockColumn.internalColumnEditor as ColumnEditor).customStructure = { value: 'option', label: 'text' };
+        mockColumn.editor!.collection = [{ option: 'male', text: 'Male' }, { option: 'female', text: 'Female' }];
+        mockColumn.editor!.customStructure = { value: 'option', label: 'text' };
         mockItemData = { id: 123, gender: { option: 'female', text: 'Female' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -390,7 +390,7 @@ describe('AutocompleterEditor', () => {
 
       it('should return an object output when calling "serializeValue" with its column definition set to "FieldType.object" with default label/value', () => {
         mockColumn.type = FieldType.object;
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
+        mockColumn.editor!.collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
         mockItemData = { id: 123, gender: { value: 'f', label: 'Female' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -402,7 +402,7 @@ describe('AutocompleterEditor', () => {
 
       it('should return an object output when calling "serializeValue" with its column definition set to "FieldType.object" with custom dataKey/labelKey pair', () => {
         mockColumn.type = FieldType.object;
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
+        mockColumn.editor!.collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
         mockColumn.dataKey = 'id';
         mockColumn.labelKey = 'name';
         mockItemData = { id: 123, gender: { value: 'f', label: 'Female' }, isActive: true };
@@ -441,7 +441,7 @@ describe('AutocompleterEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, '');
 
@@ -449,7 +449,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return True when field is required and input is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -457,7 +457,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is lower than a minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
+        mockColumn.editor!.minLength = 5;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -465,8 +465,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is lower than a minLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 5;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -474,7 +474,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return True when field is equal to the minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
+        mockColumn.editor!.minLength = 4;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -482,7 +482,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is greater than a maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -490,8 +490,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 10;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -499,7 +499,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return True when field is equal to the maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.maxLength = 16;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -507,8 +507,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -516,8 +516,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -525,8 +525,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is not between minLength & maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 10;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -534,8 +534,8 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 16;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -543,9 +543,9 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 15;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 15;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -553,9 +553,9 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
         const validation1 = editor.validate(null, 'text is 16 chars');
         const validation2 = editor.validate(null, 'text');
@@ -565,7 +565,7 @@ describe('AutocompleterEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new AutocompleterEditor(editorArguments);
         const validation = editor.validate(null, 'Task is longer than 10 chars');
 
@@ -593,7 +593,7 @@ describe('AutocompleterEditor', () => {
 
       it('should expect the "handleSelect" method to be called when the callback method is triggered', () => {
         gridOptionMock.autoCommitEdit = true;
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
+        mockColumn.editor!.collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
         mockItemData = { id: 123, gender: { value: 'f', label: 'Female' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -608,8 +608,8 @@ describe('AutocompleterEditor', () => {
 
       it('should initialize the editor with editorOptions and expect the "handleSelect" method to be called when the callback method is triggered', () => {
         gridOptionMock.autoCommitEdit = true;
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+        mockColumn.editor!.collection = [{ value: 'm', label: 'Male' }, { value: 'f', label: 'Female' }];
+        mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
         mockItemData = { id: 123, gender: { value: 'f', label: 'Female' }, isActive: true };
 
         editor = new AutocompleterEditor(editorArguments);
@@ -630,7 +630,7 @@ describe('AutocompleterEditor', () => {
         const mockOnSelect = jest.fn();
         const activeCellMock = { row: 1, cell: 0 };
         jest.spyOn(gridStub, 'getActiveCell').mockReturnValue(activeCellMock);
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3, onSelectItem: mockOnSelect } as AutocompleterOption;
+        mockColumn.editor!.editorOptions = { minLength: 3, onSelectItem: mockOnSelect } as AutocompleterOption;
 
         const event = new CustomEvent('change');
         editor = new AutocompleterEditor(editorArguments);
@@ -649,7 +649,7 @@ describe('AutocompleterEditor', () => {
       it('should provide "renderItem" in the "filterOptions" and expect the autocomplete "render" to be overriden', () => {
         const mockTemplateString = `<div>Hello World</div>`;
         const mockTemplateCallback = () => mockTemplateString;
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: ['male', 'female'],
           editorOptions: {
             showOnFocus: true,
@@ -691,7 +691,7 @@ describe('AutocompleterEditor', () => {
       const mockCollection = [{ value: 'male', label: 'Male' }, { value: 'unknown', label: 'Unknown' }];
       const event = new (window.window as any).KeyboardEvent('keydown', { key: 'm', bubbles: true, cancelable: true });
 
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         collection: mockCollection,
         editorOptions: { showOnFocus: true } as AutocompleterOption
       };
@@ -711,7 +711,7 @@ describe('AutocompleterEditor', () => {
 
     it('should call "clear" method when clear button is clicked', () => {
       const mockCollection = [{ value: 'male', label: 'Male' }, { value: 'unknown', label: 'Unknown' }];
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         collection: mockCollection,
         editorOptions: { showOnFocus: true } as AutocompleterOption
       };
@@ -728,7 +728,7 @@ describe('AutocompleterEditor', () => {
       const mockCollection = [{ value: 'female', label: 'Female' }, { value: 'undefined', label: 'Undefined' }];
       const event = new (window.window as any).KeyboardEvent('keydown', { key: 'm', bubbles: true, cancelable: true });
 
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         editorOptions: {
           showOnFocus: true,
           fetch: (_, updateCallback) => updateCallback(mockCollection)
@@ -753,7 +753,7 @@ describe('AutocompleterEditor', () => {
       const mockCollection = [{ value: 'female', label: 'Female' }, { value: 'undefined', label: 'Undefined' }];
       const event = new (window.window as any).KeyboardEvent('keydown', { key: 'm', bubbles: true, cancelable: true });
 
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         editorOptions: {
           showOnFocus: true,
           fetch: (_, updateCallback) => updateCallback(mockCollection)
@@ -926,7 +926,7 @@ describe('AutocompleterEditor', () => {
         getReturnValue: () => false
       } as any);
       gridOptionMock.autoCommitEdit = true;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = ['male', 'female'];
+      mockColumn.editor!.collection = ['male', 'female'];
       mockItemData = { id: 123, gender: 'female', isActive: true };
 
       editor = new AutocompleterEditor(editorArguments);
@@ -950,7 +950,7 @@ describe('AutocompleterEditor', () => {
         const onCompositeEditorSpy = jest.spyOn(gridStub.onCompositeEditorChange, 'notify').mockReturnValue({
           getReturnValue: () => false
         } as any);
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: ['Other', 'Male', 'Female'],
           collectionOverride: (inputCollection) => inputCollection.filter(item => item !== 'other')
         };

--- a/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { CheckboxEditor } from '../checkboxEditor';
-import { AutocompleterOption, Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { AutocompleterOption, Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 const containerId = 'demo-container';
@@ -45,7 +45,7 @@ describe('CheckboxEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'isActive', field: 'isActive', editable: true, editor: { model: Editors.checkbox }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'isActive', field: 'isActive', editable: true, editor: { model: Editors.checkbox }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -76,7 +76,7 @@ describe('CheckboxEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, title: 'task 1', isActive: true };
-      mockColumn = { id: 'isActive', field: 'isActive', editable: true, editor: { model: Editors.checkbox }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'isActive', field: 'isActive', editable: true, editor: { model: Editors.checkbox }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -100,7 +100,7 @@ describe('CheckboxEditor', () => {
     });
 
     it('should initialize the editor even when user define his own editor options', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+      mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
       editor = new CheckboxEditor(editorArguments);
       const editorCount = divContainer.querySelectorAll('input.editor-checkbox.editor-isActive').length;
 
@@ -109,7 +109,7 @@ describe('CheckboxEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new CheckboxEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-checkbox.editor-isActive') as HTMLInputElement;
@@ -119,13 +119,13 @@ describe('CheckboxEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         title: 'test title',
       };
 
       editor = new CheckboxEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" with true and expect the DOM element value to return true (representing checked)', () => {
@@ -207,7 +207,7 @@ describe('CheckboxEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the isActive property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, title: 'task 1', isActive: true };
 
         editor = new CheckboxEditor(editorArguments);
@@ -217,7 +217,7 @@ describe('CheckboxEditor', () => {
       });
 
       it('should apply the value to the title property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.isActive';
         mockItemData = { id: 1, part: { isActive: true } };
 
@@ -324,7 +324,7 @@ describe('CheckboxEditor', () => {
 
       it('should not call anything when the input value is false but is required', () => {
         mockItemData = { id: 1, title: 'task 1', isActive: false };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
@@ -338,7 +338,7 @@ describe('CheckboxEditor', () => {
 
       it('should not call anything when the input value is null but is required', () => {
         mockItemData = { id: 1, title: 'task 1', isActive: null };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
@@ -351,7 +351,7 @@ describe('CheckboxEditor', () => {
       });
 
       it('should not save when custom validation fails', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (!value) {
             return { valid: false, msg: 'This must be accepted' };
           }
@@ -372,7 +372,7 @@ describe('CheckboxEditor', () => {
     describe('validate method', () => {
       it('should return False when field is required and field is empty, null or false', () => {
         const expectation = { valid: false, msg: 'Field is required' };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new CheckboxEditor(editorArguments);
         const validation1 = editor.validate(null, '');
         const validation2 = editor.validate(null, null);
@@ -384,7 +384,7 @@ describe('CheckboxEditor', () => {
       });
 
       it('should return True when field is required and input is provided with True', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new CheckboxEditor(editorArguments);
         const validation = editor.validate(null, true);
 
@@ -392,7 +392,7 @@ describe('CheckboxEditor', () => {
       });
 
       it('should return True when field is required and input is provided with any text', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new CheckboxEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -3,7 +3,7 @@ import moment from 'moment-mini';
 import { Editors } from '../index';
 import { DateEditor } from '../dateEditor';
 import { FieldType } from '../../enums/index';
-import { Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
@@ -55,7 +55,7 @@ describe('DateEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'startDate', field: 'startDate', editable: true, editor: { model: Editors.date }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'startDate', field: 'startDate', editable: true, editor: { model: Editors.date }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -86,7 +86,7 @@ describe('DateEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, startDate: '2001-01-02T11:02:02.000Z', isActive: true };
-      mockColumn = { id: 'startDate', field: 'startDate', editable: true, editor: { model: Editors.date }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'startDate', field: 'startDate', editable: true, editor: { model: Editors.date }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -119,7 +119,7 @@ describe('DateEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new DateEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-startDate') as HTMLTextAreaElement;
@@ -129,7 +129,7 @@ describe('DateEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new DateEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-startDate') as HTMLTextAreaElement;
@@ -138,14 +138,14 @@ describe('DateEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         placeholder: 'test placeholder',
         title: 'test title',
       };
 
       editor = new DateEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same string when calling "getValue"', () => {
@@ -222,7 +222,7 @@ describe('DateEditor', () => {
     describe('isValueChanged method', () => {
       it('should return True when date is changed in the picker', () => {
         // change to allow input value only for testing purposes & use the regular flatpickr input to test that one too
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { allowInput: true, altInput: false };
+        mockColumn.editor!.editorOptions = { allowInput: true, altInput: false };
         mockItemData = { id: 1, startDate: '2001-01-02T11:02:02.000Z', isActive: true };
 
         editor = new DateEditor(editorArguments);
@@ -238,7 +238,7 @@ describe('DateEditor', () => {
 
       it('should return True when date is reset by the clear date button', () => {
         // change to allow input value only for testing purposes & use the regular flatpickr input to test that one too
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { allowInput: true, altInput: false };
+        mockColumn.editor!.editorOptions = { allowInput: true, altInput: false };
         mockItemData = { id: 1, startDate: '2001-01-02T11:02:02.000Z', isActive: true };
 
         editor = new DateEditor(editorArguments);
@@ -256,7 +256,7 @@ describe('DateEditor', () => {
 
       it('should also return True when date is reset by the clear date button even if the previous date was empty', () => {
         // change to allow input value only for testing purposes & use the regular flatpickr input to test that one too
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { allowInput: true, altInput: false };
+        mockColumn.editor!.editorOptions = { allowInput: true, altInput: false };
         mockItemData = { id: 1, startDate: '', isActive: true };
 
         editor = new DateEditor(editorArguments);
@@ -273,7 +273,7 @@ describe('DateEditor', () => {
 
       it('should return False when date in the picker is the same as the current date', () => {
         mockItemData = { id: 1, startDate: '2001-01-02T11:02:02.000Z', isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { allowInput: true }; // change to allow input value only for testing purposes
+        mockColumn.editor!.editorOptions = { allowInput: true }; // change to allow input value only for testing purposes
 
         editor = new DateEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -288,7 +288,7 @@ describe('DateEditor', () => {
       it('should return False when input date is invalid', () => {
         mockItemData = { id: 1, startDate: '1900-02-32', isActive: true };
         mockColumn.type = FieldType.dateUs;
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { allowInput: true }; // change to allow input value only for testing purposes
+        mockColumn.editor!.editorOptions = { allowInput: true }; // change to allow input value only for testing purposes
 
         editor = new DateEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -303,7 +303,7 @@ describe('DateEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the startDate property with ISO format when no "outputType" is defined and when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.type = FieldType.date;
         mockItemData = { id: 1, startDate: '2001-04-05T11:33:42.000Z', isActive: true };
 
@@ -316,7 +316,7 @@ describe('DateEditor', () => {
       });
 
       it('should apply the value to the startDate property with "outputType" format with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.type = FieldType.date;
         mockColumn.outputType = FieldType.dateTimeIsoAmPm;
         mockColumn.field = 'employee.startDate';
@@ -331,7 +331,7 @@ describe('DateEditor', () => {
       });
 
       it('should apply the value to the startDate property with output format defined by "saveOutputType" when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.type = FieldType.date;
         mockColumn.saveOutputType = FieldType.dateTimeIsoAmPm;
         mockItemData = { id: 1, startDate: '2001-04-05T11:33:42.000Z', isActive: true };
@@ -345,7 +345,7 @@ describe('DateEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.length > 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -438,7 +438,7 @@ describe('DateEditor', () => {
 
       it('should not call anything when the input value is empty but is required', () => {
         mockItemData = { id: 1, startDate: '', isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
@@ -451,7 +451,7 @@ describe('DateEditor', () => {
 
       it('should not throw any error when date is invalid when lower than required "minDate" defined in the "editorOptions" and "autoCommitEdit" is enabled', () => {
         // change to allow input value only for testing purposes & use the regular flatpickr input to test that one too
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minDate: 'today', altInput: true };
+        mockColumn.editor!.editorOptions = { minDate: 'today', altInput: true };
         mockItemData = { id: 1, startDate: '500-01-02T11:02:02.000Z', isActive: true };
         gridOptionMock.autoCommitEdit = true;
         gridOptionMock.autoEdit = true;
@@ -470,7 +470,7 @@ describe('DateEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new DateEditor(editorArguments);
         const validation = editor.validate(null, '');
 
@@ -478,7 +478,7 @@ describe('DateEditor', () => {
       });
 
       it('should return True when field is required and input is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new DateEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -644,7 +644,7 @@ describe('DateEditor', () => {
 
     it('should expect "onCompositeEditorChange" to have been triggered with the new value showing up in its "formValues" object', () => {
       const activeCellMock = { row: 0, cell: 0 };
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { allowInput: true, altInput: false };
+      mockColumn.editor!.editorOptions = { allowInput: true, altInput: false };
       mockColumn.type = FieldType.dateIso;
       const getCellSpy = jest.spyOn(gridStub, 'getActiveCell').mockReturnValue(activeCellMock);
       const onBeforeEditSpy = jest.spyOn(gridStub.onBeforeEditCell, 'notify').mockReturnValue({

--- a/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { DualInputEditor } from '../dualInputEditor';
-import { Column, ColumnEditor, ColumnEditorDualInput, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, ColumnEditorDualInput, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 const containerId = 'demo-container';
@@ -49,7 +49,7 @@ describe('DualInputEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -91,8 +91,7 @@ describe('DualInputEditor', () => {
       const editorParams = { leftInput: { field: 'from', type: 'float' }, rightInput: { field: 'to', type: 'float' } } as ColumnEditorDualInput;
       mockItemData = { id: 1, from: 1, to: 22, isActive: true };
       mockColumn = {
-        id: 'range', field: 'range', editable: true, internalColumnEditor: { params: editorParams },
-        editor: { model: Editors.dualInput, params: editorParams },
+        id: 'range', field: 'range', editable: true, editor: { model: Editors.dualInput, params: editorParams },
       } as Column;
 
       editorArguments.column = mockColumn;
@@ -118,7 +117,7 @@ describe('DualInputEditor', () => {
 
     it('should have a placeholder on the left input when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.placeholder = testValue;
+      mockColumn.editor!.params.leftInput.placeholder = testValue;
 
       editor = new DualInputEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.dual-editor-text.editor-range.left') as HTMLInputElement;
@@ -128,7 +127,7 @@ describe('DualInputEditor', () => {
 
     it('should have a placeholder on the right input when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.placeholder = testValue;
+      mockColumn.editor!.params.rightInput.placeholder = testValue;
 
       editor = new DualInputEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.dual-editor-text.editor-range.right') as HTMLInputElement;
@@ -138,7 +137,7 @@ describe('DualInputEditor', () => {
 
     it('should have a title (tooltip) on left input when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.title = testValue;
+      mockColumn.editor!.params.leftInput.title = testValue;
 
       editor = new DualInputEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.dual-editor-text.editor-range.left') as HTMLInputElement;
@@ -148,7 +147,7 @@ describe('DualInputEditor', () => {
 
     it('should have a title (tooltip) on right input when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.title = testValue;
+      mockColumn.editor!.params.rightInput.title = testValue;
 
       editor = new DualInputEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.dual-editor-text.editor-range.right') as HTMLInputElement;
@@ -157,8 +156,8 @@ describe('DualInputEditor', () => {
     });
 
     it('should have a left input as type number and right input as readonly text input when that right input is set to "readonly"', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.type = 'float';
-      (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'readonly';
+      mockColumn.editor!.params.leftInput.type = 'float';
+      mockColumn.editor!.params.rightInput.type = 'readonly';
 
       editor = new DualInputEditor(editorArguments);
       const editorLeftElm = divContainer.querySelector('input.dual-editor-text.editor-range.left') as HTMLInputElement;
@@ -171,7 +170,7 @@ describe('DualInputEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).params = {
+      mockColumn.editor!.params = {
         leftInput: {
           field: 'from',
           placeholder: 'test placeholder',
@@ -185,7 +184,7 @@ describe('DualInputEditor', () => {
 
       editor = new DualInputEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same string when calling "getValue"', () => {
@@ -276,7 +275,7 @@ describe('DualInputEditor', () => {
 
       it('should return True when left input last dispatched keyboard event is ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.alwaysSaveOnEnterKey = true;
+        mockColumn.editor!.params.leftInput.alwaysSaveOnEnterKey = true;
 
         editor = new DualInputEditor(editorArguments);
         const editorLeftElm = divContainer.querySelector('input.editor-range.left') as HTMLInputElement;
@@ -290,7 +289,7 @@ describe('DualInputEditor', () => {
 
       it('should return True when right input last dispatched keyboard event is ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.alwaysSaveOnEnterKey = true;
+        mockColumn.editor!.params.rightInput.alwaysSaveOnEnterKey = true;
 
         editor = new DualInputEditor(editorArguments);
         const editorRightElm = divContainer.querySelector('input.editor-range.right') as HTMLInputElement;
@@ -305,7 +304,7 @@ describe('DualInputEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the range property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.validator = null;
+        mockColumn.editor!.params.leftInput.validator = null;
         mockItemData = { id: 1, range: '1-22', from: 0, to: 22, isActive: true };
 
         editor = new DualInputEditor(editorArguments);
@@ -315,10 +314,10 @@ describe('DualInputEditor', () => {
       });
 
       it('should apply the value to the range property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.validator = null;
+        mockColumn.editor!.params.leftInput.validator = null;
         mockColumn.field = 'part.from';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.field = 'part.from';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.field = 'part.to';
+        mockColumn.editor!.params.leftInput.field = 'part.from';
+        mockColumn.editor!.params.rightInput.field = 'part.to';
         mockItemData = { id: 1, part: { range: '1-22', from: 0, to: 44 }, isActive: true };
 
         editor = new DualInputEditor(editorArguments);
@@ -328,7 +327,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return item data with an empty string in its left input value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.validator = (value: any) => {
+        mockColumn.editor!.params.leftInput.validator = (value: any) => {
           if (+value < 10) {
             return { valid: false, msg: 'From value must be over 10.' };
           }
@@ -343,7 +342,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return item data with an empty string in its right input value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.validator = (value: any) => {
+        mockColumn.editor!.params.rightInput.validator = (value: any) => {
           if (+value > 150) {
             return { valid: false, msg: 'To value must be below 150.' };
           }
@@ -358,7 +357,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return item data with an empty strings when the shared validator fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (values: any) => {
+        mockColumn.editor!.validator = (values: any) => {
           if (values.from < 10 || values.to > 200) {
             return { valid: false, msg: '"From" value must be over 10 and "To" value below 200.' };
           }
@@ -392,8 +391,8 @@ describe('DualInputEditor', () => {
 
       it('should return serialized value as a float number when "decimal" is set to 2', () => {
         mockItemData = { id: 1, range: '32.789-45.67', from: 32.789, to: 45.67, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.decimal = 1;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.decimal = 3;
+        mockColumn.editor!.params.leftInput.decimal = 1;
+        mockColumn.editor!.params.rightInput.decimal = 3;
 
         editor = new DualInputEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -454,8 +453,8 @@ describe('DualInputEditor', () => {
 
       it('should return value as a number when using a dot (.) notation for complex object', () => {
         mockColumn.field = 'part.from';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.field = 'part.from';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.field = 'part.to';
+        mockColumn.editor!.params.leftInput.field = 'part.from';
+        mockColumn.editor!.params.rightInput.field = 'part.to';
         mockItemData = { id: 1, part: { range: '5-44', from: 5, to: 44 }, isActive: true };
 
         editor = new DualInputEditor(editorArguments);
@@ -479,8 +478,8 @@ describe('DualInputEditor', () => {
 
       it('should return decimal step as 0.1 increment when decimal is set to 1 decimal', () => {
         mockItemData = { id: 1, range: '2-32.7', from: 2, to: 32.7, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.decimal = 1;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.decimal = 2;
+        mockColumn.editor!.params.leftInput.decimal = 1;
+        mockColumn.editor!.params.rightInput.decimal = 2;
 
         editor = new DualInputEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -491,8 +490,8 @@ describe('DualInputEditor', () => {
 
       it('should return decimal step as 0.01 increment when decimal is set to 2 decimal', () => {
         mockItemData = { id: 1, range: '2-32.7', from: 2, to: 32.7, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.decimal = 1;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.decimal = 2;
+        mockColumn.editor!.params.leftInput.decimal = 1;
+        mockColumn.editor!.params.rightInput.decimal = 2;
 
         editor = new DualInputEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -599,7 +598,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.required = true;
+        mockColumn.editor!.params.leftInput.required = true;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: '' });
 
@@ -607,7 +606,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when left input field is required and its value is empty when set by "setValues"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.required = true;
+        mockColumn.editor!.params.leftInput.required = true;
         editor = new DualInputEditor(editorArguments);
         editor.setValues(['', 3]);
         const validation = editor.validate(null);
@@ -616,7 +615,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when left input field is required and its value is empty when set by "setValues"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.required = true;
+        mockColumn.editor!.params.rightInput.required = true;
         editor = new DualInputEditor(editorArguments);
         editor.setValues([2, '']);
         const validation = editor.validate(null);
@@ -625,7 +624,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when editor is float but its field is not a valid float number', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.required = true;
+        mockColumn.editor!.params.rightInput.required = true;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 'abc' });
 
@@ -633,8 +632,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when editor is integer but its field is not a valid integer number', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'integer';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.required = true;
+        mockColumn.editor!.params.rightInput.type = 'integer';
+        mockColumn.editor!.params.rightInput.required = true;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 'abc' });
 
@@ -642,8 +641,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when editor is a required text input but its text value is not provided', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'text';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.required = true;
+        mockColumn.editor!.params.rightInput.type = 'text';
+        mockColumn.editor!.params.rightInput.required = true;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: '' });
 
@@ -651,8 +650,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when editor is a required password input but its text value is not provided', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'password';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.required = true;
+        mockColumn.editor!.params.rightInput.type = 'password';
+        mockColumn.editor!.params.rightInput.required = true;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: '' });
 
@@ -660,7 +659,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field is lower than a minValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.minValue = 10.2;
+        mockColumn.editor!.params.leftInput.minValue = 10.2;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 10 });
 
@@ -668,8 +667,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field is lower than a minValue defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.minValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.operatorConditionalType = 'exclusive';
+        mockColumn.editor!.params.leftInput.minValue = 10.2;
+        mockColumn.editor!.params.leftInput.operatorConditionalType = 'exclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 10 });
 
@@ -677,7 +676,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field is equal to the minValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.minValue = 10.2;
+        mockColumn.editor!.params.rightInput.minValue = 10.2;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 10.2 });
 
@@ -685,7 +684,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 10.2;
+        mockColumn.editor!.params.leftInput.maxValue = 10.2;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 10.22 });
 
@@ -693,8 +692,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.operatorConditionalType = 'exclusive';
+        mockColumn.editor!.params.leftInput.maxValue = 10.2;
+        mockColumn.editor!.params.leftInput.operatorConditionalType = 'exclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 10.22 });
 
@@ -702,8 +701,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field is equal to the maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'float';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.maxValue = 10.2;
+        mockColumn.editor!.params.rightInput.type = 'float';
+        mockColumn.editor!.params.rightInput.maxValue = 10.2;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 10.2 });
 
@@ -711,9 +710,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when type is set to float and its field is equal to the maxValue defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'float';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.operatorConditionalType = 'inclusive';
+        mockColumn.editor!.params.rightInput.type = 'float';
+        mockColumn.editor!.params.leftInput.maxValue = 10.2;
+        mockColumn.editor!.params.leftInput.operatorConditionalType = 'inclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 10.2 });
 
@@ -721,9 +720,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when type is set to integer and its field is equal to the maxValue defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.type = 'integer';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 11;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.operatorConditionalType = 'inclusive';
+        mockColumn.editor!.params.leftInput.type = 'integer';
+        mockColumn.editor!.params.leftInput.maxValue = 11;
+        mockColumn.editor!.params.leftInput.operatorConditionalType = 'inclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 11 });
 
@@ -731,9 +730,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when type is set to float and its field is equal to the maxValue defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'float';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.maxValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.operatorConditionalType = 'exclusive';
+        mockColumn.editor!.params.rightInput.type = 'float';
+        mockColumn.editor!.params.rightInput.maxValue = 10.2;
+        mockColumn.editor!.params.rightInput.operatorConditionalType = 'exclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 10.2 });
 
@@ -741,9 +740,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when type is set to float and its field is equal to the maxValue defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.type = 'integer';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.maxValue = 11;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.operatorConditionalType = 'exclusive';
+        mockColumn.editor!.params.rightInput.type = 'integer';
+        mockColumn.editor!.params.rightInput.maxValue = 11;
+        mockColumn.editor!.params.rightInput.operatorConditionalType = 'exclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 11 });
 
@@ -751,8 +750,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when type is set to float and its field is not between minValue & maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 99.5;
+        mockColumn.editor!.params.leftInput.minValue = 10.5;
+        mockColumn.editor!.params.leftInput.maxValue = 99.5;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 99.6 });
 
@@ -760,9 +759,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when type is set to integer and its field is not between minValue & maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.type = 'integer';
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.minValue = 11;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 99;
+        mockColumn.editor!.params.leftInput.type = 'integer';
+        mockColumn.editor!.params.leftInput.minValue = 11;
+        mockColumn.editor!.params.leftInput.maxValue = 99;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 100 });
 
@@ -770,8 +769,8 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field is is equal to maxValue defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.maxValue = 99.5;
+        mockColumn.editor!.params.rightInput.minValue = 10.5;
+        mockColumn.editor!.params.rightInput.maxValue = 99.5;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 99.5 });
 
@@ -779,9 +778,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field is is equal to minValue defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.maxValue = 99.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.operatorConditionalType = 'inclusive';
+        mockColumn.editor!.params.leftInput.minValue = 10.5;
+        mockColumn.editor!.params.leftInput.maxValue = 99.5;
+        mockColumn.editor!.params.leftInput.operatorConditionalType = 'inclusive';
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 10.5 });
 
@@ -789,9 +788,9 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field is equal to maxValue but "operatorType" is set to "exclusive" when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.maxValue = 99.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.operatorConditionalType = 'exclusive';
+        mockColumn.editor!.params.rightInput.minValue = 10.5;
+        mockColumn.editor!.params.rightInput.maxValue = 99.5;
+        mockColumn.editor!.params.rightInput.operatorConditionalType = 'exclusive';
         editor = new DualInputEditor(editorArguments);
         const validation1 = editor.validate(null, { position: 'rightInput', inputValue: 99.5 });
         const validation2 = editor.validate(null, { position: 'rightInput', inputValue: 10.5 });
@@ -801,7 +800,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return False when field has more decimals than the "decimal" which is the maximum decimal allowed', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.decimal = 2;
+        mockColumn.editor!.params.leftInput.decimal = 2;
 
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 99.6433 });
@@ -810,7 +809,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field has less decimals than the "decimal" which is valid', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.decimal = 2;
+        mockColumn.editor!.params.rightInput.decimal = 2;
 
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'rightInput', inputValue: 99.6 });
@@ -819,7 +818,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field has same number of decimals than the "decimal" which is also valid', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.leftInput.decimal = 2;
+        mockColumn.editor!.params.leftInput.decimal = 2;
 
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 99.65 });
@@ -828,7 +827,7 @@ describe('DualInputEditor', () => {
       });
 
       it('should return True when field is required and field is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params.rightInput.required = true;
+        mockColumn.editor!.params.rightInput.required = true;
         editor = new DualInputEditor(editorArguments);
         const validation = editor.validate(null, { position: 'leftInput', inputValue: 2.5 });
 
@@ -847,8 +846,7 @@ describe('DualInputEditor', () => {
       const editorParams = { leftInput: { field: 'from', type: 'float' }, rightInput: { field: 'to', type: 'float' } } as ColumnEditorDualInput;
       mockItemData = { id: 1, from: 1, to: 22, isActive: true };
       mockColumn = {
-        id: 'range', field: 'range', editable: true, internalColumnEditor: { params: editorParams },
-        editor: { model: Editors.dualInput, params: editorParams },
+        id: 'range', field: 'range', editable: true, editor: { model: Editors.dualInput, params: editorParams },
       } as Column;
 
       editorArguments.column = mockColumn;

--- a/packages/common/src/editors/__tests__/floatEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/floatEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { FloatEditor } from '../floatEditor';
-import { Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 const containerId = 'demo-container';
@@ -48,7 +48,7 @@ describe('FloatEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -79,7 +79,7 @@ describe('FloatEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, price: 213, isActive: true };
-      mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -115,7 +115,7 @@ describe('FloatEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new FloatEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
@@ -125,7 +125,7 @@ describe('FloatEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new FloatEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
@@ -134,7 +134,7 @@ describe('FloatEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         placeholder: 'test placeholder',
         title: 'test title',
         alwaysSaveOnEnterKey: false,
@@ -142,7 +142,7 @@ describe('FloatEditor', () => {
 
       editor = new FloatEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same but as a string when calling "getValue"', () => {
@@ -238,7 +238,7 @@ describe('FloatEditor', () => {
 
       it('should return True when previously dispatched keyboard event as ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).alwaysSaveOnEnterKey = true;
+        mockColumn.editor!.alwaysSaveOnEnterKey = true;
 
         editor = new FloatEditor(editorArguments);
         const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
@@ -252,7 +252,7 @@ describe('FloatEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the price property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, price: 456, isActive: true };
 
         editor = new FloatEditor(editorArguments);
@@ -262,7 +262,7 @@ describe('FloatEditor', () => {
       });
 
       it('should apply the value to the price property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.price';
         mockItemData = { id: 1, part: { price: 456 }, isActive: true };
 
@@ -273,7 +273,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (+value < 10) {
             return { valid: false, msg: 'Value must be over 10.' };
           }
@@ -302,7 +302,7 @@ describe('FloatEditor', () => {
 
       it('should return serialized value as a float number when "decimalPlaces" is set to 2', () => {
         mockItemData = { id: 1, price: 32.7, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).params = { decimalPlaces: 2 };
+        mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -378,7 +378,7 @@ describe('FloatEditor', () => {
 
       it('should return decimal step as 0.1 increment when decimalPlaces is set to 1 decimal', () => {
         mockItemData = { id: 1, price: 32.7, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).params = { decimalPlaces: 1 };
+        mockColumn.editor!.params = { decimalPlaces: 1 };
 
         editor = new FloatEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -388,7 +388,7 @@ describe('FloatEditor', () => {
 
       it('should return decimal step as 0.01 increment when decimalPlaces is set to 2 decimal', () => {
         mockItemData = { id: 1, price: 32.7, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).params = { decimalPlaces: 2 };
+        mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -465,7 +465,7 @@ describe('FloatEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, '');
 
@@ -473,7 +473,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is not a valid float number', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 'abc');
 
@@ -481,7 +481,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is lower than a minValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.2;
+        mockColumn.editor!.minValue = 10.2;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10);
 
@@ -489,8 +489,8 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is lower than a minValue defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minValue = 10.2;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10);
 
@@ -498,7 +498,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is equal to the minValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.2;
+        mockColumn.editor!.minValue = 10.2;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.2);
 
@@ -506,7 +506,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10.2;
+        mockColumn.editor!.maxValue = 10.2;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.22);
 
@@ -514,8 +514,8 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxValue = 10.2;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.22);
 
@@ -523,7 +523,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is equal to the maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10.2;
+        mockColumn.editor!.maxValue = 10.2;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.2);
 
@@ -531,8 +531,8 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is equal to the maxValue defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.maxValue = 10.2;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.2);
 
@@ -540,8 +540,8 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is equal to the maxValue defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10.2;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxValue = 10.2;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.2);
 
@@ -549,8 +549,8 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is not between minValue & maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99.5;
+        mockColumn.editor!.minValue = 10.5;
+        mockColumn.editor!.maxValue = 99.5;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 99.6);
 
@@ -558,8 +558,8 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is is equal to maxValue defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99.5;
+        mockColumn.editor!.minValue = 10.5;
+        mockColumn.editor!.maxValue = 99.5;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 99.5);
 
@@ -567,9 +567,9 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is is equal to minValue defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.minValue = 10.5;
+        mockColumn.editor!.maxValue = 99.5;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 10.5);
 
@@ -577,9 +577,9 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field is equal to maxValue but "operatorType" is set to "exclusive" when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99.5;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minValue = 10.5;
+        mockColumn.editor!.maxValue = 99.5;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
         const validation1 = editor.validate(null, 99.5);
         const validation2 = editor.validate(null, 10.5);
@@ -589,7 +589,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return False when field has more decimals than the "decimalPlaces" which is the maximum decimal allowed', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params = { decimalPlaces: 2 };
+        mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 99.6433);
@@ -598,7 +598,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field has less decimals than the "decimalPlaces" which is valid', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params = { decimalPlaces: 2 };
+        mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 99.6);
@@ -607,7 +607,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field has same number of decimals than the "decimalPlaces" which is also valid', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).params = { decimalPlaces: 2 };
+        mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 99.65);
@@ -616,7 +616,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is required and field is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, 2.5);
 
@@ -624,7 +624,7 @@ describe('FloatEditor', () => {
       });
 
       it('should return True when field is required and field is a valid decimal value without 0 suffix', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
         const validation = editor.validate(null, '.5');
 

--- a/packages/common/src/editors/__tests__/inputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { InputEditor } from '../inputEditor';
-import { AutocompleterOption, Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { AutocompleterOption, Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 jest.useFakeTimers();
@@ -48,7 +48,7 @@ describe('InputEditor (TextEditor)', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -79,7 +79,7 @@ describe('InputEditor (TextEditor)', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, title: 'task 1', isActive: true };
-      mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -115,7 +115,7 @@ describe('InputEditor (TextEditor)', () => {
     });
 
     it('should initialize the editor even when user define his own editor options', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+      mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
       editor = new InputEditor(editorArguments, 'text');
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-title').length;
 
@@ -124,7 +124,7 @@ describe('InputEditor (TextEditor)', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new InputEditor(editorArguments, 'text');
       const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
@@ -134,7 +134,7 @@ describe('InputEditor (TextEditor)', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new InputEditor(editorArguments, 'text');
       const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
@@ -143,7 +143,7 @@ describe('InputEditor (TextEditor)', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         placeholder: 'test placeholder',
         title: 'test title',
         alwaysSaveOnEnterKey: false,
@@ -151,7 +151,7 @@ describe('InputEditor (TextEditor)', () => {
 
       editor = new InputEditor(editorArguments, 'text');
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same string when calling "getValue"', () => {
@@ -236,7 +236,7 @@ describe('InputEditor (TextEditor)', () => {
 
       it('should return True when previously dispatched keyboard event as ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).alwaysSaveOnEnterKey = true;
+        mockColumn.editor!.alwaysSaveOnEnterKey = true;
 
         editor = new InputEditor(editorArguments, 'text');
         const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
@@ -250,7 +250,7 @@ describe('InputEditor (TextEditor)', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the title property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, title: 'task 1', isActive: true };
 
         editor = new InputEditor(editorArguments, 'text');
@@ -260,7 +260,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should apply the value to the title property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.title';
         mockItemData = { id: 1, part: { title: 'task 1' }, isActive: true };
 
@@ -271,7 +271,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -362,7 +362,7 @@ describe('InputEditor (TextEditor)', () => {
 
       it('should not call anything when the input value is empty but is required', () => {
         mockItemData = { id: 1, title: 'task', isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
@@ -395,7 +395,7 @@ describe('InputEditor (TextEditor)', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, '');
 
@@ -403,7 +403,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return True when field is required and input is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text');
 
@@ -411,7 +411,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is lower than a minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
+        mockColumn.editor!.minLength = 5;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text');
 
@@ -419,8 +419,8 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is lower than a minLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 5;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text');
 
@@ -428,7 +428,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return True when field is equal to the minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
+        mockColumn.editor!.minLength = 4;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text');
 
@@ -436,7 +436,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is greater than a maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -444,8 +444,8 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 10;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -453,7 +453,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return True when field is equal to the maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.maxLength = 16;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -461,8 +461,8 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -470,8 +470,8 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -479,8 +479,8 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is not between minLength & maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 10;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -488,8 +488,8 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 16;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -497,9 +497,9 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 15;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 15;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'text');
 
@@ -507,9 +507,9 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
         const validation1 = editor.validate(null, 'text is 16 chars');
         const validation2 = editor.validate(null, 'text');
@@ -519,7 +519,7 @@ describe('InputEditor (TextEditor)', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new InputEditor(editorArguments, 'text');
         const validation = editor.validate(null, 'Task is longer than 10 chars');
 

--- a/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { InputPasswordEditor } from '../inputPasswordEditor';
-import { AutocompleterOption, Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { AutocompleterOption, Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 jest.useFakeTimers();
@@ -48,7 +48,7 @@ describe('InputPasswordEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -79,7 +79,7 @@ describe('InputPasswordEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, title: 'task 1', isActive: true };
-      mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.text }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -115,7 +115,7 @@ describe('InputPasswordEditor', () => {
     });
 
     it('should initialize the editor even when user define his own editor options', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+      mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
       editor = new InputPasswordEditor(editorArguments);
       const editorCount = divContainer.querySelectorAll('input.editor-text.editor-title').length;
 
@@ -124,7 +124,7 @@ describe('InputPasswordEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new InputPasswordEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
@@ -134,7 +134,7 @@ describe('InputPasswordEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new InputPasswordEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-title') as HTMLInputElement;
@@ -143,7 +143,7 @@ describe('InputPasswordEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         placeholder: 'test placeholder',
         title: 'test title',
         alwaysSaveOnEnterKey: false,
@@ -151,7 +151,7 @@ describe('InputPasswordEditor', () => {
 
       editor = new InputPasswordEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same string when calling "getValue"', () => {
@@ -237,7 +237,7 @@ describe('InputPasswordEditor', () => {
 
       it('should return True when previously dispatched keyboard event as ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).alwaysSaveOnEnterKey = true;
+        mockColumn.editor!.alwaysSaveOnEnterKey = true;
 
         editor = new InputPasswordEditor(editorArguments);
         const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
@@ -252,7 +252,7 @@ describe('InputPasswordEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the title property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, title: 'task 1', isActive: true };
 
         editor = new InputPasswordEditor(editorArguments);
@@ -262,7 +262,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should apply the value to the title property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.title';
         mockItemData = { id: 1, part: { title: 'task 1' }, isActive: true };
 
@@ -273,7 +273,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -364,7 +364,7 @@ describe('InputPasswordEditor', () => {
 
       it('should not call anything when the input value is empty but is required', () => {
         mockItemData = { id: 1, title: 'task', isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
@@ -397,7 +397,7 @@ describe('InputPasswordEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, '');
 
@@ -405,7 +405,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return True when field is required and input is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -413,7 +413,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is lower than a minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
+        mockColumn.editor!.minLength = 5;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -421,8 +421,8 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is lower than a minLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 5;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -430,7 +430,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return True when field is equal to the minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
+        mockColumn.editor!.minLength = 4;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -438,7 +438,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is greater than a maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -446,8 +446,8 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 10;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -455,7 +455,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return True when field is equal to the maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.maxLength = 16;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -463,8 +463,8 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -472,8 +472,8 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -481,8 +481,8 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is not between minLength & maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 10;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -490,8 +490,8 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 16;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text is 16 chars');
 
@@ -499,9 +499,9 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 15;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 15;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'text');
 
@@ -509,9 +509,9 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
         const validation1 = editor.validate(null, 'text is 16 chars');
         const validation2 = editor.validate(null, 'text');
@@ -521,7 +521,7 @@ describe('InputPasswordEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new InputPasswordEditor(editorArguments);
         const validation = editor.validate(null, 'Task is longer than 10 chars');
 

--- a/packages/common/src/editors/__tests__/integerEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/integerEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { IntegerEditor } from '../integerEditor';
-import { Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 const containerId = 'demo-container';
@@ -48,7 +48,7 @@ describe('IntegerEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.integer }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.integer }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -79,7 +79,7 @@ describe('IntegerEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, price: 213, isActive: true };
-      mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.integer }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.integer }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -116,7 +116,7 @@ describe('IntegerEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new IntegerEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
@@ -126,7 +126,7 @@ describe('IntegerEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new IntegerEditor(editorArguments);
       const editorElm = divContainer.querySelector('input.editor-text.editor-price') as HTMLInputElement;
@@ -135,7 +135,7 @@ describe('IntegerEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         placeholder: 'test placeholder',
         title: 'test title',
         alwaysSaveOnEnterKey: false,
@@ -143,7 +143,7 @@ describe('IntegerEditor', () => {
 
       editor = new IntegerEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same but as a string when calling "getValue"', () => {
@@ -242,7 +242,7 @@ describe('IntegerEditor', () => {
 
       it('should return True when previously dispatched keyboard event as ENTER and "alwaysSaveOnEnterKey" is enabled', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).alwaysSaveOnEnterKey = true;
+        mockColumn.editor!.alwaysSaveOnEnterKey = true;
 
         editor = new IntegerEditor(editorArguments);
         const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
@@ -257,7 +257,7 @@ describe('IntegerEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the price property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, price: 456, isActive: true };
 
         editor = new IntegerEditor(editorArguments);
@@ -267,7 +267,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should apply the value to the price property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.price';
         mockItemData = { id: 1, part: { price: 456 }, isActive: true };
 
@@ -278,7 +278,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (+value < 10) {
             return { valid: false, msg: 'Value must be over 10.' };
           }
@@ -433,7 +433,7 @@ describe('IntegerEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, '');
 
@@ -441,7 +441,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is not a valid integer', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, '.2');
 
@@ -449,7 +449,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is lower than a minValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
+        mockColumn.editor!.minValue = 10;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 3);
 
@@ -457,8 +457,8 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is lower than a minValue defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minValue = 10;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 3);
 
@@ -466,7 +466,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return True when field is equal to the minValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 9;
+        mockColumn.editor!.minValue = 9;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 9);
 
@@ -474,7 +474,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10;
+        mockColumn.editor!.maxValue = 10;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 33);
 
@@ -482,8 +482,8 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxValue = 10;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 33);
 
@@ -491,7 +491,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return True when field is equal to the maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99;
+        mockColumn.editor!.maxValue = 99;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 99);
 
@@ -499,8 +499,8 @@ describe('IntegerEditor', () => {
       });
 
       it('should return True when field is equal to the maxValue defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 9;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.maxValue = 9;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 9);
 
@@ -508,8 +508,8 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is equal to the maxValue defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 9;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxValue = 9;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 9);
 
@@ -517,8 +517,8 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is not between minValue & maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99;
+        mockColumn.editor!.minValue = 10;
+        mockColumn.editor!.maxValue = 99;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 345);
 
@@ -526,8 +526,8 @@ describe('IntegerEditor', () => {
       });
 
       it('should return True when field is is equal to maxValue defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 89;
+        mockColumn.editor!.minValue = 10;
+        mockColumn.editor!.maxValue = 89;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 89);
 
@@ -535,9 +535,9 @@ describe('IntegerEditor', () => {
       });
 
       it('should return True when field is is equal to minValue defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 89;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.minValue = 10;
+        mockColumn.editor!.maxValue = 89;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 10);
 
@@ -545,9 +545,9 @@ describe('IntegerEditor', () => {
       });
 
       it('should return False when field is equal to maxValue but "operatorType" is set to "exclusive" when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 89;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minValue = 10;
+        mockColumn.editor!.maxValue = 89;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
         const validation1 = editor.validate(null, 89);
         const validation2 = editor.validate(null, 10);
@@ -557,7 +557,7 @@ describe('IntegerEditor', () => {
       });
 
       it('should return True when field is required and field is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new IntegerEditor(editorArguments);
         const validation = editor.validate(null, 2);
 

--- a/packages/common/src/editors/__tests__/longTextEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/longTextEditor.spec.ts
@@ -6,7 +6,7 @@ jest.mock('@slickgrid-universal/utils', () => ({
 
 import { Editors } from '../index';
 import { LongTextEditor } from '../longTextEditor';
-import { AutocompleterOption, Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { AutocompleterOption, Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
 import { getOffset } from '@slickgrid-universal/utils';
@@ -65,7 +65,7 @@ describe('LongTextEditor', () => {
     document.body.style.height = '700px';
     document.body.style.width = '1024px';
     document.body.appendChild(divContainer);
-    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.longText }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.longText }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -96,7 +96,7 @@ describe('LongTextEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, title: 'task 1', isActive: true };
-      mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.longText }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'title', field: 'title', editable: true, editor: { model: Editors.longText }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -152,7 +152,7 @@ describe('LongTextEditor', () => {
     });
 
     it('should initialize the editor even when user define his own editor options', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+      mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
       editor = new LongTextEditor(editorArguments);
       const editorCount = document.body.querySelectorAll('.slick-large-editor-text.editor-title textarea').length;
 
@@ -161,7 +161,7 @@ describe('LongTextEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
+      mockColumn.editor!.placeholder = testValue;
 
       editor = new LongTextEditor(editorArguments);
       const editorElm = document.body.querySelector('.slick-large-editor-text.editor-title textarea') as HTMLTextAreaElement;
@@ -171,7 +171,7 @@ describe('LongTextEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new LongTextEditor(editorArguments);
       const editorElm = document.body.querySelector('.slick-large-editor-text.editor-title textarea') as HTMLTextAreaElement;
@@ -180,14 +180,14 @@ describe('LongTextEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         placeholder: 'test placeholder',
         title: 'test title',
       };
 
       editor = new LongTextEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" and expect the DOM element value to be the same string when calling "getValue"', () => {
@@ -251,7 +251,7 @@ describe('LongTextEditor', () => {
       it('should return True when previously dispatched keyboard event is a new char "a" and it should also update the text counter accordingly', () => {
         const eventKeyDown = new (window.window as any).KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true });
         const eventInput = new (window.window as any).KeyboardEvent('input', { key: 'a', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 255;
+        mockColumn.editor!.maxLength = 255;
 
         editor = new LongTextEditor(editorArguments);
         editor.setValue('z');
@@ -303,7 +303,7 @@ describe('LongTextEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the title property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, title: 'task 1', isActive: true };
 
         editor = new LongTextEditor(editorArguments);
@@ -313,7 +313,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should apply the value to the title property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.title';
         mockItemData = { id: 1, part: { title: 'task 1' }, isActive: true };
 
@@ -324,7 +324,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -403,7 +403,7 @@ describe('LongTextEditor', () => {
       it('should call "commitChanges" method when "hasAutoCommitEdit" is enabled but value is invalid', () => {
         mockItemData = { id: 1, title: 'task', isActive: true };
         gridOptionMock.autoCommitEdit = true;
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -436,7 +436,7 @@ describe('LongTextEditor', () => {
 
       it('should not call anything when the input value is empty but is required', () => {
         mockItemData = { id: 1, title: '', isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
@@ -605,7 +605,7 @@ describe('LongTextEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, '');
 
@@ -613,7 +613,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return True when field is required and input is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text');
 
@@ -621,7 +621,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is lower than a minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
+        mockColumn.editor!.minLength = 5;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text');
 
@@ -629,8 +629,8 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is lower than a minLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 5;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 5;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text');
 
@@ -638,7 +638,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return True when field is equal to the minLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
+        mockColumn.editor!.minLength = 4;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text');
 
@@ -646,7 +646,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is greater than a maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -654,8 +654,8 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 10;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -663,7 +663,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return True when field is equal to the maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.maxLength = 16;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -671,8 +671,8 @@ describe('LongTextEditor', () => {
       });
 
       it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -680,8 +680,8 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -689,8 +689,8 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is not between minLength & maxLength defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 10;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -698,8 +698,8 @@ describe('LongTextEditor', () => {
       });
 
       it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 0;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
+        mockColumn.editor!.minLength = 0;
+        mockColumn.editor!.maxLength = 16;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text is 16 chars');
 
@@ -707,9 +707,9 @@ describe('LongTextEditor', () => {
       });
 
       it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 15;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'inclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 15;
+        mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'text');
 
@@ -717,9 +717,9 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minLength = 4;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 16;
-        (mockColumn.internalColumnEditor as ColumnEditor).operatorConditionalType = 'exclusive';
+        mockColumn.editor!.minLength = 4;
+        mockColumn.editor!.maxLength = 16;
+        mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
         const validation1 = editor.validate(undefined, 'text is 16 chars');
         const validation2 = editor.validate(undefined, 'text');
@@ -729,7 +729,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should return False when field is greater than a maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
         editor = new LongTextEditor(editorArguments);
         const validation = editor.validate(undefined, 'Task is longer than 10 chars');
 
@@ -740,7 +740,7 @@ describe('LongTextEditor', () => {
     describe('Truncate Text when using maxLength', () => {
       it('should truncate text to 10 chars when the provided text (with input/keydown event) is more than maxLength(10)', () => {
         const eventInput = new (window.window as any).KeyboardEvent('input', { key: 'a', bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
 
         editor = new LongTextEditor(editorArguments);
 
@@ -762,7 +762,7 @@ describe('LongTextEditor', () => {
 
       it('should truncate text to 10 chars when the provided text (with paste event) is more than maxLength(10)', () => {
         const eventPaste = new (window.window as any).CustomEvent('paste', { bubbles: true, cancelable: true });
-        (mockColumn.internalColumnEditor as ColumnEditor).maxLength = 10;
+        mockColumn.editor!.maxLength = 10;
 
         editor = new LongTextEditor(editorArguments);
 

--- a/packages/common/src/editors/__tests__/multipleSelectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/multipleSelectEditor.spec.ts
@@ -3,7 +3,7 @@ import 'multiple-select-vanilla';
 
 import { Editors } from '../index';
 import { MultipleSelectEditor } from '../multipleSelectEditor';
-import { Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import type { SlickDataView } from '../../core';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
 import { type SlickGrid } from '../../core/index';
@@ -53,7 +53,7 @@ describe('MultipleSelectEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -73,8 +73,8 @@ describe('MultipleSelectEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, gender: 'male', isActive: true };
-      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -85,7 +85,7 @@ describe('MultipleSelectEditor', () => {
     });
 
     it('should initialize the editor', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
       gridOptionMock.translater = translateService;
       editor = new MultipleSelectEditor(editorArguments, 0);
       const editorCount = document.body.querySelectorAll('select.ms-filter.editor-gender').length;

--- a/packages/common/src/editors/__tests__/selectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/selectEditor.spec.ts
@@ -5,7 +5,7 @@ import { SlickEvent, type SlickDataView } from '../../core/index';
 import { Editors } from '../index';
 import { SelectEditor } from '../selectEditor';
 import { FieldType, OperatorType } from '../../enums/index';
-import { AutocompleterOption, Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { AutocompleterOption, Column, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
 import { type SlickGrid } from '../../core/index';
 
@@ -58,7 +58,7 @@ describe('SelectEditor', () => {
     document.body.innerHTML = '';
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -87,7 +87,7 @@ describe('SelectEditor', () => {
 
     it('should throw an error when there is no collection provided in the editor property', (done) => {
       try {
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = undefined;
+        mockColumn.editor!.collection = undefined;
         editor = new SelectEditor(editorArguments, true);
       } catch (e) {
         expect(e.toString()).toContain(`[Slickgrid-Universal] You need to pass a "collection" (or "collectionAsync") inside Column Definition Editor for the MultipleSelect/SingleSelect Editor to work correctly.`);
@@ -97,7 +97,7 @@ describe('SelectEditor', () => {
 
     it('should throw an error when collection is not a valid array', (done) => {
       try {
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = { hello: 'world' } as any;
+        mockColumn.editor!.collection = { hello: 'world' } as any;
         editor = new SelectEditor(editorArguments, true);
       } catch (e) {
         expect(e.toString()).toContain(`The "collection" passed to the Select Editor is not a valid array.`);
@@ -107,7 +107,7 @@ describe('SelectEditor', () => {
 
     it('should throw an error when collection is not a valid value/label pair array', (done) => {
       try {
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ hello: 'world' }];
+        mockColumn.editor!.collection = [{ hello: 'world' }];
         editor = new SelectEditor(editorArguments, true);
       } catch (e) {
         expect(e.toString()).toContain(`[Slickgrid-Universal] Select Filter/Editor collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`);
@@ -118,8 +118,8 @@ describe('SelectEditor', () => {
     it('should throw an error when "enableTranslateLabel" is set without a valid I18N Service', (done) => {
       try {
         translateService = undefined as any;
-        (mockColumn.internalColumnEditor as ColumnEditor).enableTranslateLabel = true;
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+        mockColumn.editor!.enableTranslateLabel = true;
+        mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
         editor = new SelectEditor(editorArguments, true);
       } catch (e) {
         expect(e.toString()).toContain(`[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.`);
@@ -131,8 +131,8 @@ describe('SelectEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, gender: 'male', isActive: true };
-      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }, { value: 'other', label: 'other' }];
+      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }, { value: 'other', label: 'other' }];
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -143,7 +143,7 @@ describe('SelectEditor', () => {
     });
 
     it('should initialize the editor', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
       gridOptionMock.translater = translateService;
       editor = new SelectEditor(editorArguments, true);
       editor.focus();
@@ -156,8 +156,8 @@ describe('SelectEditor', () => {
     it('should initialize the editor with element being disabled in the DOM when passing a collectionAsync and an empty collection property', () => {
       const mockCollection = ['male', 'female'];
       const promise = Promise.resolve(mockCollection);
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = null as any;
-      (mockColumn.internalColumnEditor as ColumnEditor).collectionAsync = promise;
+      mockColumn.editor!.collection = null as any;
+      mockColumn.editor!.collectionAsync = promise;
       gridOptionMock.translater = translateService;
 
       editor = new SelectEditor(editorArguments, true);
@@ -171,7 +171,7 @@ describe('SelectEditor', () => {
     });
 
     it('should initialize the editor even when user define its own editor options', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { minLength: 3 } as AutocompleterOption;
+      mockColumn.editor!.editorOptions = { minLength: 3 } as AutocompleterOption;
       editor = new SelectEditor(editorArguments, true);
       const editorCount = document.body.querySelectorAll('select.ms-filter.editor-gender').length;
 
@@ -180,8 +180,8 @@ describe('SelectEditor', () => {
 
     it('should have a placeholder when defined in its column definition', () => {
       const testValue = 'test placeholder';
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = testValue;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.placeholder = testValue;
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
       editor = new SelectEditor(editorArguments, true);
       const editorElm = divContainer.querySelector('.ms-filter.editor-gender .ms-placeholder') as HTMLSpanElement;
@@ -191,7 +191,7 @@ describe('SelectEditor', () => {
 
     it('should enable Dark Mode and expect ".ms-dark-mode" CSS class to be found on parent element', () => {
       gridOptionMock.darkMode = true;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
       editor = new SelectEditor(editorArguments, true);
       const editorElm = divContainer.querySelector('.ms-parent.editor-gender') as HTMLSpanElement;
@@ -200,12 +200,12 @@ describe('SelectEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-      (mockColumn.internalColumnEditor as ColumnEditor).placeholder = 'test placeholder';
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.placeholder = 'test placeholder';
 
       editor = new SelectEditor(editorArguments, true);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should call "setValue" with a single string and expect the string to be returned in a single string array when calling "getValue" when using single select', () => {
@@ -233,8 +233,8 @@ describe('SelectEditor', () => {
     });
 
     it('should create the multi-select editor with a blank entry at the beginning of the collection when "addBlankEntry" is set in the "collectionOptions" property', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-      (mockColumn.internalColumnEditor as ColumnEditor).collectionOptions = { addBlankEntry: true };
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collectionOptions = { addBlankEntry: true };
 
       editor = new SelectEditor(editorArguments, true, 0);
       const editorBtnElm = divContainer.querySelector('.ms-parent.ms-filter.editor-gender button.ms-choice') as HTMLButtonElement;
@@ -249,8 +249,8 @@ describe('SelectEditor', () => {
     });
 
     it('should create the multi-select editor with a custom entry at the beginning of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-      (mockColumn.internalColumnEditor as ColumnEditor).collectionOptions = { addCustomFirstEntry: { value: null as any, label: '' } };
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collectionOptions = { addCustomFirstEntry: { value: null as any, label: '' } };
 
       editor = new SelectEditor(editorArguments, true, 0);
       const editorBtnElm = divContainer.querySelector('.ms-parent.ms-filter.editor-gender button.ms-choice') as HTMLButtonElement;
@@ -265,8 +265,8 @@ describe('SelectEditor', () => {
     });
 
     it('should create the multi-select editor with a custom entry at the end of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-      (mockColumn.internalColumnEditor as ColumnEditor).collectionOptions = { addCustomLastEntry: { value: null as any, label: '' } };
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collectionOptions = { addCustomLastEntry: { value: null as any, label: '' } };
 
       editor = new SelectEditor(editorArguments, true, 0);
       const editorBtnElm = divContainer.querySelector('.ms-parent.ms-filter.editor-gender button.ms-choice') as HTMLButtonElement;
@@ -375,7 +375,7 @@ describe('SelectEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the gender property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, gender: 'male', isActive: true };
 
         editor = new SelectEditor(editorArguments, true);
@@ -385,7 +385,7 @@ describe('SelectEditor', () => {
       });
 
       it('should apply the value to the gender (last property) when field has a dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'person.bio.gender';
         mockItemData = { id: 1, person: { bio: { gender: 'male' } }, isActive: true };
 
@@ -396,8 +396,8 @@ describe('SelectEditor', () => {
       });
 
       it('should apply the value to the bio property (second last) when field has a dot notation (complex object) value provided is an object and it that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
-        (mockColumn.internalColumnEditor as ColumnEditor).complexObjectPath = 'person.bio';
+        mockColumn.editor!.validator = null as any;
+        mockColumn.editor!.complexObjectPath = 'person.bio';
         mockColumn.field = 'person.bio.gender';
         mockItemData = { id: 1, person: { bio: { gender: 'male' } }, isActive: true };
 
@@ -408,7 +408,7 @@ describe('SelectEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (value.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
@@ -423,7 +423,7 @@ describe('SelectEditor', () => {
       });
 
       it('should apply the value to the gender property as an array with multiple when the input value is a CSV string', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, gender: 'male', isActive: true };
 
         editor = new SelectEditor(editorArguments, true);
@@ -433,9 +433,9 @@ describe('SelectEditor', () => {
       });
 
       it('should parse the value as a float when field type is defined as float then apply the value', () => {
-        mockColumn = { id: 'age', field: 'age', type: FieldType.boolean, editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
+        mockColumn = { id: 'age', field: 'age', type: FieldType.boolean, editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
         mockItemData = { id: 1, gender: 'male', isActive: true, age: 26 };
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 20, label: '20' }, { value: 25, label: '25' }];
+        mockColumn.editor!.collection = [{ value: 20, label: '20' }, { value: 25, label: '25' }];
 
         editorArguments.column = mockColumn;
         editor = new SelectEditor(editorArguments, true);
@@ -480,7 +480,7 @@ describe('SelectEditor', () => {
 
       it('should return value as a string when using a dot (.) notation for complex object with a collection of string values', () => {
         mockColumn.field = 'employee.gender';
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = ['male', 'female'];
+        mockColumn.editor!.collection = ['male', 'female'];
         mockItemData = { id: 1, employee: { id: 24, gender: 'male' }, isActive: true };
 
         editor = new SelectEditor(editorArguments, true);
@@ -504,7 +504,7 @@ describe('SelectEditor', () => {
       it('should return all object values when using a dot (.) notation for complex object with a collection of option/label pair and using "serializeComplexValueFormat" as "object"', () => {
         mockColumn.field = 'employee.gender';
         mockItemData = { id: 1, employee: { id: 24, gender: ['male', 'other'] }, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).serializeComplexValueFormat = 'object';
+        mockColumn.editor!.serializeComplexValueFormat = 'object';
         editor = new SelectEditor(editorArguments, true);
         editor.loadValue(mockItemData);
         const output = editor.serializeValue();
@@ -516,7 +516,7 @@ describe('SelectEditor', () => {
       it('should return a single object value when using a dot (.) notation for complex object with a collection of option/label pair and using "serializeComplexValueFormat" as "object"', () => {
         mockColumn.field = 'employee.gender';
         mockItemData = { id: 1, employee: { id: 24, gender: 'male' }, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).serializeComplexValueFormat = 'object';
+        mockColumn.editor!.serializeComplexValueFormat = 'object';
         editor = new SelectEditor(editorArguments, false);
         editor.loadValue(mockItemData);
         const output = editor.serializeValue();
@@ -528,7 +528,7 @@ describe('SelectEditor', () => {
       it('should return flat value when using a dot (.) notation for complex object with a collection of option/label pair and using "serializeComplexValueFormat" as "flat"', () => {
         mockColumn.field = 'employee.gender';
         mockItemData = { id: 1, employee: { id: 24, gender: ['male', 'other'] }, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).serializeComplexValueFormat = 'flat';
+        mockColumn.editor!.serializeComplexValueFormat = 'flat';
         editor = new SelectEditor(editorArguments, true);
         editor.loadValue(mockItemData);
         const output = editor.serializeValue();
@@ -540,7 +540,7 @@ describe('SelectEditor', () => {
       it('should return object value when using a dot (.) notation and we override the object path using "complexObjectPath" to find correct values', () => {
         mockColumn.field = 'employee.bio';
         mockItemData = { id: 1, employee: { id: 24, bio: { gender: ['male', 'other'] } }, isActive: true };
-        (mockColumn.internalColumnEditor as ColumnEditor).complexObjectPath = 'employee.bio.gender';
+        mockColumn.editor!.complexObjectPath = 'employee.bio.gender';
         editor = new SelectEditor(editorArguments, true);
         editor.loadValue(mockItemData);
         const output = editor.serializeValue();
@@ -628,7 +628,7 @@ describe('SelectEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new SelectEditor(editorArguments, true);
         const validation = editor.validate(null as any, '');
 
@@ -636,7 +636,7 @@ describe('SelectEditor', () => {
       });
 
       it('should return True when field is required and input is a valid input value', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new SelectEditor(editorArguments, true);
         const validation = editor.validate(null as any, 'text');
 
@@ -646,7 +646,7 @@ describe('SelectEditor', () => {
 
     describe('initialize with collection', () => {
       it('should create the multi-select editor with a default search term when passed as a filter argument even with collection an array of strings', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = ['male', 'female'];
+        mockColumn.editor!.collection = ['male', 'female'];
 
         editor = new SelectEditor(editorArguments, true, 0);
         const editorBtnElm = divContainer.querySelector('.ms-parent.ms-filter.editor-gender button.ms-choice') as HTMLButtonElement;
@@ -663,7 +663,7 @@ describe('SelectEditor', () => {
 
     describe('collectionSortBy setting', () => {
       it('should create the multi-select editor and sort the string collection when "collectionSortBy" is set', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: ['other', 'male', 'female'],
           collectionSortBy: {
             sortDesc: true,
@@ -683,7 +683,7 @@ describe('SelectEditor', () => {
       });
 
       it('should create the multi-select editor and sort the value/label pair collection when "collectionSortBy" is set', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }],
           collectionSortBy: {
             property: 'value',
@@ -710,7 +710,7 @@ describe('SelectEditor', () => {
 
     describe('collectionFilterBy setting', () => {
       it('should create the multi-select editor and filter the string collection when "collectionFilterBy" is set', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: ['other', 'male', 'female'],
           collectionFilterBy: {
             operator: OperatorType.equal,
@@ -728,7 +728,7 @@ describe('SelectEditor', () => {
       });
 
       it('should create the multi-select editor and filter the value/label pair collection when "collectionFilterBy" is set', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }],
           collectionFilterBy: [
             { property: 'value', operator: OperatorType.notEqual, value: 'other' },
@@ -750,7 +750,7 @@ describe('SelectEditor', () => {
       });
 
       it('should create the multi-select editor and filter the value/label pair collection when "collectionFilterBy" is set and "filterResultAfterEachPass" is set to "merge"', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }],
           collectionFilterBy: [
             { property: 'value', operator: OperatorType.equal, value: 'other' },
@@ -778,7 +778,7 @@ describe('SelectEditor', () => {
 
     describe('collectionOverride callback option', () => {
       it('should create the multi-select editor and expect a different collection outputed when using the override', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: ['other', 'male', 'female'],
           collectionOverride: (inputCollection) => inputCollection.filter(item => item !== 'other')
         };
@@ -796,7 +796,7 @@ describe('SelectEditor', () => {
 
     describe('collectionInsideObjectProperty setting', () => {
       it('should create the multi-select editor with a value/label pair collection that is inside an object when "collectionInsideObjectProperty" is defined with a dot notation', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: { deep: { myCollection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }] } } as any,
           collectionOptions: {
             collectionInsideObjectProperty: 'deep.myCollection'
@@ -821,7 +821,7 @@ describe('SelectEditor', () => {
 
     describe('enableRenderHtml property', () => {
       it('should create the multi-select editor with a default search term and have the HTML rendered when "enableRenderHtml" is set', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           enableRenderHtml: true,
           collection: [{ value: true, label: 'True', labelPrefix: `<i class="fa fa-check"></i> ` }, { value: false, label: 'False' }],
           customStructure: {
@@ -841,7 +841,7 @@ describe('SelectEditor', () => {
       });
 
       it('should create the multi-select editor with a default search term and have the HTML rendered and sanitized when "enableRenderHtml" is set and has <script> tag', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           enableRenderHtml: true,
           collection: [{ isEffort: true, label: 'True', labelPrefix: `<script>alert('test')></script><i class="fa fa-check"></i> ` }, { isEffort: false, label: 'False' }],
           collectionOptions: {
@@ -869,7 +869,7 @@ describe('SelectEditor', () => {
       });
 
       it('should create the multi-select editor with a default search term and have the HTML rendered and sanitized when using a custom "sanitizer" and "enableRenderHtml" flag is set and has <script> tag', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           enableRenderHtml: true,
           collection: [{ isEffort: true, label: 'True', labelPrefix: `<script>alert('test')></script><i class="fa fa-check"></i> ` }, { isEffort: false, label: 'False' }],
           collectionOptions: {
@@ -907,8 +907,8 @@ describe('SelectEditor', () => {
       } as EditorArguments;
 
       mockItemData = { id: 1, gender: 'male', isActive: true };
-      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }, { value: 'other', label: 'other' }];
+      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }, { value: 'other', label: 'other' }];
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -1044,7 +1044,7 @@ describe('SelectEditor', () => {
         const onCompositeEditorSpy = jest.spyOn(gridStub.onCompositeEditorChange, 'notify').mockReturnValue({
           getReturnValue: () => false
         } as any);
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           collection: [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }, { value: 'other', label: 'other' }],
           collectionOverride: (inputCollection) => inputCollection.filter(item => item.value !== 'other')
         };

--- a/packages/common/src/editors/__tests__/singleSelectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/singleSelectEditor.spec.ts
@@ -3,7 +3,7 @@ import 'multiple-select-vanilla';
 
 import { Editors } from '../index';
 import { SingleSelectEditor } from '../singleSelectEditor';
-import { Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub';
 import type { SlickDataView, SlickGrid } from '../../core';
 
@@ -50,7 +50,7 @@ describe('SingleSelectEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -70,8 +70,8 @@ describe('SingleSelectEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, gender: 'male', isActive: true };
-      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, internalColumnEditor: {} } as Column;
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: '', label: '' }, { value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn = { id: 'gender', field: 'gender', editable: true, editor: { model: Editors.multipleSelect }, editorClass: {} as Editor } as Column;
+      mockColumn.editor!.collection = [{ value: '', label: '' }, { value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -82,7 +82,7 @@ describe('SingleSelectEditor', () => {
     });
 
     it('should initialize the editor', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.editor!.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
       gridOptionMock.translater = translateService;
       editor = new SingleSelectEditor(editorArguments);
       const editorCount = document.body.querySelectorAll('select.ms-filter.editor-gender').length;
@@ -155,7 +155,7 @@ describe('SingleSelectEditor', () => {
       });
 
       it('should return False after re-selecting the same option as the one loaded', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = ['male', 'female'];
+        mockColumn.editor!.collection = ['male', 'female'];
         mockItemData = { id: 1, gender: 'male', isActive: true };
 
         editor = new SingleSelectEditor(editorArguments, 0);
@@ -219,7 +219,7 @@ describe('SingleSelectEditor', () => {
 
       it('should return value as a string when using a dot (.) notation for complex object', () => {
         mockColumn.field = 'employee.gender';
-        (mockColumn.internalColumnEditor as ColumnEditor).collection = ['male', 'female'];
+        mockColumn.editor!.collection = ['male', 'female'];
         mockItemData = { id: 1, employee: { gender: 'male' }, isActive: true };
 
         editor = new SingleSelectEditor(editorArguments);
@@ -232,7 +232,7 @@ describe('SingleSelectEditor', () => {
 
     describe('enableRenderHtml property', () => {
       it('should create the multi-select editor with a default value and have the HTML rendered when "enableRenderHtml" is set', () => {
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           enableRenderHtml: true,
           collection: [{ value: true, label: 'True', labelPrefix: `<i class="fa fa-check"></i> ` }, { value: false, label: 'False' }],
           customStructure: {
@@ -257,7 +257,7 @@ describe('SingleSelectEditor', () => {
 
       it('should create the multi-select editor with a default value and have the HTML rendered and sanitized when "enableRenderHtml" is set and has <script> tag', () => {
         mockColumn.field = 'isEffort';
-        mockColumn.internalColumnEditor = {
+        mockColumn.editor = {
           enableRenderHtml: true,
           collection: [{ isEffort: true, label: 'True', labelPrefix: `<script>alert('test')></script><i class="fa fa-check"></i> ` }, { isEffort: false, label: 'False' }],
           collectionOptions: {

--- a/packages/common/src/editors/__tests__/sliderEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/sliderEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { SliderEditor } from '../sliderEditor';
-import { Column, ColumnEditor, EditorArguments, GridOption } from '../../interfaces/index';
+import { Column, ColumnEditor, Editor, EditorArguments, GridOption } from '../../interfaces/index';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index';
 
 jest.useFakeTimers();
@@ -49,7 +49,7 @@ describe('SliderEditor', () => {
     divContainer.innerHTML = template;
     document.body.appendChild(divContainer);
 
-    mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, internalColumnEditor: {} } as Column;
+    mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float } } as Column;
 
     editorArguments = {
       grid: gridStub,
@@ -80,7 +80,7 @@ describe('SliderEditor', () => {
   describe('with valid Editor instance', () => {
     beforeEach(() => {
       mockItemData = { id: 1, price: 213, isActive: true };
-      mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, internalColumnEditor: {} } as Column;
+      mockColumn = { id: 'price', field: 'price', editable: true, editor: { model: Editors.float }, editorClass: {} as Editor } as Column;
 
       editorArguments.column = mockColumn;
       editorArguments.item = mockItemData;
@@ -105,7 +105,7 @@ describe('SliderEditor', () => {
 
     it('should have a title (tooltip) when defined in its column definition', () => {
       const testValue = 'test title';
-      (mockColumn.internalColumnEditor as ColumnEditor).title = testValue;
+      mockColumn.editor!.title = testValue;
 
       editor = new SliderEditor(editorArguments);
       const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;
@@ -114,17 +114,17 @@ describe('SliderEditor', () => {
     });
 
     it('should call "columnEditor" GETTER and expect to equal the editor settings we provided', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         title: 'test title',
       };
 
       editor = new SliderEditor(editorArguments);
 
-      expect(editor.columnEditor).toEqual(mockColumn.internalColumnEditor);
+      expect(editor.columnEditor).toEqual(mockColumn.editor);
     });
 
     it('should create the input editor with defined value and a different step size when "valueStep" is provided', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).valueStep = 5;
+      mockColumn.editor!.valueStep = 5;
       mockItemData = { id: 1, price: 15, isActive: true };
 
       editor = new SliderEditor(editorArguments);
@@ -138,7 +138,7 @@ describe('SliderEditor', () => {
     });
 
     it('should create the input editor with min slider values being set by editor "minValue"', () => {
-      mockColumn.internalColumnEditor = {
+      mockColumn.editor = {
         minValue: 4,
         maxValue: 69,
       };
@@ -154,7 +154,7 @@ describe('SliderEditor', () => {
     });
 
     it('should create the input editor with min/max slider values being set by editor "sliderStartValue" through the editor editorOptions', () => {
-      mockColumn.internalColumnEditor = { editorOptions: { sliderStartValue: 4 } };
+      mockColumn.editor = { editorOptions: { sliderStartValue: 4 } };
       mockItemData = { id: 1, price: null, isActive: true };
 
       editor = new SliderEditor(editorArguments);
@@ -170,7 +170,7 @@ describe('SliderEditor', () => {
     });
 
     it('should create the input editor with default search terms range but without showing side numbers when "hideSliderNumber" is set in editorOptions', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { hideSliderNumber: true };
+      mockColumn.editor!.editorOptions = { hideSliderNumber: true };
       mockItemData = { id: 1, price: null, isActive: true };
 
       editor = new SliderEditor(editorArguments);
@@ -205,7 +205,7 @@ describe('SliderEditor', () => {
     });
 
     it('should define an item datacontext containing a string as cell value and expect this value to be loaded in the editor when calling "loadValue"', () => {
-      mockColumn.internalColumnEditor = { maxValue: 500 };
+      mockColumn.editor = { maxValue: 500 };
       editor = new SliderEditor(editorArguments);
       editor.loadValue(mockItemData);
       const editorInputElm = editor.editorInputDomElement;
@@ -218,7 +218,7 @@ describe('SliderEditor', () => {
 
     it('should update slider number every time a change event happens on the input slider', () => {
       const cellMouseEnterSpy = jest.spyOn(gridStub.onMouseEnter, 'notify');
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { hideSliderNumber: false };
+      mockColumn.editor!.editorOptions = { hideSliderNumber: false };
       mockItemData = { id: 1, price: 32, isActive: true };
       editor = new SliderEditor(editorArguments);
       editor.loadValue(mockItemData);
@@ -237,7 +237,7 @@ describe('SliderEditor', () => {
 
     describe('isValueChanged method', () => {
       it('should return True when previously dispatched change event is a different slider input number', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { sliderStartValue: 5 };
+        mockColumn.editor!.editorOptions = { sliderStartValue: 5 };
         mockItemData = { id: 1, price: 32, isActive: true };
         editor = new SliderEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -271,7 +271,7 @@ describe('SliderEditor', () => {
       });
 
       it('should return False when previously dispatched change event is the same input number as "sliderStartValue" provided by the user', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { sliderStartValue: 5 };
+        mockColumn.editor!.editorOptions = { sliderStartValue: 5 };
         mockItemData = { id: 1, price: 5, isActive: true };
         editor = new SliderEditor(editorArguments);
         editor.loadValue(mockItemData);
@@ -285,7 +285,7 @@ describe('SliderEditor', () => {
 
     describe('applyValue method', () => {
       it('should apply the value to the price property when it passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockItemData = { id: 1, price: 456, isActive: true };
 
         editor = new SliderEditor(editorArguments);
@@ -295,7 +295,7 @@ describe('SliderEditor', () => {
       });
 
       it('should apply the value to the price property with a field having dot notation (complex object) that passes validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = null as any;
+        mockColumn.editor!.validator = null as any;
         mockColumn.field = 'part.price';
         mockItemData = { id: 1, part: { price: 456 }, isActive: true };
 
@@ -306,7 +306,7 @@ describe('SliderEditor', () => {
       });
 
       it('should return item data with an empty string in its value when it fails the custom validation', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).validator = (value: any) => {
+        mockColumn.editor!.validator = (value: any) => {
           if (+value < 10) {
             return { valid: false, msg: 'Value must be over 10.' };
           }
@@ -363,7 +363,7 @@ describe('SliderEditor', () => {
       });
 
       it('should return serialized value as the custom "sliderStartValue" number when item value is null', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { sliderStartValue: 5 };
+        mockColumn.editor!.editorOptions = { sliderStartValue: 5 };
         mockItemData = { id: 1, price: null, isActive: true };
 
         editor = new SliderEditor(editorArguments);
@@ -452,7 +452,7 @@ describe('SliderEditor', () => {
 
     describe('validate method', () => {
       it('should return False when field is required and field is empty', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).required = true;
+        mockColumn.editor!.required = true;
         editor = new SliderEditor(editorArguments);
         const validation = editor.validate(null as any, '');
 
@@ -460,8 +460,8 @@ describe('SliderEditor', () => {
       });
 
       it('should return False when field is not between minValue & maxValue defined', () => {
-        (mockColumn.internalColumnEditor as ColumnEditor).minValue = 10;
-        (mockColumn.internalColumnEditor as ColumnEditor).maxValue = 99;
+        mockColumn.editor!.minValue = 10;
+        mockColumn.editor!.maxValue = 99;
         editor = new SliderEditor(editorArguments);
         const validation = editor.validate(null as any, 100);
 
@@ -470,7 +470,7 @@ describe('SliderEditor', () => {
     });
 
     it('should enableSliderTrackColoring and trigger a change event and expect slider track to have background color', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { sliderStartValue: 5, enableSliderTrackColoring: true };
+      mockColumn.editor!.editorOptions = { sliderStartValue: 5, enableSliderTrackColoring: true };
       mockItemData = { id: 1, price: 80, isActive: true };
       editor = new SliderEditor(editorArguments);
       editor.loadValue(mockItemData);
@@ -483,7 +483,7 @@ describe('SliderEditor', () => {
     });
 
     it('should click on the slider track and expect handle to move to the new position', () => {
-      (mockColumn.internalColumnEditor as ColumnEditor).editorOptions = { sliderStartValue: 5, enableSliderTrackColoring: true };
+      mockColumn.editor!.editorOptions = { sliderStartValue: 5, enableSliderTrackColoring: true };
       editor = new SliderEditor(editorArguments);
 
       const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -122,7 +122,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor || {} as ColumnEditor;
+    return this.columnDef?.editor || {} as ColumnEditor;
   }
 
   /** Getter for the Custom Structure if exist */

--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -43,7 +43,7 @@ export class CheckboxEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor || {} as ColumnEditor;
+    return this.columnDef?.editor || {} as ColumnEditor;
   }
 
   /** Getter for the item data context object */

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -73,7 +73,7 @@ export class DateEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor || {} as ColumnEditor;
+    return this.columnDef?.editor || {} as ColumnEditor;
   }
 
   /** Getter for the item data context object */

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -66,7 +66,7 @@ export class DualInputEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor || {} as ColumnEditor;
+    return this.columnDef?.editor || {} as ColumnEditor;
   }
 
   /** Getter for the item data context object */

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -37,14 +37,14 @@ export class InputEditor implements Editor {
   /** Grid options */
   gridOptions: GridOption;
 
-  constructor(protected readonly args: EditorArguments, inputType: string) {
+  constructor(protected readonly args: EditorArguments, inputType = 'text') {
     if (!args) {
       throw new Error('[Slickgrid-Universal] Something is wrong with this grid, an Editor must always have valid arguments.');
     }
     this.grid = args.grid;
     this.gridOptions = args.grid && args.grid.getOptions() as GridOption;
     this._bindEventService = new BindingEventService();
-    this.inputType = inputType || 'text';
+    this.inputType = inputType;
     this.init();
   }
 
@@ -55,7 +55,7 @@ export class InputEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor || {} as ColumnEditor;
+    return this.columnDef?.editor || {} as ColumnEditor;
   }
 
   /** Getter for the item data context object */

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -72,7 +72,7 @@ export class LongTextEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor ?? {} as ColumnEditor;
+    return this.columnDef?.editor ?? {} as ColumnEditor;
   }
 
   /** Getter for the item data context object */

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -176,7 +176,7 @@ export class SelectEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor | undefined {
-    return this.columnDef?.internalColumnEditor ?? {} as ColumnEditor;
+    return this.columnDef?.editor ?? {} as ColumnEditor;
   }
 
   /** Getter for item data context object */
@@ -195,7 +195,7 @@ export class SelectEditor implements Editor {
 
   /** Getter for the Custom Structure if exist */
   protected get customStructure(): CollectionCustomStructure | undefined {
-    return this.columnDef?.internalColumnEditor?.customStructure;
+    return this.columnDef?.editor?.customStructure;
   }
 
   get hasAutoCommitEdit(): boolean {
@@ -307,7 +307,7 @@ export class SelectEditor implements Editor {
   }
 
   init() {
-    if (!this.columnDef || !this.columnDef.internalColumnEditor || (!this.columnDef.internalColumnEditor.collection && !this.columnDef.internalColumnEditor.collectionAsync)) {
+    if (!this.columnDef || !this.columnDef.editor || (!this.columnDef.editor.collection && !this.columnDef.editor.collectionAsync)) {
       throw new Error(`[Slickgrid-Universal] You need to pass a "collection" (or "collectionAsync") inside Column Definition Editor for the MultipleSelect/SingleSelect Editor to work correctly.
       Also each option should include a value/label pair (or value/labelKey when using Locale).
       For example: { editor: { collection: [{ value: true, label: 'True' },{ value: false, label: 'False'}] } }`);
@@ -744,7 +744,7 @@ export class SelectEditor implements Editor {
     const placeholder = this.columnEditor?.placeholder ?? '';
     this.defaultOptions.placeholder = placeholder || '';
 
-    const editorOptions = this.columnDef?.internalColumnEditor?.editorOptions ?? {};
+    const editorOptions = this.columnDef?.editor?.editorOptions ?? {};
     this.editorElmOptions = { ...this.defaultOptions, ...editorOptions, data: dataCollection };
     this._msInstance = multipleSelect(selectElement, this.editorElmOptions) as MultipleSelectInstance;
     this.editorElm = this._msInstance.getParentElement();

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -60,7 +60,7 @@ export class SliderEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor ?? {} as ColumnEditor;
+    return this.columnDef?.editor ?? {} as ColumnEditor;
   }
 
   /** Getter for the item data context object */

--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -80,9 +80,9 @@ describe('CellExternalCopyManager', () => {
   lastNameElm.textContent = 'Last Name';
   const mockEventCallback = () => { };
   const mockColumns = [
-    { id: 'firstName', field: 'firstName', name: 'First Name', editor: Editors.text, internalColumnEditor: Editors.text },
+    { id: 'firstName', field: 'firstName', name: 'First Name', editor: Editors.text, editorClass: Editors.text },
     { id: 'lastName', field: 'lastName', name: lastNameElm, },
-    { id: 'age', field: 'age', name: 'Age', editor: Editors.text, internalColumnEditor: Editors.text },
+    { id: 'age', field: 'age', name: 'Age', editor: Editors.text, editorClass: Editors.text },
   ] as Column[];
   let plugin: SlickCellExternalCopyManager;
   const gridOptionsMock = {
@@ -161,20 +161,20 @@ describe('CellExternalCopyManager', () => {
 
     it('should call "getDataItemValueForColumn" and expect the ouput to be what "dataItemColumnValueExtractor" returns when it is provided', () => {
       plugin.init(gridStub, { dataItemColumnValueExtractor: (item, col) => col.field === 'firstName' ? 'Full Name' : 'Last Name' });
-      const output = plugin.getDataItemValueForColumn({ firstName: 'John', lastName: 'Doe' }, mockColumns[0], new Event('mousedown'));
+      const output = plugin.getDataItemValueForColumn({ firstName: 'John', lastName: 'Doe' }, mockColumns[0], 0, 0, new SlickEventData());
       expect(output).toEqual('Full Name');
     });
 
     it('should call "getDataItemValueForColumn" and expect the editor serialized value returned when an Editor is provided', () => {
       jest.spyOn(mockTextEditor, 'serializeValue').mockReturnValue('serialized output');
       plugin.init(gridStub);
-      const output = plugin.getDataItemValueForColumn({ firstName: 'John', lastName: 'Doe' }, mockColumns[0], new Event('mousedown'));
+      const output = plugin.getDataItemValueForColumn({ firstName: 'John', lastName: 'Doe' }, mockColumns[0], 0, 0, new SlickEventData());
       expect(output).toEqual('serialized output');
     });
 
     it('should call "getDataItemValueForColumn" and expect the column "field" value returned when there is no Editor provided', () => {
       plugin.init(gridStub);
-      const output = plugin.getDataItemValueForColumn({ firstName: 'John', lastName: 'Doe' }, mockColumns[1], new Event('mousedown'));
+      const output = plugin.getDataItemValueForColumn({ firstName: 'John', lastName: 'Doe' }, mockColumns[1], 0, 0, new SlickEventData());
       expect(output).toEqual('Doe');
     });
 

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -198,7 +198,7 @@ describe('GroupItemMetadataProvider Service', () => {
           0: {
             colspan: '1',
             formatter: service.getOptions().groupFormatter,
-            editor: null
+            editorClass: null
           }
         }
       });
@@ -218,7 +218,7 @@ describe('GroupItemMetadataProvider Service', () => {
           0: {
             colspan: '*',
             formatter: service.getOptions().groupFormatter,
-            editor: null
+            editorClass: null
           }
         }
       });
@@ -232,7 +232,7 @@ describe('GroupItemMetadataProvider Service', () => {
 
       const output = service.getTotalsRowMetadata({ group: { count: 12, level: undefined as any, groupingKey: 'age', value: 33 } });
       expect(output).toEqual({
-        editor: null,
+        editorClass: null,
         selectable: false,
         focusable: mockOptions.totalsFocusable,
         cssClasses: `groupy-totals slick-group-level-0`,
@@ -243,7 +243,7 @@ describe('GroupItemMetadataProvider Service', () => {
     it('should return a formatted Group Totals with defaults options when nothing is provided', () => {
       const output = service.getTotalsRowMetadata({ group: { count: 12, level: 3, groupingKey: 'age', value: 33 } });
       expect(output).toEqual({
-        editor: null,
+        editorClass: null,
         focusable: false,
         selectable: false,
         cssClasses: `slick-group-totals slick-group-level-3`,

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -94,7 +94,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
         0: {
           colspan: this._options.includeHeaderTotals ? '1' : '*',
           formatter: this._options.groupFormatter,
-          editor: null
+          editorClass: null
         }
       }
     };
@@ -106,7 +106,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
       focusable: this._options.totalsFocusable,
       cssClasses: `${this._options.totalsCssClass} slick-group-level-${item?.group?.level || 0}`,
       formatter: this._options.totalsFormatter,
-      editor: null
+      editorClass: null
     };
   }
 

--- a/packages/common/src/formatters/__tests__/collectionEditorFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/collectionEditorFormatter.spec.ts
@@ -13,8 +13,8 @@ describe('the CollectionEditor Formatter', () => {
         model: Editors.singleSelect,
         collection: [{ value: 1, label: 'foo' }, { value: 2, label: 'bar' }]
       }
-    } as Column;
-    columnDef.internalColumnEditor = columnDef.editor;
+    } as unknown as Column;
+    columnDef.editorClass = columnDef.editor?.model;
   });
 
   it('should return same output when no value is passed', () => {

--- a/packages/common/src/formatters/collectionEditorFormatter.ts
+++ b/packages/common/src/formatters/collectionEditorFormatter.ts
@@ -11,14 +11,14 @@ import { findOrDefault } from '../services/index';
  * const dataset = [1, 2];
  */
 export const collectionEditorFormatter: Formatter = (row, cell, value, columnDef, dataContext, grid) => {
-  if (!value || !columnDef || !columnDef.internalColumnEditor || !columnDef.internalColumnEditor.collection
-    || !columnDef.internalColumnEditor.collection.length) {
+  if (!value || !columnDef || !columnDef.editor || !columnDef.editor.collection
+    || !columnDef.editor.collection.length) {
     return value;
   }
 
-  const { internalColumnEditor, internalColumnEditor: { collection } } = columnDef;
-  const labelName = (internalColumnEditor.customStructure) ? internalColumnEditor.customStructure.label : 'label';
-  const valueName = (internalColumnEditor.customStructure) ? internalColumnEditor.customStructure.value : 'value';
+  const { editor, editor: { collection } } = columnDef;
+  const labelName = (editor.customStructure) ? editor.customStructure.label : 'label';
+  const valueName = (editor.customStructure) ? editor.customStructure.value : 'value';
 
   if (Array.isArray(value)) {
     if (collection.every((x: any) => typeof x === 'string')) {

--- a/packages/common/src/interfaces/column.interface.ts
+++ b/packages/common/src/interfaces/column.interface.ts
@@ -5,6 +5,8 @@ import type {
   ColumnExcelExportOption,
   ColumnFilter,
   CustomTooltipOption,
+  Editor,
+  EditorConstructor,
   EditorValidator,
   Formatter,
   Grouping,
@@ -90,8 +92,14 @@ export interface Column<T = any> {
    */
   disableTooltip?: boolean;
 
-  /** Any inline editor function that implements Editor for the cell value or ColumnEditor */
-  editor?: any;
+  /**
+   * Editor definition for an inline editor assigned to a cell value.
+   * Note, do not confuse this property with `editorClass`, because `editorClass` is used by SlickGrid and is a reference pointer to `editor.model`
+   */
+  editor?: ColumnEditor | null;
+
+  /** Any inline Editor class or Editor constructor, this is mostly used internally by SlickGrid */
+  editorClass?: Editor | EditorConstructor | null;
 
   /** Editor number fixed decimal places */
   editorFixedDecimalPlaces?: number;
@@ -198,7 +206,8 @@ export interface Column<T = any> {
   id: number | string;
 
   /**
-   * @reserved This is a RESERVED property and is used internally by the library to copy over the Column Editor Options.
+   * @deprecated @use `editor` for the editor definition or use `editorClass` for the SlickGrid editor class.
+   * This is a RESERVED property and is used internally by the library to copy over the Column Editor Options.
    * You can read this property if you wish, but DO NOT override it (unless you know what you're doing) since could cause serious problems with your editors.
    */
   internalColumnEditor?: ColumnEditor;

--- a/packages/common/src/interfaces/columnEditor.interface.ts
+++ b/packages/common/src/interfaces/columnEditor.interface.ts
@@ -6,7 +6,7 @@ import type {
   CollectionOption,
   CollectionOverrideArgs,
   CollectionSortBy,
-  // Editor,
+  EditorConstructor,
   EditorValidator,
 } from './index';
 
@@ -103,8 +103,8 @@ export interface ColumnEditor {
   /** Minimum value of the editor, works only with Editors supporting it (number, float, slider) */
   minValue?: number | string;
 
-  /** Any inline editor function that implements Editor for the cell */
-  model?: any;
+  /** SlickGrid Editor class or EditorConstructor function that implements Editor for the cell inline editing */
+  model?: EditorConstructor;
 
   /**
    * Placeholder text that can be used by some Editors.

--- a/packages/common/src/interfaces/compositeEditorOption.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorOption.interface.ts
@@ -1,4 +1,4 @@
-import type { Editor } from './editor.interface';
+import type { Editor, EditorConstructor } from './editor.interface';
 import type { CompositeEditorModalType } from '../enums/compositeEditorModalType.type';
 
 export interface CompositeEditorOption {
@@ -27,7 +27,7 @@ export interface CompositeEditorOption {
    * Object containing all Editor instance references used by the Composite Editor modal window
    * The object is formed by the column id being the object key which contain each Editor instance
    */
-  editors: { [columnId: string]: Editor; };
+  editors: { [columnId: string]: Editor | EditorConstructor; };
 
   /**
    * Object containing all the modal form values that got changed.

--- a/packages/common/src/interfaces/editor.interface.ts
+++ b/packages/common/src/interfaces/editor.interface.ts
@@ -1,4 +1,4 @@
-import type { Column, EditorArguments, EditorValidationResult, GridOption } from './index';
+import type { EditorArguments, EditorValidationResult } from './index';
 
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo
@@ -123,7 +123,7 @@ export interface Editor {
 }
 
 export type EditorConstructor = {
-  new <TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>>(args?: EditorArguments<TData, C, O>): Editor;
+  new(args: EditorArguments): Editor;
 
   /** Static flag used in makeActiveCellEditable. */
   suppressClearOnEdit?: boolean;

--- a/packages/common/src/interfaces/editorArguments.interface.ts
+++ b/packages/common/src/interfaces/editorArguments.interface.ts
@@ -1,8 +1,8 @@
-import type { Column, CompositeEditorOption, ElementPosition, GridOption } from './index';
+import type { Column, CompositeEditorOption, ElementPosition } from './index';
 import type { PositionMethod } from '../enums/positionMethod.type';
 import type { SlickDataView, SlickGrid } from '../core/index';
 
-export interface EditorArguments<TData = any, C extends Column<TData> = Column<TData>, O extends GridOption<C> = GridOption<C>> {
+export interface EditorArguments {
   /** Column Definition */
   column: Column;
 
@@ -19,7 +19,7 @@ export interface EditorArguments<TData = any, C extends Column<TData> = Column<T
   event: Event;
 
   /** Slick Grid object */
-  grid: SlickGrid<TData, C, O>;
+  grid: SlickGrid;
 
   /** Grid Position */
   gridPosition: ElementPosition;

--- a/packages/common/src/interfaces/gridEvents.interface.ts
+++ b/packages/common/src/interfaces/gridEvents.interface.ts
@@ -1,4 +1,4 @@
-import type { Column, CompositeEditorOption, CssStyleHash, Editor, EditorValidationResult, GridOption } from './index';
+import type { Column, CompositeEditorOption, CssStyleHash, Editor, EditorConstructor, EditorValidationResult, GridOption } from './index';
 import type { SlickGrid } from '../core/index';
 
 export interface SlickGridArg { grid: SlickGrid; }
@@ -21,7 +21,7 @@ export interface OnColumnsDragEventArgs extends SlickGridArg { triggeredByColumn
 export interface OnColumnsReorderedEventArgs extends SlickGridArg { impactedColumns: Column[]; }
 export interface OnColumnsResizedEventArgs extends SlickGridArg { triggeredByColumn: string; }
 export interface OnColumnsResizeDblClickEventArgs extends SlickGridArg { triggeredByColumn: string; }
-export interface OnCompositeEditorChangeEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor; }; triggeredBy?: 'user' | 'system'; }
+export interface OnCompositeEditorChangeEventArgs extends SlickGridArg { row?: number; cell?: number; item: any; column: Column; formValues: any; editors: { [columnId: string]: Editor | EditorConstructor; }; triggeredBy?: 'user' | 'system'; }
 export interface OnClickEventArgs extends SlickGridArg { row: number; cell: number; }
 export interface OnDblClickEventArgs extends SlickGridArg { row: number; cell: number; }
 export interface OnFooterContextMenuEventArgs extends SlickGridArg { column: Column; }

--- a/packages/common/src/interfaces/itemMetadata.interface.ts
+++ b/packages/common/src/interfaces/itemMetadata.interface.ts
@@ -1,4 +1,4 @@
-import type { Column, Formatter, GroupTotalsFormatter } from './index';
+import type { Column, Editor, EditorConstructor, Formatter, GroupTotalsFormatter } from './index';
 
 /**
  * Provides a powerful way to specify additional informations of data item that can be used customize the grid appearance
@@ -23,6 +23,6 @@ export interface ItemMetadata {
   /** column-level metadata */
   columns?: {
     // properties describing metadata related to individual columns
-    [colIdOrIdx in string | number]: Pick<Column, 'colspan' | 'editor' | 'focusable' | 'formatter' | 'selectable'>;
+    [colIdOrIdx in string | number]: Pick<Column, 'colspan' | 'focusable' | 'formatter' | 'selectable'> & { editor?: Editor | EditorConstructor | null };
   }
 }

--- a/packages/common/src/interfaces/itemMetadata.interface.ts
+++ b/packages/common/src/interfaces/itemMetadata.interface.ts
@@ -1,4 +1,4 @@
-import type { Column, Editor, EditorConstructor, Formatter, GroupTotalsFormatter } from './index';
+import type { Column, Formatter, GroupTotalsFormatter } from './index';
 
 /**
  * Provides a powerful way to specify additional informations of data item that can be used customize the grid appearance
@@ -23,6 +23,6 @@ export interface ItemMetadata {
   /** column-level metadata */
   columns?: {
     // properties describing metadata related to individual columns
-    [colIdOrIdx in string | number]: Pick<Column, 'colspan' | 'focusable' | 'formatter' | 'selectable'> & { editor?: Editor | EditorConstructor | null };
+    [colIdOrIdx in string | number]: Pick<Column, 'colspan' | 'editorClass' | 'focusable' | 'formatter' | 'selectable'>;
   }
 }

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -21,7 +21,7 @@ import type { TranslaterService } from './translater.service';
 export function buildMsSelectCollectionList(type: 'editor' | 'filter', collection: any[], columnDef: Column, grid: SlickGrid, isMultiSelect = false, translaterService?: TranslaterService, searchTerms?: SearchTerm[]): { selectElement: HTMLSelectElement; dataCollection: OptionRowData[]; hasFoundSearchTerm: boolean; } {
   const columnId = columnDef?.id ?? '';
   const gridOptions = grid.getOptions();
-  const columnFilterOrEditor = (type === 'editor' ? columnDef?.internalColumnEditor : columnDef?.filter) ?? {};
+  const columnFilterOrEditor = (type === 'editor' ? columnDef?.editor : columnDef?.filter) ?? {};
   const collectionOptions = columnFilterOrEditor?.collectionOptions ?? {};
   const separatorBetweenLabels = collectionOptions?.separatorBetweenTextLabels ?? '';
   const enableTranslateLabel = columnFilterOrEditor?.enableTranslateLabel ?? false;

--- a/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
@@ -56,10 +56,10 @@ const gridStub = {
 } as unknown as SlickGrid;
 
 const columnsMock: Column[] = [
-  { id: 'productName', field: 'productName', width: 100, name: 'Product', nameKey: 'PRODUCT', editor: Editors.text as any },
+  { id: 'productName', field: 'productName', width: 100, name: 'Product', nameKey: 'PRODUCT', editorClass: Editors.text as any },
   { id: 'field2', field: 'field2', width: 75, name: 'Field 2' },
-  { id: 'field3', field: 'field3', width: 75, name: 'Field 3', nameKey: 'DURATION', editor: Editors.date as any, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' },
-  { id: 'zip', field: 'adress.zip', width: 75, name: 'Zip', editor: Editors.integer as any, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' }
+  { id: 'field3', field: 'field3', width: 75, name: 'Field 3', nameKey: 'DURATION', editorClass: Editors.date as any, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' },
+  { id: 'zip', field: 'adress.zip', width: 75, name: 'Zip', editorClass: Editors.integer as any, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' }
 ];
 const compositeEditorOptionsMock = {
   labels: {
@@ -123,7 +123,7 @@ describe('Composite Editor Factory', () => {
       cancelChanges: cancelChangeMock,
       commitChanges: commitChangeMock,
     };
-    editors = columnsMock.map(col => col.editor);
+    editors = columnsMock.map(col => col.editorClass);
     compositeOptions = { destroy: destroyMock, modalType: 'create', validationMsgPrefix: '* ', formValues: {}, editors };
 
     containers = [container1, container2, container3, container4];
@@ -291,7 +291,7 @@ describe('Composite Editor Factory', () => {
     modalElm.className = 'slick-editor-modal';
 
     for (const column of columnsMock) {
-      if (column.editor) {
+      if (column.editorClass) {
         const validationEditorElm = document.createElement('div');
         validationEditorElm.className = `item-details-validation editor-${column.id}`;
         const labelEditorElm = document.createElement('div');
@@ -327,7 +327,7 @@ describe('Composite Editor Factory', () => {
     modalElm.className = 'slick-editor-modal';
 
     for (const column of columnsMock) {
-      if (column.editor) {
+      if (column.editorClass) {
         const validationEditorElm = document.createElement('div');
         validationEditorElm.className = `item-details-validation editor-${column.id}`;
         const labelEditorElm = document.createElement('div');

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -77,7 +77,7 @@ export function SlickCompositeEditor(this: any, columns: Column[], containers: A
       let newArgs: Partial<CompositeEditorArguments> = {};
       let idx = 0;
       while (idx < columns.length) {
-        if (columns[idx].editor) {
+        if (columns[idx].editorClass) {
           const column = columns[idx];
           newArgs = { ...args };
           newArgs.container = containers[idx];
@@ -88,7 +88,7 @@ export function SlickCompositeEditor(this: any, columns: Column[], containers: A
           newArgs.compositeEditorOptions = options;
           newArgs.formValues = {};
 
-          const currentEditor = new (column.editor as any)(newArgs) as Editor & { args: EditorArguments };
+          const currentEditor = new (column.editorClass as any)(newArgs) as Editor & { args: EditorArguments };
           options.editors[column.id] = currentEditor; // add every Editor instance refs
           editors.push(currentEditor);
         }

--- a/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
@@ -121,7 +121,7 @@ const rowSelectionModelStub = {
 function createNewColumDefinitions(count: number) {
   const columnsMock: Column[] = [];
   for (let i = 0; i < count; i++) {
-    columnsMock.push({ id: `field${i}`, field: `field${i}`, name: `Field ${i}`, editor: { model: Editors.text, massUpdate: true }, width: 75 });
+    columnsMock.push({ id: `field${i}`, field: `field${i}`, name: `Field ${i}`, editorClass: Editors.text, editor: { model: Editors.text, massUpdate: true }, width: 75 });
   }
   return columnsMock;
 }
@@ -132,10 +132,10 @@ describe('CompositeEditorService', () => {
   let div: HTMLDivElement;
   let translateService: TranslateServiceStub;
   const columnsMock: Column[] = [
-    { id: 'productName', field: 'productName', width: 100, name: 'Product', nameKey: 'PRODUCT', editor: { model: Editors.text } },
+    { id: 'productName', field: 'productName', width: 100, name: 'Product', nameKey: 'PRODUCT', editorClass: Editors.text, editor: { model: Editors.text } },
     { id: 'field2', field: 'field2', width: 75, name: 'Field 2' },
-    { id: 'field3', field: 'field3', width: 75, name: 'Field 3', nameKey: 'DURATION', editor: { model: Editors.date, massUpdate: true }, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' },
-    { id: 'zip', field: 'adress.zip', width: 75, name: 'Zip', editor: { model: Editors.integer, massUpdate: true }, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' }
+    { id: 'field3', field: 'field3', width: 75, name: 'Field 3', nameKey: 'DURATION', editorClass: Editors.date, editor: { model: Editors.date, massUpdate: true }, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' },
+    { id: 'zip', field: 'adress.zip', width: 75, name: 'Zip', editorClass: Editors.integer, editor: { model: Editors.integer, massUpdate: true }, columnGroup: 'Group Name', columnGroupKey: 'GROUP_NAME' }
   ];
 
   beforeEach(() => {
@@ -377,12 +377,11 @@ describe('CompositeEditorService', () => {
     it('should make sure Slick-Composite-Editor is being created and expect form inputs to be in specific order when user provides column def "compositeEditorFormOrder"', () => {
       const mockProduct = { id: 222, address: { zip: 123456 }, productName: 'Product ABC', price: 12.55 };
       const sortedColumnsMock = [
-        { id: 'age', field: 'age', width: 100, name: 'Age', editor: { model: Editors.float, compositeEditorFormOrder: 2, } },
-        { id: 'middleName', field: 'middleName', width: 100, name: 'Middle Name', editor: { model: Editors.text } },
-        { id: 'lastName', field: 'lastName', width: 100, name: 'Last Name', editor: { model: Editors.text, compositeEditorFormOrder: 1, } },
-        { id: 'firstName', field: 'firstName', width: 100, name: 'First Name', editor: { model: Editors.text, compositeEditorFormOrder: 0, } },
+        { id: 'age', field: 'age', width: 100, name: 'Age', editorClass: Editors.float, editor: { model: Editors.float, compositeEditorFormOrder: 2, } },
+        { id: 'middleName', field: 'middleName', width: 100, name: 'Middle Name', editorClass: Editors.text, editor: { model: Editors.text } },
+        { id: 'lastName', field: 'lastName', width: 100, name: 'Last Name', editorClass: Editors.text, editor: { model: Editors.text, compositeEditorFormOrder: 1, } },
+        { id: 'firstName', field: 'firstName', width: 100, name: 'First Name', editorClass: Editors.text, editor: { model: Editors.text, compositeEditorFormOrder: 0, } },
       ] as Column[];
-      sortedColumnsMock.forEach(col => col.internalColumnEditor = col.editor!); // do the editor swap that the lib does internally
       jest.spyOn(gridStub, 'getColumns').mockReturnValue(sortedColumnsMock);
       jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
 
@@ -1591,7 +1590,7 @@ describe('CompositeEditorService', () => {
 
       it('should activate next available cell with an Editor when current active cell does not have an Editor', () => {
         const mockProduct = { id: 222, address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
-        columnsMock[2].internalColumnEditor = { massUpdate: true };
+        columnsMock[2].editor = { massUpdate: true };
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
         jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ row: 4, cell: 1 }); // column index 1 has no Editor
         const setActiveSpy = jest.spyOn(gridStub, 'setActiveCell');

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -189,7 +189,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     if (columnDef && fieldName?.includes('.')) {
       // when it's a complex object, user could override the object path (where the editable object is located)
       // else we use the path provided in the Field Column Definition
-      const objectPath = columnDef.internalColumnEditor?.complexObjectPath ?? fieldName ?? '';
+      const objectPath = columnDef.editor?.complexObjectPath ?? fieldName ?? '';
       setDeepValue(this._formValues ?? {}, objectPath, newValue);
     } else {
       this._formValues = { ...this._formValues, [columnId]: outputValue };
@@ -212,7 +212,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     if (fieldName?.includes('.')) {
       // when it's a complex object, user could override the object path (where the editable object is located)
       // else we use the path provided in the Field Column Definition
-      const objectPath = columnDef?.internalColumnEditor?.complexObjectPath ?? fieldName ?? '';
+      const objectPath = columnDef?.editor?.complexObjectPath ?? fieldName ?? '';
       setDeepValue(this._formValues, objectPath, newValue);
     } else {
       this._formValues = { ...this._formValues, [columnId]: newValue };
@@ -340,16 +340,16 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         let modalColumns: Column[] = [];
         if (isWithMassChange) {
           // when using Mass Update, we only care about the columns that have the "massUpdate: true", we disregard anything else
-          modalColumns = this._columnDefinitions.filter(col => col.editor && col.internalColumnEditor?.massUpdate === true);
+          modalColumns = this._columnDefinitions.filter(col => col.editorClass && col.editor?.massUpdate === true);
         } else {
-          modalColumns = this._columnDefinitions.filter(col => col.editor);
+          modalColumns = this._columnDefinitions.filter(col => col.editorClass);
         }
 
         // user could optionally show the form inputs in a specific order instead of using default column definitions order
-        if (modalColumns.some(col => col.internalColumnEditor?.compositeEditorFormOrder !== undefined)) {
+        if (modalColumns.some(col => col.editor?.compositeEditorFormOrder !== undefined)) {
           modalColumns.sort((col1: Column, col2: Column) => {
-            const val1 = col1?.internalColumnEditor?.compositeEditorFormOrder ?? Infinity;
-            const val2 = col2?.internalColumnEditor?.compositeEditorFormOrder ?? Infinity;
+            const val1 = col1?.editor?.compositeEditorFormOrder ?? Infinity;
+            const val2 = col2?.editor?.compositeEditorFormOrder ?? Infinity;
             return numericSortComparer(val1, val2, SortDirectionNumber.asc);
           });
         }
@@ -442,7 +442,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         this._modalElm.appendChild(modalContentElm);
 
         for (const columnDef of modalColumns) {
-          if (columnDef.editor) {
+          if (columnDef.editorClass) {
             const itemContainer = createDomElement('div', { className: `item-details-container editor-${columnDef.id}` });
 
             if (layoutColCount === 1) {
@@ -740,7 +740,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     const activeCellIndex = (isWithMassChange && !this.gridOptions.enableAddRow && (rowIndex >= this.dataViewLength)) ? this.dataViewLength - 1 : rowIndex;
 
     let columnIndexWithEditor = columnIndex;
-    const cellEditor = columns[columnIndex].editor;
+    const cellEditor = columns[columnIndex].editorClass;
     let activeEditorCellNode = this.grid.getCellNode(activeCellIndex, columnIndex);
 
     if (!cellEditor || !activeEditorCellNode || !this.getActiveCellEditor(activeCellIndex, columnIndex)) {
@@ -770,7 +770,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
 
     for (let colIndex = 0; colIndex < columns.length; colIndex++) {
       const col = columns[colIndex];
-      if (col.editor && (!isWithMassUpdate || (isWithMassUpdate && col.internalColumnEditor?.massUpdate))) {
+      if (col.editorClass && (!isWithMassUpdate || (isWithMassUpdate && col.editor?.massUpdate))) {
         // we can check that the cell is really editable by checking the onBeforeEditCell event not returning false (returning undefined, null also mean it is editable)
         const isCellEditable = this.grid.onBeforeEditCell.notify({ row: rowIndex, cell: colIndex, item: dataContext, column: col, grid: this.grid, target: 'composite', compositeEditorOptions: this._compositeOptions }).getReturnValue();
         this.grid.setActiveCell(rowIndex, colIndex, false);

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -440,8 +440,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   // TODO: revisit later, this is conflicting with Grid State & Presets
   it.skip('should update column definitions when onPluginColumnsChanged event is triggered with updated columns', () => {
     const columnsMock = [
-      { id: 'firstName', field: 'firstName', editor: undefined, internalColumnEditor: {} },
-      { id: 'lastName', field: 'lastName', editor: undefined, internalColumnEditor: {} }
+      { id: 'firstName', field: 'firstName', editor: undefined, editorClass: {} },
+      { id: 'lastName', field: 'lastName', editor: undefined, editorClass: {} }
     ];
     eventPubSubService.publish('onPluginColumnsChanged', {
       columns: columnsMock,


### PR DESCRIPTION
- rename SlickGrid `editor` to a new `editorClass` column property
- this small rename will allow us to deprecate `internalColumnEditor` and simply tell users to use `editor` which will stay aligned with what the user defined in its column definitions (prior to this change, the users had to use `internalColumnEditor` after the grid was loaded, but with this change we no longer need to do that since it will simply keep the same editor definition assignment)
- in summary `editor` is an editor definition and `editorClass` is a SlickGrid editor class (which is pulled from `editor.model`)

### TODOs
- [x] make sure all unit tests are still passing
- [x] make sure all E2E tests are still passing
- [x] test in Angular-Slickgrid (especially Custom Editor)
- [ ] in a separate PR (just keeping trace to not forget), we should replace the `any` type on `filter.model` to a `FilterConstructor` type (similar to this PR)