### PR TITLE
fix(filters): new `filterPredicate` shouldn't break other column filters

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example14.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example14.ts
@@ -159,14 +159,17 @@ export default class Example14 {
             if (searchVals?.length) {
               const columnId = searchFilterArgs.columnId;
               const searchVal = searchVals[0] as string;
-              const results = searchVal.matchAll(/^%([^%\r\n]+)[^%\r\n]*$|%(.+)%(.*)|(.+)%(.+)|([^%\r\n]+)%$/gi);
+              const results = searchVal.matchAll(/^%([^%\r\n]+)[^%\r\n]*$|(.*)%(.+)%(.*)|(.+)%(.+)|([^%\r\n]+)%$/gi);
               const arrayOfMatches = Array.from(results);
               const matches = arrayOfMatches.length ? arrayOfMatches[0] : [];
-              const [_, endW, contain, containEndW, comboSW, comboEW, startW] = matches;
+              const [_, endW, containSW, contain, containEndW, comboSW, comboEW, startW] = matches;
 
               if (endW) {
                 // example: "%001" ends with A
                 return dataContext[columnId].endsWith(endW);
+              } else if (containSW && contain) {
+                // example: "%Ti%001", contains A + ends with B
+                return dataContext[columnId].startsWith(containSW) && dataContext[columnId].includes(contain);
               } else if (contain && containEndW) {
                 // example: "%Ti%001", contains A + ends with B
                 return dataContext[columnId].includes(contain) && dataContext[columnId].endsWith(containEndW);

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -366,7 +366,11 @@ export class FilterService {
 
           // user could provide a custom filter predicate on the column definition
           if (typeof columnFilterDef?.filterPredicate === 'function') {
-            return columnFilterDef.filterPredicate(item, searchColFilter);
+            const fpResult = columnFilterDef.filterPredicate(item, searchColFilter);
+            if (!fpResult) {
+              // only return on false, when row is filtered out and no further filter to be considered
+              return false;
+            }
           } else {
             // otherwise execute built-in filter condition checks
             const conditionOptions = this.preProcessFilterConditionOnDataContext(item, searchColFilter, grid);

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -335,6 +335,22 @@ describe('Example 14 - Columns Resize by Content', () => {
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 330');
     });
 
+    it('should return 14 rows using "Ta%30%" (starts with "Ta" + ends with 30)', () => {
+      cy.get('.search-filter.filter-title')
+        .clear()
+        .type('Ta%30%');
+
+      cy.get('[data-test="total-items"]')
+        .should('contain', 4);
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 30');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 130');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 230');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 300');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 301');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).should('contain', 'Task 302');
+    });
+
     it('should return all 400 rows using "Ta%" (starts with "Ta")', () => {
       cy.get('.search-filter.filter-title')
         .clear()

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -373,5 +373,24 @@ describe('Example 14 - Columns Resize by Content', () => {
       cy.get('[data-test="total-items"]')
         .should('contain', 0);
     });
+
+    it('return some rows (not all 400) filtering Title as "%ask%" AND a Duration ">50" to test few filters still working', () => {
+      cy.get('.search-filter.filter-title')
+        .clear()
+        .type('%ask%');
+
+      cy.get('[data-test="total-items"]')
+        .should('contain', 400);
+
+      cy.get('.search-filter.filter-duration')
+        .clear()
+        .type('>50');
+
+      cy.get('[data-test="total-items"]')
+        .should('not.contain', 0);
+
+      cy.get('[data-test="total-items"]')
+        .should('not.contain', 400);
+    });
   });
 });


### PR DESCRIPTION
- the previous PR to implement `filterPredicate` regressed with a new issue and that was not caught in the original PR. It had the indirect effect of breaking the other filter columns (I forgot to test that in the original PR), the issue was caused by the fact that calling a `return` within the `for` loop of all filters was cancelling all other filters in the loop because a `return` breaks the entire loop.
- So the fix is to only call `return` when the `filterPredicate` returns `false` which mean that at point the row data context is officially filtered out and so stopping inspection of further filters does make sense at that point in time.
- also improve SQL LIKE with filter of `Ta%30%`, it wasn't working correctly before and it is now equivalent to: StartsWith "Ta" and Contains "30" anywhere

below with the fix, other column filters now work (before the fix, the 2nd column filter wasn't doing anything)

![msedge_bbEm4vYgpN](https://github.com/ghiscoding/slickgrid-universal/assets/643976/cabdc136-2537-4b1c-ad7b-0bb87e23388d)
