### PR TITLE
feat(export): add missing `valueParserCallback` dataContext & new demo

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/app-routing.ts
+++ b/examples/vite-demo-vanilla-bundle/src/app-routing.ts
@@ -23,6 +23,7 @@ import Example19 from './examples/example19';
 import Example20 from './examples/example20';
 import Example21 from './examples/example21';
 import Example22 from './examples/example22';
+import Example23 from './examples/example23';
 
 export class AppRouting {
   constructor(private config: RouterConfig) {
@@ -51,6 +52,7 @@ export class AppRouting {
       { route: 'example20', name: 'example20', view: './examples/example20.html', viewModel: Example20, title: 'Example20', },
       { route: 'example21', name: 'example21', view: './examples/example21.html', viewModel: Example21, title: 'Example21', },
       { route: 'example22', name: 'example22', view: './examples/example22.html', viewModel: Example22, title: 'Example22', },
+      { route: 'example23', name: 'example23', view: './examples/example23.html', viewModel: Example23, title: 'Example23', },
       { route: '', redirect: 'example01' },
       { route: '**', redirect: 'example01' }
     ];

--- a/examples/vite-demo-vanilla-bundle/src/app.html
+++ b/examples/vite-demo-vanilla-bundle/src/app.html
@@ -103,7 +103,7 @@
             Example22 - Row Based Editing
           </a>
           <a class="navbar-item" onclick.delegate="loadRoute('example23')">
-            Example23 - Excel Export Formula
+            Example23 - Excel Export Formulas
           </a>
         </div>
       </div>

--- a/examples/vite-demo-vanilla-bundle/src/app.html
+++ b/examples/vite-demo-vanilla-bundle/src/app.html
@@ -102,6 +102,9 @@
           <a class="navbar-item" onclick.delegate="loadRoute('example22')">
             Example22 - Row Based Editing
           </a>
+          <a class="navbar-item" onclick.delegate="loadRoute('example23')">
+            Example23 - Excel Export Formula
+          </a>
         </div>
       </div>
     </div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.html
@@ -1,0 +1,34 @@
+<h3 class="title is-3">
+  Example 23 - Excel Export Formula
+  <span class="subtitle">(with Salesforce Theme)</span>
+  <div class="subtitle code-link">
+    <span class="is-size-6">see</span>
+    <a class="is-size-5" target="_blank"
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/examples/vite-demo-vanilla-bundle/src/examples/example23.ts">
+      <span class="mdi mdi-link-variant"></span> code
+    </a>
+  </div>
+</h3>
+
+<h5 class="title is-5 mb-3">
+  Calculate Totals via Custom Formatters in the UI, but use Excel Formula when exporting via <code>excelExportOptions.valueParserCallback</code>
+</h5>
+
+<section class="row mb-2">
+  <div class="mb-1">
+    <button class="button is-small" data-test="export-excel-btn" onclick.delegate="exportToExcel()">
+      <span class="mdi mdi-file-excel-outline text-color-success"></span>
+      <span>Export to Excel</span>
+    </button>
+    <span class="ml-5 text-bold">
+      Tax Rate:
+      <input type="number" value.bind="taxRate" class="is-narrow input is-small" step="0.25" />
+      <button class="button is-small" onclick.delegate="changeTaxRate()" data-test="set-count-btn">
+        Update
+      </button>
+    </span>
+  </div>
+</section>
+
+<div class="grid23">
+</div>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.html
@@ -1,6 +1,5 @@
 <h3 class="title is-3">
-  Example 23 - Excel Export Formula
-  <span class="subtitle">(with Salesforce Theme)</span>
+  Example 23 - Excel Export Formulas
   <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a class="is-size-5" target="_blank"
@@ -11,10 +10,10 @@
 </h3>
 
 <h5 class="title is-5 mb-3">
-  Calculate Totals via Custom Formatters in the UI, but use Excel Formula when exporting via <code>excelExportOptions.valueParserCallback</code>
+  Calculate Totals via Formatters in the UI, but use Excel Formula when exporting via <code>excelExportOptions.valueParserCallback</code>
 </h5>
 <h6 class="is-6 mb-4">
-  When Grouped we will also calculate the Group Totals in the UI via Group Formatter and we again use Excel Formula to calculate the Group Totals (sum) dynamically.
+  When Grouped we will also calculate the Group Totals in the UI via Group Formatter and we again use Excel Formula to calculate the Group Totals (sum) dynamically. For Grouping we need to use <code>groupTotalsExcelExportOptions.valueParserCallback</code> instead.
 </h6>
 
 <section class="row mb-2">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.html
@@ -13,6 +13,9 @@
 <h5 class="title is-5 mb-3">
   Calculate Totals via Custom Formatters in the UI, but use Excel Formula when exporting via <code>excelExportOptions.valueParserCallback</code>
 </h5>
+<h6 class="is-6 mb-4">
+  When Grouped we will also calculate the Group Totals in the UI via Group Formatter and we again use Excel Formula to calculate the Group Totals (sum) dynamically.
+</h6>
 
 <section class="row mb-2">
   <div class="mb-1">
@@ -20,13 +23,19 @@
       <span class="mdi mdi-file-excel-outline text-color-success"></span>
       <span>Export to Excel</span>
     </button>
-    <span class="ml-5 text-bold">
+    <span>
+      <button class="button is-small" onclick.delegate="groupByTaxable()" data-test="group-by-btn">
+        <span>Group by Taxable</span>
+      </button>
+    </span>
+    <span class="ml-6 text-bold">
       Tax Rate:
-      <input type="number" value.bind="taxRate" class="is-narrow input is-small" step="0.25" />
-      <button class="button is-small" onclick.delegate="changeTaxRate()" data-test="set-count-btn">
+      <input type="number" value.bind="taxRate" class="is-narrow input is-small" step="0.25" data-test="taxrate" />
+      <button class="button is-small" onclick.delegate="updateTaxRate()" data-test="update-btn">
         Update
       </button>
     </span>
+
   </div>
 </section>
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.scss
@@ -8,4 +8,16 @@
     display: flex !important;
     justify-content: center;
   }
+  .text-sub-total {
+    font-style: italic;
+    color: #215073;
+  }
+  .text-taxes {
+    font-style: italic;
+    color: #C65911;
+  }
+  .text-total {
+    font-weight: bold;
+    color: #005A9E;
+  }
 }

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.scss
@@ -1,0 +1,11 @@
+.grid23 {
+  .slick-row:not(.slick-group) >.cell-unselectable {
+    background: #ececec !important;
+    font-weight: bold;
+  }
+
+  .header-centered {
+    display: flex !important;
+    justify-content: center;
+  }
+}

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.scss
@@ -4,20 +4,16 @@
     font-weight: bold;
   }
 
