### PR TITLE
fix(tooltip): allow multiple tooltips per grid cell

### DIFF
--- a/docs/events/Available-Events.md
+++ b/docs/events/Available-Events.md
@@ -147,9 +147,13 @@ handleOnHeaderMenuCommand(e) {
   - `onHeaderContextMenu`
   - `onHeaderMouseEnter`
   - `onHeaderMouseLeave`
+  - `onHeaderMouseOver`
+  - `onHeaderMouseOut`
   - `onHeaderRowCellRendered`
   - `onHeaderRowMouseEnter`
   - `onHeaderRowMouseLeave`
+  - `onHeaderRowMouseOver`
+  - `onHeaderRowMouseOut`
   - `onKeyDown`
   - `onMouseEnter`
   - `onMouseLeave`

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -24,6 +24,7 @@ import {
   formatNumber,
 } from '@slickgrid-universal/common';
 import { BindingEventService } from '@slickgrid-universal/binding';
+import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import moment from 'moment-mini';
@@ -303,7 +304,7 @@ export default class Example11 {
       excelExportOptions: {
         exportWithFormatter: true
       },
-      externalResources: [new ExcelExportService()],
+      externalResources: [new ExcelExportService(), new SlickCustomTooltip()],
       enableFiltering: true,
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)

--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -153,7 +153,7 @@ export default class Example12 {
   initializeGrid() {
     this.columnDefinitions = [
       {
-        id: 'title', name: '<span title="Task must always be followed by a number" class="color-info mdi mdi-alert-circle"></span> Title', field: 'title', sortable: true, type: FieldType.string, minWidth: 75,
+        id: 'title', name: '<span title="Task must always be followed by a number" class="color-warning-dark mdi mdi-alert-outline"></span> Title <span title="Title is always rendered as UPPERCASE" class="mdi mdi-information-outline"></span>', field: 'title', sortable: true, type: FieldType.string, minWidth: 75,
         cssClass: 'text-bold text-uppercase',
         filterable: true, columnGroup: 'Common Factor',
         filter: { model: Filters.compoundInputText },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example16.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example16.scss
@@ -27,6 +27,9 @@
 
 // it's preferable to use CSS Variables (or SASS) but if you want to change colors of your tooltip for 1 column in particular you can do it this way
 // e.g. change css of 5th column 4 (zero index: l4)
+.l4 {
+  --slick-tooltip-color: #fff;
+}
 .l4 .header-tooltip-title,
 .l4 .headerrow-tooltip-title {
   color: #ffffff;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example16.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example16.ts
@@ -111,6 +111,7 @@ export default class Example16 {
         // define tooltip options here OR for the entire grid via the grid options (cell tooltip options will have precedence over grid options)
         customTooltip: {
           useRegularTooltip: true, // note regular tooltip will try to find a "title" attribute in the cell formatter (it won't work without a cell formatter)
+          useRegularTooltipFromCellTextOnly: true,
         },
       },
       {
@@ -168,7 +169,12 @@ export default class Example16 {
         formatter: Formatters.percentCompleteBar,
         sortable: true, filterable: true,
         filter: { model: Filters.sliderRange, operator: '>=', filterOptions: { hideSliderNumbers: true } as SliderRangeOption },
-        customTooltip: { position: 'center', formatter: (_row, _cell, value) => `${value}%`, headerFormatter: null as any, headerRowFormatter: null as any },
+        customTooltip: {
+          position: 'center',
+          formatter: (_row, _cell, value) => typeof value === 'string' && value.includes('%') ? value : `${value}%`,
+          headerFormatter: undefined,
+          headerRowFormatter: undefined
+        },
       },
       {
         id: 'start', name: 'Start', field: 'start', sortable: true,
@@ -459,12 +465,12 @@ export default class Example16 {
 
   tooltipFormatter(row, cell, _value, column, dataContext, grid) {
     const tooltipTitle = 'Custom Tooltip';
-    const effortDrivenHtml = Formatters.checkmarkMaterial(row, cell, dataContext.effortDriven, column, dataContext, grid);
+    const effortDrivenHtml = Formatters.checkmarkMaterial(row, cell, dataContext.effortDriven, column, dataContext, grid) as HTMLElement;
 
     return `<div class="header-tooltip-title">${tooltipTitle}</div>
     <div class="tooltip-2cols-row"><div>Id:</div> <div>${dataContext.id}</div></div>
     <div class="tooltip-2cols-row"><div>Title:</div> <div>${dataContext.title}</div></div>
-    <div class="tooltip-2cols-row"><div>Effort Driven:</div> <div>${effortDrivenHtml}</div></div>
+    <div class="tooltip-2cols-row"><div>Effort Driven:</div> <div>${effortDrivenHtml.outerHTML || ''}</div></div>
     <div class="tooltip-2cols-row"><div>Completion:</div> <div>${this.loadCompletionIcons(dataContext.percentComplete)}</div></div>
     `;
   }
@@ -474,9 +480,9 @@ export default class Example16 {
 
     // use a 2nd Formatter to get the percent completion
     // any properties provided from the `asyncPost` will end up in the `__params` property (unless a different prop name is provided via `asyncParamsPropName`)
-    const completionBar = Formatters.percentCompleteBarWithText(row, cell, dataContext.percentComplete, column, dataContext, grid);
+    const completionBar = Formatters.percentCompleteBarWithText(row, cell, dataContext.percentComplete, column, dataContext, grid) as HTMLElement;
     const out = `<div class="color-sf-primary-dark header-tooltip-title">${tooltipTitle}</div>
-      <div class="tooltip-2cols-row"><div>Completion:</div> <div>${completionBar}</div></div>
+      <div class="tooltip-2cols-row"><div>Completion:</div> <div>${completionBar.outerHTML || ''}</div></div>
       <div class="tooltip-2cols-row"><div>Lifespan:</div> <div>${dataContext.__params.lifespan.toFixed(2)}</div></div>
       <div class="tooltip-2cols-row"><div>Ratio:</div> <div>${dataContext.__params.ratio.toFixed(2)}</div></div>
     `;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example22.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example22.ts
@@ -5,6 +5,7 @@ import {
   type GridOption,
   Editors,
 } from '@slickgrid-universal/common';
+import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import { ExampleGridOptions } from './example-grid-options';
 
@@ -173,33 +174,34 @@ export default class Example22 {
           maxWidth: 100,
         },
         actionButtons: {
-          editButtonClassName: 'button-style padding-1px mr-2',
+          editButtonClassName: 'button-style padding-3px mr-2',
           iconEditButtonClassName: 'mdi mdi-pencil',
           // since no title and no titleKey is provided, it will fallback to the default text provided by the plugin
           // if the title is provided but no titleKey, it will override the default text
           // last but not least if a titleKey is provided, it will use the translation key to translate the text
           // editButtonTitle: 'Edit row',
 
-          cancelButtonClassName: 'button-style padding-1px',
+          cancelButtonClassName: 'button-style padding-3px',
           cancelButtonTitle: 'Cancel row',
           cancelButtonTitleKey: 'RBE_BTN_CANCEL',
           iconCancelButtonClassName: 'mdi mdi-undo color-danger',
           cancelButtonPrompt: 'Are you sure you want to cancel your changes?',
 
-          updateButtonClassName: 'button-style padding-1px mr-2',
+          updateButtonClassName: 'button-style padding-3px mr-2',
           updateButtonTitle: 'Update row',
           updateButtonTitleKey: 'RBE_BTN_UPDATE',
           iconUpdateButtonClassName: 'mdi mdi-check color-success',
           updateButtonPrompt: 'Save changes?',
 
-          deleteButtonClassName: 'button-style padding-1px',
+          deleteButtonClassName: 'button-style padding-3px',
           deleteButtonTitle: 'Delete row',
           iconDeleteButtonClassName: 'mdi mdi-trash-can color-danger',
           deleteButtonPrompt: 'Are you sure you want to delete this row?',
         },
       },
       enableTranslate: true,
-      translater: this.translateService
+      translater: this.translateService,
+      externalResources: [new SlickCustomTooltip()]
     };
   }
 

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -5120,6 +5120,26 @@ describe('SlickGrid core file', () => {
         expect(onHeaderMouseEnterSpy).not.toHaveBeenCalled();
       });
 
+      it('should trigger onHeaderMouseOver notify when hovering a header', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });
+        const onHeaderMouseOverSpy = jest.spyOn(grid.onHeaderMouseOver, 'notify');
+        container.querySelector('.slick-header-column')!.dispatchEvent(new CustomEvent('mouseover'));
+
+        expect(onHeaderMouseOverSpy).toHaveBeenCalled();
+      });
+
+      it('should NOT trigger onHeaderMouseOver notify when hovering a header when "slick-header-column" class is not found', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });
+        const onHeaderMouseOverSpy = jest.spyOn(grid.onHeaderMouseOver, 'notify');
+        const headerRowElm = container.querySelector('.slick-header-column');
+        headerRowElm!.classList.remove('slick-header-column');
+        headerRowElm!.dispatchEvent(new CustomEvent('mouseover'));
+
+        expect(onHeaderMouseOverSpy).not.toHaveBeenCalled();
+      });
+
       it('should trigger onHeaderMouseLeave notify when leaving the hovering of a header when "slick-header-column" class is not found', () => {
         const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });
@@ -5140,6 +5160,26 @@ describe('SlickGrid core file', () => {
         expect(onHeaderMouseLeaveSpy).not.toHaveBeenCalled();
       });
 
+      it('should trigger onHeaderMouseOut notify when leaving the hovering of a header when "slick-header-column" class is not found', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });
+        const onHeaderMouseOutSpy = jest.spyOn(grid.onHeaderMouseOut, 'notify');
+        container.querySelector('.slick-header-column')!.dispatchEvent(new CustomEvent('mouseout'));
+
+        expect(onHeaderMouseOutSpy).toHaveBeenCalled();
+      });
+
+      it('should NOT trigger onHeaderMouseOut notify when leaving the hovering of a header', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });
+        const onHeaderMouseOutSpy = jest.spyOn(grid.onHeaderMouseOut, 'notify');
+        const headerRowElm = container.querySelector('.slick-header-column');
+        headerRowElm!.classList.remove('slick-header-column');
+        headerRowElm!.dispatchEvent(new CustomEvent('mouseout'));
+
+        expect(onHeaderMouseOutSpy).not.toHaveBeenCalled();
+      });
+
       it('should trigger onHeaderRowMouseEnter notify when hovering a header', () => {
         const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true, enableCellNavigation: true });
