### PR TITLE
fix(core): Editor.keyCaptureList is an array of numbers

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4346,7 +4346,7 @@ describe('SlickGrid core file', () => {
 
         expect(grid.getCellFromEvent(null as any)).toBeNull();
         expect(grid.getCellFromEvent(new SlickEventData(null))).toBeNull();
-      })
+      });
 
       it('should return null when clicked cell is not a slick-cell closest ancestor', () => {
         grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, enableCellNavigation: true });
@@ -5568,7 +5568,7 @@ describe('SlickGrid core file', () => {
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         grid.setActiveCell(0, 1);
         grid.editActiveCell(InputEditor as any, true);
-        (InputEditor.prototype as any).keyCaptureList = ['1', '2', '3'];
+        (InputEditor.prototype as any).keyCaptureList = [1, 2, 3];
         const onKeyDownSpy = jest.spyOn(grid.onKeyDown, 'notify');
         const event = new CustomEvent('keydown');
         const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4761,7 +4761,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (!e.shiftKey && !e.altKey) {
         // editor may specify an array of keys to bubble
         if (this._options.editable && this.currentEditor?.keyCaptureList) {
-          if (this.currentEditor.keyCaptureList.indexOf(String(e.which)) > -1) {
+          if (this.currentEditor.keyCaptureList.indexOf(e.which) > -1) {
             return;
           }
         }

--- a/packages/common/src/interfaces/editor.interface.ts
+++ b/packages/common/src/interfaces/editor.interface.ts
@@ -11,8 +11,8 @@ export interface Editor {
   /** is the Editor disabled when we first open it? This could happen when we use "collectionAsync" and we wait for the "collection" to be filled before enabling the Editor. */
   disabled?: boolean;
 
-  /** editor may specify an array of keys to bubble */
-  keyCaptureList?: string;
+  /** List of key codes, which will not be captured by default slickgrid hotkeys listeners */
+  keyCaptureList?: number[];
 
   /** Initialize the Editor */
   init: (args?: EditorArguments) => void;


### PR DESCRIPTION
as per original SlickGrid [PR 1006](https://github.com/6pac/SlickGrid/pull/1006)

> The 'keyCaptureList' variable of the Editor class is an array of numbers.