### PR TITLE
fix(styling): properly import Vanilla-Calendar CSS and only once

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -30,7 +30,7 @@
     "moment-tiny": "^2.30.3",
     "multiple-select-vanilla": "^3.1.0",
     "rxjs": "^7.8.1",
-    "vanilla-calendar-picker": "^2.11.3",
+    "vanilla-calendar-picker": "^2.11.4",
     "whatwg-fetch": "^3.6.20"
   },
   "devDependencies": {

--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -30,7 +30,7 @@
     "moment-tiny": "^2.30.3",
     "multiple-select-vanilla": "^3.1.0",
     "rxjs": "^7.8.1",
-    "vanilla-calendar-picker": "^2.11.2",
+    "vanilla-calendar-picker": "^2.11.3",
     "whatwg-fetch": "^3.6.20"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.7.1",
-    "vanilla-calendar-picker": "^2.11.3",
+    "vanilla-calendar-picker": "^2.11.4",
     "whatwg-fetch": "^3.6.20"
   },
   "funding": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.7.1",
-    "vanilla-calendar-picker": "^2.11.2",
+    "vanilla-calendar-picker": "^2.11.3",
     "whatwg-fetch": "^3.6.20"
   },
   "funding": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -80,7 +80,7 @@
     "multiple-select-vanilla": "^3.1.0",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
-    "vanilla-calendar-picker": "^2.11.2"
+    "vanilla-calendar-picker": "^2.11.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -80,7 +80,7 @@
     "multiple-select-vanilla": "^3.1.0",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
-    "vanilla-calendar-picker": "^2.11.3"
+    "vanilla-calendar-picker": "^2.11.4"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -1,3 +1,6 @@
+// import external lib CSS files (without the .css extension)
+@import 'vanilla-calendar-picker/build/vanilla-calendar.min';
+
 /*
  * SlickGrid-Universal theming variables, used by all Themes
  * Lib Website (https://github.com/ghiscoding/slickgrid-universal)

--- a/packages/common/src/styles/slickgrid-theme-bootstrap.scss
+++ b/packages/common/src/styles/slickgrid-theme-bootstrap.scss
@@ -4,8 +4,7 @@
  * @author: Ghislain B. (ghiscoding)
  */
 
- /** SlickGrid Bootstrap Theme */
-@import 'vanilla-calendar-picker/build/vanilla-calendar.min.css';
+/** SlickGrid Bootstrap Theme */
 @import './slick-grid';
 @import './slick-editors';
 @import './slick-plugins';

--- a/packages/common/src/styles/slickgrid-theme-material.scss
+++ b/packages/common/src/styles/slickgrid-theme-material.scss
@@ -9,7 +9,6 @@
  * sames as `slickgrid-theme-material.lite.scss` but includes all external 3rd party lib styling
  */
 
-@import 'vanilla-calendar-picker/build/vanilla-calendar.min.css';
 @import './roboto-font';
 @import './variables-theme-material';
 @import './slick-without-bootstrap-min-styling';

--- a/packages/common/src/styles/slickgrid-theme-salesforce.scss
+++ b/packages/common/src/styles/slickgrid-theme-salesforce.scss
@@ -10,8 +10,6 @@
  */
 
 @import './sass-utilities';
-@import 'vanilla-calendar-picker/build/vanilla-calendar.min.css';
-
 @import './variables-theme-salesforce';
 @import './slick-without-bootstrap-min-styling';
 @import './slick-grid';

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -60,7 +60,7 @@
     "@slickgrid-universal/utils": "workspace:~",
     "dequal": "^2.0.3",
     "sortablejs": "^1.15.2",
