### PR TITLE
chore: use node-`extend()` from within `deepCopy`

### DIFF
--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -1,5 +1,5 @@
 import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import { deepCopy, extend, stripTags } from '@slickgrid-universal/utils';
+import { extend, stripTags } from '@slickgrid-universal/utils';
 import { dequal } from 'dequal/lite';
 
 import { Constants } from '../constants';
@@ -402,7 +402,7 @@ export class FilterService {
    * @returns FilterConditionOption
    */
   parseFormInputFilterConditions(inputSearchTerms: SearchTerm[] | undefined, columnFilter: Omit<SearchColumnFilter, 'searchTerms'>): Omit<FilterConditionOption, 'cellValue'> {
-    const searchValues: SearchTerm[] = deepCopy(inputSearchTerms) || [];
+    const searchValues: SearchTerm[] = extend(true, [], inputSearchTerms) || [];
     let fieldSearchValue = (Array.isArray(searchValues) && searchValues.length === 1) ? searchValues[0] : '';
     const columnDef = columnFilter.columnDef;
     const fieldType = columnDef.filter?.type ?? columnDef.type ?? FieldType.string;
@@ -576,7 +576,7 @@ export class FilterService {
       if (typeof columnFilters === 'object') {
         Object.keys(columnFilters).forEach(columnId => {
           const columnFilter = columnFilters[columnId] as SearchColumnFilter;
-          const searchValues: SearchTerm[] = columnFilter?.searchTerms ? deepCopy(columnFilter.searchTerms) : [];
+          const searchValues: SearchTerm[] = columnFilter?.searchTerms ? extend(true, [], columnFilter.searchTerms) : [];
           const inputSearchConditions = this.parseFormInputFilterConditions(searchValues, columnFilter);
 
           const columnDef = columnFilter.columnDef;

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -1,5 +1,5 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { deepCopy, deepMerge, emptyObject, setDeepValue, classNameToList, getHtmlStringOutput } from '@slickgrid-universal/utils';
+import { deepMerge, emptyObject, setDeepValue, classNameToList, getHtmlStringOutput, extend } from '@slickgrid-universal/utils';
 import type {
   Column,
   CompositeEditorLabel,
@@ -312,7 +312,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
       } else {
         const isWithMassChange = (modalType === 'mass-update' || modalType === 'mass-selection');
         const dataContext = !isWithMassChange ? this.grid.getDataItem(activeRow) : {};
-        this._originalDataContext = deepCopy(dataContext);
+        this._originalDataContext = extend(true, {}, dataContext);
         this._columnDefinitions = this.grid.getColumns();
         const selectedRowsIndexes = this.hasRowSelectionEnabled() ? this.grid.getSelectedRows() : [];
         const fullDatasetLength = this.dataView?.getItemCount() ?? 0;
@@ -567,7 +567,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   /** Apply Mass Update Changes (form values) to the entire dataset */
   protected applySaveMassUpdateChanges(formValues: any, _selection: DataSelection, applyToDataview = true): any[] {
     // not applying to dataView means that we're doing a preview of dataset and we should use a deep copy of it instead of applying changes directly to it
-    const data = applyToDataview ? this.dataView.getItems() : deepCopy(this.dataView.getItems());
+    const data = applyToDataview ? this.dataView.getItems() : extend(true, [], this.dataView.getItems());
 
     // from the "lastCompositeEditor" object that we kept as reference, it contains all the changes inside the "formValues" property
     // we can loop through these changes and apply them on the selected row indexes
@@ -595,7 +595,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     const selectedTmpItems = selectedItemIds.map(itemId => this.dataView.getItemById(itemId));
 
     // not applying to dataView means that we're doing a preview of dataset and we should use a deep copy of it instead of applying changes directly to it
-    const selectedItems = applyToDataview ? selectedTmpItems : deepCopy(selectedTmpItems);
+    const selectedItems = applyToDataview ? selectedTmpItems : extend(true, [], selectedTmpItems);
 
     // from the "lastCompositeEditor" object that we kept as reference, it contains all the changes inside the "formValues" property
     // we can loop through these changes and apply them on the selected row indexes

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -33,7 +33,7 @@ import {
   getTranslationPrefix,
   isColumnDateType,
 } from '@slickgrid-universal/common';
-import { addWhiteSpaces, deepCopy, getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
+import { addWhiteSpaces, extend, getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
 
 import {
   type ExcelFormatter,
@@ -136,7 +136,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
       throw new Error('[Slickgrid-Universal] it seems that the SlickGrid & DataView objects and/or PubSubService are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
     }
     this._pubSubService?.publish(`onBeforeExportToExcel`, true);
-    this._excelExportOptions = deepCopy({ ...DEFAULT_EXPORT_OPTIONS, ...this._gridOptions.excelExportOptions, ...options });
+    this._excelExportOptions = extend(true, {}, { ...DEFAULT_EXPORT_OPTIONS, ...this._gridOptions.excelExportOptions, ...options });
     this._fileFormat = this._excelExportOptions.format || FileType.xlsx;
 
     // reset references of detected Excel formats

--- a/packages/text-export/src/textExport.service.ts
+++ b/packages/text-export/src/textExport.service.ts
@@ -22,7 +22,7 @@ import {
   getTranslationPrefix,
   htmlEntityDecode,
 } from '@slickgrid-universal/common';
-import { addWhiteSpaces, deepCopy, getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
+import { addWhiteSpaces, extend, getHtmlStringOutput, stripTags, titleCase } from '@slickgrid-universal/utils';
 
 const DEFAULT_EXPORT_OPTIONS: TextExportOption = {
   delimiter: DelimiterType.comma,
@@ -110,7 +110,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
 
     return new Promise(resolve => {
       this._pubSubService?.publish(`onBeforeExportToTextFile`, true);
-      this._exportOptions = deepCopy({ ...DEFAULT_EXPORT_OPTIONS, ...this._gridOptions.textExportOptions, ...options });
+      this._exportOptions = extend(true, {}, { ...DEFAULT_EXPORT_OPTIONS, ...this._gridOptions.textExportOptions, ...options });
       this._delimiter = this._exportOptions.delimiterOverride || this._exportOptions.delimiter || '';
       this._fileFormat = this._exportOptions.format || FileType.csv;
 

--- a/packages/utils/src/nodeExtend.ts
+++ b/packages/utils/src/nodeExtend.ts
@@ -3,6 +3,7 @@
  * The reason for the reimplementation was mostly because the original project is not ESM compatible
  * and written with old ES6 IIFE syntax, the goal was to reimplement and fix these old syntax and build problems.
  * e.g. it used `var` everywhere, it used `arguments` to get function arguments, ...
+ * See `jQuery.extend()` for multiple usage demos: https://api.jquery.com/jquery.extend/
  *
  * The previous lib can be found here at this Github link:
  *     https://github.com/justmoon/node-extend

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,4 +1,5 @@
 import type { AnyFunction } from './models/types';
+import { extend } from './nodeExtend';
 
 /**
  * Add an item to an array only when the item does not exists, when the item is an object we will be using their "id" to compare
@@ -43,50 +44,20 @@ export function arrayRemoveItemByIndex<T>(array: T[], index: number): T[] {
 }
 
 /**
- * Create an immutable clone of an array or object
- * (c) 2019 Chris Ferdinandi, MIT License, https://gomakethings.com
- * @param  {Array|Object} objectOrArray - the array or object to copy
- * @return {Array|Object} - the clone of the array or object
+ * @use `extend()` when possible.
+ * Create an immutable clone of an array or object (native type will be returned "as is").
+ * This function will deep copy whatever is provided as the first argument, but nonetheless it is now an alias to `extend()` (node-extend) function.
+ * We'll keep the method to avoid breaking users of `deepCopy()`, however we suggest to directly use `extend(true, {}, obj)` whenever possible
  */
 export function deepCopy(objectOrArray: any | any[]): any | any[] {
-  /**
-   * Create an immutable copy of an object
-   * @return {Object}
-   */
-  const cloneObj = () => {
-    // Create new object
-    const clone = {};
-
-    // Loop through each item in the original
-    // Recursively copy it's value and add to the clone
-    Object.keys(objectOrArray).forEach(key => {
-      if (Object.prototype.hasOwnProperty.call(objectOrArray, key)) {
-        (clone as any)[key] = deepCopy(objectOrArray[key]);
-      }
-    });
-    return clone;
-  };
-
-  /**
-   * Create an immutable copy of an array
-   * @return {Array}
-   */
-  const cloneArr = () => objectOrArray.map((item: any) => deepCopy(item));
-
-  // -- init --//
-  // Get object type
-  const type = Object.prototype.toString.call(objectOrArray).slice(8, -1).toLowerCase();
-
-  // If an object
-  if (type === 'object') {
-    return cloneObj();
+  // we previously had a full implementation but we can now use node-extend to do the job
+  // except that we need couple of small priors checks (native will be returned as is)
+  if (!Array.isArray(objectOrArray) && !isObject(objectOrArray)) {
+    return objectOrArray;
   }
-  // If an array
-  if (type === 'array') {
-    return cloneArr();
-  }
-  // Otherwise, return it as-is
-  return objectOrArray;
+  // Array or Object need 2nd arg to be either [] or {} for a deep copy to assign to when using node-extend (same as jQuery.extend())
+  const assignment = Array.isArray(objectOrArray) ? [] : {};
+  return extend(true, assignment, objectOrArray);
 }
 
 /**

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -43,18 +43,17 @@ import {
   TreeDataService,
 
   // utilities
-  deepCopy,
   emptyElement,
   unsubscribeAll,
   SlickEventHandler,
   SlickDataView,
   SlickGrid
 } from '@slickgrid-universal/common';
+import { extend } from '@slickgrid-universal/utils';
 import { EventNamingStyle, EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
 import { SlickFooterComponent } from '@slickgrid-universal/custom-footer-component';
 import { SlickPaginationComponent } from '@slickgrid-universal/pagination-component';
-import { extend } from '@slickgrid-universal/utils';
 
 import { type SlickerGridInstance } from '../interfaces/slickerGridInstance.interface';
 import { UniversalContainerService } from '../services/universalContainer.service';
@@ -147,7 +146,7 @@ export class SlickVanillaGridBundle<TData = any> {
     const prevDatasetLn = this._currentDatasetLength;
     const isDatasetEqual = dequal(newDataset, this.dataset || []);
     const isDeepCopyDataOnPageLoadEnabled = !!(this._gridOptions?.enableDeepCopyDatasetOnPageLoad);
-    let data = isDeepCopyDataOnPageLoadEnabled ? deepCopy(newDataset || []) : newDataset;
+    let data = isDeepCopyDataOnPageLoadEnabled ? extend(true, [], newDataset) : newDataset;
 
     // when Tree Data is enabled and we don't yet have the hierarchical dataset filled, we can force a convert+sort of the array
     if (this.slickGrid && this.gridOptions?.enableTreeData && Array.isArray(newDataset) && (newDataset.length > 0 || newDataset.length !== prevDatasetLn || !isDatasetEqual)) {
@@ -373,7 +372,7 @@ export class SlickVanillaGridBundle<TData = any> {
     this.groupingService = services?.groupingAndColspanService ?? new GroupingAndColspanService(this.extensionUtility, this._eventPubSubService);
 
     if (hierarchicalDataset) {
-      this.sharedService.hierarchicalDataset = (isDeepCopyDataOnPageLoadEnabled ? deepCopy(hierarchicalDataset || []) : hierarchicalDataset) || [];
+      this.sharedService.hierarchicalDataset = (isDeepCopyDataOnPageLoadEnabled ? extend(true, [], hierarchicalDataset) : hierarchicalDataset) || [];
     }
     const eventHandler = new SlickEventHandler();
 


### PR DESCRIPTION
- I created `deepCopy` before adding node-extend, I think that we no longer need the implementation of `deepCopy()`, however to avoid breaking users of the function, I'll keep it in place but simply call `extend()` behind the scene. However, there are 2 simple checks that need to be performed before calling node-extend.
- node-extend has the exact same usage as jQuery.extend(), you can see jQuery's doc for more demos