### PR TITLE
chore(common): add `EditorConstructor` type whenever possible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,6 @@ jobs:
 
       - name: Upload Jest coverage to Codecov
         if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
-        continue-on-error: true
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -92,7 +91,7 @@ jobs:
           verbose: true
 
       - name: Retry Codecov upload when 1st try failed
-        if: ${{ !contains(github.event.head_commit.message, 'chore(release)') && failure() }}
+        if: ${{ failure() && !contains(github.event.head_commit.message, 'chore(release)') }}
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -27,7 +27,7 @@ export class SliderEditor implements Editor {
   protected _defaultValue = 0;
   protected _isValueTouched = false;
   protected _originalValue?: number | string;
-  protected _cellContainerElm!: HTMLDivElement;
+  protected _cellContainerElm!: HTMLElement;
   protected _editorElm!: HTMLDivElement;
   protected _inputElm!: HTMLInputElement;
   protected _sliderOptions!: CurrentSliderOption;

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -136,8 +136,10 @@ export class SlickCellExternalCopyManager {
           position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-          /* istanbul ignore next */ cancelChanges: () => { },
-          /* istanbul ignore next */ commitChanges: () => { },
+          /* istanbul ignore next */
+          cancelChanges: () => { },
+          /* istanbul ignore next */
+          commitChanges: () => { },
         });
         editor.loadValue(item);
         retVal = editor.serializeValue();
@@ -167,8 +169,10 @@ export class SlickCellExternalCopyManager {
           position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-          /* istanbul ignore next */ cancelChanges: () => { },
-          /* istanbul ignore next */ commitChanges: () => { },
+          /* istanbul ignore next */
+          cancelChanges: () => { },
+          /* istanbul ignore next */
+          commitChanges: () => { },
         }) as Editor;
         editor.loadValue(item);
         const validationResults = editor.validate(undefined, value);

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -1,6 +1,6 @@
 import { createDomElement, getHtmlStringOutput, stripTags } from '@slickgrid-universal/utils';
 
-import type { Column, Editor, ExcelCopyBufferOption, ExternalCopyClipCommand, OnEventArgs } from '../interfaces/index';
+import type { Column, Editor, EditorConstructor, ElementPosition, ExcelCopyBufferOption, ExternalCopyClipCommand, OnEventArgs } from '../interfaces/index';
 import { SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, SlickRange, type SlickDataView, Utils as SlickUtils } from '../core/index';
 
 // using external SlickGrid JS libraries
