### PR TITLE
fix(styling): couple of small alignment issues when using flex

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -28,7 +28,7 @@
     "fetch-jsonp": "^1.3.0",
     "isomorphic-dompurify": "^2.7.0",
     "moment-tiny": "^2.30.3",
-    "multiple-select-vanilla": "^3.1.0",
+    "multiple-select-vanilla": "^3.1.2",
     "rxjs": "^7.8.1",
     "vanilla-calendar-picker": "^2.11.4",
     "whatwg-fetch": "^3.6.20"

--- a/examples/vite-demo-vanilla-bundle/src/examples/example05.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example05.scss
@@ -4,6 +4,6 @@
   .slick-cell {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    column-gap: 4px;
   }
 }

--- a/examples/vite-demo-vanilla-bundle/src/examples/example06.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example06.scss
@@ -4,7 +4,7 @@
   .slick-cell {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    column-gap: 4px;
   }
 
   .avg-total {

--- a/examples/vite-demo-vanilla-bundle/src/examples/example21.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example21.scss
@@ -2,7 +2,7 @@
   .slick-cell {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    column-gap: 4px;
   }
   .preload {
     font-size: 18px;

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -76,7 +76,7 @@
     "excel-builder-vanilla": "3.0.1",
     "isomorphic-dompurify": "^2.7.0",
     "moment-tiny": "^2.30.3",
-    "multiple-select-vanilla": "^3.1.0",
+    "multiple-select-vanilla": "^3.1.2",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
     "vanilla-calendar-picker": "^2.11.4"

--- a/packages/common/src/styles/slick-component.scss
+++ b/packages/common/src/styles/slick-component.scss
@@ -47,7 +47,7 @@
 .slick-empty-data-warning {
   display: flex;
   align-items: center;
-  gap: 5px;
+  column-gap: 5px;
   position: relative;
   color: var(--slick-empty-data-warning-color, $slick-empty-data-warning-color);
   font-family: var(--slick-empty-data-warning-font-family, $slick-empty-data-warning-font-family);
@@ -60,7 +60,7 @@
   div {
     display: flex;
     align-items: center;
-    gap: 5px;
+    column-gap: 5px;
   }
 }
 
@@ -107,7 +107,7 @@
       vertical-align: top;
       display: inline-flex;
       align-items: center;
-      gap: 4px;
+      column-gap: 4px;
       padding: 0 5px;
       height: inherit;
 

--- a/packages/common/src/styles/slick-editors.scss
+++ b/packages/common/src/styles/slick-editors.scss
@@ -72,6 +72,7 @@
   .vanilla-picker.input-group {
     display: flex;
     align-items: center;
+    flex: 1;
     height: var(--slick-date-editor-height, $slick-date-editor-height);
     .input-group-btn {
       &.input-group-append {

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -656,9 +656,6 @@ li.hidden {
   height: var(--slick-header-input-height, $slick-header-input-height);
 
   span {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
     font-size: var(--slick-multiselect-input-filter-font-size, $slick-multiselect-input-filter-font-size);
     font-family: var(--slick-multiselect-input-filter-font-family, $slick-multiselect-input-filter-font-family);
   }
@@ -707,10 +704,7 @@ li.hidden {
   label {
     span {
       cursor: pointer;
-      display: inline-flex;
       margin-left: var(--slick-multiselect-checkbox-margin-left, $slick-multiselect-checkbox-margin-left);
-      position: relative;
-      top: 1px;
     }
   }
   .ms-select-all {
@@ -1026,6 +1020,7 @@ input.search-filter {
 .slider-container {
   display: flex;
   height: 100%;
+  flex: 1;
 
   input[type=range] {
     /*removes default webkit styles*/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^2.30.3
         version: 2.30.3
       multiple-select-vanilla:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.2
+        version: 3.1.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -253,8 +253,8 @@ importers:
         specifier: ^2.30.3
         version: 2.30.3
       multiple-select-vanilla:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.2
+        version: 3.1.2
       sortablejs:
         specifier: ^1.15.2
         version: 1.15.2
@@ -6913,8 +6913,8 @@ packages:
       minimatch: 9.0.4
     dev: true
 
-  /multiple-select-vanilla@3.1.0:
-    resolution: {integrity: sha512-2UtPlinsO+dYH6bLisLLlvcsMAd1A6LnWpbiPNBT+97xSYSPnipEqlAQTwkxg9MoekpvG2jMZrthAHuZwki+vA==}
+  /multiple-select-vanilla@3.1.2:
+    resolution: {integrity: sha512-NeZn6j5UY+yvs+/V6LsQ4sGtSmqVLwe+CAqEJKaX6wFQm1UbXzF+90WJViIeqc76dchBHitEXBmm3y2yp3ET5Q==}
     dependencies:
       '@types/trusted-types': 2.0.7
     dev: false


### PR DESCRIPTION
- when using flex on `.slick-cell` like in Example 7, a couple of small issues came up mostly with flex alignment
- also fix some flex issues directly in ms-select lib and update it here to get fixes, also remove some now duplicate CSS
- we should use `column-gap` instead of `gap` to only change the gap horizontally but not vertically

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/02b02728-e557-4cb4-a11e-3090e9ee5fdd)

![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/5eff36de-8a5a-4f27-bbf7-a2d207e21b18)