@@ -5147,6 +5187,15 @@ describe('SlickGrid core file', () => {
         container.querySelector('.slick-headerrow-column')!.dispatchEvent(new CustomEvent('mouseenter'));
 
         expect(onHeaderRowMouseEnterSpy).toHaveBeenCalled();
+      });
+
+      it('should trigger onHeaderRowMouseOver notify when hovering a header', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true, enableCellNavigation: true });
+        const onHeaderRowMouseOverSpy = jest.spyOn(grid.onHeaderRowMouseOver, 'notify');
+        container.querySelector('.slick-headerrow-column')!.dispatchEvent(new CustomEvent('mouseover'));
+
+        expect(onHeaderRowMouseOverSpy).toHaveBeenCalled();
       });
 
       it('should update viewport top/left scrollLeft when scrolling in headerRow DOM element', () => {
@@ -5202,6 +5251,17 @@ describe('SlickGrid core file', () => {
         expect(onHeaderRowMouseEnterSpy).not.toHaveBeenCalled();
       });
 
+      it('should NOT trigger onHeaderRowMouseOver notify when hovering a header when "slick-headerrow-column" class is not found', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true, enableCellNavigation: true });
+        const onHeaderRowMouseOverSpy = jest.spyOn(grid.onHeaderRowMouseOver, 'notify');
+        const headerRowElm = container.querySelector('.slick-headerrow-column');
+        headerRowElm!.classList.remove('slick-headerrow-column');
+        headerRowElm!.dispatchEvent(new CustomEvent('mouseover'));
+
+        expect(onHeaderRowMouseOverSpy).not.toHaveBeenCalled();
+      });
+
       it('should trigger onHeaderRowMouseLeave notify when leaving the hovering of a header', () => {
         const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true, enableCellNavigation: true });
