### PR TITLE
fix: tweak setupColumnSort() to fix exception when col no longer exists

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1784,8 +1784,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               multiColumnSort: true,
               previousSortColumns,
               sortCols: this.sortColumns.map((col) => {
-                return { columnId: this.columns[this.getColumnIndex(col.columnId)].id, sortCol: this.columns[this.getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
-              })
+                const tempCol = this.columns[this.getColumnIndex(col.columnId)];
+                return !tempCol ? null : { columnId: tempCol.id, sortCol: tempCol, sortAsc: col.sortAsc };
+              }).filter((el) => el)
             };
           }
 


### PR DESCRIPTION
- this follows original SlickGrid [PR 1016](https://github.com/6pac/SlickGrid/pull/1016) to address a bug found in that repo