### PR TITLE
chore(plugin): move `preHeaderPanelWidth` to SlickGrid core defaults

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -231,6 +231,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     createPreHeaderPanel: false,
     showPreHeaderPanel: false,
     preHeaderPanelHeight: 25,
+    preHeaderPanelWidth: 'auto', // mostly useful for Draggable Grouping dropzone to take full width
     showTopPanel: false,
     topPanelHeight: 25,
     formatterFactory: null,

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -248,7 +248,6 @@ export const GlobalGridOptions: Partial<GridOption> = {
   headerRowHeight: 35,
   rowHeight: 35,
   topPanelHeight: 30,
-  preHeaderPanelWidth: '100%', // mostly useful for Draggable Grouping dropzone to take full width
   translationNamespaceSeparator: ':',
   resetFilterSearchValueAfterOnBeforeCancellation: true,
   resizeByContentOnlyOnFirstLoad: true,

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -656,7 +656,7 @@ export interface GridOption<C extends Column = Column> {
   /** Extra pre-header panel height (on top of column header) */
   preHeaderPanelHeight?: number;
 
-  /** Extra pre-header panel (on top of column header) width, it could be a number (pixels) or a string ("100%") */
+  /** Defaults to "auto", extra pre-header panel (on top of column header) width, it could be a number (pixels) or a string ("100%" or "auto") */
   preHeaderPanelWidth?: number | string;
 
   /** Do we want to preserve copied selection on paste? */


### PR DESCRIPTION
- also use `auto` instead of `100%` to take full width but without being wider than its actual container