@@ -5220,6 +5280,26 @@ describe('SlickGrid core file', () => {
         headerRowElm!.dispatchEvent(new CustomEvent('mouseleave'));
 
         expect(onHeaderRowMouseLeaveSpy).not.toHaveBeenCalled();
+      });
+
+      it('should trigger onHeaderRowMouseOut notify when leaving the hovering of a header', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true, enableCellNavigation: true });
+        const onHeaderRowMouseOutSpy = jest.spyOn(grid.onHeaderRowMouseOut, 'notify');
+        container.querySelector('.slick-headerrow-column')!.dispatchEvent(new CustomEvent('mouseout'));
+
+        expect(onHeaderRowMouseOutSpy).toHaveBeenCalled();
+      });
+
+      it('should NOT trigger onHeaderRowMouseOut notify when leaving the hovering of a header when "slick-headerrow-column" class is not found', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true, enableCellNavigation: true });
+        const onHeaderRowMouseOutSpy = jest.spyOn(grid.onHeaderRowMouseOut, 'notify');
+        const headerRowElm = container.querySelector('.slick-headerrow-column');
+        headerRowElm!.classList.remove('slick-headerrow-column');
+        headerRowElm!.dispatchEvent(new CustomEvent('mouseout'));
+
+        expect(onHeaderRowMouseOutSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -166,10 +166,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onHeaderClick: SlickEvent<OnHeaderClickEventArgs>;
   onHeaderContextMenu: SlickEvent<OnHeaderContextMenuEventArgs>;
   onHeaderMouseEnter: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderMouseOver: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderMouseOut: SlickEvent<OnHeaderMouseEventArgs>;
   onHeaderMouseLeave: SlickEvent<OnHeaderMouseEventArgs>;
   onHeaderRowCellRendered: SlickEvent<OnHeaderRowCellRenderedEventArgs>;
   onHeaderRowMouseEnter: SlickEvent<OnHeaderMouseEventArgs>;
   onHeaderRowMouseLeave: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderRowMouseOver: SlickEvent<OnHeaderMouseEventArgs>;
+  onHeaderRowMouseOut: SlickEvent<OnHeaderMouseEventArgs>;
   onKeyDown: SlickEvent<OnKeyDownEventArgs>;
   onMouseEnter: SlickEvent<OnHeaderMouseEventArgs>;
   onMouseLeave: SlickEvent<OnHeaderMouseEventArgs>;
@@ -526,7 +530,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onHeaderClick = new SlickEvent<OnHeaderClickEventArgs>('onHeaderClick', externalPubSub);
     this.onHeaderContextMenu = new SlickEvent<OnHeaderContextMenuEventArgs>('onHeaderContextMenu', externalPubSub);
     this.onHeaderMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderMouseEnter', externalPubSub);
+    this.onHeaderMouseOver = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderMouseOver', externalPubSub);
+    this.onHeaderMouseOut = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderMouseOut', externalPubSub);
     this.onHeaderMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderMouseLeave', externalPubSub);
+    this.onHeaderRowMouseOver = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderRowMouseOver', externalPubSub);
+    this.onHeaderRowMouseOut = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderRowMouseOut', externalPubSub);
     this.onHeaderRowCellRendered = new SlickEvent<OnHeaderRowCellRenderedEventArgs>('onHeaderRowCellRendered', externalPubSub);
     this.onHeaderRowMouseEnter = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderRowMouseEnter', externalPubSub);
     this.onHeaderRowMouseLeave = new SlickEvent<OnHeaderMouseEventArgs>('onHeaderRowMouseLeave', externalPubSub);
@@ -1619,6 +1627,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       this._bindingEventService.bind(header, 'mouseenter', this.handleHeaderMouseEnter.bind(this) as EventListener);
       this._bindingEventService.bind(header, 'mouseleave', this.handleHeaderMouseLeave.bind(this) as EventListener);
+      this._bindingEventService.bind(header, 'mouseover', this.handleHeaderMouseOver.bind(this) as EventListener);
+      this._bindingEventService.bind(header, 'mouseout', this.handleHeaderMouseOut.bind(this) as EventListener);
 
       Utils.storage.put(header, 'column', m);
 
@@ -1658,6 +1668,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
         this._bindingEventService.bind(headerRowCell, 'mouseenter', this.handleHeaderRowMouseEnter.bind(this) as EventListener);
         this._bindingEventService.bind(headerRowCell, 'mouseleave', this.handleHeaderRowMouseLeave.bind(this) as EventListener);
+        this._bindingEventService.bind(headerRowCell, 'mouseover', this.handleHeaderRowMouseOver.bind(this) as EventListener);
+        this._bindingEventService.bind(headerRowCell, 'mouseout', this.handleHeaderRowMouseOut.bind(this) as EventListener);
 
         Utils.storage.put(headerRowCell, 'column', m);
 
@@ -2533,9 +2545,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     [].forEach.call(headerColumns, (column) => {
       this._bindingEventService.unbindByEventName(column, 'mouseenter');
       this._bindingEventService.unbindByEventName(column, 'mouseleave');
-
-      this._bindingEventService.unbindByEventName(column, 'mouseenter');
-      this._bindingEventService.unbindByEventName(column, 'mouseleave');
+      this._bindingEventService.unbindByEventName(column, 'mouseover');
+      this._bindingEventService.unbindByEventName(column, 'mouseout');
     });
 
     emptyElement(this._container);
@@ -4886,10 +4897,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!c) {
       return;
     }
-    this.triggerEvent(this.onHeaderMouseEnter, {
-      column: c,
-      grid: this
-    }, e);
+    this.triggerEvent(this.onHeaderMouseEnter, { column: c, grid: this }, e);
+  }
+
+  protected handleHeaderMouseOver(e: MouseEvent & { target: HTMLElement; }) {
+    const c = Utils.storage.get(e.target.closest('.slick-header-column'), 'column');
+    if (!c) {
+      return;
+    }
+    this.triggerEvent(this.onHeaderMouseOver, { column: c, grid: this }, e);
   }
 
   protected handleHeaderMouseLeave(e: MouseEvent & { target: HTMLElement; }) {
@@ -4897,10 +4913,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!c) {
       return;
     }
-    this.triggerEvent(this.onHeaderMouseLeave, {
-      column: c,
-      grid: this
-    }, e);
+    this.triggerEvent(this.onHeaderMouseLeave, { column: c, grid: this }, e);
+  }
+
+  protected handleHeaderMouseOut(e: MouseEvent & { target: HTMLElement; }) {
+    const c = Utils.storage.get(e.target.closest('.slick-header-column'), 'column');
+    if (!c) {
+      return;
+    }
+    this.triggerEvent(this.onHeaderMouseOut, { column: c, grid: this }, e);
   }
 
   protected handleHeaderRowMouseEnter(e: MouseEvent & { target: HTMLElement; }) {
@@ -4908,10 +4929,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!c) {
       return;
     }