-    "vanilla-calendar-picker": "^2.11.2",
+    "vanilla-calendar-picker": "^2.11.3",
     "whatwg-fetch": "^3.6.20"
   },
   "devDependencies": {

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -60,7 +60,7 @@
     "@slickgrid-universal/utils": "workspace:~",
     "dequal": "^2.0.3",
     "sortablejs": "^1.15.2",
-    "vanilla-calendar-picker": "^2.11.3",
+    "vanilla-calendar-picker": "^2.11.4",
     "whatwg-fetch": "^3.6.20"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1(eslint@9.1.1)(typescript@5.4.5)
       vanilla-calendar-picker:
-        specifier: ^2.11.3
-        version: 2.11.3
+        specifier: ^2.11.4
+        version: 2.11.4
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -189,8 +189,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       vanilla-calendar-picker:
-        specifier: ^2.11.3
-        version: 2.11.3
+        specifier: ^2.11.4
+        version: 2.11.4
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -262,8 +262,8 @@ importers:
         specifier: ^2.0.12
         version: 2.0.12
       vanilla-calendar-picker:
-        specifier: ^2.11.3
-        version: 2.11.3
+        specifier: ^2.11.4
+        version: 2.11.4
     devDependencies:
       autoprefixer:
         specifier: ^10.4.19
@@ -470,8 +470,8 @@ importers:
         specifier: ^1.15.2
         version: 1.15.2
       vanilla-calendar-picker:
-        specifier: ^2.11.3
-        version: 2.11.3
+        specifier: ^2.11.4
+        version: 2.11.4
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -9165,8 +9165,8 @@ packages:
       builtins: 5.0.1
     dev: true
 
-  /vanilla-calendar-picker@2.11.3:
-    resolution: {integrity: sha512-UwhZWk2xotPWA5Is5bu6lPhEjm5h6XHpWKBRVdpzBYWErpmibCgAL6v4Bn90eX+FxluG1U18x5yNDlLDg99p1w==}
+  /vanilla-calendar-picker@2.11.4:
+    resolution: {integrity: sha512-0FJixXnw7qIf1Uvr6FbhJP4OP+hnLPjuhVRj05Uy98Or5UiXTiLoGEolNH5BvEG/bOdyPIkGohOMIrizSthDnA==}
 
   /verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1(eslint@9.1.1)(typescript@5.4.5)
       vanilla-calendar-picker:
-        specifier: ^2.11.2
-        version: 2.11.2
+        specifier: ^2.11.3
+        version: 2.11.3
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -189,8 +189,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       vanilla-calendar-picker:
-        specifier: ^2.11.2
-        version: 2.11.2
+        specifier: ^2.11.3
+        version: 2.11.3
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -262,8 +262,8 @@ importers:
         specifier: ^2.0.12
         version: 2.0.12
       vanilla-calendar-picker:
-        specifier: ^2.11.2
-        version: 2.11.2
+        specifier: ^2.11.3
+        version: 2.11.3
     devDependencies:
       autoprefixer:
         specifier: ^10.4.19
@@ -470,8 +470,8 @@ importers:
         specifier: ^1.15.2
         version: 1.15.2
       vanilla-calendar-picker:
-        specifier: ^2.11.2
-        version: 2.11.2
+        specifier: ^2.11.3
+        version: 2.11.3
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -9165,8 +9165,8 @@ packages:
       builtins: 5.0.1
     dev: true
 
-  /vanilla-calendar-picker@2.11.2:
-    resolution: {integrity: sha512-ZAlQEqcuTPVj9+vHCzaMRqVY63d4mBeyyvG3rNvzD2FatbOipiz0K4oiRYwJJgURJOeWZeDPDSieJ+vPlN4crQ==}
+  /vanilla-calendar-picker@2.11.3:
+    resolution: {integrity: sha512-UwhZWk2xotPWA5Is5bu6lPhEjm5h6XHpWKBRVdpzBYWErpmibCgAL6v4Bn90eX+FxluG1U18x5yNDlLDg99p1w==}
 
   /verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}


### PR DESCRIPTION
- we should have only 1 import and for it to be properly imported in SASS, we need to remove the file externsion when importing
- fixes invalid import and missing CSS when tested in Salesforce