### PR TITLE
fix(editors): only open ms-select drop when exists

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -28,7 +28,7 @@
     "bulma": "^1.0.0",
     "dompurify": "^3.1.2",
     "fetch-jsonp": "^1.3.0",
-    "multiple-select-vanilla": "^3.2.0",
+    "multiple-select-vanilla": "^3.2.1",
     "rxjs": "^7.8.1",
     "whatwg-fetch": "^3.6.20"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -74,7 +74,7 @@
     "autocompleter": "^9.2.1",
     "dequal": "^2.0.3",
     "excel-builder-vanilla": "3.0.1",
-    "multiple-select-vanilla": "^3.2.0",
+    "multiple-select-vanilla": "^3.2.1",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
     "vanilla-calendar-picker": "^2.11.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       multiple-select-vanilla:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.2.1
+        version: 3.2.1
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -244,8 +244,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       multiple-select-vanilla:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.2.1
+        version: 3.2.1
       sortablejs:
         specifier: ^1.15.2
         version: 1.15.2
@@ -6832,8 +6832,8 @@ packages:
       minimatch: 9.0.4
     dev: true
 
-  /multiple-select-vanilla@3.2.0:
-    resolution: {integrity: sha512-rqsgTKbn8S0+oVYoNOBe/0P7BpimWChRf7hv42uOtZPkPSHOmNt8bDxJAGCRhT4nvOnlamaHMm0U1zQPfH9IDA==}
+  /multiple-select-vanilla@3.2.1:
+    resolution: {integrity: sha512-2Ed9Kn9NpD2OgwvZRDKmnUVMlje7883JnwMlQgoGbd4pZLFamJKk0Qk73u27QRhyBy4Nzf/MhOdAk21PAfoRuA==}
     dependencies:
       '@types/trusted-types': 2.0.7
     dev: false

--- a/test/cypress/e2e/example15.cy.ts
+++ b/test/cypress/e2e/example15.cy.ts
@@ -707,7 +707,7 @@ describe('Example 15 - OData Grid using RxJS', () => {
       const expectedOptions = ['male', 'female', 'other'];
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
-        .click();
+        .dblclick();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
         .should('contain', 'male')

--- a/test/cypress/e2e/example15.cy.ts
+++ b/test/cypress/e2e/example15.cy.ts
@@ -734,7 +734,7 @@ describe('Example 15 - OData Grid using RxJS', () => {
         .click();
     });
 
-    it('should open Gender filter and now expect to see 1 more option in its list ([blank], male, female, other)', () => {
+    it('should open again Gender filter and still expect to see 4 option in its list ([blank], male, female, other)', () => {
       const expectedOptions = ['', 'male', 'female', 'other'];
       cy.get('.ms-filter.filter-gender:visible').click();
 

--- a/test/cypress/e2e/example15.cy.ts
+++ b/test/cypress/e2e/example15.cy.ts
@@ -686,8 +686,28 @@ describe('Example 15 - OData Grid using RxJS', () => {
       cy.get('[data-test="add-gender-btn"]').should('be.disabled');
     });
 
+    it('should open Gender filter and now expect to see 1 more option in its list ([blank], male, female, other)', () => {
+      const expectedOptions = ['', 'male', 'female', 'other'];
+      cy.get('.ms-filter.filter-gender:visible').click();
+
+      cy.get('[data-name="filter-gender"].ms-drop')
+        .find('li:visible')
+        .should('have.length', 4);
+
+      cy.get('[data-name="filter-gender"].ms-drop')
+        .find('li:visible span')
+        .each(($li, index) => expect($li.text()).to.eq(expectedOptions[index]));
+
+      cy.get('[data-name="filter-gender"].ms-drop')
+        .find('li:visible:nth(0)')
+        .click();
+    });
+
     it('should open the "Gender" editor on the first row and expect to find 1 more option the editor list (male, female, other)', () => {
       const expectedOptions = ['male', 'female', 'other'];
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
+        .click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
         .should('contain', 'male')

--- a/test/cypress/e2e/example15.cy.ts
+++ b/test/cypress/e2e/example15.cy.ts
@@ -686,28 +686,19 @@ describe('Example 15 - OData Grid using RxJS', () => {
       cy.get('[data-test="add-gender-btn"]').should('be.disabled');
     });
 
-    it('should open Gender filter and now expect to see 1 more option in its list ([blank], male, female, other)', () => {
-      const expectedOptions = ['', 'male', 'female', 'other'];
-      cy.get('.ms-filter.filter-gender:visible').click();
-
-      cy.get('[data-name="filter-gender"].ms-drop')
-        .find('li:visible')
-        .should('have.length', 4);
-
-      cy.get('[data-name="filter-gender"].ms-drop')
-        .find('li:visible span')
-        .each(($li, index) => expect($li.text()).to.eq(expectedOptions[index]));
-
-      cy.get('[data-name="filter-gender"].ms-drop')
-        .find('li:visible:nth(0)')
+    it('should select 1st row', () => {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`)
         .click();
+
+      cy.get('.grid15')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected')
+        .should('have.length', 1);
     });
 
     it('should open the "Gender" editor on the first row and expect to find 1 more option the editor list (male, female, other)', () => {
       const expectedOptions = ['male', 'female', 'other'];
-
-      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
-        .dblclick();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
         .should('contain', 'male')
@@ -734,7 +725,7 @@ describe('Example 15 - OData Grid using RxJS', () => {
         .click();
     });
 
-    it('should open again Gender filter and still expect to see 4 option in its list ([blank], male, female, other)', () => {
+    it('should open Gender filter and now expect to see 1 more option in its list ([blank], male, female, other)', () => {
       const expectedOptions = ['', 'male', 'female', 'other'];
       cy.get('.ms-filter.filter-gender:visible').click();
 


### PR DESCRIPTION
- when Row Selection in combo with single click open Editor, it was selecting the row and conflicting with the ms-select open, the issue was caused by a 0ms delay to open the ms-select editor and by the time it was calling open (after delay), the ms-select was in fact destroyed already because of the row selection causing a phantom select in top left corner that wasn't being removed and became an orphan element