### PR TITLE
feat(core): add optional Top-Header for Drag Grouping & Header Grouping

### DIFF
--- a/docs/grid-functionalities/grouping-aggregators.md
+++ b/docs/grid-functionalities/grouping-aggregators.md
@@ -2,6 +2,7 @@
 - [Demo](#demo)
 - [Description](#description)
 - [Setup](#setup)
+- [Draggable Dropzone Location](#draggable-dropzone-location)
 - [Aggregators](#aggregators)
 - [SortComparers](https://github.com/ghiscoding/slickgrid-universal/blob/master/packages/common/src/sortComparers/sortComparers.index.ts)
 - [GroupTotalsFormatter](#group-totals-formatter)
@@ -27,6 +28,43 @@ The important thing to understand while working with `SlickGrid` is that Groupin
    - Slickgrid-Universal provides the following built-in `Aggregators`: `Avg`, `Min`, `Max`, `Sum`, `Clone`, `Distinct`
 2. You need to add a `groupTotalsFormatter` on the column definition you want it to be calculated
    - this is very similar to a Formatter, except that they are designed to show aggregate results, e.g:: `Total: 142.50$`
+
+### Draggable Dropzone Location
+
+The Draggable Grouping can be located in either the Top-Header or the Pre-Header as described below.
+
+#### Pre-Heaader
+Draggable Grouping can be located in either the Pre-Header of the Top-Header, however when it is located in the Pre-Header then the Header Grouping will not be available (because both of them would conflict with each other). Note that prior to the version 5.1 of Slickgrid-Universal, the Pre-Header was the default and only available option.
+
+```ts
+this.gridOptions = {
+  createPreHeaderPanel: true,
+  showPreHeaderPanel: true,
+  preHeaderPanelHeight: 26,
+  draggableGrouping: {
+    // ... any draggable plugin option
+  },
+}
+```
+
+#### Top-Heaader
+##### requires v5.1 and higher
+This is the preferred section since the Top-Header is on top of all headers (including pre-header) and it will always be the full grid width. Using the Top-Header also frees up the Pre-Header section for the potential use of Header Grouping.
+
+When using Draggable Grouping and Header Grouping together, you need to enable both top-header and pre-header.
+```ts
+this.gridOptions = {
+    // we'll use top-header for the Draggable Grouping
+  createTopHeaderPanel: true,
+  showTopHeaderPanel: true,
+  topHeaderPanelHeight: 35,
+
+  // pre-header will include our Header Grouping (i.e. "Common Factor")
+  createPreHeaderPanel: true,
+  showPreHeaderPanel: true,
+  preHeaderPanelHeight: 26,
+}
+```
 
 ### Aggregators
 The `Aggregators` is basically the accumulator, the logic that will do the sum (or any other aggregate we defined). We simply need to instantiate the `Aggregator` by passing the column definition `field` that will be used to accumulate. For example, if we have a column definition of Cost and we want to calculate it's sum, we can call the `Aggregator` as follow

--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
@@ -316,12 +316,18 @@ export default class Example03 {
         selectActiveRow: false
       },
       showCustomFooter: true,
+
+      // pre-header will include our Header Grouping (i.e. "Common Factor")
+      // Draggable Grouping could be located in either the Pre-Header OR the new Top-Header
       createPreHeaderPanel: true,
       showPreHeaderPanel: true,
       preHeaderPanelHeight: 26,
+
+      // when Top-Header is created, it will be used by the Draggable Grouping (otherwise the Pre-Header will be used)
       createTopHeaderPanel: true,
       showTopHeaderPanel: true,
       topHeaderPanelHeight: 35,
+
       rowHeight: 33,
       headerRowHeight: 35,
       enableDraggableGrouping: true,

--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
@@ -77,7 +77,8 @@ export default class Example03 {
   initializeGrid() {
     this.columnDefinitions = [
       {
-        id: 'title', name: 'Title', field: 'title', sortable: true, type: FieldType.string,
+        id: 'title', name: 'Title', field: 'title', columnGroup: 'Common Factor',
+        sortable: true, type: FieldType.string,
         editor: {
           model: Editors.longText,
           required: true,
@@ -95,7 +96,8 @@ export default class Example03 {
         }
       },
       {
-        id: 'duration', name: 'Duration', field: 'duration', sortable: true, filterable: true,
+        id: 'duration', name: 'Duration', field: 'duration', columnGroup: 'Common Factor',
+        sortable: true, filterable: true,
         editor: {
           model: Editors.float,
           // required: true,
@@ -118,7 +120,45 @@ export default class Example03 {
         }
       },
       {
-        id: 'cost', name: 'Cost', field: 'cost',
+        id: 'start', name: 'Start', field: 'start', sortable: true, columnGroup: 'Period',
+        // formatter: Formatters.dateIso,
+        type: FieldType.date, outputType: FieldType.dateIso,
+        filterable: true, filter: { model: Filters.compoundDate },
+        formatter: Formatters.dateIso,
+        editor: { model: Editors.date },
+        grouping: {
+          getter: 'start',
+          formatter: (g) => `Start: ${g.value} <span class="text-color-primary">(${g.count} items)</span>`,
+          aggregators: [
+            new Aggregators.Sum('cost')
+          ],
+          aggregateCollapsed: false,
+          collapsed: false
+        }
+      },
+      {
+        id: 'finish', name: 'Finish', field: 'finish', columnGroup: 'Period',
+        sortable: true,
+        editor: {
+          model: Editors.date,
+          editorOptions: { range: { min: 'today' } } as VanillaCalendarOption
+        },
+        // formatter: Formatters.dateIso,
+        type: FieldType.date, outputType: FieldType.dateIso,
+        formatter: Formatters.dateIso,
+        filterable: true, filter: { model: Filters.dateRange },
+        grouping: {
+          getter: 'finish',
+          formatter: (g) => `Finish: ${g.value} <span class="text-color-primary">(${g.count} items)</span>`,
+          aggregators: [
+            new Aggregators.Sum('cost')
+          ],
+          aggregateCollapsed: false,
+          collapsed: false
+        }
+      },
+      {
+        id: 'cost', name: 'Cost', field: 'cost', columnGroup: 'Analysis',
         width: 90,
         sortable: true,
         filterable: true,
@@ -138,7 +178,8 @@ export default class Example03 {
         }
       },
       {
-        id: 'percentComplete', name: '% Complete', field: 'percentComplete', type: FieldType.number,
+        id: 'percentComplete', name: '% Complete', field: 'percentComplete', columnGroup: 'Analysis',
+        type: FieldType.number,
         editor: {
           model: Editors.slider,
           minValue: 0,
@@ -160,44 +201,7 @@ export default class Example03 {
         params: { groupFormatterPrefix: '<i>Avg</i>: ' },
       },
       {
-        id: 'start', name: 'Start', field: 'start', sortable: true,
-        // formatter: Formatters.dateIso,
-        type: FieldType.date, outputType: FieldType.dateIso,
-        filterable: true, filter: { model: Filters.compoundDate },
-        formatter: Formatters.dateIso,
-        editor: { model: Editors.date },
-        grouping: {
-          getter: 'start',
-          formatter: (g) => `Start: ${g.value} <span class="text-color-primary">(${g.count} items)</span>`,
-          aggregators: [
-            new Aggregators.Sum('cost')
-          ],
-          aggregateCollapsed: false,
-          collapsed: false
-        }
-      },
-      {
-        id: 'finish', name: 'Finish', field: 'finish', sortable: true,
-        editor: {
-          model: Editors.date,
-          editorOptions: { range: { min: 'today' } } as VanillaCalendarOption
-        },
-        // formatter: Formatters.dateIso,
-        type: FieldType.date, outputType: FieldType.dateIso,
-        formatter: Formatters.dateIso,
-        filterable: true, filter: { model: Filters.dateRange },
-        grouping: {
-          getter: 'finish',
-          formatter: (g) => `Finish: ${g.value} <span class="text-color-primary">(${g.count} items)</span>`,
-          aggregators: [
-            new Aggregators.Sum('cost')
-          ],
-          aggregateCollapsed: false,
-          collapsed: false
-        }
-      },
-      {
-        id: 'effortDriven', name: 'Effort-Driven', field: 'effortDriven',
+        id: 'effortDriven', name: 'Effort-Driven', field: 'effortDriven', columnGroup: 'Analysis',
         width: 80, minWidth: 20, maxWidth: 100,
         cssClass: 'cell-effort-driven',
         sortable: true,
@@ -314,7 +318,10 @@ export default class Example03 {
       showCustomFooter: true,
       createPreHeaderPanel: true,
       showPreHeaderPanel: true,
-      preHeaderPanelHeight: 35,
+      preHeaderPanelHeight: 26,
+      createTopHeaderPanel: true,
+      showTopHeaderPanel: true,
+      topHeaderPanelHeight: 35,
       rowHeight: 33,
       headerRowHeight: 35,
       enableDraggableGrouping: true,
@@ -425,7 +432,7 @@ export default class Example03 {
   groupByDuration() {
     this.clearGrouping();
     if (this.draggableGroupingPlugin?.setDroppedGroups) {
-      this.showPreHeader();
+      this.showTopHeader();
       this.draggableGroupingPlugin.setDroppedGroups('duration');
       this.sgb?.slickGrid?.invalidate(); // invalidate all rows and re-render
     }
@@ -445,14 +452,14 @@ export default class Example03 {
   groupByDurationEffortDriven() {
     this.clearGrouping();
     if (this.draggableGroupingPlugin?.setDroppedGroups) {
-      this.showPreHeader();
+      this.showTopHeader();
       this.draggableGroupingPlugin.setDroppedGroups(['duration', 'effortDriven']);
       this.sgb?.slickGrid?.invalidate(); // invalidate all rows and re-render
     }
   }
 
-  showPreHeader() {
-    this.sgb?.slickGrid?.setPreHeaderPanelVisibility(true);
+  showTopHeader() {
+    this.sgb?.slickGrid?.setTopHeaderPanelVisibility(true);
   }
 
   toggleDarkMode() {
@@ -469,7 +476,7 @@ export default class Example03 {
 
   toggleDraggableGroupingRow() {
     this.clearGroupsAndSelects();
-    this.sgb?.slickGrid?.setPreHeaderPanelVisibility(!this.sgb?.slickGrid?.getOptions().showPreHeaderPanel);
+    this.sgb?.slickGrid?.setTopHeaderPanelVisibility(!this.sgb?.slickGrid?.getOptions().showTopHeaderPanel);
   }
 
   onGroupChanged(change: { caller?: string; groupColumns: Grouping[]; }) {

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -18,7 +18,6 @@ const pubSubServiceStub = {
 } as BasePubSubService;
 
 const DEFAULT_COLUMN_HEIGHT = 25;
-const DEFAULT_COLUMN_MIN_WIDTH = 30;
 const DEFAULT_COLUMN_WIDTH = 80;
 const DEFAULT_GRID_HEIGHT = 600;
 const DEFAULT_GRID_WIDTH = 800;
@@ -451,6 +450,44 @@ describe('SlickGrid core file', () => {
       preheaderElms = container.querySelectorAll<HTMLDivElement>('.slick-preheader-panel');
       expect(preheaderElms[0].style.display).toBe('none');
       expect(preheaderElms[1].style.display).toBe('none');
+    });
+  });
+
+  describe('Top-Header Panel', () => {
+    it('should create a topheader panel when enabled', () => {
+      const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
+      const gridOptions = { ...defaultOptions, enableCellNavigation: true, topHeaderPanelHeight: 30, showTopHeaderPanel: true, frozenColumn: 0, createTopHeaderPanel: true } as GridOption;
+      grid = new SlickGrid<any, Column>(container, [], columns, gridOptions);
+      grid.init();
+      const topheaderElm = container.querySelector('.slick-topheader-panel');
+      const topheaderElms = container.querySelectorAll<HTMLDivElement>('.slick-topheader-panel');
+
+      expect(grid).toBeTruthy();
+      expect(topheaderElm).toBeTruthy();
+      expect(topheaderElm?.querySelectorAll('div').length).toBe(3);
+      expect(topheaderElms[0].style.display).not.toBe('none');
+      expect(grid.getTopHeaderPanel()).toBeTruthy();
+      expect(grid.getTopHeaderPanel()).toEqual(grid.getTopHeaderPanel());
+    });
+
+    it('should hide column headers div when "showTopHeaderPanel" is disabled', () => {
+      const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
+      const gridOptions = { ...defaultOptions, enableCellNavigation: true, topHeaderPanelHeight: 30, showTopHeaderPanel: false, createTopHeaderPanel: true } as GridOption;
+      grid = new SlickGrid<any, Column>(container, [], columns, gridOptions);
+      grid.init();
+      let topheaderElms = container.querySelectorAll<HTMLDivElement>('.slick-topheader-panel');
+
+      expect(grid).toBeTruthy();
+      expect(topheaderElms).toBeTruthy();
+      expect(topheaderElms[0].style.display).toBe('none');
+
+      grid.setTopHeaderPanelVisibility(true);
+      topheaderElms = container.querySelectorAll<HTMLDivElement>('.slick-topheader-panel');
+      expect(topheaderElms[0].style.display).not.toBe('none');
+
+      grid.setTopHeaderPanelVisibility(false);
+      topheaderElms = container.querySelectorAll<HTMLDivElement>('.slick-topheader-panel');
+      expect(topheaderElms[0].style.display).toBe('none');
     });
   });
 
@@ -5216,10 +5253,26 @@ describe('SlickGrid core file', () => {
         const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, createPreHeaderPanel: true, preHeaderPanelHeight: 44, showPreHeaderPanel: true, enableCellNavigation: true });
         const preheaderElm = container.querySelector('.slick-preheader-panel') as HTMLDivElement;
-        const preheaderElms = container.querySelectorAll<HTMLDivElement>('.slick-preheader-panel');
         Object.defineProperty(preheaderElm, 'scrollLeft', { writable: true, value: 25 });
 
         preheaderElm.dispatchEvent(new CustomEvent('scroll'));
+
+        const viewportTopLeft = container.querySelector('.slick-viewport-top.slick-viewport-left') as HTMLDivElement;
+        expect(viewportTopLeft.scrollLeft).toBe(25);
+
+        // when enableTextSelectionOnCells isn't enabled and trigger IE related code
+        const selectStartEvent = new CustomEvent('selectstart');
+        Object.defineProperty(selectStartEvent, 'target', { writable: true, value: document.createElement('TextArea') });
+        viewportTopLeft.dispatchEvent(selectStartEvent);
+      });
+
+      it('should update viewport top/left scrollLeft when scrolling in topHeader DOM element', () => {
+        const columns = [{ id: 'name', field: 'name', name: 'Name' }, { id: 'age', field: 'age', name: 'Age' }] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, createTopHeaderPanel: true, topHeaderPanelHeight: 44, showTopHeaderPanel: true, enableCellNavigation: true });
+        const topheaderElm = container.querySelector('.slick-topheader-panel') as HTMLDivElement;
+        Object.defineProperty(topheaderElm, 'scrollLeft', { writable: true, value: 25 });
+
+        topheaderElm.dispatchEvent(new CustomEvent('scroll'));
 
         const viewportTopLeft = container.querySelector('.slick-viewport-top.slick-viewport-left') as HTMLDivElement;
         expect(viewportTopLeft.scrollLeft).toBe(25);

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -79,6 +79,7 @@ const gridStub = {
   getHeaderColumn: jest.fn(),
   getOptions: jest.fn(),
   getPreHeaderPanel: jest.fn(),
+  getTopHeaderPanel: jest.fn(),
   getData: () => dataViewStub,
   getEditorLock: () => getEditorLockMock,
   getUID: () => GRID_UID,

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -25,7 +25,7 @@ import { type SlickDataView, SlickEvent, SlickEventData, SlickEventHandler, type
  *  github.com/muthukumarse/Slickgrid
  *
  * NOTES:
- *     This plugin provides the Draggable Grouping feature
+ *     This plugin provides the Draggable Grouping feature which could be located in either the Top-Header or the Pre-Header
  *
  * A plugin to add drop-down menus to column headers.
  * To specify a custom button in a column header, extend the column definition like so:
@@ -131,7 +131,7 @@ export class SlickDraggableGrouping {
     if (grid) {
       this._gridUid = grid.getUID();
       this._gridColumns = grid.getColumns();
-      this._dropzoneElm = grid.getPreHeaderPanel();
+      this._dropzoneElm = grid.getTopHeaderPanel() || grid.getPreHeaderPanel();
       this._dropzoneElm.classList.add('slick-dropzone');
 
       // add PubSub instance to all SlickEvent
@@ -216,7 +216,7 @@ export class SlickDraggableGrouping {
     this._eventHandler.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
     this._bindingEventService.unbindAll();
-    emptyElement(this.gridContainer.querySelector(`.${this.gridUid} .slick-preheader-panel`));
+    emptyElement(this.gridContainer.querySelector(`.${this.gridUid} .slick-preheader-panel,.${this.gridUid} .slick-topheader-panel`));
   }
 
   clearDroppedGroups() {
@@ -277,7 +277,7 @@ export class SlickDraggableGrouping {
    */
   setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, _columns: Column[], getColumnIndex: (columnId: string) => number, _uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) {
     this.destroySortableInstances();
-    const dropzoneElm = grid.getPreHeaderPanel();
+    const dropzoneElm = grid.getTopHeaderPanel() || grid.getPreHeaderPanel();
     const draggablePlaceholderElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-draggable-dropzone-placeholder');
     const groupTogglerElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-group-toggle-all');
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -208,11 +208,14 @@ export interface GridOption<C extends Column = Column> {
   /** Context menu options (mouse right+click) */
   contextMenu?: ContextMenu;
 
-  /** Defaults to false, which leads to create the footer row of the grid */
+  /** Defaults to false, which leads to creating the footer row of the grid */
   createFooterRow?: boolean;
 
-  /** Default to false, which leads to create an extra pre-header panel (on top of column header) for column grouping purposes */
+  /** Default to false, which leads to creating an extra pre-header panel (on top of column header) for column grouping purposes */
   createPreHeaderPanel?: boolean;
+
+  /** Default to false, which leads to creating an extra pre-header panel (on top of column header & pre-header) for column grouping purposes */
+  createTopHeaderPanel?: boolean;
 
   /** Custom Footer Options */
   customFooterOptions?: CustomFooterOption;
@@ -659,6 +662,12 @@ export interface GridOption<C extends Column = Column> {
   /** Defaults to "auto", extra pre-header panel (on top of column header) width, it could be a number (pixels) or a string ("100%" or "auto") */
   preHeaderPanelWidth?: number | string;
 
+  /** Extra top-header panel height (on top of column header & pre-header) */
+  topHeaderPanelHeight?: number;
+
+  /** Defaults to "auto", extra pre-header panel (on top of column header & pre-header) width, it could be a number (pixels) or a string ("100%" or "auto") */
+  topHeaderPanelWidth?: number | string;
+
   /** Do we want to preserve copied selection on paste? */
   preserveCopiedSelectionOnPaste?: boolean;
 
@@ -755,6 +764,9 @@ export interface GridOption<C extends Column = Column> {
 
   /** Do we want to show the extra pre-header panel (on top of column header) for column grouping purposes */
   showPreHeaderPanel?: boolean;
+
+  /** Do we want to show the extra top-header panel (on top of column header & pre-header) for column grouping purposes */
+  showTopHeaderPanel?: boolean;
 
   /** Do we want to show top panel row? */
   showTopPanel?: boolean;

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -214,7 +214,7 @@ export interface GridOption<C extends Column = Column> {
   /** Default to false, which leads to creating an extra pre-header panel (on top of column header) for column grouping purposes */
   createPreHeaderPanel?: boolean;
 
-  /** Default to false, which leads to creating an extra pre-header panel (on top of column header & pre-header) for column grouping purposes */
+  /** Default to false, which leads to creating an extra top-header panel (on top of column header & pre-header) for column grouping purposes */
   createTopHeaderPanel?: boolean;
 
   /** Custom Footer Options */
@@ -665,7 +665,7 @@ export interface GridOption<C extends Column = Column> {
   /** Extra top-header panel height (on top of column header & pre-header) */
   topHeaderPanelHeight?: number;
 
-  /** Defaults to "auto", extra pre-header panel (on top of column header & pre-header) width, it could be a number (pixels) or a string ("100%" or "auto") */
+  /** Defaults to "auto", extra top-header panel (on top of column header & pre-header) width, it could be a number (pixels) or a string ("100%" or "auto") */
   topHeaderPanelWidth?: number | string;
 
   /** Do we want to preserve copied selection on paste? */

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -100,18 +100,19 @@ export class GroupingAndColspanService {
 
   /** Create or Render the Pre-Header Row Grouping Titles */
   renderPreHeaderRowGroupingTitles() {
-    if (this._gridOptions && this._gridOptions.frozenColumn !== undefined && this._gridOptions.frozenColumn >= 0) {
+    const colsCount = this._columnDefinitions.length;
+
+    if (this._gridOptions?.frozenColumn !== undefined && this._gridOptions.frozenColumn >= 0) {
+      const frozenCol = this._gridOptions.frozenColumn;
+
       // Add column groups to left panel
-      let preHeaderPanelElm = this._grid.getPreHeaderPanelLeft();
-      this.renderHeaderGroups(preHeaderPanelElm, 0, this._gridOptions.frozenColumn + 1);
+      this.renderHeaderGroups(this._grid.getPreHeaderPanelLeft(), 0, frozenCol + 1);
 
       // Add column groups to right panel
-      preHeaderPanelElm = this._grid.getPreHeaderPanelRight();
-      this.renderHeaderGroups(preHeaderPanelElm, this._gridOptions?.frozenColumn + 1, this._columnDefinitions.length);
+      this.renderHeaderGroups(this._grid.getPreHeaderPanelRight(), frozenCol + 1, colsCount);
     } else {
       // regular grid (not a frozen grid)
-      const preHeaderPanelElm = this._grid.getPreHeaderPanel();
-      this.renderHeaderGroups(preHeaderPanelElm, 0, this._columnDefinitions.length);
+      this.renderHeaderGroups(this._grid.getPreHeaderPanel(), 0, colsCount);
     }
   }
 

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -697,7 +697,8 @@
   }
 
   /** Header Grouping **/
-  .slick-preheader-panel.slick-state-default  {
+  .slick-preheader-panel.slick-state-default,
+  .slick-topheader-panel.slick-state-default {
     border-bottom: var(--slick-preheader-border-bottom, $slick-preheader-border-bottom);
 
     .slick-header-columns {
@@ -730,7 +731,8 @@
     border-right: var(--slick-frozen-header-row-border-right, $slick-frozen-header-row-border-right);
   }
   .slick-pane-left {
-    .slick-preheader-panel .slick-header-column.frozen:last-child {
+    .slick-preheader-panel .slick-header-column.frozen:last-child,
+    .slick-topheader-panel .slick-header-column.frozen:last-child {
       border-right: var(--slick-frozen-preheader-row-border-right, $slick-frozen-preheader-row-border-right);
     }
   }

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -893,7 +893,8 @@ input.search-filter {
 // Draggable Grouping Plugin
 // ----------------------------------------------
 
-.slick-preheader-panel {
+.slick-preheader-panel,
+.slick-topheader-panel {
   .slick-dropzone, .slick-dropzone-hover {
     display: flex;
     align-items: center;

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1006,15 +1006,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(spy).toHaveBeenCalledWith(mockGrid, container);
       });
 
-      it('should not initialize groupingAndColspanService when "createPreHeaderPanel" grid option is enabled and "enableDraggableGrouping" is also enabled', () => {
-        const spy = jest.spyOn(groupingAndColspanServiceStub, 'init');
-
-        component.gridOptions = { createPreHeaderPanel: true, enableDraggableGrouping: true } as unknown as GridOption;
-        component.initialization(divContainer, slickEventHandler);
-
-        expect(spy).not.toHaveBeenCalled();
-      });
-
       it('should call "translateColumnHeaders" from ExtensionService when "enableTranslate" is set', () => {
         const spy = jest.spyOn(extensionServiceStub, 'translateColumnHeaders');
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -761,7 +761,7 @@ export class SlickVanillaGridBundle<TData = any> {
       this._eventPubSubService.subscribe('onLanguageChange', (args: { language: string; }) => {
         if (gridOptions.enableTranslate) {
           this.extensionService.translateAllExtensions(args.language);
-          if (gridOptions.createPreHeaderPanel) {
+          if ((gridOptions.createPreHeaderPanel && gridOptions.createTopHeaderPanel) || (gridOptions.createPreHeaderPanel && !gridOptions.enableDraggableGrouping)) {
             this.groupingService.translateGroupingAndColSpan();
           }
         }
@@ -1378,7 +1378,7 @@ export class SlickVanillaGridBundle<TData = any> {
     this._registeredResources.push(this.gridService, this.gridStateService);
 
     // when using Grouping/DraggableGrouping/Colspan register its Service
-    if (this.gridOptions.createPreHeaderPanel) {
+    if ((this.gridOptions.createPreHeaderPanel && this.gridOptions.createTopHeaderPanel) || (this.gridOptions.createPreHeaderPanel && !this.gridOptions.enableDraggableGrouping)) {
       this._registeredResources.push(this.groupingService);
     }
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -761,7 +761,7 @@ export class SlickVanillaGridBundle<TData = any> {
       this._eventPubSubService.subscribe('onLanguageChange', (args: { language: string; }) => {
         if (gridOptions.enableTranslate) {
           this.extensionService.translateAllExtensions(args.language);
-          if (gridOptions.createPreHeaderPanel && !gridOptions.enableDraggableGrouping) {
+          if (gridOptions.createPreHeaderPanel) {
             this.groupingService.translateGroupingAndColSpan();
           }
         }
@@ -1378,7 +1378,7 @@ export class SlickVanillaGridBundle<TData = any> {
     this._registeredResources.push(this.gridService, this.gridStateService);
 
     // when using Grouping/DraggableGrouping/Colspan register its Service
-    if (this.gridOptions.createPreHeaderPanel && !this.gridOptions.enableDraggableGrouping) {
+    if (this.gridOptions.createPreHeaderPanel) {
       this._registeredResources.push(this.groupingService);
     }
 

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -469,15 +469,6 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
         expect(spy).toHaveBeenCalledWith(mockGrid, container);
       });
 
-      it('should not initialize groupingAndColspanService when "createPreHeaderPanel" grid option is enabled and "enableDraggableGrouping" is also enabled', () => {
-        const spy = jest.spyOn(groupingAndColspanServiceStub, 'init');
-
-        component.gridOptions = { createPreHeaderPanel: true, enableDraggableGrouping: true } as unknown as GridOption;
-        component.initialization(divContainer, slickEventHandler);
-
-        expect(spy).not.toHaveBeenCalled();
-      });
-
       it('should call "translateColumnHeaders" from ExtensionService when "enableTranslate" is set', () => {
         const spy = jest.spyOn(extensionServiceStub, 'translateColumnHeaders');
 

--- a/packages/vanilla-force-bundle/src/vanilla-force-bundle.ts
+++ b/packages/vanilla-force-bundle/src/vanilla-force-bundle.ts
@@ -126,7 +126,7 @@ export class VanillaForceGridBundle extends SlickVanillaGridBundle {
     this._registeredResources.push(this.gridService, this.gridStateService);
 
     // when using Grouping/DraggableGrouping/Colspan register its Service
-    if (this.gridOptions.createPreHeaderPanel) {
+    if ((this.gridOptions.createPreHeaderPanel && this.gridOptions.createTopHeaderPanel) || (this.gridOptions.createPreHeaderPanel && !this.gridOptions.enableDraggableGrouping)) {
       this._registeredResources.push(this.groupingService);
     }
 

--- a/packages/vanilla-force-bundle/src/vanilla-force-bundle.ts
+++ b/packages/vanilla-force-bundle/src/vanilla-force-bundle.ts
@@ -126,7 +126,7 @@ export class VanillaForceGridBundle extends SlickVanillaGridBundle {
     this._registeredResources.push(this.gridService, this.gridStateService);
 
     // when using Grouping/DraggableGrouping/Colspan register its Service
-    if (this.gridOptions.createPreHeaderPanel && !this.gridOptions.enableDraggableGrouping) {
+    if (this.gridOptions.createPreHeaderPanel) {
       this._registeredResources.push(this.groupingService);
     }
 

--- a/test/cypress/e2e/example02.cy.ts
+++ b/test/cypress/e2e/example02.cy.ts
@@ -201,7 +201,6 @@ describe('Example 02 - Grouping & Aggregators', () => {
       cy.get('.item-count')
         .should('contain', 5000);
 
-
       cy.get('.search-filter.filter-title')
         .clear()
         .type('Ta*33');

--- a/test/cypress/e2e/example03.cy.ts
+++ b/test/cypress/e2e/example03.cy.ts
@@ -1,5 +1,5 @@
 describe('Example 03 - Draggable Grouping', () => {
-  const fullTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Effort-Driven', 'Action'];
+  const fullTitles = ['', 'Title', 'Duration', 'Start', 'Finish', 'Cost', '% Complete', 'Effort-Driven', 'Action'];
   const GRID_ROW_HEIGHT = 33;
 
   it('should display Example title', () => {
@@ -10,7 +10,7 @@ describe('Example 03 - Draggable Grouping', () => {
 
   it('should have exact column titles on 1st grid', () => {
     cy.get('.grid3')
-      .find('.slick-header-columns')
+      .find('.slick-header:not(.slick-preheader-panel) .slick-header-columns')
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
@@ -51,7 +51,7 @@ describe('Example 03 - Draggable Grouping', () => {
     });
 
     it('should collapse all rows and make sure Duration group is sorted in descending order', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Duration: 100');
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Duration: 99');
@@ -64,7 +64,7 @@ describe('Example 03 - Draggable Grouping', () => {
     });
 
     it('should collapse all rows again and make sure Duration group is sorted in descending order', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Duration: 0');
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Duration: 1');
@@ -125,8 +125,8 @@ describe('Example 03 - Draggable Grouping', () => {
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).should('contain', '0');
     });
 
-    it('should use the preheader Toggle All button and expect all groups to now be collapsed', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+    it('should use the topheader Toggle All button and expect all groups to now be collapsed', () => {
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Effort-Driven: False');
@@ -179,8 +179,8 @@ describe('Example 03 - Draggable Grouping', () => {
         .should('exist');
     });
 
-    it('should use the preheader Toggle All button and expect all groups to now be expanded', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+    it('should use the topheader Toggle All button and expect all groups to now be expanded', () => {
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Effort-Driven: False');
@@ -191,8 +191,8 @@ describe('Example 03 - Draggable Grouping', () => {
         .should('have.css', 'marginLeft').and('eq', `15px`);
     });
 
-    it('should use the preheader Toggle All button again and expect all groups to now be collapsed', () => {
-      cy.get('.slick-preheader-panel .slick-group-toggle-all').click();
+    it('should use the topheader Toggle All button again and expect all groups to now be collapsed', () => {
+      cy.get('.slick-topheader-panel .slick-group-toggle-all').click();
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-toggle.collapsed`).should('have.length', 1);
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0) .slick-group-title`).should('contain', 'Effort-Driven: False');

--- a/test/cypress/e2e/example03.cy.ts
+++ b/test/cypress/e2e/example03.cy.ts
@@ -1,4 +1,5 @@
 describe('Example 03 - Draggable Grouping', () => {
+  const preHeaders = ['', 'Common Factor', 'Period', 'Analysis', ''];
   const fullTitles = ['', 'Title', 'Duration', 'Start', 'Finish', 'Cost', '% Complete', 'Effort-Driven', 'Action'];
   const GRID_ROW_HEIGHT = 33;
 
@@ -8,11 +9,24 @@ describe('Example 03 - Draggable Grouping', () => {
     cy.get('h3 span.subtitle').should('contain', '(with Salesforce Theme)');
   });
 
-  it('should have exact column titles on 1st grid', () => {
+  it('should have exact column (pre-header) grouping titles in grid', () => {
+    cy.get('.grid3')
+      .find('.slick-preheader-panel .slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(preHeaders[index]));
+  });
+
+  it('should have exact column titles in grid', () => {
     cy.get('.grid3')
       .find('.slick-header:not(.slick-preheader-panel) .slick-header-columns')
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should have a draggable dropzone on top of the grid in the top-header section', () => {
+    cy.get('.grid3')
+      .find('.slick-topheader-panel .slick-dropzone:visible')
+      .contains('Drop a column header here to group by the column');
   });
 
   it('should open the Cell Menu on 2nd and 3rd row and change the Effort-Driven to "True" and expect the cell to be updated and have checkmark to be enabled', () => {


### PR DESCRIPTION
- prior to this PR, we could not use Draggable Grouping & Header Grouping because both features were using the pre-header and it would have conflict, now to avoid this I am adding an extra Top-Header that will show over all header and pre-header.
- NOTE: Draggable Grouping can now be displayed in either the new Top-Header OR the Pre-Header. However, the users who do want to use both features will need to explicitely enable both top/pre headers.
- I was getting a little out of ideas to get a name (since "pre" is already taken), so I decided to go with Top-Header which is completely on the top and even before the pre-header. 
- Another note is that this new Top-Header is not following the frozen columns (like header & pre-header do) and is rather always the same width as the grid. I purposely did not want this top-header to follow the grid frozen columns because I wanted a simpler header and also because I expect this to be mostly (and only) be used by the Draggable Grouping.

#### TODOs
- [x] need more unit tests
- [x] need more Cypress E2E tests (Example 3)
- [x] Example 18 is now broken (not currently able to show Draggable Grouping without Header Grouping)
- [ ] throws an error when following these 2 steps (1. drag a column to group, 2. freeze a column)
   - it should be fixed in separate PR since it's an existing bug (reproducable in previous version)
- [ ] also throws when calling unfreeze all columns
- [x] see if we need docs update

![brave_exnFdfLkAn](https://github.com/ghiscoding/slickgrid-universal/assets/643976/96b63917-6c6a-4d01-a535-35cf014f4fc5)
