### PR TITLE
fix(common): switch to `autocompleter-es` to get ESM build

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -72,7 +72,7 @@
     "@slickgrid-universal/utils": "workspace:~",
     "@types/dompurify": "^3.0.5",
     "@types/sortablejs": "^1.15.8",
-    "autocompleter": "^9.1.2",
+    "autocompleter-es": "^9.1.4",
     "dequal": "^2.0.3",
     "excel-builder-vanilla": "3.0.1",
     "flatpickr": "^4.6.13",

--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteItem } from 'autocompleter';
+import type { AutocompleteItem } from 'autocompleter-es';
 
 import type { AutocompleterOption } from '../interfaces/index';
 

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -1,5 +1,5 @@
-import autocompleter from 'autocompleter';
-import type { AutocompleteItem, AutocompleteResult, AutocompleteSettings } from 'autocompleter';
+import autocompleter from 'autocompleter-es';
+import type { AutocompleteItem, AutocompleteResult, AutocompleteSettings } from 'autocompleter-es';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { classNameToList, createDomElement, isObject, isPrimitiveValue, setDeepValue, toKebabCase } from '@slickgrid-universal/utils';
 

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -1,5 +1,5 @@
-import autocompleter from 'autocompleter';
-import type { AutocompleteItem, AutocompleteSettings } from 'autocompleter';
+import autocompleter from 'autocompleter-es';
+import type { AutocompleteItem, AutocompleteSettings } from 'autocompleter-es';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { classNameToList, createDomElement, emptyElement, isPrimitiveValue, toKebabCase, toSentenceCase } from '@slickgrid-universal/utils';
 

--- a/packages/common/src/interfaces/autocompleterOption.interface.ts
+++ b/packages/common/src/interfaces/autocompleterOption.interface.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteItem, AutocompleteSettings } from 'autocompleter';
+import type { AutocompleteItem, AutocompleteSettings } from 'autocompleter-es';
 import type { Column } from './column.interface';
 
 export interface AutoCompleterRenderItemDefinition {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,9 @@ importers:
       '@types/sortablejs':
         specifier: ^1.15.8
         version: 1.15.8
-      autocompleter:
-        specifier: ^9.1.2
-        version: 9.1.2
+      autocompleter-es:
+        specifier: ^9.1.4
+        version: 9.1.4
       dequal:
         specifier: ^2.0.3
         version: 2.0.3
@@ -3096,8 +3096,8 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
-  /autocompleter@9.1.2:
-    resolution: {integrity: sha512-L4DJ2UIsIy/YrTchKHHfyQRng2p8m9xpari1uHYZ/5DynQombeshF73uVQbrtdLxLSlK0R7ObhpnbPBkI8j8xA==}
+  /autocompleter-es@9.1.4:
+    resolution: {integrity: sha512-rC/EGS0lFLqDzpN1iOlwlNYSNjzPoK3E7Yq41ffaKuWHU3Dv4wtkxuxQMFMrV2JWrDCfu6l4zYZZkTPIjPSJrg==}
     dev: false
 
   /autoprefixer@10.4.19(postcss@8.4.38):


### PR DESCRIPTION
- migrate to a temp package `autocompleter-es` until my opened PR on `autocompleter` is merged and hopefully release sometime in the future.
- the goal of this switch is to have an ESM build so that we can remove it from `allowedCommonJsDependencies` (`angular.json`) for Angular-Slickgrid to have 1 less CJS dependency