### PR TITLE
fix(styling): empty warning should separate icon & text

### DIFF
--- a/packages/common/src/styles/slick-component.scss
+++ b/packages/common/src/styles/slick-component.scss
@@ -45,6 +45,9 @@
 // ----------------------------------------------
 
 .slick-empty-data-warning {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   position: relative;
   color: var(--slick-empty-data-warning-color, $slick-empty-data-warning-color);
   font-family: var(--slick-empty-data-warning-font-family, $slick-empty-data-warning-font-family);
@@ -54,6 +57,11 @@
   margin: var(--slick-empty-data-warning-margin, $slick-empty-data-warning-margin);
   padding: var(--slick-empty-data-warning-padding, $slick-empty-data-warning-padding);
   z-index: var(--slick-empty-data-warning-z-index, $slick-empty-data-warning-z-index);
+  div {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
 }
 
 

--- a/packages/empty-warning-component/src/slick-empty-warning.component.ts
+++ b/packages/empty-warning-component/src/slick-empty-warning.component.ts
@@ -110,9 +110,9 @@ export class SlickEmptyWarningComponent implements ExternalResource {
     // when using a frozen/pinned grid, we also have extra options to hide left/right message
     if (this._warningLeftElement) {
       // display/hide right/left messages
-      let leftDisplay = isShowing ? 'block' : 'none';
+      let leftDisplay = isShowing ? 'flex' : 'none';
       if (isFrozenGrid && isShowing) {
-        leftDisplay = (mergedOptions.hideFrozenLeftWarning) ? 'none' : 'block';
+        leftDisplay = (mergedOptions.hideFrozenLeftWarning) ? 'none' : 'flex';
       }
       this._warningLeftElement.style.display = leftDisplay;
 
@@ -123,9 +123,9 @@ export class SlickEmptyWarningComponent implements ExternalResource {
 
     if (this._warningRightElement) {
       // use correct left margin (defaults to 40% on regular grid or 10px on frozen grid)
-      let rightDisplay = isShowing ? 'block' : 'none';
+      let rightDisplay = isShowing ? 'flex' : 'none';
       if (isFrozenGrid && isShowing) {
-        rightDisplay = (mergedOptions.hideFrozenRightWarning) ? 'none' : 'block';
+        rightDisplay = (mergedOptions.hideFrozenRightWarning) ? 'none' : 'flex';
       }
       this._warningRightElement.style.display = rightDisplay;
 

--- a/packages/empty-warning-component/src/slick-empty-warning.spec.ts
+++ b/packages/empty-warning-component/src/slick-empty-warning.spec.ts
@@ -100,8 +100,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.textContent).toBe('No data to display.');
       expect(componentRightElm.textContent).toBe('No data to display.');
     });
@@ -139,7 +139,7 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
       expect(componentLeftElm.style.display).toBe('none');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('0px');
       expect(componentRightElm.style.marginLeft).toBe('0px');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -159,8 +159,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('40%');
       expect(componentRightElm.style.marginLeft).toBe('0px');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -183,8 +183,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('40%');
       expect(componentRightElm.style.marginLeft).toBe('0px');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -215,8 +215,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('40%');
       expect(componentRightElm.style.marginLeft).toBe('0px');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -269,8 +269,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('0px');
       expect(componentRightElm.style.marginLeft).toBe('40%');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -291,8 +291,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('15px');
       expect(componentRightElm.style.marginLeft).toBe('0px');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -313,8 +313,8 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
-      expect(componentRightElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
+      expect(componentRightElm.style.display).toBe('flex');
       expect(componentLeftElm.style.marginLeft).toBe('0px');
       expect(componentRightElm.style.marginLeft).toBe('22px');
       expect(componentLeftElm.textContent).toBe('No data to display.');
@@ -335,7 +335,7 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentLeftElm).toBeTruthy();
-      expect(componentLeftElm.style.display).toBe('block');
+      expect(componentLeftElm.style.display).toBe('flex');
       expect(componentRightElm.style.display).toBe('none');
       expect(componentLeftElm.textContent).toBe('No data to display.');
       expect(componentRightElm.textContent).toBe('No data to display.');
@@ -352,7 +352,7 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentElm).toBeTruthy();
-      expect(componentElm.style.display).toBe('block');
+      expect(componentElm.style.display).toBe('flex');
       expect(componentElm.classList.contains('custom-class')).toBeTruthy();
       expect(componentElm.innerHTML).toBe('<span class="mdi mdi-alert text-color-warning"></span> No Record found.');
     });
@@ -372,7 +372,7 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentElm).toBeTruthy();
-      expect(componentElm.style.display).toBe('block');
+      expect(componentElm.style.display).toBe('flex');
       expect(componentElm.classList.contains('custom-class')).toBeTruthy();
       expect(componentElm.innerHTML).toBe('<span class="mdi mdi-alert text-color-warning"></span> No Record found.');
     });
@@ -392,7 +392,7 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentElm).toBeTruthy();
-      expect(componentElm.style.display).toBe('block');
+      expect(componentElm.style.display).toBe('flex');
       expect(componentElm.classList.contains('custom-class')).toBeTruthy();
       expect(componentElm.innerHTML).toBe('<div class="container"><span class="mdi mdi-alert text-color-warning"></span> No Record found.</div>');
     });
@@ -410,7 +410,7 @@ describe('Slick-Empty-Warning Component', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(componentElm).toBeTruthy();
-      expect(componentElm.style.display).toBe('block');
+      expect(componentElm.style.display).toBe('flex');
       expect(componentElm.textContent).toBe('Aucune donnée à afficher.');
     });
   });

--- a/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
+++ b/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
@@ -4,7 +4,7 @@ import { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
 // create empty warning message as Document Fragment to be CSP safe
 const emptyWarningElm = document.createElement('div');
 emptyWarningElm.appendChild(createDomElement('span', { className: 'mdi mdi-alert text-color-warning' }));
-emptyWarningElm.appendChild(document.createTextNode(' No data to display.'));
+emptyWarningElm.appendChild(createDomElement('span', { textContent: 'No data to display.' }));
 
 /** Global Grid Options Defaults for Salesforce */
 export const SalesforceGlobalGridOptions = {


### PR DESCRIPTION
- the previous code was using the `:before` pseudo and we were able to add text to the same div but that is no longer feasible with the new pure CSS icons since the div is the icon and nothing else, so the text has to be in a separate div
- also use flex to align the text and icon in the middle