### PR TITLE
fix(pagination): out of boundaries page Grid Preset should be unset

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example09.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example09.ts
@@ -267,8 +267,8 @@ export default class Example09 {
         throw new Error('Server could not sort using the field "Company"');
       }
 
-      // read the json and create a fresh copy of the data that we are free to modify
-      let data = Data as unknown as { name: string; gender: string; company: string; id: string, category: { id: string; name: string } }[];
+      // read the JSON and create a fresh copy of the data that we are free to modify
+      let data = Data as unknown as { name: string; gender: string; company: string; id: string, category: { id: string; name: string; }; }[];
       data = JSON.parse(JSON.stringify(data));
 
       // Sort the data
@@ -299,7 +299,7 @@ export default class Example09 {
       }
 
       // Read the result field from the JSON response.
-      const firstRow = skip;
+      let firstRow = skip;
       let filteredData = data;
       if (columnFilters) {
         for (const columnId in columnFilters) {
@@ -337,6 +337,12 @@ export default class Example09 {
           }
         }
         countTotalItems = filteredData.length;
+      }
+
+      // make sure page skip is not out of boundaries, if so reset to first page & remove skip from query
+      if (firstRow > filteredData.length) {
+        query = query.replace(`$skip=${firstRow}`, '');
+        firstRow = 0;
       }
       const updatedData = filteredData.slice(firstRow, firstRow + top);
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example15.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example15.ts
@@ -335,7 +335,7 @@ export default class Example15 {
       }
 
       // Read the result field from the JSON response.
-      const firstRow = skip;
+      let firstRow = skip;
       let filteredData = data;
       if (columnFilters) {
         for (const columnId in columnFilters) {
@@ -361,6 +361,12 @@ export default class Example15 {
           }
         }
         countTotalItems = filteredData.length;
+      }
+
+      // make sure page skip is not out of boundaries, if so reset to first page & remove skip from query
+      if (firstRow > filteredData.length) {
+        query = query.replace(`$skip=${firstRow}`, '');
+        firstRow = 0;
       }
       const updatedData = filteredData.slice(firstRow, firstRow + top);
 

--- a/packages/common/src/services/__tests__/pagination.service.spec.ts
+++ b/packages/common/src/services/__tests__/pagination.service.spec.ts
@@ -1,3 +1,4 @@
+import 'jest-extended';
 import { of, throwError } from 'rxjs';
 
 import { PaginationService } from './../pagination.service';
@@ -376,7 +377,7 @@ describe('PaginationService', () => {
       service.goToPreviousPage(null, false);
 
       expect(service.getCurrentPageNumber()).toBe(1);
-      expect(spy).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('should not expect "processOnPageChanged" method to be called when we are already on first page', () => {

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -451,7 +451,7 @@ export class PaginationService {
 
   recalculateFromToIndexes() {
     // when page is out of boundaries, reset it to page 1
-    if (((this._pageNumber - 1) * this._itemsPerPage > this._totalItems)) {
+    if (((this._pageNumber - 1) * this._itemsPerPage > this._totalItems) || (this._totalItems > 0 && this._pageNumber === 0)) {
       this._pageNumber = 1;
     }
 
@@ -465,9 +465,6 @@ export class PaginationService {
       if (this._dataTo > this._totalItems) {
         this._dataTo = this._totalItems;
       }
-    }
-    if (this._totalItems > 0 && this._pageNumber === 0) {
-      this._pageNumber = 1;
     }
 
     // do a final check on the From/To and make sure they are not greater or smaller than min/max acceptable values


### PR DESCRIPTION
- in the OData example, we have a Grid Preset of page number 2 and that demo also uses local storage, if we keep the Gender filter and also add a Name filter like "G", it results to a total of 9 items and it works fine unless we refresh the page. After a page refresh, and when our page size is set to 20, we are now out of bound and the 9 items weren't showing up because the system thought it was on page 2 even though we shouldn't... So let's make sure to never be out of boundaries and reset to first page when that happens (or page 0 when no items found)
- a side note, I the issue described above and shown below would probably never happened with a real server since the OData server would never return a page number that is outside of boundaries, which is probably why no one ever reported the issue
- also add a prop observer on the `gridOptions.pagination.totalItems` since the user could change it but forgets to call `refreshPagination()`

![brave_8q5FQvOIsO](https://github.com/ghiscoding/slickgrid-universal/assets/643976/eeb978ac-e6ae-4994-8d36-3e2a7040cc6d)
