### PR TITLE
chore: migrate some `setTimeout` to `queueMicrotask`

### DIFF
--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -827,8 +827,8 @@ export class FilterService {
       // in some occasion, we might be dealing with a dataset that is hierarchical from the start (the source dataset is already a tree structure)
       // and we did not have time to convert it to a flat dataset yet (for SlickGrid to use),
       // we would end up calling the pre-filter too early because these pre-filter works only a flat dataset
-      // for that use case (like Example 6), we need to delay for at least a cycle the pre-filtering (so we can simply recall the same method after a delay of 0 which equal to 1 CPU cycle)
-      setTimeout(() => this.refreshTreeDataFilters());
+      // for that use case (like Example 6), we can queue a microtask to be executed at the end of current task
+      queueMicrotask(() => this.refreshTreeDataFilters());
     }
   }
 

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -131,7 +131,7 @@ export class PaginationService {
           this._previousPagination = { pageNumber: pagingInfo.pageNum, pageSize: pagingInfo.pageSize, pageSizes: this.availablePageSizes, totalItems: pagingInfo.totalRows };
         }
       });
-      setTimeout(() => {
+      queueMicrotask(() => {
         if (this.dataView) {
           this.dataView.setRefreshHints({ isFilterUnchanged: true });
           this.dataView.setPagingOptions({ pageSize: this.paginationOptions.pageSize, pageNum: (this._pageNumber - 1) }); // dataView page starts at 0 instead of 1

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -183,8 +183,8 @@ export class SlickVanillaGridBundle<TData = any> {
       this.sortService.processTreeDataInitialSort();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
-      // however we need 1 cpu cycle before having the DataView refreshed, so we need to wrap this check in a setTimeout
-      setTimeout(() => {
+      // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready
+      queueMicrotask(() => {
         const flatDatasetLn = this.dataView?.getItemCount() ?? 0;
         if (flatDatasetLn > 0 && (flatDatasetLn !== prevFlatDatasetLn || !isDatasetEqual)) {
           this.filterService.refreshTreeDataFilters();
@@ -893,8 +893,8 @@ export class SlickVanillaGridBundle<TData = any> {
         const query = (typeof backendApiService.buildQuery === 'function') ? backendApiService.buildQuery() : '';
         const process = isExecuteCommandOnInit ? (backendApi.process?.(query) ?? null) : (backendApi.onInit?.(query) ?? null);
 
-        // wrap this inside a setTimeout to avoid timing issue since the gridOptions needs to be ready before running this onInit
-        setTimeout(() => {
+        // wrap this inside a microtask to be executed at the end of the task and avoid timing issue since the gridOptions needs to be ready before running this onInit
+        queueMicrotask(() => {
           const backendUtilityService = this.backendUtilityService as BackendUtilityService;
           // keep start time & end timestamps & return it after process execution
           const startTime = new Date();
@@ -1216,8 +1216,8 @@ export class SlickVanillaGridBundle<TData = any> {
           }
         });
       } else if (this.rxjs?.isObservable(collectionAsync)) {
-        // wrap this inside a setTimeout to avoid timing issue since updateEditorCollection requires to call SlickGrid getColumns() method
-        setTimeout(() => {
+        // wrap this inside a microtask at the end of the task to avoid timing issue since updateEditorCollection requires to call SlickGrid getColumns() method after columns are available
+        queueMicrotask(() => {
           this.subscriptions.push(
             (collectionAsync as Observable<any>).subscribe((resolvedCollection) => this.updateEditorCollection(column, resolvedCollection))
           );


### PR DESCRIPTION
- the `setTimeout` in some cases were used as a way to execute certain things after all other tasks are finished, but some cases we `queueMicrotask(f)`, see this article: https://javascript.info/event-loop#macrotasks-and-microtasks
- I tested a Tree Data grid that we have in Salesforce and it's still working as expected, most of the code change in here is related to Tree Data