### PR TITLE
fix(editors): body click or Escape key should cancel Select Editor

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -28,7 +28,7 @@
     "bulma": "^1.0.0",
     "dompurify": "^3.1.2",
     "fetch-jsonp": "^1.3.0",
-    "multiple-select-vanilla": "^3.1.4",
+    "multiple-select-vanilla": "^3.2.0",
     "rxjs": "^7.8.1",
     "vanilla-calendar-picker": "^2.11.4",
     "whatwg-fetch": "^3.6.20"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -74,7 +74,7 @@
     "autocompleter": "^9.2.1",
     "dequal": "^2.0.3",
     "excel-builder-vanilla": "3.0.1",
-    "multiple-select-vanilla": "^3.1.4",
+    "multiple-select-vanilla": "^3.2.0",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
     "vanilla-calendar-picker": "^2.11.4"

--- a/packages/common/src/editors/__tests__/selectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/selectEditor.spec.ts
@@ -631,6 +631,38 @@ describe('SelectEditor', () => {
         expect(saveSpy).toHaveBeenCalledWith(false);
       });
 
+      it('should cancel changes when Escape key is pressed and should not call "save()"', () => {
+        mockItemData = { id: 1, gender: 'male', isActive: true };
+        gridOptionMock.autoCommitEdit = false;
+
+        editor = new SelectEditor(editorArguments, true);
+        const cancelSpy = jest.spyOn(editor, 'cancel');
+        const saveSpy = jest.spyOn(editor, 'save');
+
+        editor.loadValue(mockItemData);
+        editor.msInstance?.close('key.escape');
+        editor.destroy();
+
+        expect(cancelSpy).toHaveBeenCalled();
+        expect(saveSpy).not.toHaveBeenCalled();
+      });
+
+      it('should not "save()" when clicking ouside the select on body', () => {
+        mockItemData = { id: 1, gender: 'male', isActive: true };
+        gridOptionMock.autoCommitEdit = false;
+
+        editor = new SelectEditor(editorArguments, true);
+        const cancelSpy = jest.spyOn(editor, 'cancel');
+        const saveSpy = jest.spyOn(editor, 'save');
+
+        editor.loadValue(mockItemData);
+        editor.msInstance?.close('body.click');
+        editor.destroy();
+
+        expect(cancelSpy).not.toHaveBeenCalled();
+        expect(saveSpy).not.toHaveBeenCalled();
+      });
+
       it('should not call "commitCurrentEdit" when "hasAutoCommitEdit" is disabled', () => {
         mockItemData = { id: 1, gender: 'male', isActive: true };
         gridOptionMock.autoCommitEdit = false;

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -124,7 +124,14 @@ export class SelectEditor implements Editor {
       onClick: () => this._isValueTouched = true,
       onCheckAll: () => this._isValueTouched = true,
       onUncheckAll: () => this._isValueTouched = true,
-      onClose: () => {
+      onClose: (reason) => {
+        if (reason === 'key.escape' || reason === 'body.click' || (!this.hasAutoCommitEdit && !this.isValueChanged())) {
+          if (reason === 'key.escape') {
+            this.cancel();
+          }
+          return;
+        }
+
         if (compositeEditorOptions) {
           this.handleChangeOnCompositeEditor(compositeEditorOptions);
         } else {
@@ -361,6 +368,12 @@ export class SelectEditor implements Editor {
       if (compositeEditorOptions && triggerOnCompositeEditorChange) {
         this.handleChangeOnCompositeEditor(compositeEditorOptions, 'system');
       }
+    }
+  }
+
+  cancel() {
+    if (this.args?.cancelChanges) {
+      this.args.cancelChanges();
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       multiple-select-vanilla:
-        specifier: ^3.1.4
-        version: 3.1.4
+        specifier: ^3.2.0
+        version: 3.2.0
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -250,8 +250,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       multiple-select-vanilla:
-        specifier: ^3.1.4
-        version: 3.1.4
+        specifier: ^3.2.0
+        version: 3.2.0
       sortablejs:
         specifier: ^1.15.2
         version: 1.15.2
@@ -6903,8 +6903,8 @@ packages:
       minimatch: 9.0.4
     dev: true
 
-  /multiple-select-vanilla@3.1.4:
-    resolution: {integrity: sha512-tYZOelEDbTl7p0hu/l1WLUWCgQuoLTT70bJQIEtO404kVbNUHKWmesF8U23jqekOL1+WlYm9cARYI8eci42g8w==}
+  /multiple-select-vanilla@3.2.0:
+    resolution: {integrity: sha512-rqsgTKbn8S0+oVYoNOBe/0P7BpimWChRf7hv42uOtZPkPSHOmNt8bDxJAGCRhT4nvOnlamaHMm0U1zQPfH9IDA==}
     dependencies:
       '@types/trusted-types': 2.0.7
     dev: false


### PR DESCRIPTION
- add reason to `onClose(reason)` feature in external repo
- Escape key should cancel any edit change (that would mostly only happen when multiple selection since single select would close after single selection
- when clicking outside the select (body click), wouldn't call a save either