-    this.triggerEvent(this.onHeaderRowMouseEnter, {
-      column: c,
-      grid: this
-    }, e);
+    this.triggerEvent(this.onHeaderRowMouseEnter, { column: c, grid: this }, e);
+  }
+
+  protected handleHeaderRowMouseOver(e: MouseEvent & { target: HTMLElement; }) {
+    const c = Utils.storage.get(e.target.closest('.slick-headerrow-column'), 'column');
+    if (!c) {
+      return;
+    }
+    this.triggerEvent(this.onHeaderRowMouseOver, { column: c, grid: this }, e);
   }
 
   protected handleHeaderRowMouseLeave(e: MouseEvent & { target: HTMLElement; }) {
@@ -4919,10 +4945,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!c) {
       return;
     }
-    this.triggerEvent(this.onHeaderRowMouseLeave, {
-      column: c,
-      grid: this
-    }, e);
+    this.triggerEvent(this.onHeaderRowMouseLeave, { column: c, grid: this }, e);
+  }
+
+  protected handleHeaderRowMouseOut(e: MouseEvent & { target: HTMLElement; }) {
+    const c = Utils.storage.get(e.target.closest('.slick-headerrow-column'), 'column');
+    if (!c) {
+      return;
+    }
+    this.triggerEvent(this.onHeaderRowMouseOut, { column: c, grid: this }, e);
   }
 
   protected handleHeaderContextMenu(e: MouseEvent & { target: HTMLElement; }) {

--- a/packages/common/src/interfaces/customTooltipOption.interface.ts
+++ b/packages/common/src/interfaces/customTooltipOption.interface.ts
@@ -27,6 +27,9 @@ export interface CustomTooltipOption<T = any> {
   /** defaults to False, should we hide the tooltip pointer arrow? */
   hideArrow?: boolean;
 
+  /** defaults to "tooltip-body" class name */
+  bodyClassName?: string;
+
   /** defaults to "slick-custom-tooltip" */
   className?: string;
 
@@ -65,6 +68,9 @@ export interface CustomTooltipOption<T = any> {
 
   /** defaults to False, when set to True it will skip custom tooltip formatter and instead will parse through the regular cell formatter and try to find a `title` to show regular tooltip */
   useRegularTooltip?: boolean;
+
+  /** defaults to False, when set to True it will skip custom tooltip formatter and ONLY use the cell value as tooltip */
+  useRegularTooltipFromCellTextOnly?: boolean;
 
   /**
    * defaults to False, optionally force to retrieve the `title` from the Formatter result instead of the cell itself.

--- a/packages/common/src/interfaces/customTooltipOption.interface.ts
+++ b/packages/common/src/interfaces/customTooltipOption.interface.ts
@@ -43,6 +43,9 @@ export interface CustomTooltipOption<T = any> {
   /** optional maximum width number (in pixel) of the tooltip container */
   maxWidth?: number;
 
+  /** defaults to 3, arrow position offset that is also used in CSS (see `$slick-tooltip-arrow-side-margin` variable) */
+  offsetArrow?: number;
+
   /** defaults to 0, optional left offset, it must be a positive/negative number (in pixel) that will be added to the offset position calculation of the tooltip container. */
   offsetLeft?: number;
 

--- a/packages/common/src/interfaces/customTooltipOption.interface.ts
+++ b/packages/common/src/interfaces/customTooltipOption.interface.ts
@@ -66,6 +66,9 @@ export interface CustomTooltipOption<T = any> {
    */
   position?: 'auto' | 'top' | 'bottom' | 'left-align' | 'right-align' | 'center';
 
+  /** should we reposition the tooltip by the mouse target on mouseover */
+  repositionByMouseOverTarget?: boolean;
+
   /** defaults to False, when set to True it will skip custom tooltip formatter and instead will parse through the regular cell formatter and try to find a `title` to show regular tooltip */
   useRegularTooltip?: boolean;
 

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -958,7 +958,7 @@ $slick-tooltip-color:                                       inherit !default;
 $slick-tooltip-height:                                      auto !default;
 $slick-tooltip-padding:                                     7px !default;
 $slick-tooltip-width:                                       auto !default;
-$slick-tooltip-overflow:                                    inherit !default;
+$slick-tooltip-overflow:                                    hidden !default;
 $slick-tooltip-text-overflow:                               ellipsis !default;
 $slick-tooltip-white-space:                                 normal !default;
 $slick-tooltip-z-index:                                     9999 !default;

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -954,7 +954,7 @@ $slick-tooltip-border-color:                                #BFBDBD !default;
 $slick-tooltip-border:                                      2px solid #{$slick-tooltip-border-color} !default;
 $slick-tooltip-border-radius:                               4px !default;
 $slick-tooltip-font-size:                                   calc(#{$slick-font-size-base} - 1px) !default;
-$slick-tooltip-color:                                       inherit !default;
+$slick-tooltip-color:                                       $slick-text-color !default;
 $slick-tooltip-height:                                      auto !default;
 $slick-tooltip-padding:                                     7px !default;
 $slick-tooltip-width:                                       auto !default;

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -412,9 +412,12 @@ li.hidden {
   height: var(--slick-tooltip-height, $slick-tooltip-height);
   width: var(--slick-tooltip-width, $slick-tooltip-width);
   z-index: var(--slick-tooltip-z-index, $slick-tooltip-z-index);
-  overflow: var(--slick-tooltip-overflow, $slick-tooltip-overflow);
-  text-overflow: var(--slick-tooltip-text-overflow, $slick-tooltip-text-overflow);
-  white-space: var(--slick-tooltip-white-space, $slick-tooltip-white-space);
+
+  .tooltip-body {
+    overflow: var(--slick-tooltip-overflow, $slick-tooltip-overflow);
+    text-overflow: var(--slick-tooltip-text-overflow, $slick-tooltip-text-overflow);
+    white-space: var(--slick-tooltip-white-space, $slick-tooltip-white-space);
+  }
 
   &.tooltip-arrow::after {
     content: "";

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -406,7 +406,6 @@ li.hidden {
   background-color: var(--slick-tooltip-background-color, $slick-tooltip-background-color);
   border: var(--slick-tooltip-border, $slick-tooltip-border);
   border-radius: var(--slick-tooltip-border-radius, $slick-tooltip-border-radius);
-  color: var(--slick-tooltip-color, $slick-tooltip-color);
   padding: var(--slick-tooltip-padding, $slick-tooltip-padding);
   font-size: var(--slick-tooltip-font-size, $slick-tooltip-font-size);
   height: var(--slick-tooltip-height, $slick-tooltip-height);
@@ -414,6 +413,7 @@ li.hidden {
   z-index: var(--slick-tooltip-z-index, $slick-tooltip-z-index);
 
   .tooltip-body {
+    color: var(--slick-tooltip-color, $slick-tooltip-color);
     overflow: var(--slick-tooltip-overflow, $slick-tooltip-overflow);
     text-overflow: var(--slick-tooltip-text-overflow, $slick-tooltip-text-overflow);
     white-space: var(--slick-tooltip-white-space, $slick-tooltip-white-space);

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -368,6 +368,132 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeFalsy();
   });
 
+  it('should create a tooltip with only the tooltip pulled from the cell text when enabling option "useRegularTooltip" & "useRegularTooltipFromCellTextOnly" and column definition has a regular formatter with a "title" attribute filled', () => {
+    const cellNode = document.createElement('div');
+    cellNode.className = 'slick-cell l2 r2';
+    cellNode.setAttribute('title', 'tooltip text');
+    const mockColumns = [{ id: 'firstName', field: 'firstName', formatter: () => `<span title="formatter tooltip text">Hello World</span>` }] as Column[];
+    jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
+    jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
+    jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
+
+    plugin.init(gridStub, container);
+    plugin.setOptions({ useRegularTooltip: true, useRegularTooltipFromCellTextOnly: true, maxHeight: 100 });
+    (document as any).elementFromPoint.mockReturnValue(cellNode);
+
+    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
+
+    const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
+    expect(tooltipElm).toBeTruthy();
+    expect(tooltipElm.textContent).toBe('tooltip text');
+    expect(tooltipElm.style.maxHeight).toBe('100px');
+    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
+  });
+
+  it('should create a tooltip aligned left from a cell with multiple span and title attributes', () => {
+    const cellNode = document.createElement('div');
+    const icon1Elm = document.createElement('span');
+    const icon2Elm = document.createElement('span');
+    cellNode.className = 'slick-cell l2 r2';
+    icon1Elm.className = 'mdi mdi-check';
+    icon1Elm.title = 'Click here when successful';
+    icon2Elm.className = 'mdi mdi-cancel';
+    icon2Elm.title = 'Click here to cancel the action';
+    cellNode.appendChild(icon1Elm);
+    cellNode.appendChild(icon2Elm);
+
+    cellNode.setAttribute('title', 'tooltip text');
+    const mockColumns = [{ id: 'firstName', field: 'firstName' }] as Column[];
+    jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
+    jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
+    jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
+    (getOffset as jest.Mock)
+      .mockReturnValueOnce({ top: 100, left: 333, height: 75, width: 400 }) // mock cell position
+      .mockReturnValueOnce({ top: 100, left: 333, height: 75, width: 400 }); // mock cell position
+
+    plugin.init(gridStub, container);
+    plugin.setOptions({ useRegularTooltip: true, maxHeight: 100 });
+    (document as any).elementFromPoint.mockReturnValue(icon2Elm);
+
+    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
+
+    const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
+    expect(tooltipElm).toBeTruthy();
+    expect(tooltipElm.textContent).toBe('Click here to cancel the action');
+    expect(tooltipElm.style.maxHeight).toBe('100px');
+    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
+  });
+
+  it('should create a tooltip aligned right from a cell with multiple span and title attributes', () => {
+    const cellNode = document.createElement('div');
+    const icon1Elm = document.createElement('span');
+    const icon2Elm = document.createElement('span');
+    cellNode.className = 'slick-cell l2 r2';
+    icon1Elm.className = 'mdi mdi-check';
+    icon1Elm.title = 'Click here when successful';
+    icon2Elm.className = 'mdi mdi-cancel';
+    icon2Elm.title = 'Click here to cancel the action';
+    cellNode.appendChild(icon1Elm);
+    cellNode.appendChild(icon2Elm);
+
+    cellNode.setAttribute('title', 'tooltip text');
+    const mockColumns = [{ id: 'firstName', field: 'firstName' }] as Column[];
+    jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
+    jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
+    jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
+    (getOffset as jest.Mock)
+      .mockReturnValueOnce({ top: 100, left: 1030, height: 75, width: 400 }) // mock cell position
+      .mockReturnValueOnce({ top: 100, left: 1030, height: 75, width: 400 }); // mock cell position
+
+    plugin.init(gridStub, container);
+    plugin.setOptions({ useRegularTooltip: true, maxHeight: 100 });
+    (document as any).elementFromPoint.mockReturnValue(icon2Elm);
+
+    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
+
+    const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
+    expect(tooltipElm).toBeTruthy();
+    expect(tooltipElm.textContent).toBe('Click here to cancel the action');
+    expect(tooltipElm.style.maxHeight).toBe('100px');
+    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
+  });
+
+  it('should NOT create a tooltip from a cell with multiple span and title attributes but it is actually hidden', () => {
+    const cellNode = document.createElement('div');
+    const icon1Elm = document.createElement('span');
+    const icon2Elm = document.createElement('span');
+    cellNode.className = 'slick-cell l2 r2';
+    icon1Elm.className = 'mdi mdi-check';
+    icon1Elm.title = 'Click here when successful';
+    icon2Elm.className = 'mdi mdi-cancel';
+    icon2Elm.title = 'Click here to cancel the action';
+    icon2Elm.style.display = 'none';
+    cellNode.appendChild(icon1Elm);
+    cellNode.appendChild(icon2Elm);
+
+    cellNode.setAttribute('title', 'tooltip text');
+    const mockColumns = [{ id: 'firstName', field: 'firstName' }] as Column[];
+    jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
+    jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
+    jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
+
+    plugin.init(gridStub, container);
+    plugin.setOptions({ useRegularTooltip: true, maxHeight: 100 });
+    (document as any).elementFromPoint.mockReturnValue(icon2Elm);
+
+    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
+
+    const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
+    expect(tooltipElm).toBeFalsy();
+  });
+
   it('should create a tooltip with only the tooltip formatter output when tooltip option has "useRegularTooltip" & "useRegularTooltipFromFormatterOnly" enabled and column definition has a regular formatter with a "title" attribute filled', () => {
     const cellNode = document.createElement('div');
     cellNode.className = 'slick-cell l2 r2';

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -57,6 +57,7 @@ describe('SlickCustomTooltip plugin', () => {
     plugin = new SlickCustomTooltip();
     divContainer.className = `slickgrid-container ${GRID_UID}`;
     document.body.appendChild(divContainer);
+    (document as any).elementFromPoint = jest.fn(); // document.elementFromPoint() doesn't exist in JSDOM but we can mock it
   });
 
   afterEach(() => {

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -72,6 +72,7 @@ describe('SlickCustomTooltip plugin', () => {
 
   it('should be able to change plugin options', () => {
     const mockOptions = {
+      bodyClassName: 'tooltip-body',
       className: 'some-class',
       offsetArrow: 3,
       offsetLeft: 5,

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -36,11 +36,11 @@ const gridStub = {
   registerPlugin: jest.fn(),
   sanitizeHtmlString: (s) => s,
   onMouseEnter: new SlickEvent(),
-  onHeaderMouseEnter: new SlickEvent(),
-  onHeaderRowMouseEnter: new SlickEvent(),
+  onHeaderMouseOver: new SlickEvent(),
+  onHeaderRowMouseOver: new SlickEvent(),
   onMouseLeave: new SlickEvent(),
-  onHeaderMouseLeave: new SlickEvent(),
-  onHeaderRowMouseLeave: new SlickEvent(),
+  onHeaderMouseOut: new SlickEvent(),
+  onHeaderRowMouseOut: new SlickEvent(),
 } as unknown as SlickGrid;
 
 describe('SlickCustomTooltip plugin', () => {
@@ -73,6 +73,7 @@ describe('SlickCustomTooltip plugin', () => {
   it('should be able to change plugin options', () => {
     const mockOptions = {
       className: 'some-class',
+      offsetArrow: 3,
       offsetLeft: 5,
       offsetRight: 7,
       offsetTopBottom: 8,
@@ -101,26 +102,26 @@ describe('SlickCustomTooltip plugin', () => {
     expect(document.body.querySelector('.slick-custom-tooltip')).toBeFalsy();
   });
 
-  it('should return without creating a tooltip when column definition has "disableTooltip: true" when "onHeaderMouseEnter" event is triggered', () => {
+  it('should return without creating a tooltip when column definition has "disableTooltip: true" when "onHeaderMouseOver" event is triggered', () => {
     const mockColumns = [{ id: 'firstName', field: 'firstName', disableTooltip: true }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
     jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
 
     plugin.init(gridStub, container);
-    gridStub.onHeaderMouseEnter.notify({ column: mockColumns[0], grid: gridStub });
+    gridStub.onHeaderMouseOver.notify({ column: mockColumns[0], grid: gridStub });
 
     expect(document.body.querySelector('.slick-custom-tooltip')).toBeFalsy();
   });
 
-  it('should return without creating a tooltip when column definition has "disableTooltip: true" when "onHeaderRowMouseEnter" event is triggered', () => {
+  it('should return without creating a tooltip when column definition has "disableTooltip: true" when "onHeaderRowMouseOver" event is triggered', () => {
     const mockColumns = [{ id: 'firstName', field: 'firstName', disableTooltip: true }] as Column[];
     jest.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
     jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
     jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
 
     plugin.init(gridStub, container);
-    gridStub.onHeaderRowMouseEnter.notify({ column: mockColumns[0], grid: gridStub });
+    gridStub.onHeaderRowMouseOver.notify({ column: mockColumns[0], grid: gridStub });
 
     expect(document.body.querySelector('.slick-custom-tooltip')).toBeFalsy();
   });
@@ -293,7 +294,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
-  it('should create a tooltip as regular tooltip with coming from text content when it is filled & also expect "hideTooltip" to be called after leaving the cell when "onHeaderMouseLeave" event is triggered', () => {
+  it('should create a tooltip as regular tooltip with coming from text content when it is filled & also expect "hideTooltip" to be called after leaving the cell when "onHeaderMouseOut" event is triggered', () => {
     const cellNode = document.createElement('div');
     cellNode.className = 'slick-cell l2 r2';
     cellNode.textContent = 'some text content';
@@ -360,7 +361,7 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, tooltipTextMaxLength: 23 });
-    gridStub.onHeaderMouseEnter.notify({ column: mockColumns[0], grid: gridStub }, { ...new SlickEventData(), target: cellNode } as any);
+    gridStub.onHeaderMouseOver.notify({ column: mockColumns[0], grid: gridStub }, { ...new SlickEventData(), target: cellNode } as any);
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeFalsy();
@@ -570,7 +571,7 @@ describe('SlickCustomTooltip plugin', () => {
     });
   });
 
-  it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseEnter" is triggered', () => {
+  it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseOver" is triggered', () => {
     const cellNode = document.createElement('div');
     cellNode.className = 'slick-cell';
     cellNode.setAttribute('title', 'tooltip text');
@@ -587,7 +588,7 @@ describe('SlickCustomTooltip plugin', () => {
     const div = document.createElement('div');
     div.className = 'toggle';
     Object.defineProperty(eventData, 'target', { writable: true, value: div });
-    gridStub.onHeaderMouseEnter.notify({ column: mockColumns[0], grid: gridStub }, eventData);
+    gridStub.onHeaderMouseOver.notify({ column: mockColumns[0], grid: gridStub }, eventData);
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -596,7 +597,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 
-  it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseEnter" is triggered', () => {
+  it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseOver" is triggered', () => {
     const cellNode = document.createElement('div');
     cellNode.className = 'slick-cell';
     cellNode.setAttribute('title', 'tooltip text');
@@ -616,7 +617,7 @@ describe('SlickCustomTooltip plugin', () => {
     divHeaders.appendChild(divHeaderColumn);
     divHeaders.className = 'toggle';
     Object.defineProperty(eventData, 'target', { writable: true, value: divHeaderColumn });
-    gridStub.onHeaderMouseEnter.notify({ column: mockColumns[0], grid: gridStub }, eventData);
+    gridStub.onHeaderMouseOver.notify({ column: mockColumns[0], grid: gridStub }, eventData);
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -625,7 +626,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 
-  it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseEnter" is triggered', () => {
+  it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseOver" is triggered', () => {
     const cellNode = document.createElement('div');
     cellNode.className = 'slick-cell';
     cellNode.setAttribute('title', 'tooltip text');
@@ -645,7 +646,7 @@ describe('SlickCustomTooltip plugin', () => {
     divHeaders.appendChild(divHeaderColumn);
     divHeaders.className = 'toggle';
     Object.defineProperty(eventData, 'target', { writable: true, value: divHeaderColumn });
-    gridStub.onHeaderRowMouseEnter.notify({ column: mockColumns[0], grid: gridStub }, eventData);
+    gridStub.onHeaderRowMouseOver.notify({ column: mockColumns[0], grid: gridStub }, eventData);
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -489,7 +489,7 @@ export class SlickCustomTooltip {
       }
 
       // when having multiple tooltips, we'll try to reposition tooltip to mouse position
-      if (this._tooltipElm && this._hasMultipleTooltips) {
+      if (this._tooltipElm && (this._hasMultipleTooltips || this.cellAddonOptions?.repositionByMouseOverTarget)) {
         const mouseElmOffset = getOffset(this._mouseTarget)!;
         if (finalTooltipPosition.includes('left') || finalTooltipPosition === 'top-center') {
           newPositionLeft = mouseElmOffset.left - (this._addonOptions?.offsetArrow ?? 3);

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -458,7 +458,7 @@ export class SlickCustomTooltip {
       // or when using "auto" and we detect not enough available space then we'll position to the "left" of the cell
       // NOTE the class name is for the arrow and is inverse compare to the tooltip itself, so if user ask for "left-align", then the arrow will in fact be "arrow-right-align"
       const position = this._cellAddonOptions?.position ?? 'auto';
-      let finalTooltipPosition = 'right-top';
+      let finalTooltipPosition = '';
       if (position === 'center') {
         newPositionLeft += (cellContainerWidth / 2) - (calculatedTooltipWidth / 2) + (this._cellAddonOptions?.offsetRight ?? 0);
         finalTooltipPosition = 'top-center';

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -495,7 +495,7 @@ describe('Example 11 - Batch Editing', () => {
       .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
   });
 
-  it('should click on "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
+  it('should "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
     cy.get('[data-test="clear-storage-btn"]')
       .click();
 
@@ -724,7 +724,7 @@ describe('Example 11 - Batch Editing', () => {
       .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
   });
 
-  it('should have 3 filters with "filled" css class when having values', () => {
+  it('should expect 3 filters with "filled" css class when having values', () => {
     cy.get('.filter-title.filled').should('exist');
     cy.get('.filter-duration.filled').should('exist');
     cy.get('.filter-countryOfOrigin.filled').should('exist');
@@ -828,5 +828,23 @@ describe('Example 11 - Batch Editing', () => {
       .should($span => {
         expect(Number($span.text())).to.eq(100);
       });
+  });
+
+  it('should display 2 different tooltips when hovering icons from "Action" column', () => {
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(10)`).as('first-row-action-cell');
+    cy.get('@first-row-action-cell').find('.action-btns .mdi-close').as('delete-row-btn');
+    cy.get('@first-row-action-cell').find('.action-btns .mdi-check-underline').as('mark-completed-btn');
+
+    cy.get('@delete-row-btn')
+      .trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip .tooltip-body').contains('Delete Current Row');
+
+    cy.get('@mark-completed-btn')
+      .trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip .tooltip-body').contains('Mark as Completed');
   });
 });

--- a/test/cypress/e2e/example12.cy.ts
+++ b/test/cypress/e2e/example12.cy.ts
@@ -2,7 +2,7 @@ import { changeTimezone, zeroPadding } from '../plugins/utilities';
 
 describe('Example 12 - Composite Editor Modal', () => {
   const fullPreTitles = ['', 'Common Factor', 'Analysis', 'Period', 'Item', ''];
-  const fullTitles = ['', ' Title', 'Duration', 'Cost', '% Complete', 'Complexity', 'Start', 'Completed', 'Finish', 'Product', 'Country of Origin', 'Action'];
+  const fullTitles = ['', ' Title ', 'Duration', 'Cost', '% Complete', 'Complexity', 'Start', 'Completed', 'Finish', 'Product', 'Country of Origin', 'Action'];
 
   const GRID_ROW_HEIGHT = 33;
   const UNSAVED_RGB_COLOR = 'rgb(221, 219, 218)';

--- a/test/cypress/e2e/example12.cy.ts
+++ b/test/cypress/e2e/example12.cy.ts
@@ -31,6 +31,23 @@ describe('Example 12 - Composite Editor Modal', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should display 2 different tooltips when hovering icons on "Title" column', () => {
+    cy.get('.slick-column-name').as('title-column');
+    cy.get('@title-column')
+      .find('.mdi-alert-outline')
+      .trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip .tooltip-body').contains('Task must always be followed by a number');
+
+    cy.get('@title-column')
+      .find('.mdi-information-outline')
+      .trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip .tooltip-body').contains('Title is always rendered as UPPERCASE');
+  });
+
   it('should have "TASK 0" (uppercase) incremented by 1 after each row', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`)
       .contains('TASK 0', { matchCase: false })
@@ -372,7 +389,7 @@ describe('Example 12 - Composite Editor Modal', () => {
     cy.get('.slick-editor-modal').should('not.exist');
   });
 
-  it('should have new TASK 8888 displayed on first row', () => {
+  it('should have new TASK 8899 displayed on first row', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 8899', { matchCase: false });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`).should('contain', '33 days');
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should('contain', '17');

--- a/test/cypress/e2e/example16.cy.ts
+++ b/test/cypress/e2e/example16.cy.ts
@@ -37,6 +37,9 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
     cy.get('.slick-custom-tooltip').should('be.visible');
     cy.get('.slick-custom-tooltip').contains('Task 2 - (async tooltip)');
 
+    cy.get('.tooltip-2cols-row:nth(0)').find('div:nth(0)').contains('Completion:');
+    cy.get('.tooltip-2cols-row:nth(0)').find('div').should('have.class', 'percent-complete-bar-with-text');
+
     cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(0)').contains('Lifespan:');
     cy.get('.tooltip-2cols-row:nth(1)').find('div:nth(1)').contains(/\d+$/); // use regexp to make sure it's a number
 
@@ -168,7 +171,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
 
   it('should mouse over header-row (filter) 2nd column Title and expect a tooltip to show rendered from an headerRowFormatter', () => {
     cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(1)`).as('checkbox0-filter');
-    cy.get('@checkbox0-filter').trigger('mouseenter');
+    cy.get('@checkbox0-filter').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('be.visible');
     cy.get('.slick-custom-tooltip').contains('Custom Tooltip - Header Row (filter)');
@@ -181,7 +184,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
 
   it('should mouse over header-row (filter) Finish column and NOT expect any tooltip to show since it is disabled on that column', () => {
     cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(8)`).as('finish-filter');
-    cy.get('@finish-filter').trigger('mouseenter');
+    cy.get('@finish-filter').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');
     cy.get('@finish-filter').trigger('mouseout');
@@ -189,7 +192,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
 
   it('should mouse over header-row (filter) Prerequisite column and expect to see tooltip of selected filter options', () => {
     cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(10)`).as('checkbox10-header');
-    cy.get('@checkbox10-header').trigger('mouseenter');
+    cy.get('@checkbox10-header').trigger('mouseover');
 
     cy.get('.filter-prerequisites .ms-choice span').contains('15 of 500 selected');
     cy.get('.slick-custom-tooltip').should('be.visible');
@@ -200,7 +203,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
 
   it('should mouse over header title on 1st column with checkbox and NOT expect any tooltip to show since it is disabled on that column', () => {
     cy.get(`.slick-header-columns .slick-header-column:nth(0)`).as('checkbox-header');
-    cy.get('@checkbox-header').trigger('mouseenter');
+    cy.get('@checkbox-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');
     cy.get('@checkbox-header').trigger('mouseout');
@@ -208,7 +211,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
 
   it('should mouse over header title on 2nd column with Title name and expect a tooltip to show rendered from an headerFormatter', () => {
     cy.get(`.slick-header-columns .slick-header-column:nth(1)`).as('checkbox0-header');
-    cy.get('@checkbox0-header').trigger('mouseenter');
+    cy.get('@checkbox0-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('be.visible');
     cy.get('.slick-custom-tooltip').contains('Custom Tooltip - Header');
@@ -221,7 +224,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
 
   it('should mouse over header title on 2nd column with Finish name and NOT expect any tooltip to show since it is disabled on that column', () => {
     cy.get(`.slick-header-columns .slick-header-column:nth(8)`).as('finish-header');
-    cy.get('@finish-header').trigger('mouseenter');
+    cy.get('@finish-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');
     cy.get('@finish-header').trigger('mouseout');

--- a/test/cypress/e2e/example22.cy.ts
+++ b/test/cypress/e2e/example22.cy.ts
@@ -142,20 +142,26 @@ describe('Example 22 - Row Based Editing', () => {
     cy.get('[data-test="toggle-language"]').click();
     cy.get('[data-test="selected-locale"]').should('contain', 'fr.json');
 
-    // this seems to be a bug in Cypress, it doesn't seem to be able to click on the button
-    // but at least it triggers a rerender, which makes it refetch the actual button instead of a cached one
-    cy.get('.action-btns--update').first().click({ force: true });
+    cy.get('.action-btns--edit').first().click();
 
-    cy.get('.action-btns--update')
-      .first()
-      .should(($btn) => {
-        expect($btn.attr('title')).to.equal('Mettre à jour la ligne actuelle');
-      });
+    cy.get('.action-btns--cancel').first().as('cancel-btn');
+    cy.get('@cancel-btn').should(($btn) => {
+      expect($btn.attr('title')).to.equal('Annuler la ligne actuelle');
+    });
+    cy.get('@cancel-btn').trigger('mouseover');
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip .tooltip-body').contains('Annuler la ligne actuelle');
 
-    cy.get('.action-btns--cancel')
-      .first()
-      .should(($btn) => {
-        expect($btn.attr('title')).to.equal('Annuler la ligne actuelle');
-      });
+    cy.get('.action-btns--update').first().as('update-btn');
+    cy.get('@update-btn').should(($btn) => {
+      expect($btn.attr('title')).to.equal('Mettre à jour la ligne actuelle');
+    });
+
+    cy.get('@update-btn').trigger('mouseover');
+
+    cy.get('.slick-custom-tooltip').should('be.visible');
+    cy.get('.slick-custom-tooltip .tooltip-body').contains('Mettre à jour la ligne actuelle');
+    cy.get('@update-btn').trigger('mouseout');
+    cy.get('@update-btn').first().click();
   });
 });

--- a/test/mockSlickEvent.ts
+++ b/test/mockSlickEvent.ts
@@ -1,4 +1,4 @@
-import { Handler, SlickEvent, SlickEventData } from '@slickgrid-universal/common';
+import type { Handler, SlickEvent, SlickEventData } from '@slickgrid-universal/common';
 type MergeTypes<A, B> = { [key in keyof A]: key extends keyof B ? B[key] : A[key]; } & B;
 
 export class MockSlickEvent<ArgType = any> implements SlickEvent {


### PR DESCRIPTION
- prior to this PR, we could only have 1 tooltip per cell, but in some occasions, we might have a cell with multiple icons & tooltips, if that happens then we should have separate tooltips (with their dedicated & different tooltipt text) positioned on that inner icon

#### TODOs
- [x] possibly reposition the arrow at the mouse location?
- [x] possibly center tooltip with center of target element?
- [x] test with multiple tooltips for header row/filter row elements as well
  - this actually requires new SlickEvents because the existing events for header/headerRow are using `mouseenter` but we need `mouseover` to differentiate multiple tooltip within the same header (`mouseenter` only gets triggered once while `mouseover` gets triggered multiple times while hovering any of element within container). So instead of possible chaning the previous behavior, I decided to duplicate `onHeaderMouseEnter` to `onHeaderMouseOver` and the same goes for `onHeaderRowMouseEnter` and also `...MouseOut` for both header types too (so adding 4 new events to cover all use cases). The funny thing is that the event for the cell `onMouseEnter` is actually using `mouseover` which is not actually matching with its name.
- [x] add new option to align tooltip to target element (default to false unless we have multiple tooltips, in that case it's always true)
- [x] unit test coverage
- [x] E2E test coverage

> for now the POC is mostly working, note that I purposely set a negative top margin in order to also test tooltip that can sometime show at the bottom (in 95% of the case it's showing on top except when there's not enough space on top)

### Example 22 (align right)
![brave_9GJWaisxNl](https://github.com/ghiscoding/slickgrid-universal/assets/643976/d70b812a-9ae6-42e3-a804-147f1412e9e0)

### Example 11 (align left)

![brave_3DHk9zGNbF](https://github.com/ghiscoding/slickgrid-universal/assets/643976/d56e0cb3-8e4f-431f-9d61-30807eea83b1)

### Example 12 (multiple tooltips in header row)

![brave_lvAr9wqtJK](https://github.com/ghiscoding/slickgrid-universal/assets/643976/2a10b776-bcbb-4377-95ae-5dc74ec90be9)

## existing bugs
- [x] found existing bug when opening slider editor (not a new bug, this one existed before opening this PR)
![brave_AvWeTzevAt](https://github.com/ghiscoding/slickgrid-universal/assets/643976/946651b9-aa88-44ed-ba70-3cbf8fa81c01)
- [x] another bug when tooltip text is too wide, we should use text overflow ellipsis
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/802a5e62-f73b-4bc7-bbda-f20f8f4b5461)