@@ -129,13 +129,16 @@ export class SlickCellExternalCopyManager {
     if (columnDef) {
       if (columnDef.editorClass) {
         const tmpP = document.createElement('p');
-        const editor = new (columnDef as any).editorClass({
+        const editor = new (columnDef.editorClass as EditorConstructor)({
           container: tmpP,  // a dummy container
           column: columnDef,
           event,
-          position: { top: 0, left: 0 },  // a dummy position required by some editors
+          position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
+          gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-        }) as Editor;
+          /* istanbul ignore next */ cancelChanges: () => { },
+          /* istanbul ignore next */ commitChanges: () => { },
+        });
         editor.loadValue(item);
         retVal = editor.serializeValue();
         editor.destroy();
@@ -157,11 +160,15 @@ export class SlickCellExternalCopyManager {
       // if a custom setter is not defined, we call applyValue of the editor to unserialize
       if (columnDef.editorClass) {
         const tmpDiv = document.createElement('div');
-        const editor = new (columnDef as any).editorClass({
+        const editor = new (columnDef.editorClass as EditorConstructor)({
           container: tmpDiv, // a dummy container
           column: columnDef,
-          position: { top: 0, left: 0 },  // a dummy position required by some editors
-          grid: this._grid
+          event: null as any,
+          position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
+          gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
+          grid: this._grid,
+          /* istanbul ignore next */ cancelChanges: () => { },
+          /* istanbul ignore next */ commitChanges: () => { },
         }) as Editor;
         editor.loadValue(item);
         const validationResults = editor.validate(undefined, value);

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -7,6 +7,9 @@ import { SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, SlickRan
 const CLEAR_COPY_SELECTION_DELAY = 2000;
 const CLIPBOARD_PASTE_DELAY = 100;
 
+/* istanbul ignore next */
+const noop = () => { };
+
 /*
   This manager enables users to copy/paste data from/to an external Spreadsheet application
   such as MS-Excel® or OpenOffice-Spreadsheet.
@@ -136,8 +139,8 @@ export class SlickCellExternalCopyManager {
           position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-          cancelChanges: /* istanbul ignore next */ () => { },
-          commitChanges: /* istanbul ignore next */ () => { },
+          cancelChanges: noop,
+          commitChanges: noop,
         });
         editor.loadValue(item);
         retVal = editor.serializeValue();
@@ -167,8 +170,8 @@ export class SlickCellExternalCopyManager {
           position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-          cancelChanges: /* istanbul ignore next */ () => { },
-          commitChanges: /* istanbul ignore next */ () => { },
+          cancelChanges: noop,
+          commitChanges: noop,
         }) as Editor;
         editor.loadValue(item);
         const validationResults = editor.validate(undefined, value);

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -136,10 +136,8 @@ export class SlickCellExternalCopyManager {
           position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-          /* istanbul ignore next */
-          cancelChanges: () => { },
-          /* istanbul ignore next */
-          commitChanges: () => { },
+          cancelChanges: /* istanbul ignore next */ () => { },
+          commitChanges: /* istanbul ignore next */ () => { },
         });
         editor.loadValue(item);
         retVal = editor.serializeValue();
@@ -169,10 +167,8 @@ export class SlickCellExternalCopyManager {
           position: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           gridPosition: { top: 0, left: 0 } as unknown as ElementPosition,  // a dummy position required by some editors
           grid: this._grid,
-          /* istanbul ignore next */
-          cancelChanges: () => { },
-          /* istanbul ignore next */
-          commitChanges: () => { },
+          cancelChanges: /* istanbul ignore next */ () => { },
+          commitChanges: /* istanbul ignore next */ () => { },
         }) as Editor;
         editor.loadValue(item);
         const validationResults = editor.validate(undefined, value);

--- a/packages/common/src/interfaces/editorArguments.interface.ts
+++ b/packages/common/src/interfaces/editorArguments.interface.ts
@@ -1,22 +1,22 @@
 import type { Column, CompositeEditorOption, ElementPosition } from './index';
 import type { PositionMethod } from '../enums/positionMethod.type';
-import type { SlickDataView, SlickGrid } from '../core/index';
+import type { SlickDataView, SlickEventData, SlickGrid } from '../core/index';
 
 export interface EditorArguments {
   /** Column Definition */
   column: Column;
 
   /** Column MetaData */
-  columnMetaData: any;
+  columnMetaData?: any;
 
   /** Editor HTML DOM element container */
-  container: HTMLDivElement;
+  container: HTMLElement;
 
   /** Slick DataView */
   dataView?: SlickDataView;
 
   /** Event that was triggered */
-  event: Event;
+  event: Event | SlickEventData;
 
   /** Slick Grid object */
   grid: SlickGrid;
@@ -25,7 +25,7 @@ export interface EditorArguments {
   gridPosition: ElementPosition;
 
   /** Item DataContext */
-  item: any;
+  item?: any;
 
   /** Editor Position  */
   position: PositionMethod | ElementPosition;

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -1,5 +1,5 @@
 import { emptyElement, getOffset, } from '@slickgrid-universal/common';
-import type { Column, CompositeEditorOption, Editor, EditorArguments, EditorValidationResult, ElementPosition, } from '@slickgrid-universal/common';
+import type { Column, CompositeEditorOption, Editor, EditorArguments, EditorConstructor, EditorValidationResult, ElementPosition, } from '@slickgrid-universal/common';
 import type { HtmlElementPosition } from '@slickgrid-universal/utils';
 
 export interface CompositeEditorArguments extends EditorArguments {
@@ -71,15 +71,15 @@ export function SlickCompositeEditor(this: any, columns: Column[], containers: A
   function editor(this: any, args: EditorArguments) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const context: any = this;
-    let editors: Array<Editor & { args: EditorArguments }> = [];
+    let editors: Array<Editor & { args: EditorArguments; }> = [];
 
     function init() {
-      let newArgs: Partial<CompositeEditorArguments> = {};
+      let newArgs = {} as CompositeEditorArguments;
       let idx = 0;
       while (idx < columns.length) {
         if (columns[idx].editorClass) {
           const column = columns[idx];
-          newArgs = { ...args };
+          newArgs = { ...args } as CompositeEditorArguments;
           newArgs.container = containers[idx];
           newArgs.column = column;
           newArgs.position = getContainerBox(idx);
@@ -88,9 +88,9 @@ export function SlickCompositeEditor(this: any, columns: Column[], containers: A
           newArgs.compositeEditorOptions = options;
           newArgs.formValues = {};
 
-          const currentEditor = new (column.editorClass as any)(newArgs) as Editor & { args: EditorArguments };
+          const currentEditor = new (column.editorClass as EditorConstructor)(newArgs);
           options.editors[column.id] = currentEditor; // add every Editor instance refs
-          editors.push(currentEditor);
+          editors.push(currentEditor as Editor & { args: EditorArguments; });
         }
         idx++;
       }


### PR DESCRIPTION
- this is extends previous PR #1462 which is now using `editorClass` but was missing the correct type of `EditorConstructor` and we should use it whenever possible (instead of `any` to get rid of the typing issue)