### PR TITLE
chore(sort): instead of using `99e+10` number, we should use `Infinity`

### DIFF
--- a/packages/common/src/interfaces/sorter.interface.ts
+++ b/packages/common/src/interfaces/sorter.interface.ts
@@ -2,4 +2,4 @@ import type { Column } from './column.interface';
 import type { GridOption } from './gridOption.interface';
 import type { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
-export type SortComparer = (value1: any, value2: any, sortDirection: SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => number;
+export type SortComparer = (value1: any, value2: any, sortDirection?: SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => number;

--- a/packages/common/src/sortComparers/__tests__/objectStringSortComparer.spec.ts
+++ b/packages/common/src/sortComparers/__tests__/objectStringSortComparer.spec.ts
@@ -2,7 +2,7 @@ import { SortDirectionNumber } from '../../enums/sortDirectionNumber.enum';
 import { objectStringSortComparer } from '../objectStringSortComparer';
 
 describe('the Object w/String SortComparer', () => {
-  let collection = [];
+  let collection: any[] = [];
 
   beforeEach(() => {
     collection = [
@@ -16,7 +16,7 @@ describe('the Object w/String SortComparer', () => {
   });
 
   afterEach(() => {
-    collection = undefined;
+    collection = undefined as any;
   });
 
   it('should throw an error when "dataKey" is missing in the column definition', () => {
@@ -27,8 +27,8 @@ describe('the Object w/String SortComparer', () => {
       .toThrowError('Sorting a "FieldType.object" requires you to provide the "dataKey"');
   });
 
-  it('should return original unsorted array when no direction is provided', () => {
-    const direction = null;
+  it('should return original unsorted array when direction is undefined', () => {
+    const direction = undefined;
     const columnDef = { id: 'users', field: 'users', dataKey: 'firstName' };
 
     collection.sort((value1, value2) => objectStringSortComparer(value1, value2, direction, columnDef));

--- a/packages/common/src/sortComparers/booleanSortComparer.ts
+++ b/packages/common/src/sortComparers/booleanSortComparer.ts
@@ -1,10 +1,7 @@
 import type { SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
-export const booleanSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber) => {
-  if (sortDirection === undefined || sortDirection === null) {
-    sortDirection = SortDirectionNumber.neutral;
-  }
+export const booleanSortComparer: SortComparer = (value1: any, value2: any, sortDirection: SortDirectionNumber = SortDirectionNumber.neutral) => {
   let position = 0;
 
   if (value1 === value2) {

--- a/packages/common/src/sortComparers/numericSortComparer.ts
+++ b/packages/common/src/sortComparers/numericSortComparer.ts
@@ -1,8 +1,9 @@
+import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 import type { Column, GridOption, SortComparer } from '../interfaces/index';
 
-export const numericSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number, sortColumn?: Column, gridOptions?: GridOption) => {
+export const numericSortComparer: SortComparer = (value1: any, value2: any, sortDirection: SortDirectionNumber = SortDirectionNumber.neutral, sortColumn?: Column, gridOptions?: GridOption) => {
   const checkForUndefinedValues = sortColumn?.valueCouldBeUndefined ?? gridOptions?.cellValueCouldBeUndefined ?? false;
-  const x = (isNaN(value1) || value1 === '' || value1 === null || (checkForUndefinedValues && value1 === undefined)) ? -99e+10 : parseFloat(value1);
-  const y = (isNaN(value2) || value2 === '' || value2 === null || (checkForUndefinedValues && value2 === undefined)) ? -99e+10 : parseFloat(value2);
+  const x = (isNaN(value1) || value1 === '' || value1 === null || (checkForUndefinedValues && value1 === undefined)) ? -Infinity : parseFloat(value1);
+  const y = (isNaN(value2) || value2 === '' || value2 === null || (checkForUndefinedValues && value2 === undefined)) ? -Infinity : parseFloat(value2);
   return sortDirection * (x === y ? 0 : (x > y ? 1 : -1));
 };

--- a/packages/common/src/sortComparers/objectStringSortComparer.ts
+++ b/packages/common/src/sortComparers/objectStringSortComparer.ts
@@ -1,7 +1,7 @@
 import type { Column, GridOption, SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
-export const objectStringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => {
+export const objectStringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: SortDirectionNumber = SortDirectionNumber.neutral, sortColumn?: Column, gridOptions?: GridOption) => {
   if (!sortColumn || !sortColumn.dataKey) {
     throw new Error('Sorting a "FieldType.object" requires you to provide the "dataKey" (object property name) of the object so that we can use it to sort correctly');
   }
@@ -10,15 +10,11 @@ export const objectStringSortComparer: SortComparer = (value1: any, value2: any,
   const stringValue2 = value2?.hasOwnProperty(sortColumn.dataKey) ? value2[sortColumn.dataKey] : value2;
   const checkForUndefinedValues = sortColumn?.valueCouldBeUndefined ?? gridOptions?.cellValueCouldBeUndefined ?? false;
 
-  if (sortDirection === undefined || sortDirection === null) {
-    sortDirection = SortDirectionNumber.neutral;
-  }
-
   let position = 0;
   if (typeof value1 !== 'object') {
-    position = -99e+10;
+    position = -Infinity;
   } else if (typeof value2 !== 'object') {
-    position = 99e+10;
+    position = Infinity;
   } else if (stringValue1 === null || (checkForUndefinedValues && stringValue1 === undefined)) {
     position = -1;
   } else if (stringValue2 === null || (checkForUndefinedValues && stringValue2 === undefined)) {

--- a/packages/common/src/sortComparers/stringSortComparer.ts
+++ b/packages/common/src/sortComparers/stringSortComparer.ts
@@ -3,10 +3,7 @@ import { removeAccentFromText } from '@slickgrid-universal/utils';
 import type { Column, GridOption, SortComparer } from '../interfaces/index';
 import { SortDirectionNumber } from '../enums/sortDirectionNumber.enum';
 
-export const stringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) => {
-  if (sortDirection === undefined || sortDirection === null) {
-    sortDirection = SortDirectionNumber.neutral;
-  }
+export const stringSortComparer: SortComparer = (value1: any, value2: any, sortDirection: SortDirectionNumber = SortDirectionNumber.neutral, sortColumn?: Column, gridOptions?: GridOption) => {
   let position = 0;
   const checkForUndefinedValues = sortColumn?.valueCouldBeUndefined ?? gridOptions?.cellValueCouldBeUndefined ?? false;
 


### PR DESCRIPTION
- so instead of using a super large number, we should just use `Infinity` which is valid
- also revisit the SortComparer interface and assign neutral sort direction if none is provided (null/undefined)