### PR TITLE
fix(filters): skipCompoundOperatorFilterWithNullInput skip empty string

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -489,7 +489,8 @@ export default class Example12 {
             this.toggleBodyBackground();
           }
         }
-      }
+      },
+      skipCompoundOperatorFilterWithNullInput: true
     };
   }
 

--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -228,6 +228,40 @@ describe('CompoundDateFilter', () => {
     expect(spyCallback).not.toHaveBeenCalled();
   });
 
+  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True and value is undefined', () => {
+    mockColumn.filter!.operator = '>';
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
+    const callbackSpy = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['']);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-finish select') as HTMLInputElement;
+
+    filterInputElm.value = undefined as any;
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+
+  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True and value is empty string', () => {
+    mockColumn.filter!.operator = '>';
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
+    const callbackSpy = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['']);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-finish select') as HTMLInputElement;
+
+    filterInputElm.value = '';
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+
   it('should change operator dropdown without a date entered and expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as False', () => {
     mockColumn.filter!.operator = '>';
     mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = false;

--- a/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
@@ -205,6 +205,23 @@ describe('CompoundInputFilter', () => {
     expect(callbackSpy).not.toHaveBeenCalled();
   });
 
+  it('should change operator dropdown without a value entered and expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" but value was changed from set to unset', () => {
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
+    mockColumn.type = FieldType.number;
+    const callbackSpy = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-duration select') as HTMLInputElement;
+    filter.setValues(['abc']);
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    filter.setValues(['']);
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).toHaveBeenCalled();
+  });
+
   it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as False', () => {
     mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = false;
     mockColumn.type = FieldType.number;

--- a/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
@@ -176,12 +176,27 @@ describe('CompoundInputFilter', () => {
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '<=', searchTerms: ['9'], shouldTriggerQuery: true });
   });
 
-  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True', () => {
+  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True and value is undefined', () => {
     mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
     mockColumn.type = FieldType.number;
     const callbackSpy = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-duration select') as HTMLInputElement;
+
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+
+  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True and value is empty string', () => {
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
+    mockColumn.type = FieldType.number;
+    const callbackSpy = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['']);
     const filterSelectElm = divContainer.querySelector('.search-filter.filter-duration select') as HTMLInputElement;
 
     filterSelectElm.value = '<=';

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -496,7 +496,7 @@ export class DateFilter implements Filter {
 
         // when changing compound operator, we don't want to trigger the filter callback unless the date input is also provided
         const skipCompoundOperatorFilterWithNullInput = this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput === undefined;
-        if (!skipCompoundOperatorFilterWithNullInput || this._currentDateOrDates !== undefined) {
+        if (!skipCompoundOperatorFilterWithNullInput || (this._currentDateOrDates !== undefined && this._currentDateOrDates !== '')) {
           this.callback(e, { columnDef: this.columnDef, searchTerms: (this._currentValue ? [this._currentValue] : null), operator: selectedOperator || '', shouldTriggerQuery: this._shouldTriggerQuery });
         }
       }

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -1,5 +1,5 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { createDomElement, emptyElement, extend, } from '@slickgrid-universal/utils';
+import { createDomElement, emptyElement, extend, isDefined, } from '@slickgrid-universal/utils';
 import { format, parse } from '@formkit/tempo';
 import { VanillaCalendar, type IOptions } from 'vanilla-calendar-picker';
 
@@ -495,8 +495,8 @@ export class DateFilter implements Filter {
         this._currentValue ? this._filterElm.classList.add('filled') : this._filterElm.classList.remove('filled');
 
         // when changing compound operator, we don't want to trigger the filter callback unless the date input is also provided
-        const skipCompoundOperatorFilterWithNullInput = this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput === undefined;
-        if (!skipCompoundOperatorFilterWithNullInput || (this._currentDateOrDates !== undefined && this._currentDateOrDates !== '')) {
+        const skipNullInput = this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput === undefined;
+        if (!skipNullInput || (skipNullInput && isDefined(this._currentDateOrDates))) {
           this.callback(e, { columnDef: this.columnDef, searchTerms: (this._currentValue ? [this._currentValue] : null), operator: selectedOperator || '', shouldTriggerQuery: this._shouldTriggerQuery });
         }
       }

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -336,7 +336,7 @@ export class InputFilter implements Filter {
       const typingDelay = (eventType === 'keyup' && (event as KeyboardEvent)?.key !== 'Enter') ? this._debounceTypingDelay : 0;
 
       const skipCompoundOperatorFilterWithNullInput = this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput;
-      if (this.inputFilterType === 'single' || !skipCompoundOperatorFilterWithNullInput || this._currentValue !== undefined) {
+      if (this.inputFilterType === 'single' || !skipCompoundOperatorFilterWithNullInput || (this._currentValue !== undefined && this._currentValue !== '')) {
         if (typingDelay > 0) {
           clearTimeout(this._timer as NodeJS.Timeout);
           this._timer = setTimeout(() => this.callback(event, callbackArgs), typingDelay);

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -337,7 +337,7 @@ export class InputFilter implements Filter {
       const typingDelay = (eventType === 'keyup' && (event as KeyboardEvent)?.key !== 'Enter') ? this._debounceTypingDelay : 0;
 
       const skipNullInput = this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput;
-      const hasSkipNullValChanged = skipNullInput && isDefined(this._currentValue) || (this._currentValue === '' && isDefined(this._lastSearchValue));
+      const hasSkipNullValChanged = (skipNullInput && isDefined(this._currentValue)) || (this._currentValue === '' && isDefined(this._lastSearchValue));
 
       if (this.inputFilterType === 'single' || !skipNullInput || hasSkipNullValChanged) {
         if (typingDelay > 0) {

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -337,11 +337,9 @@ export class InputFilter implements Filter {
       const typingDelay = (eventType === 'keyup' && (event as KeyboardEvent)?.key !== 'Enter') ? this._debounceTypingDelay : 0;
 
       const skipNullInput = this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput;
-      if (
-        this.inputFilterType === 'single'
-        || !skipNullInput
-        || (skipNullInput && isDefined(this._currentValue) || (this._currentValue === '' && isDefined(this._lastSearchValue)))
-      ) {
+      const hasSkipNullValChanged = skipNullInput && isDefined(this._currentValue) || (this._currentValue === '' && isDefined(this._lastSearchValue));
+
+      if (this.inputFilterType === 'single' || !skipNullInput || hasSkipNullValChanged) {
         if (typingDelay > 0) {
           clearTimeout(this._timer as NodeJS.Timeout);
           this._timer = setTimeout(() => this.callback(event, callbackArgs), typingDelay);


### PR DESCRIPTION
- when enabling `skipCompoundOperatorFilterWithNullInput` it was only working the first time and if the user clicked on the input (or type something and then erases it), it no longer undefined and was no longer skipping null input like it should. So we simply need to compare against not just `undefined` but also against empty string `''` and if so then skip it filtering
- note however that we should only skip null value when previous value was not null so that we get full list back

#### below is a demo of the small bug

![msedge_3Bv1hGTjPP](https://github.com/ghiscoding/slickgrid-universal/assets/643976/7362f40c-e0e9-4816-b81e-0b30da402fcc)

#### after fix

![msedge_DBCAquYb3y](https://github.com/ghiscoding/slickgrid-universal/assets/643976/c53e6f1f-b27d-408b-aa67-0b65c250ace5)
