### PR TITLE
fix(common): don't try to strip tags on object input to calc cell width

### DIFF
--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -1,6 +1,6 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
 import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
-import { getInnerSize, getOffset, stripTags } from '@slickgrid-universal/utils';
+import { getInnerSize, getOffset, isPrimitiveOrHTML, stripTags } from '@slickgrid-universal/utils';
 
 import { FieldType, } from '../enums/index';
 import type {
@@ -505,7 +505,7 @@ export class ResizerService {
     if (!columnDef.originalWidth) {
       const charWidthPx = columnDef?.resizeCharWidthInPx ?? resizeCellCharWidthInPx;
       const formattedData = parseFormatterWhenExist(columnDef?.formatter, rowIdx, colIdx, columnDef, item, this._grid);
-      const formattedDataSanitized = stripTags(formattedData);
+      const formattedDataSanitized = isPrimitiveOrHTML(formattedData) ? stripTags(formattedData) : '';
       const formattedTextWidthInPx = Math.ceil(formattedDataSanitized.length * charWidthPx);
       const resizeMaxWidthThreshold = columnDef.resizeMaxWidthThreshold;
       if (columnDef && (initialMininalColumnWidth === undefined || formattedTextWidthInPx > initialMininalColumnWidth)) {


### PR DESCRIPTION
- when calculating cell content width, we parse the cell data to its Formatter if it exists but if it doesn't then in some cases it could return the entire dataContext and that would then throw when passed to `stripTags()` method, for these cases we can simply assume that the cell width is not calculable since the cell data is not a primitive result (not text, boolean,, number nor HTML)