### PR TITLE
fix(tooltip): only show tooltip that has value

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6296,13 +6296,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /**
-   * Sanitize possible dirty html string (remove any potential XSS code like scripts and others) when provided as grid option
-   * @param dirtyHtml: dirty html string
+   * Sanitize possible dirty html string (remove any potential XSS code like scripts and others) when provided via `sanitizer` grid option.
+   * The logic will only call the sanitizer if it exists and is a defined string, anything else will be skipped (number, boolean, TrustedHTML will all be skipped)
+   * @param {*} dirtyHtml: dirty html string
    */
-  sanitizeHtmlString<T extends string | TrustedHTML>(dirtyHtml: string): T {
-    if (typeof this._options?.sanitizer === 'function') {
-      return this._options.sanitizer(dirtyHtml) as T;
+  sanitizeHtmlString<T extends string | TrustedHTML>(dirtyHtml: unknown): T {
+    if (typeof this._options?.sanitizer !== 'function' || !dirtyHtml || typeof dirtyHtml !== 'string') {
+      return dirtyHtml as T;
     }
-    return dirtyHtml as T;
+    return this._options.sanitizer(dirtyHtml) as T;
   }
 }

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -428,7 +428,7 @@ export class SlickCustomTooltip {
     }
 
     // when do have text to show, then append the new tooltip to the html body & reposition the tooltip
-    if (finalOutputText) {
+    if (finalOutputText.toString()) {
       document.body.appendChild(this._tooltipElm);
 
       // reposition the tooltip on top of the cell that triggered the mouse over event


### PR DESCRIPTION
- the previous code was having a simple check of the final output text, however when using DOMPurify it returns a TrustedHTML object which is considered defined even though it could be empty.
- we can fix the issue via 2 changes (1. sanitize only string value, 2. check tooltip value against `toString()`