-  .header-centered {
-    display: flex !important;
-    justify-content: center;
-  }
   .text-sub-total {
     font-style: italic;
-    color: #215073;
+    color: rgb(33, 80, 115);
   }
   .text-taxes {
     font-style: italic;
-    color: #C65911;
+    color: rgb(198, 89, 17);
   }
   .text-total {
     font-weight: bold;
-    color: #005A9E;
+    color: rgb(0, 90, 158);
   }
 }

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
@@ -397,11 +397,9 @@ export default class Example19 {
         excelVal = `${excelPriceCol}*${excelQtyCol}`; // like "C4*D4"
         break;
       case 'taxes':
-        if (dataContext.taxable) {
-          excelVal = `${excelPriceCol}*${excelQtyCol}*${this.taxRate / 100}`;
-        } else {
-          excelVal = '';
-        }
+        excelVal = (dataContext.taxable)
+          ? `${excelPriceCol}*${excelQtyCol}*${this.taxRate / 100}`
+          : '';
         break;
       case 'total':
         excelVal = `(${excelPriceCol}*${excelQtyCol})+${excelTaxesCol}`;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
@@ -336,7 +336,7 @@ export default class Example19 {
     this.excelExportService.exportToExcel();
   }
 
-  excelGroupCellParser(totals: SlickGroupTotals, columnDef: Column, groupType, excelFormatterId: number | undefined, _stylesheet, dataRowIdx: number) {
+  excelGroupCellParser(totals: SlickGroupTotals, columnDef: Column, _groupType, excelFormatterId: number | undefined, _stylesheet, dataRowIdx: number) {
     const colOffset = 0; // col offset of 1x because we skipped 1st column OR 0 offset if we use a Group because the Group column replaces the skip
     const rowOffset = 3; // row offset of 3x because: 1x Title, 1x Headers and Excel row starts at 1 => 3
     const priceIdx = this.sgb.slickGrid?.getColumnIndex('price') || 0;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
@@ -67,7 +67,7 @@ export default class Example19 {
         formatter: Formatters.multiple,
         params: {
           formatters: [
-            (row, cell, value, coldef, dataContext) => dataContext.price * dataContext.qty,
+            (_row, _cell, _value, _coldef, dataContext) => dataContext.price * dataContext.qty,
             Formatters.dollar
           ]
         },
@@ -83,7 +83,7 @@ export default class Example19 {
       {
         id: 'taxable', name: 'Taxable', field: 'taxable', cssClass: 'text-center', sortable: true, width: 60, filterable: true,
         formatter: Formatters.checkmarkMaterial,
-        exportCustomFormatter: (row, cell, val) => val ? '✓' : '',
+        exportCustomFormatter: (_row, _cell, val) => val ? '✓' : '',
         excelExportOptions: {
           style: {
             alignment: {
@@ -97,7 +97,7 @@ export default class Example19 {
         formatter: Formatters.multiple,
         params: {
           formatters: [
-            (row, cell, value, coldef, dataContext) => {
+            (_row, _cell, _value, _coldef, dataContext) => {
               if (dataContext.taxable) {
                 return dataContext.price * dataContext.qty * (this.taxRate / 100);
               }
@@ -120,7 +120,7 @@ export default class Example19 {
         cssClass: 'text-bold', formatter: Formatters.multiple,
         params: {
           formatters: [
-            (row, cell, value, coldef, dataContext) => {
+            (_row, _cell, _value, _coldef, dataContext) => {
               let subTotal = dataContext.price * dataContext.qty;
               if (dataContext.taxable) {
                 subTotal += subTotal * (this.taxRate / 100);
@@ -194,7 +194,7 @@ export default class Example19 {
   /**
    * We'll use a generic parser to reuse similar logic for all 3 calculable columns (SubTotal, Taxes, Total)
    */
-  excelColumnParser(_data, colDef, excelFormatterId, excelStylesheet, gridOptions, dataContext: GroceryItem) {
+  excelColumnParser(_data, colDef, excelFormatterId, _stylesheet, _gridOptions, dataContext: GroceryItem) {
     // assuming that we want to calculate: (Price * Qty) => Sub-Total
     const colOffset = 1; // 1st column is not exported
     const rowOffset = 3; // 1x Title, 1x Headers and Excel row starts at 1 => 3

--- a/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example23.ts
@@ -1,0 +1,259 @@
+import { type Column, Editors, type GridOption, FileType, Formatters, FieldType, } from '@slickgrid-universal/common';
+import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+import { ExcelExportService } from '@slickgrid-universal/excel-export';
+
+import { ExampleGridOptions } from './example-grid-options';
+import './example23.scss';
+
+interface GroceryItem {
+  id: number;
+  name: string;
+  qty: number;
+  price: number;
+  taxable: boolean;
+  subTotal: number;
+  taxes: number;
+  total: number;
+}
+
+export default class Example19 {
+  columnDefinitions: Column<GroceryItem>[] = [];
+  dataset: any[] = [];
+  gridOptions!: GridOption;
+  gridContainerElm: HTMLDivElement;
+  sgb: SlickVanillaGridBundle;
+  excelExportService: ExcelExportService;
+  taxRate = 7.5;
+
+  constructor() {
+    this.excelExportService = new ExcelExportService();
+  }
+
+  attached() {
+    // define the grid options & columns and then create the grid itself
+    this.defineGrid();
+
+    // mock some data (different in each dataset)
+    this.dataset = this.getData();
+    this.gridContainerElm = document.querySelector<HTMLDivElement>('.grid23') as HTMLDivElement;
+    this.sgb = new Slicker.GridBundle(document.querySelector('.grid23') as HTMLDivElement, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, this.dataset);
+    document.body.classList.add('salesforce-theme');
+  }
+
+  dispose() {
+    this.sgb?.dispose();
+    this.gridContainerElm.remove();
+    document.body.classList.remove('salesforce-theme');
+  }
+
+  /* Define grid Options and Columns */
+  defineGrid() {
+    this.columnDefinitions = [
+      {
+        id: 'sel',
+        name: '#',
+        field: 'id',
+        headerCssClass: 'header-centered',
+        cssClass: 'cell-unselectable text-center',
+        excludeFromExport: true,
+        maxWidth: 30,
+      },
+      { id: 'name', name: 'Name', field: 'name', sortable: true, width: 140, filterable: true, excelExportOptions: { width: 18 } },
+      { id: 'price', name: 'Price', field: 'price', type: FieldType.number, editor: { model: Editors.float }, sortable: true, width: 70, filterable: true },
+      { id: 'qty', name: 'Quantity', field: 'qty', type: FieldType.number, editor: { model: Editors.integer }, sortable: true, width: 60, filterable: true },
+      {
+        id: 'subTotal', name: 'Sub-Total', field: 'subTotal', cssClass: 'text-italic', type: FieldType.number, sortable: true, width: 70, filterable: true,
+        exportWithFormatter: false,
+        formatter: Formatters.multiple,
+        params: {
+          formatters: [
+            (row, cell, value, coldef, dataContext) => dataContext.price * dataContext.qty,
+            Formatters.dollar
+          ]
+        },
+        excelExportOptions: {
+          style: {
+            font: { outline: true, italic: true },
+            format: '$0.00', // currency format
+          },
+          width: 12,
+          valueParserCallback: this.excelColumnParser.bind(this),
+        },
+      },
+      {
+        id: 'taxable', name: 'Taxable', field: 'taxable', cssClass: 'text-center', sortable: true, width: 60, filterable: true,
+        formatter: Formatters.checkmarkMaterial,
+        exportCustomFormatter: (row, cell, val) => val ? '✓' : '',
+        excelExportOptions: {
+          style: {
+            alignment: {
+              horizontal: 'center',
+            },
+          }
+        }
+      },
+      {
+        id: 'taxes', name: 'Taxes', field: 'taxes', cssClass: 'text-italic', type: FieldType.number, sortable: true, width: 70, filterable: true,
+        formatter: Formatters.multiple,
+        params: {
+          formatters: [
+            (row, cell, value, coldef, dataContext) => {
+              if (dataContext.taxable) {
+                return dataContext.price * dataContext.qty * (this.taxRate / 100);
+              }
+              return null;
+            },
+            Formatters.dollar
+          ]
+        },
+        excelExportOptions: {
+          style: {
+            font: { outline: true, italic: true },
+            format: '$0.00', // currency format
+          },
+          width: 12,
+          valueParserCallback: this.excelColumnParser.bind(this),
+        },
+      },
+      {
+        id: 'total', name: 'Total', field: 'total', type: FieldType.number, sortable: true, width: 70, filterable: true,
+        cssClass: 'text-bold', formatter: Formatters.multiple,
+        params: {
+          formatters: [
+            (row, cell, value, coldef, dataContext) => {
+              let subTotal = dataContext.price * dataContext.qty;
+              if (dataContext.taxable) {
+                subTotal += subTotal * (this.taxRate / 100);
+              }
+              return subTotal;
+            },
+            Formatters.dollar
+          ]
+        },
+        excelExportOptions: {
+          style: {
+            font: { outline: true, bold: true },
+            format: '$0.00', // currency format
+          },
+          width: 12,
+          valueParserCallback: this.excelColumnParser.bind(this),
+        },
+      },
+    ];
+
+    this.gridOptions = {
+      gridHeight: 410,
+      gridWidth: 750,
+      enableCellNavigation: true,
+      autoEdit: true,
+      editable: true,
+      rowHeight: 33,
+      formatterOptions: {
+        maxDecimal: 2,
+        minDecimal: 2,
+      },
+      externalResources: [this.excelExportService],
+      enableExcelExport: true,
+      excelExportOptions: {
+        filename: 'my-export',
+        sanitizeDataExport: true,
+        columnHeaderStyle: {
+          font: { color: 'FFFFFFFF' },
+          fill: { type: 'pattern', patternType: 'solid', fgColor: 'FF4a6c91' }
+        },
+
+        // optionally pass a custom header to the Excel Sheet
+        // a lot of the info can be found on Web Archive of Excel-Builder
+        // https://ghiscoding.gitbook.io/excel-builder-vanilla/cookbook/fonts-and-colors
+        customExcelHeader: (workbook, sheet) => {
+          const formatterId = workbook.getStyleSheet().createFormat({
+            // every color is prefixed with FF, then regular HTML color
+            font: { size: 18, fontName: 'Calibri', bold: true, color: 'FFFFFFFF' },
+            alignment: { wrapText: true, horizontal: 'center' },
+            fill: { type: 'pattern', patternType: 'solid', fgColor: 'FF203764' },
+          });
+          sheet.setRowInstructions(0, { height: 40 }); // change height of row 0
+
+          // excel cells start with A1 which is upper left corner
+          const customTitle = 'Grocery Shopping List';
+          sheet.mergeCells('A1', 'G1');
+          sheet.data.push([{ value: customTitle, metadata: { style: formatterId.id } }]);
+        },
+      },
+    };
+  }
+
+  changeTaxRate() {
+    this.sgb.slickGrid?.invalidate();
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({ filename: 'export', format: FileType.xlsx, });
+  }
+
+  /**
+   * We'll use a generic parser to reuse similar logic for all 3 calculable columns (SubTotal, Taxes, Total)
+   */
+  excelColumnParser(_data, colDef, excelFormatterId, excelStylesheet, gridOptions, dataContext: GroceryItem) {
+    // assuming that we want to calculate: (Price * Qty) => Sub-Total
+    const colOffset = 1; // 1st column is not exported
+    const rowOffset = 3; // 1x Title, 1x Headers and Excel row starts at 1 => 3
+    const itemRow = this.sgb.dataView?.getRowById(dataContext.id) || 0;
+    const priceIdx = this.sgb.slickGrid?.getColumnIndex('price') || 0;
+    const qtyIdx = this.sgb.slickGrid?.getColumnIndex('qty') || 0;
+    const taxesIdx = this.sgb.slickGrid?.getColumnIndex('taxes') || 0;
+
+    // the code below calculates Excel column position dynamically, technically Price is at "B" and Qty is "C"
+    const excelPriceCol = `${String.fromCharCode('A'.charCodeAt(0) + priceIdx - colOffset)}${itemRow + rowOffset}`;
+    const excelQtyCol = `${String.fromCharCode('A'.charCodeAt(0) + qtyIdx - colOffset)}${itemRow + rowOffset}`;
+    const excelTaxesCol = `${String.fromCharCode('A'.charCodeAt(0) + taxesIdx - colOffset)}${itemRow + rowOffset}`;
+
+    // `value` is our Excel cells to calculat (e.g.: "B4*C4")
+    // metadata `type` has to be set to "formula" and the `style` is what we defined in `excelExportOptions.style` which is `excelFormatterId` in the callback arg
+
+    let excelVal = '';
+    switch (colDef.id) {
+      case 'subTotal':
+        excelVal = `${excelPriceCol}*${excelQtyCol}`;
+        break;
+      case 'taxes':
+        if (dataContext.taxable) {
+          excelVal = `${excelPriceCol}*${excelQtyCol}*${this.taxRate / 100}`;
+        } else {
+          excelVal = '';
+        }
+        break;
+      case 'total':
+        excelVal = `(${excelPriceCol}*${excelQtyCol})+${excelTaxesCol}`;
+        break;
+    }
+    return { value: excelVal, metadata: { type: 'formula', style: excelFormatterId } };
+  }
+
+  getData() {
+    let i = 1;
+    const datasetTmp = [
+      { id: i++, name: 'Oranges', qty: 4, taxable: false, price: 2.22 },
+      { id: i++, name: 'Apples', qty: 3, taxable: false, price: 1.55 },
+      { id: i++, name: 'Honeycomb Cereals', qty: 2, taxable: true, price: 4.55 },
+      { id: i++, name: 'Raisins', qty: 77, taxable: false, price: 0.23 },
+      { id: i++, name: 'Corn Flake Cereals', qty: 1, taxable: true, price: 6.62 },
+      { id: i++, name: 'Tomatoes', qty: 3, taxable: false, price: 1.88 },
+      { id: i++, name: 'Butter', qty: 1, taxable: false, price: 3.33 },
+      { id: i++, name: 'BBQ Chicken', qty: 1, taxable: false, price: 12.33 },
+      { id: i++, name: 'Chicken Wings', qty: 12, taxable: true, price: .53 },
+      { id: i++, name: 'Drinkable Yogurt', qty: 6, taxable: true, price: 1.22 },
+      { id: i++, name: 'Milk', qty: 3, taxable: true, price: 3.11 },
+    ];
+
+    return datasetTmp;
+  }
+
+  generatePhoneNumber(): string {
+    let phone = '';
+    for (let i = 0; i < 10; i++) {
+      phone += Math.round(Math.random() * 9) + '';
+    }
+    return phone;
+  }
+}

--- a/packages/common/src/interfaces/columnExcelExportOption.interface.ts
+++ b/packages/common/src/interfaces/columnExcelExportOption.interface.ts
@@ -2,6 +2,7 @@ import type { ExcelColumnMetadata, ExcelStyleInstruction, StyleSheet } from 'exc
 
 import type { Column } from './column.interface';
 import type { GridOption } from './gridOption.interface';
+import type { SlickGroupTotals } from '../core/index';
 
 /** Excel custom export options (formatting & width) that can be applied to a column */
 export interface ColumnExcelExportOption {
@@ -30,7 +31,10 @@ export interface GroupTotalExportOption {
 
   /** Cell data value parser callback function */
   valueParserCallback?: GetGroupTotalValueCallback;
+
+  /** Allows to define a group type (sum, avg, ...) when auto-detect doesn't work when used with `valueParserCallback` without a `groupTotalsFormatter` to auto-detect. */
+  groupType?: string;
 }
 
-export type GetDataValueCallback = (data: Date | string | number, columnDef: Column, excelFormatterId: number | undefined, excelStylesheet: StyleSheet, gridOptions: GridOption, item: any) => Date | string | number | ExcelColumnMetadata;
-export type GetGroupTotalValueCallback = (totals: any, columnDef: Column, groupType: string, excelStylesheet: StyleSheet) => Date | string | number;
+export type GetDataValueCallback = (data: Date | string | number, columnDef: Column, excelFormatterId: number | undefined, excelStylesheet: StyleSheet, gridOptions: GridOption, rowNumber: number, item: any) => Date | string | number | ExcelColumnMetadata;
+export type GetGroupTotalValueCallback = (totals: SlickGroupTotals, columnDef: Column, groupType: string, excelFormatterId: number | undefined, excelStylesheet: StyleSheet, rowNumber: number) => Date | string | number | ExcelColumnMetadata;

--- a/packages/common/src/interfaces/columnExcelExportOption.interface.ts
+++ b/packages/common/src/interfaces/columnExcelExportOption.interface.ts
@@ -1,4 +1,4 @@
-import type { ExcelColumnMetadata, ExcelStyleInstruction } from 'excel-builder-vanilla';
+import type { ExcelColumnMetadata, ExcelStyleInstruction, StyleSheet } from 'excel-builder-vanilla';
 
 import type { Column } from './column.interface';
 import type { GridOption } from './gridOption.interface';
@@ -32,5 +32,5 @@ export interface GroupTotalExportOption {
   valueParserCallback?: GetGroupTotalValueCallback;
 }
 
-export type GetDataValueCallback = (data: Date | string | number, columnDef: Column, excelFormatterId: number | undefined, excelStylesheet: unknown, gridOptions: GridOption) => Date | string | number | ExcelColumnMetadata;
-export type GetGroupTotalValueCallback = (totals: any, columnDef: Column, groupType: string, excelStylesheet: unknown) => Date | string | number;
+export type GetDataValueCallback = (data: Date | string | number, columnDef: Column, excelFormatterId: number | undefined, excelStylesheet: StyleSheet, gridOptions: GridOption, item: any) => Date | string | number | ExcelColumnMetadata;
+export type GetGroupTotalValueCallback = (totals: any, columnDef: Column, groupType: string, excelStylesheet: StyleSheet) => Date | string | number;

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -562,8 +562,8 @@ describe('ExcelExportService', () => {
                   { metadata: { style: 1, }, value: 'StartDate', },
                   { metadata: { style: 1, }, value: 'EndDate', },
                 ],
-                ['1E06', 'John', 'X', 'SALES_REP', '2005-12-20T18:19:19.992Z', ''],
-                ['1E09', 'Jane', 'Doe', 'HUMAN_RESOURCES', '2010-10-09T18:19:19.992Z', '2024-01-02'],
+                ['1E06', 'John', 'X', { metadata: { style: 4 }, value: 'SALES_REP' }, '2005-12-20T18:19:19.992Z', ''],
+                ['1E09', 'Jane', 'Doe', { metadata: { style: 4 }, value: 'HUMAN_RESOURCES' }, '2010-10-09T18:19:19.992Z', '2024-01-02'],
               ]
             })]
           }),

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -898,15 +898,8 @@ describe('ExcelExportService', () => {
           }),
           'export.xlsx', { mimeType: mimeTypeXLSX }
         );
-        expect(service.groupTotalExcelFormats.order).toEqual({
-          groupType: 'sum',
-          stylesheetFormatter: {
-            fontId: 2,
-            id: 5,
-            numFmtId: 103,
-          }
-        });
-        expect(parserCallbackSpy).toHaveBeenNthCalledWith(1, 22, mockColumns[6], undefined, expect.anything(), mockGridOptions, expect.objectContaining({ firstName: 'John' }));
+        expect(service.groupTotalExcelFormats.order).toEqual({ groupType: 'sum', stylesheetFormatter: { fontId: 2, id: 5, numFmtId: 103 } });
+        expect(parserCallbackSpy).toHaveBeenNthCalledWith(1, 22, mockColumns[6], undefined, expect.anything(), mockGridOptions, 1, expect.objectContaining({ firstName: 'John' }));
       });
     });
 
@@ -1096,7 +1089,7 @@ describe('ExcelExportService', () => {
           .mockReturnValueOnce(mockCollection[6])
           .mockReturnValueOnce(mockCollection[7]);
         jest.spyOn(dataViewStub, 'getGrouping').mockReturnValue([mockOrderGrouping]);
-        groupTotalParserCallbackSpy.mockReturnValue(9999);
+        groupTotalParserCallbackSpy.mockReturnValue({ value: 9999, metadata: { style: 4 } });
       });
 
       it(`should have a xlsx export with grouping (same as the grid, WYSIWYG) when "enableGrouping" is set in the grid options and grouping are defined`, async () => {

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -906,7 +906,7 @@ describe('ExcelExportService', () => {
             numFmtId: 103,
           }
         });
-        expect(parserCallbackSpy).toHaveBeenCalledWith(22, mockColumns[6], undefined, expect.anything(), mockGridOptions);
+        expect(parserCallbackSpy).toHaveBeenNthCalledWith(1, 22, mockColumns[6], undefined, expect.anything(), mockGridOptions, expect.objectContaining({ firstName: 'John' }));
       });
     });
 

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -553,7 +553,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
         }
 
         const { stylesheetFormatterId, getDataValueParser } = this._regularCellExcelFormats[columnDef.id];
-        itemData = getDataValueParser(itemData, columnDef, stylesheetFormatterId, this._stylesheet, this._gridOptions);
+        itemData = getDataValueParser(itemData, columnDef, stylesheetFormatterId, this._stylesheet, this._gridOptions, itemObj);
 
         rowOutputStrings.push(itemData);
         idx++;

--- a/packages/excel-export/src/excelUtils.spec.ts
+++ b/packages/excel-export/src/excelUtils.spec.ts
@@ -43,31 +43,31 @@ describe('excelUtils', () => {
 
   describe('getExcelNumberCallback() method', () => {
     it('should return same data when input not a number', () => {
-      const output = getExcelNumberCallback('something else', {} as Column, 3, {}, mockGridOptions);
+      const output = getExcelNumberCallback('something else', {} as Column, 3, stylesheetStub, mockGridOptions, 0, {});
       expect(output).toEqual({ metadata: { style: 3 }, value: 'something else' });
     });
 
     it('should return same data when input value is already a number', () => {
-      const output = getExcelNumberCallback(9.33, {} as Column, 3, {}, mockGridOptions);
+      const output = getExcelNumberCallback(9.33, {} as Column, 3, stylesheetStub, mockGridOptions, 0, {});
       expect(output).toEqual({ metadata: { style: 3 }, value: 9.33 });
     });
 
     it('should return parsed number when input value can be parsed to a number', () => {
-      const output = getExcelNumberCallback('$1,209.33', {} as Column, 3, {}, mockGridOptions);
+      const output = getExcelNumberCallback('$1,209.33', {} as Column, 3, stylesheetStub, mockGridOptions, 0, {});
       expect(output).toEqual({ metadata: { style: 3 }, value: 1209.33 });
     });
 
     it('should return negative parsed number when input value can be parsed to a number', () => {
-      const output = getExcelNumberCallback('-$1,209.33', {} as Column, 3, {}, mockGridOptions);
+      const output = getExcelNumberCallback('-$1,209.33', {} as Column, 3, stylesheetStub, mockGridOptions, 0, {});
       expect(output).toEqual({ metadata: { style: 3 }, value: -1209.33 });
     });
 
     it('should be able to provide a number with different decimal separator as formatter options and return parsed number when input value can be parsed to a number', () => {
       const output = getExcelNumberCallback(
-        '1 244 209,33€', {} as Column, 3, {},
+        '1 244 209,33€', {} as Column, 3, stylesheetStub,
         {
           ...mockGridOptions, formatterOptions: { decimalSeparator: ',', thousandSeparator: ' ' }
-        });
+        }, 0, {});
       expect(output).toEqual({ metadata: { style: 3 }, value: 1244209.33 });
     });
   });

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -21,7 +21,9 @@ import { stripTags } from '@slickgrid-universal/utils';
 export type ExcelFormatter = object & { id: number; };
 
 // define all type of potential excel data function callbacks
-export const getExcelSameInputDataCallback: GetDataValueCallback = (data) => data;
+export const getExcelSameInputDataCallback: GetDataValueCallback = (data, _column, excelFormatterId) => {
+  return excelFormatterId !== undefined ? { value: data, metadata: { style: excelFormatterId } } : data;
+};
 export const getExcelNumberCallback: GetDataValueCallback = (data, column, excelFormatterId, _excelSheet, gridOptions) => ({
   value: typeof data === 'string' && /\d/g.test(data) ? parseNumberWithFormatterOptions(data, column, gridOptions) : data,
   metadata: { style: excelFormatterId }

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -22,7 +22,9 @@ export type ExcelFormatter = object & { id: number; };
 
 // define all type of potential excel data function callbacks
 export const getExcelSameInputDataCallback: GetDataValueCallback = (data, _column, excelFormatterId) => {
-  return excelFormatterId !== undefined ? { value: data, metadata: { style: excelFormatterId } } : data;
+  return excelFormatterId !== undefined
+    ? { value: data, metadata: { style: excelFormatterId } }
+    : data;
 };
 export const getExcelNumberCallback: GetDataValueCallback = (data, column, excelFormatterId, _excelSheet, gridOptions) => ({
   value: typeof data === 'string' && /\d/g.test(data) ? parseNumberWithFormatterOptions(data, column, gridOptions) : data,

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -137,7 +137,7 @@ export function getFormatterNumericDataType(formatter?: Formatter) {
 
 export function getExcelFormatFromGridFormatter(stylesheet: StyleSheet, stylesheetFormatters: any, columnDef: Column, grid: SlickGrid, formatterType: FormatterType) {
   let format = '';
-  let groupType = '';
+  let groupType = columnDef.groupTotalsExcelExportOptions?.groupType || '';
   let stylesheetFormatter: undefined | ExcelFormatter;
   const fieldType = getColumnFieldType(columnDef);
 

--- a/test/cypress/e2e/example23.cy.ts
+++ b/test/cypress/e2e/example23.cy.ts
@@ -1,0 +1,194 @@
+describe('Example 23 - Excel Export Formula', () => {
+  const GRID_ROW_HEIGHT = 33;
+  const fullTitles = ['#', 'Name', 'Price', 'Quantity', 'Sub-Total', 'Taxable', 'Taxes', 'Total'];
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example23`);
+    cy.get('h3').should('contain', 'Example 23 - Excel Export Formula');
+  });
+
+  it('should have exact column titles on grid', () => {
+    cy.get('.grid23')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should check first 3 rows with calculated totals', () => {
+    // 1st row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).contains('1');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('Oranges');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`).contains('$2.22');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(3)`).contains('4');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).contains('$8.88');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`).should('have.text', '');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('have.text', '');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).contains('$8.88');
+
+    // 2nd row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(0)`).contains('2');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('Apples');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).contains('$1.55');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(3)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).contains('$4.65');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(5)`).should('have.text', '');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('have.text', '');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).contains('$4.65');
+
+    // 3rd row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(0)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('Honeycomb Cereals');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).contains('$4.55');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(3)`).contains('2');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).contains('$9.10');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should('have.css', 'color').and('eq', 'rgb(33, 80, 115)');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(5)`).find('.mdi-check');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).contains('$0.68');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('have.css', 'color').and('eq', 'rgb(198, 89, 17)');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).contains('$9.78');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).should('have.css', 'color').and('eq', 'rgb(0, 90, 158)');
+  });
+
+  it('should change Price & Qty on first 3 rows and expect calculated values to be updated', () => {
+    // 1st row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).contains('1');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2) input`).clear().type('2.44{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(3)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(3) input`).clear().type('7{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).contains('$17.08');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).contains('$17.08');
+
+    // 2nd row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(0)`).contains('2');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2) input`).clear().type('1.4{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(3)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(3) input`).clear().type('3{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).contains('$4.20');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).contains('$4.20');
+
+    // 3rd row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(0)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2) input`).clear().type('4.23{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(3)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(3) input`).clear().type('3{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).contains('$12.69');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).contains('$0.95');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).contains('$13.64');
+  });
+
+  it('should be able to change Tax Rate and for first 3 rows only expect the 3rd one to be updated with different taxes and total', () => {
+    cy.get('[data-test="taxrate"]').clear().type('6.25');
+    cy.get('[data-test="update-btn"]').click();
+
+    // 1st row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).contains('1');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`).contains('$2.44');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(3)`).contains('7');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).contains('$17.08');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).contains('$17.08');
+
+    // 2nd row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(0)`).contains('2');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).contains('$1.40');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(3)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).contains('$4.20');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).contains('$4.20');
+
+    // 3rd row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(0)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).contains('$4.23');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(3)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).contains('$12.69');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).contains('$0.79');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).contains('$13.48');
+  });
+
+  it('should Group by Taxable and expect calculated totals', () => {
+    cy.get('[data-test="group-by-btn"]').click();
+
+    // last and 5th row of first Group
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(0)`).contains('11');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).contains('Milk');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(2)`).contains('$3.11');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(3)`).contains('3');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(4)`).contains('$9.33');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(5)`).find('.mdi-check');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(6)`).contains('$0.58');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(7)`).contains('$9.91');
+
+    // Taxable group total row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(2)`).contains('$15.71');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(3)`).contains('25');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(4)`).contains('$42.32');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(6)`).contains('$2.65');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(7)`).contains('$44.97');
+
+    // Non-Taxable group total row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(2)`).contains('$21.61');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(3)`).contains('92');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(4)`).contains('$60.29');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(6)`).contains('$0.00');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(7)`).contains('$60.29');
+  });
+
+  it('should change Price & Qty of item 10,11 and expect calculated values to be updated in group total', () => {
+    // item 10
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(0)`).contains('10');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('Drinkable Yogurt');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(2)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(2) input`).clear().type('1.96{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(3)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(3) input`).clear().type('4{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(4)`).contains('$7.84');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(6)`).contains('$0.49');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(7)`).contains('$8.33');
+
+    // item 11
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(0)`).contains('11');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).contains('Milk');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(2)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(2) input`).clear().type('3.85{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(3)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(3) input`).clear().type('2{enter}');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(4)`).contains('$7.70');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(6)`).contains('$0.48');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(7)`).contains('$8.18');
+
+    // group total row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(2)`).contains('$17.19');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(3)`).contains('22');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(4)`).contains('$41.21');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(6)`).contains('$2.58');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(7)`).contains('$43.79');
+
+    // Non-Taxable group total row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(2)`).contains('$21.61');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(3)`).contains('92');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(4)`).contains('$60.29');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(6)`).contains('$0.00');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 14}px;"] > .slick-cell:nth(7)`).contains('$60.29');
+  });
+
+  it('should change Tax Rate again and expect Taxes and Total to be recalculated', () => {
+    cy.get('[data-test="taxrate"]').clear().type('7');
+    cy.get('[data-test="update-btn"]').click();
+
+    // item 10
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(6)`).contains('$0.55');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(7)`).contains('$8.39');
+
+    // item 11
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(6)`).contains('$0.54');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(7)`).contains('$8.24');
+
+    // group total row
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(2)`).contains('$17.19');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(3)`).contains('22');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(4)`).contains('$41.21');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(6)`).contains('$2.88');
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(7)`).contains('$44.09');
+  });
+});


### PR DESCRIPTION
- the `excelExportOptions.valueParserCallback` was missing the dataContext which can be useful when the exported data is not the current cell value but another cell value, for example our cell is Total but is a calculated value from 2 other column dataContext (Price & Qty)
- fix a bug found with new demo, the `excelExportOptions.style` wasn't being applied on regular data cell
- add a new Example 23 to demo Excel Export with Formula
- the new demo was created with the following logic (there are 3 calculated fields: SubTotal, Taxes & Total)
  - (in UI) - use Custom Formatters for calculated fields
  - (Excel Export) - use Excel Formula for calculated fields (via `excelExportOptions.valueParserCallback`)

#### TODOs
- [x] unit tests
- [x] add Cypress E2E tests (for UI only though, we'll test the export to Excel manually)
- [x] `excelExportOptions.filename` doesn't seem to work, need to investigate
- [x] make grid editable with editor styling
- [x] center alignment doesn't seem to work with custom export formatter
- [x] improve existing docs
- [x] might need to test with grouping, see what the new dataContext is filled with, I think it will be the group row object
  - I forgot that for Groups, we actually have `groupTotalsExcelExportOptions` which I had to improve to do everything I wanted in this demo :)
- [x] add more color styling to show full features
- [x] also calculate all Totals Sums via Excel Formulas as well

#### use Excel Formulas to calculate Totals by using other dataContext props
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/871c2d84-33b2-41af-ac55-1f7eadb79cb8)

#### use Excel Formulas to calculate Group Totals 
![image](https://github.com/ghiscoding/slickgrid-universal/assets/643976/eb7a39b1-a3cb-4543-b3e5-3687efb93eed)
