### PR TITLE
feat(core): add new `preventDragFromKeys` grid option, fixes #1537

### DIFF
--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -52,7 +52,7 @@ describe('Draggable class', () => {
     dg.destroy();
   });
 
-  it('should NOT trigger dragInit event when user is pressing mousedown with Ctrl key and is considered forbidden', () => {
+  it('should NOT trigger dragInit event when user is pressing mousedown and mousemove + Ctrl key combo that we considered as forbidden via "preventDragFromKeys"', () => {
     const dragInitSpy = jest.fn();
     const dragSpy = jest.fn();
     containerElement.className = 'slick-cell';
@@ -100,7 +100,7 @@ describe('Draggable class', () => {
     expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
   });
 
-  it('should NOT trigger dragInit,dragStart events when user is pressing mousedown with Shift key and is considered forbidden', () => {
+  it('should NOT trigger dragInit,dragStart events when user is pressing mousedown and mousemove + Meta key combo that we considered as forbidden via "preventDragFromKeys"', () => {
     const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
     const dragInitSpy = jest.fn();
     const dragSpy = jest.fn();
@@ -108,15 +108,15 @@ describe('Draggable class', () => {
     const dragEndSpy = jest.fn();
     containerElement.className = 'slick-cell';
 
-    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', preventDragFromKeys: ['shiftKey'], onDrag: dragSpy, onDragInit: dragInitSpy, onDragStart: dragStartSpy, onDragEnd: dragEndSpy });
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', preventDragFromKeys: ['metaKey'], onDrag: dragSpy, onDragInit: dragInitSpy, onDragStart: dragStartSpy, onDragEnd: dragEndSpy });
 
-    const mdEvt = new MouseEvent('mousedown', { shiftKey: true });
+    const mdEvt = new MouseEvent('mousedown', { metaKey: true });
     Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
     Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
     containerElement.dispatchEvent(mdEvt);
 
-    const mmEvt = new MouseEvent('mousemove', { shiftKey: true });
-    const muEvt = new MouseEvent('mouseup', { shiftKey: true });
+    const mmEvt = new MouseEvent('mousemove', { metaKey: true });
+    const muEvt = new MouseEvent('mouseup', { metaKey: true });
     Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
     Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
     Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -30,7 +30,7 @@ describe('Draggable class', () => {
 
     dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragInitSpy });
 
-    containerElement.dispatchEvent(new Event('mousedown'));
+    containerElement.dispatchEvent(new MouseEvent('mousedown'));
 
     expect(dg).toBeTruthy();
     expect(dragInitSpy).not.toHaveBeenCalled();
@@ -43,10 +43,26 @@ describe('Draggable class', () => {
 
     dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragSpy, onDragInit: dragInitSpy });
 
-    containerElement.dispatchEvent(new Event('mousedown'));
+    containerElement.dispatchEvent(new MouseEvent('mousedown'));
 
     expect(dg).toBeTruthy();
     expect(dragInitSpy).toHaveBeenCalled();
+    expect(dragSpy).not.toHaveBeenCalled();
+
+    dg.destroy();
+  });
+
+  it('should NOT trigger dragInit event when user is pressing mousedown with Ctrl key and is considered forbidden', () => {
+    const dragInitSpy = jest.fn();
+    const dragSpy = jest.fn();
+    containerElement.className = 'slick-cell';
+
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', preventDragFromKeys: ['ctrlKey'], onDrag: dragSpy, onDragInit: dragInitSpy });
+
+    containerElement.dispatchEvent(new MouseEvent('mousedown', { ctrlKey: true }));
+
+    expect(dg).toBeTruthy();
+    expect(dragInitSpy).not.toHaveBeenCalled();
     expect(dragSpy).not.toHaveBeenCalled();
 
     dg.destroy();
@@ -62,13 +78,13 @@ describe('Draggable class', () => {
 
     dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragSpy, onDragInit: dragInitSpy, onDragStart: dragStartSpy, onDragEnd: dragEndSpy });
 
-    const mdEvt = new Event('mousedown');
+    const mdEvt = new MouseEvent('mousedown');
     Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
     Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
     containerElement.dispatchEvent(mdEvt);
 
-    const mmEvt = new Event('mousemove');
-    const muEvt = new Event('mouseup');
+    const mmEvt = new MouseEvent('mousemove');
+    const muEvt = new MouseEvent('mouseup');
     Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
     Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
     Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });
@@ -81,6 +97,38 @@ describe('Draggable class', () => {
     expect(dragStartSpy).toHaveBeenCalled();  // TODO: revisit calledWith X/Y pos, after migrating to TS class
     expect(dragSpy).toHaveBeenCalled();
     expect(dragEndSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
+  });
+
+  it('should NOT trigger dragInit,dragStart events when user is pressing mousedown with Shift key and is considered forbidden', () => {
+    const removeListenerSpy = jest.spyOn(document.body, 'removeEventListener');
+    const dragInitSpy = jest.fn();
+    const dragSpy = jest.fn();
+    const dragStartSpy = jest.fn();
+    const dragEndSpy = jest.fn();
+    containerElement.className = 'slick-cell';
+
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', preventDragFromKeys: ['shiftKey'], onDrag: dragSpy, onDragInit: dragInitSpy, onDragStart: dragStartSpy, onDragEnd: dragEndSpy });
+
+    const mdEvt = new MouseEvent('mousedown', { shiftKey: true });
+    Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
+    Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    containerElement.dispatchEvent(mdEvt);
+
+    const mmEvt = new MouseEvent('mousemove', { shiftKey: true });
+    const muEvt = new MouseEvent('mouseup', { shiftKey: true });
+    Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+    Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+    Object.defineProperty(muEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+    document.body.dispatchEvent(mmEvt);
+    document.body.dispatchEvent(muEvt);
+
+    expect(dg).toBeTruthy();
+    expect(dragInitSpy).not.toHaveBeenCalledWith(mdEvt, { startX: 10, startY: 10, deltaX: 2, deltaY: 0, dragHandle: containerElement, dragSource: containerElement, target: document.body });
+    expect(dragStartSpy).not.toHaveBeenCalled();
+    expect(dragSpy).not.toHaveBeenCalled();
+    expect(dragEndSpy).not.toHaveBeenCalled();
     expect(removeListenerSpy).toHaveBeenCalledTimes(5 * 2);
   });
 });
@@ -188,13 +236,13 @@ describe('Resizable class', () => {
 
     rsz = Resizable({ resizeableElement: containerElement, resizeableHandleElement: containerElement, onResize: resizeSpy, onResizeStart: resizeStartSpy, onResizeEnd: resizeEndSpy });
 
-    const mdEvt = new Event('mousedown');
+    const mdEvt = new MouseEvent('mousedown');
     Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
     Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
     containerElement.dispatchEvent(mdEvt);
 
-    const mmEvt = new Event('mousemove');
-    const muEvt = new Event('mouseup');
+    const mmEvt = new MouseEvent('mousemove');
+    const muEvt = new MouseEvent('mouseup');
     Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
     Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
     Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -256,7 +256,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     forceSyncScrolling: false,
     addNewRowCssClass: 'new-row',
     preserveCopiedSelectionOnPaste: false,
-    preventDragFromKeys: ['ctrlKey'],
+    preventDragFromKeys: ['ctrlKey', 'metaKey'],
     showCellSelection: true,
     viewportClass: undefined,
     minRowBuffer: 3,

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -256,6 +256,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     forceSyncScrolling: false,
     addNewRowCssClass: 'new-row',
     preserveCopiedSelectionOnPaste: false,
+    preventDragFromKeys: ['ctrlKey', 'shiftKey'],
     showCellSelection: true,
     viewportClass: undefined,
     minRowBuffer: 3,
@@ -904,6 +905,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           allowDragFrom: 'div.slick-cell',
           // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
           allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
+          preventDragFromKeys: this._options.preventDragFromKeys,
           onDragInit: this.handleDragInit.bind(this),
           onDragStart: this.handleDragStart.bind(this),
           onDrag: this.handleDrag.bind(this),

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -256,7 +256,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     forceSyncScrolling: false,
     addNewRowCssClass: 'new-row',
     preserveCopiedSelectionOnPaste: false,
-    preventDragFromKeys: ['ctrlKey', 'shiftKey'],
+    preventDragFromKeys: ['ctrlKey'],
     showCellSelection: true,
     viewportClass: undefined,
     minRowBuffer: 3,

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -28,7 +28,7 @@ import type { DragItem, DragPosition, DraggableOption, MouseWheelOption, Resizab
  */
 export function Draggable(options: DraggableOption) {
   let { containerElement } = options;
-  const { onDragInit, onDragStart, onDrag, onDragEnd } = options;
+  const { onDragInit, onDragStart, onDrag, onDragEnd, preventDragFromKeys } = options;
   let element: HTMLElement | null;
   let startX: number;
   let startY: number;
@@ -52,7 +52,7 @@ export function Draggable(options: DraggableOption) {
     }
   }
 
-  function executeDragCallbackWhenDefined(callback?: (e: DragEvent, dd: DragPosition) => boolean | void, evt?: MouseEvent | Touch | TouchEvent, dd?: DragItem) {
+  function executeDragCallbackWhenDefined(callback?: (e: DragEvent, dd: DragPosition) => boolean | void, evt?: MouseEvent | Touch | TouchEvent | KeyboardEvent, dd?: DragItem) {
     if (typeof callback === 'function') {
       return callback(evt as DragEvent, dd as DragItem);
     }
@@ -65,45 +65,62 @@ export function Draggable(options: DraggableOption) {
     }
   }
 
-  function userPressed(event: MouseEvent | TouchEvent) {
+  /** Do we want to prevent Drag events from happening (for example prevent onDrag when Ctrl key is pressed) */
+  function preventDrag(event: MouseEvent | TouchEvent | KeyboardEvent) {
+    let eventPrevented = false;
+    if (preventDragFromKeys) {
+      preventDragFromKeys.forEach(key => {
+        if ((event as KeyboardEvent)[key]) {
+          eventPrevented = true;
+        }
+      });
+    }
+    return eventPrevented;
+  }
+
+  function userPressed(event: MouseEvent | TouchEvent | KeyboardEvent) {
     element = event.target as HTMLElement;
-    const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
-    const { target } = targetEvent;
+    if (!preventDrag(event)) {
+      const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
+      const { target } = targetEvent;
 
-    if (!options.allowDragFrom || (options.allowDragFrom && (element.matches(options.allowDragFrom)) || (options.allowDragFromClosest && element.closest(options.allowDragFromClosest)))) {
-      originaldd.dragHandle = element as HTMLElement;
-      const winScrollPos = windowScrollPosition();
-      startX = winScrollPos.left + targetEvent.clientX;
-      startY = winScrollPos.top + targetEvent.clientY;
-      deltaX = targetEvent.clientX - targetEvent.clientX;
-      deltaY = targetEvent.clientY - targetEvent.clientY;
-      originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
-      const result = executeDragCallbackWhenDefined(onDragInit as (e: DragEvent, dd: DragPosition) => boolean | void, event, originaldd as DragItem);
+      if (!options.allowDragFrom || (options.allowDragFrom && (element.matches(options.allowDragFrom)) || (options.allowDragFromClosest && element.closest(options.allowDragFromClosest)))) {
+        originaldd.dragHandle = element as HTMLElement;
+        const winScrollPos = windowScrollPosition();
+        startX = winScrollPos.left + targetEvent.clientX;
+        startY = winScrollPos.top + targetEvent.clientY;
+        deltaX = targetEvent.clientX - targetEvent.clientX;
+        deltaY = targetEvent.clientY - targetEvent.clientY;
+        originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
+        const result = executeDragCallbackWhenDefined(onDragInit as (e: DragEvent, dd: DragPosition) => boolean | void, event, originaldd as DragItem);
 
-      if (result !== false) {
-        document.body.addEventListener('mousemove', userMoved);
-        document.body.addEventListener('touchmove', userMoved);
-        document.body.addEventListener('mouseup', userReleased);
-        document.body.addEventListener('touchend', userReleased);
-        document.body.addEventListener('touchcancel', userReleased);
+        if (result !== false) {
+          document.body.addEventListener('mousemove', userMoved);
+          document.body.addEventListener('touchmove', userMoved);
+          document.body.addEventListener('mouseup', userReleased);
+          document.body.addEventListener('touchend', userReleased);
+          document.body.addEventListener('touchcancel', userReleased);
+        }
       }
     }
   }
 
-  function userMoved(event: MouseEvent | TouchEvent) {
+  function userMoved(event: MouseEvent | TouchEvent | KeyboardEvent) {
     const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
-    deltaX = targetEvent.clientX - startX;
-    deltaY = targetEvent.clientY - startY;
-    const { target } = targetEvent;
+    if (!preventDrag(event)) {
+      deltaX = targetEvent.clientX - startX;
+      deltaY = targetEvent.clientY - startY;
+      const { target } = targetEvent;
 
-    if (!dragStarted) {
+      if (!dragStarted) {
+        originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
+        executeDragCallbackWhenDefined(onDragStart, event, originaldd as DragItem);
+        dragStarted = true;
+      }
+
       originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
-      executeDragCallbackWhenDefined(onDragStart, event, originaldd as DragItem);
-      dragStarted = true;
+      executeDragCallbackWhenDefined(onDrag, event, originaldd as DragItem);
     }
-
-    originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
-    executeDragCallbackWhenDefined(onDrag, event, originaldd as DragItem);
   }
 
   function userReleased(event: MouseEvent | TouchEvent) {

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -65,7 +65,7 @@ export function Draggable(options: DraggableOption) {
     }
   }
 
-  /** Do we want to prevent Drag events from happening (for example prevent onDrag when Ctrl key is pressed) */
+  /** Do we want to prevent Drag events from happening (for example prevent onDrag when Ctrl key is pressed while dragging) */
   function preventDrag(event: MouseEvent | TouchEvent | KeyboardEvent) {
     let eventPrevented = false;
     if (preventDragFromKeys) {

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -668,6 +668,9 @@ export interface GridOption<C extends Column = Column> {
   /** Defaults to false, do we want prevent the usage of DocumentFragment by the library (might not be supported by all environments, e.g. not supported by Salesforce) */
   preventDocumentFragmentUsage?: boolean;
 
+  /** Defaults to `['ctrlKey', 'shiftKey]`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
+
   /** Preselect certain rows by their row index ("enableCheckboxSelector" must be enabled) */
   preselectedRows?: number[];
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -668,7 +668,7 @@ export interface GridOption<C extends Column = Column> {
   /** Defaults to false, do we want prevent the usage of DocumentFragment by the library (might not be supported by all environments, e.g. not supported by Salesforce) */
   preventDocumentFragmentUsage?: boolean;
 
-  /** Defaults to `['ctrlKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  /** Defaults to `['ctrlKey', 'metaKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
   preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
 
   /** Preselect certain rows by their row index ("enableCheckboxSelector" must be enabled) */

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -668,7 +668,7 @@ export interface GridOption<C extends Column = Column> {
   /** Defaults to false, do we want prevent the usage of DocumentFragment by the library (might not be supported by all environments, e.g. not supported by Salesforce) */
   preventDocumentFragmentUsage?: boolean;
 
-  /** Defaults to `['ctrlKey', 'shiftKey]`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  /** Defaults to `['ctrlKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
   preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
 
   /** Preselect certain rows by their row index ("enableCheckboxSelector" must be enabled) */

--- a/packages/common/src/interfaces/interactions.interface.ts
+++ b/packages/common/src/interfaces/interactions.interface.ts
@@ -17,6 +17,9 @@ export interface DraggableOption {
   /** when defined, will allow dragging from a specific element or its closest parent by using the .closest() query selector. */
   allowDragFromClosest?: string;
 
+  /** Defaults to `['ctrlKey', 'shiftKey]`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
+
   /** drag initialized callback */
   onDragInit?: (e: DragEvent, dd: DragPosition) => boolean | void;
 

--- a/packages/common/src/interfaces/interactions.interface.ts
+++ b/packages/common/src/interfaces/interactions.interface.ts
@@ -17,7 +17,7 @@ export interface DraggableOption {
   /** when defined, will allow dragging from a specific element or its closest parent by using the .closest() query selector. */
   allowDragFromClosest?: string;
 
-  /** Defaults to `['ctrlKey', 'shiftKey]`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  /** Defaults to `['ctrlKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
   preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
 
   /** drag initialized callback */

--- a/packages/common/src/interfaces/interactions.interface.ts
+++ b/packages/common/src/interfaces/interactions.interface.ts
@@ -17,7 +17,7 @@ export interface DraggableOption {
   /** when defined, will allow dragging from a specific element or its closest parent by using the .closest() query selector. */
   allowDragFromClosest?: string;
 
-  /** Defaults to `['ctrlKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
+  /** Defaults to `['ctrlKey', 'metaKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
   preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;
 
   /** drag initialized callback */


### PR DESCRIPTION
- the issue was brought in discussion #1537, the root cause was the mouse drag sometime kicks in when the user selects a few row by using the Ctrl+click combo, however in rare occasion the user might move by even a single pixel and that sends an onDrag event which the SlickCellRangeSelector picks up when then sends a new event `onCellRangeSelecting` and then the SlickRowSelectionModel assumes it's a new range from a mouse drag and override the previous range. However we should really prevent this mouse drag from happening when the user is pressing the Ctrl/Shift keys to avoid having the issue brought in #1537