### PR TITLE
chore: enable new TypeScript 5.5 `--isolatedDeclarations`

### DIFF
--- a/packages/binding/src/binding.helper.ts
+++ b/packages/binding/src/binding.helper.ts
@@ -11,11 +11,11 @@ export class BindingHelper {
     this._querySelectorPrefix = prefix;
   }
 
-  get observers() {
+  get observers(): BindingService[] {
     return this._observers;
   }
 
-  dispose() {
+  dispose(): void {
     let observer = this._observers.pop();
     while (observer) {
       observer.dispose();
@@ -24,7 +24,7 @@ export class BindingHelper {
     this._observers = [];
   }
 
-  addElementBinding<T extends Element = Element>(variable: any, property: string, selector: string, attribute: string, events?: string | string[], callback?: (val: any) => void) {
+  addElementBinding<T extends Element = Element>(variable: any, property: string, selector: string, attribute: string, events?: string | string[], callback?: (val: any) => void): void {
     const elements = document.querySelectorAll<T>(`${this.querySelectorPrefix}${selector}`);
 
     // before creating a new observer, first check if the variable already has an associated observer
@@ -46,7 +46,7 @@ export class BindingHelper {
   }
 
   /** From a DOM element selector, which could be zero or multiple elements, add an event listener   */
-  bindEventHandler<T extends Element = Element>(selector: string, eventName: string, callback: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) {
+  bindEventHandler<T extends Element = Element>(selector: string, eventName: string, callback: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {
     const elements = document.querySelectorAll<T>(`${this.querySelectorPrefix}${selector}`);
 
     elements.forEach(elm => {
@@ -60,7 +60,7 @@ export class BindingHelper {
    * From a DOM element selector, which could be zero or multiple elements, set the value on a given attribute name
    * For example ('div.hello', 'textContent', 'world') => would set the textContent equal to 'world' on a div element having the class 'hello'
    */
-  setElementAttributeValue<T extends Element = Element>(selector: string, attribute: string, value: any) {
+  setElementAttributeValue<T extends Element = Element>(selector: string, attribute: string, value: any): void {
     const elements = document.querySelectorAll<T>(`${this.querySelectorPrefix}${selector}`);
 
     elements.forEach(elm => {

--- a/packages/binding/src/binding.service.ts
+++ b/packages/binding/src/binding.service.ts
@@ -39,21 +39,21 @@ export class BindingService {
     return this._elementBindings;
   }
 
-  get property() {
+  get property(): string {
     return this._property;
   }
 
-  dispose() {
+  dispose(): void {
     this.unbindAll();
     this._boundedEventWithListeners = [];
     this._elementBindings = [];
   }
 
-  valueGetter() {
+  valueGetter(): any {
     return this._value;
   }
 
-  valueSetter<T extends Element = Element>(val: any) {
+  valueSetter<T extends Element = Element>(val: any): void {
     this._value = val;
     if (Array.isArray(this._elementBindings)) {
       for (const binding of this._elementBindings) {
@@ -70,7 +70,7 @@ export class BindingService {
    * 2- when an event is provided, we will replace the DOM element (by an attribute) every time an event is triggered
    *    2.1- we could also provide an extra callback method to execute when the event gets triggered
    */
-  bind<T extends Element = Element>(elements: T | NodeListOf<T> | null, attribute: string, eventName?: string, eventCallback?: (val: any) => any) {
+  bind<T extends Element = Element>(elements: T | NodeListOf<T> | null, attribute: string, eventName?: string, eventCallback?: (val: any) => any): this {
     if (elements && (elements as NodeListOf<T>).forEach) {
       // multiple DOM elements coming from a querySelectorAll() call
       (elements as NodeListOf<T>).forEach(elm => this.bindSingleElement(elm, attribute, eventName, eventCallback));
@@ -83,7 +83,7 @@ export class BindingService {
   }
 
   /** Unbind (remove) an element event listener */
-  unbind(element: Element | null, eventName: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions, eventUid?: string) {
+  unbind(element: Element | null, eventName: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions, eventUid?: string): void {
     if (element) {
       element.removeEventListener(eventName, listener, options);
       const eventIdx = this._boundedEventWithListeners.findIndex(be => be.uid === eventUid);
@@ -94,7 +94,7 @@ export class BindingService {
   }
 
   /** Unbind All (remove) bounded elements with listeners */
-  unbindAll() {
+  unbindAll(): void {
     let boundedEvent = this._boundedEventWithListeners.pop();
     while (boundedEvent) {
       const { element, eventName, listener, uid } = boundedEvent;
@@ -110,7 +110,7 @@ export class BindingService {
    * 2- when an event is provided, we will replace the DOM element (by an attribute) every time an event is triggered
    *    2.1- we could also provide an extra callback method to execute when the event gets triggered
    */
-  protected bindSingleElement<T extends Element = Element>(element: T | null, attribute: string, eventName?: string, eventCallback?: (val: any) => any) {
+  protected bindSingleElement<T extends Element = Element>(element: T | null, attribute: string, eventName?: string, eventCallback?: (val: any) => any): void {
     const binding: ElementBinding<T> | ElementBindingWithListener<T> = { element, attribute };
     if (element) {
       if (eventName) {
@@ -140,7 +140,7 @@ export class BindingService {
   }
 
   /** Generate a UUID version 4 RFC compliant */
-  protected generateUuidV4() {
+  protected generateUuidV4(): string {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
       const r = Math.random() * 16 | 0;
       const v = c === 'x' ? r : (r & 0x3 | 0x8);

--- a/packages/binding/src/bindingEvent.service.ts
+++ b/packages/binding/src/bindingEvent.service.ts
@@ -12,13 +12,18 @@ export class BindingEventService {
     return this._boundedEvents;
   }
 
-  dispose() {
+  dispose(): void {
     this.unbindAll();
     this._boundedEvents = [];
   }
 
   /** Bind an event listener to any element */
-  bind(elementOrElements: Document | Element | NodeListOf<Element> | Window, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject, listenerOptions?: boolean | AddEventListenerOptions, groupName = '') {
+  bind(
+    elementOrElements: Document | Element | NodeListOf<Element> | Window,
+    eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject,
+    listenerOptions?: boolean | AddEventListenerOptions,
+    groupName = ''
+  ): void {
     // convert to array for looping in next task
     const eventNames = (Array.isArray(eventNameOrNames)) ? eventNameOrNames : [eventNameOrNames];
 
@@ -40,7 +45,7 @@ export class BindingEventService {
   }
 
   /** Unbind a specific listener that was bounded earlier */
-  unbind(elementOrElements: Element | NodeListOf<Element>, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject) {
+  unbind(elementOrElements: Element | NodeListOf<Element>, eventNameOrNames: string | string[], listener: EventListenerOrEventListenerObject): void {
     // convert to array for looping in next task
     const elements = (Array.isArray(elementOrElements)) ? elementOrElements : [elementOrElements];
     const eventNames = Array.isArray(eventNameOrNames) ? eventNameOrNames : [eventNameOrNames];
@@ -54,7 +59,7 @@ export class BindingEventService {
     }
   }
 
-  unbindByEventName(element: Element | Window, eventName: string) {
+  unbindByEventName(element: Element | Window, eventName: string): void {
     const boundedEvent = this._boundedEvents.find(e => e.element === element && e.eventName === eventName);
     if (boundedEvent) {
       this.unbind(boundedEvent.element, boundedEvent.eventName, boundedEvent.listener);
@@ -64,7 +69,7 @@ export class BindingEventService {
   /**
    * Unbind all event listeners that were bounded, optionally provide a group name to unbind all listeners assigned to that specific group only.
    */
-  unbindAll(groupName?: string | string[]) {
+  unbindAll(groupName?: string | string[]): void {
     if (groupName) {
       const groupNames = Array.isArray(groupName) ? groupName : [groupName];
 

--- a/packages/common/src/aggregators/aggregators.index.ts
+++ b/packages/common/src/aggregators/aggregators.index.ts
@@ -5,9 +5,10 @@ import { DistinctAggregator } from './distinctAggregator';
 import { MinAggregator } from './minAggregator';
 import { MaxAggregator } from './maxAggregator';
 import { SumAggregator } from './sumAggregator';
+import type { AggregatorConstructor } from '../interfaces';
 
 /** Provides a list of different Aggregators for the Group Formatter */
-export const Aggregators = {
+export const Aggregators: Record<string, AggregatorConstructor> = {
   /** Average Aggregator which calculate the average of a given group */
   Avg: AvgAggregator,
 

--- a/packages/common/src/aggregators/avgAggregator.ts
+++ b/packages/common/src/aggregators/avgAggregator.ts
@@ -58,7 +58,7 @@ export class AvgAggregator implements Aggregator {
       // not a Tree structure, we'll do a regular summation
       if (isNumber(val)) {
         this._nonNullCount++;
-        this._sum += parseFloat(val);
+        this._sum += parseFloat(val as any);
       }
     } else {
       if (isTreeParent) {
@@ -69,7 +69,7 @@ export class AvgAggregator implements Aggregator {
         this._sum = parseFloat(item.__treeTotals['sum'][this._field] ?? 0);
         this._nonNullCount = item.__treeTotals['count'][this._field] ?? 0;
       } else if (isNumber(val)) {
-        this._sum = parseFloat(val);
+        this._sum = parseFloat(val as any);
         this._nonNullCount = 1;
       }
     }

--- a/packages/common/src/aggregators/avgAggregator.ts
+++ b/packages/common/src/aggregators/avgAggregator.ts
@@ -19,7 +19,7 @@ export class AvgAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -27,7 +27,7 @@ export class AvgAggregator implements Aggregator {
     return this._type;
   }
 
-  init(item?: any, isTreeAggregator = false) {
+  init(item?: any, isTreeAggregator = false): void {
     this._sum = 0;
     this._nonNullCount = 0;
     this._isInitialized = true;
@@ -50,7 +50,7 @@ export class AvgAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any, isTreeParent = false) {
+  accumulate(item: any, isTreeParent = false): void {
     const val = item?.hasOwnProperty(this._field) ? item[this._field] : null;
 
     // when dealing with Tree Data structure, we need keep only the new sum (without doing any addition)
@@ -75,7 +75,7 @@ export class AvgAggregator implements Aggregator {
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }): void {
     let sum = this._sum;
     let itemCount = this._nonNullCount;
     this.addGroupTotalPropertiesWhenNotExist(groupTotals);
@@ -94,7 +94,7 @@ export class AvgAggregator implements Aggregator {
     }
   }
 
-  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any) {
+  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }

--- a/packages/common/src/aggregators/cloneAggregator.ts
+++ b/packages/common/src/aggregators/cloneAggregator.ts
@@ -15,7 +15,7 @@ export class CloneAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -31,14 +31,14 @@ export class CloneAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any) {
+  accumulate(item: any): void {
     const val = (item && item.hasOwnProperty(this._field)) ? item[this._field] : null;
     if (val !== null && val !== '') {
       this._data = val;
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { clone: Record<number | string, string>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { clone: Record<number | string, string>; }): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }

--- a/packages/common/src/aggregators/countAggregator.ts
+++ b/packages/common/src/aggregators/countAggregator.ts
@@ -18,7 +18,7 @@ export class CountAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -26,7 +26,7 @@ export class CountAggregator implements Aggregator {
     return this._type;
   }
 
-  init(item?: any, isTreeAggregator = false) {
+  init(item?: any, isTreeAggregator = false): void {
     this._count = 0;
     this._isInitialized = true;
     this._isTreeAggregator = isTreeAggregator;
@@ -43,7 +43,7 @@ export class CountAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any, isTreeParent = false) {
+  accumulate(item: any, isTreeParent = false): void {
     const val = item?.hasOwnProperty(this._field) ? item[this._field] : null;
 
     // when dealing with Tree Data structure, we need keep only the new sum (without doing any addition)
@@ -62,7 +62,7 @@ export class CountAggregator implements Aggregator {
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }

--- a/packages/common/src/aggregators/distinctAggregator.ts
+++ b/packages/common/src/aggregators/distinctAggregator.ts
@@ -15,7 +15,7 @@ export class DistinctAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -31,14 +31,14 @@ export class DistinctAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any) {
+  accumulate(item: any): void {
     const val = (item && item.hasOwnProperty(this._field)) ? item[this._field] : undefined;
     if (this._distinctValues.indexOf(val) === -1 && val !== undefined) {
       this._distinctValues.push(val);
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { distinct: Record<number | string, any>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { distinct: Record<number | string, any>; }): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }

--- a/packages/common/src/aggregators/maxAggregator.ts
+++ b/packages/common/src/aggregators/maxAggregator.ts
@@ -89,7 +89,7 @@ export class MaxAggregator implements Aggregator {
   protected keepMaxValueWhenFound(val: any) {
     if (isNumber(val)) {
       if (this._max === null || val > this._max) {
-        this._max = parseFloat(val);
+        this._max = parseFloat(val as any);
       }
     }
   }

--- a/packages/common/src/aggregators/maxAggregator.ts
+++ b/packages/common/src/aggregators/maxAggregator.ts
@@ -18,7 +18,7 @@ export class MaxAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -26,7 +26,7 @@ export class MaxAggregator implements Aggregator {
     return this._type;
   }
 
-  init(item?: any, isTreeAggregator = false) {
+  init(item?: any, isTreeAggregator = false): void {
     this._max = null;
     this._isInitialized = true;
 
@@ -43,7 +43,7 @@ export class MaxAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any, isTreeParent = false) {
+  accumulate(item: any, isTreeParent = false): void {
     const val = item?.hasOwnProperty(this._field) ? item[this._field] : null;
 
     // when dealing with Tree Data structure, we need keep only the new max (without doing any addition)
@@ -66,7 +66,7 @@ export class MaxAggregator implements Aggregator {
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }): void {
     let max = this._max;
     this.addGroupTotalPropertiesWhenNotExist(groupTotals);
 
@@ -80,13 +80,13 @@ export class MaxAggregator implements Aggregator {
     groupTotals[this._type][this._field] = max;
   }
 
-  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any) {
+  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }
   }
 
-  protected keepMaxValueWhenFound(val: any) {
+  protected keepMaxValueWhenFound(val: any): void {
     if (isNumber(val)) {
       if (this._max === null || val > this._max) {
         this._max = parseFloat(val as any);

--- a/packages/common/src/aggregators/minAggregator.ts
+++ b/packages/common/src/aggregators/minAggregator.ts
@@ -18,7 +18,7 @@ export class MinAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -26,7 +26,7 @@ export class MinAggregator implements Aggregator {
     return this._type;
   }
 
-  init(item?: any, isTreeAggregator = false) {
+  init(item?: any, isTreeAggregator = false): void {
     this._min = null;
     this._isInitialized = true;
 
@@ -43,7 +43,7 @@ export class MinAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any, isTreeParent = false) {
+  accumulate(item: any, isTreeParent = false): void {
     const val = item?.hasOwnProperty(this._field) ? item[this._field] : null;
 
     // when dealing with Tree Data structure, we need keep only the new min (without doing any addition)
@@ -66,7 +66,7 @@ export class MinAggregator implements Aggregator {
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }): void {
     let min = this._min;
     this.addGroupTotalPropertiesWhenNotExist(groupTotals);
 
@@ -80,13 +80,13 @@ export class MinAggregator implements Aggregator {
     groupTotals[this._type][this._field] = min;
   }
 
-  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any) {
+  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }
   }
 
-  protected keepMinValueWhenFound(val: any) {
+  protected keepMinValueWhenFound(val: any): void {
     if (isNumber(val)) {
       if (this._min === null || val < this._min) {
         this._min = parseFloat(val as any);

--- a/packages/common/src/aggregators/minAggregator.ts
+++ b/packages/common/src/aggregators/minAggregator.ts
@@ -89,7 +89,7 @@ export class MinAggregator implements Aggregator {
   protected keepMinValueWhenFound(val: any) {
     if (isNumber(val)) {
       if (this._min === null || val < this._min) {
-        this._min = parseFloat(val);
+        this._min = parseFloat(val as any);
       }
     }
   }

--- a/packages/common/src/aggregators/sumAggregator.ts
+++ b/packages/common/src/aggregators/sumAggregator.ts
@@ -19,7 +19,7 @@ export class SumAggregator implements Aggregator {
     return this._field;
   }
 
-  get isInitialized() {
+  get isInitialized(): boolean {
     return this._isInitialized;
   }
 
@@ -27,7 +27,7 @@ export class SumAggregator implements Aggregator {
     return this._type;
   }
 
-  init(item?: any, isTreeAggregator = false) {
+  init(item?: any, isTreeAggregator = false): void {
     this._isTreeAggregator = isTreeAggregator;
     this._isInitialized = true;
     this._sum = 0;
@@ -47,7 +47,7 @@ export class SumAggregator implements Aggregator {
     }
   }
 
-  accumulate(item: any, isTreeParent = false) {
+  accumulate(item: any, isTreeParent = false): void {
     const val = item?.hasOwnProperty(this._field) ? item[this._field] : null;
 
     // when dealing with Tree Data structure, we need keep only the new sum (without doing any addition)
@@ -71,7 +71,7 @@ export class SumAggregator implements Aggregator {
     }
   }
 
-  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }) {
+  storeResult(groupTotals: SlickGroupTotals & { [type: string]: Record<number | string, number | null>; }): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }
@@ -88,7 +88,7 @@ export class SumAggregator implements Aggregator {
     groupTotals[this._type][this._field] = sum;
   }
 
-  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any) {
+  protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
       groupTotals[this._type] = {};
     }

--- a/packages/common/src/aggregators/sumAggregator.ts
+++ b/packages/common/src/aggregators/sumAggregator.ts
@@ -54,7 +54,7 @@ export class SumAggregator implements Aggregator {
     if (!this._isTreeAggregator) {
       // not a Tree structure, we'll do a regular summation
       if (isNumber(val)) {
-        this._sum += parseFloat(val);
+        this._sum += parseFloat(val as any);
       }
     } else {
       if (isTreeParent) {
@@ -65,7 +65,7 @@ export class SumAggregator implements Aggregator {
         this._sum = parseFloat(item.__treeTotals[this._type][this._field] ?? 0);
         this._itemCount = item.__treeTotals['count'][this._field] ?? 0;
       } else if (isNumber(val)) {
-        this._sum = parseFloat(val);
+        this._sum = parseFloat(val as any);
         this._itemCount = 1;
       }
     }

--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -13,7 +13,7 @@ import { formatDateByFieldType, mapTempoDateFormatWithFieldType, tryParseDate } 
  * @param inputElm - autocomplete input element
  * @param autocompleterOptions - autocomplete settings
  */
-export function addAutocompleteLoadingByOverridingFetch<T extends AutocompleteItem>(inputElm: HTMLInputElement, autocompleterOptions: Partial<AutocompleterOption<T>>) {
+export function addAutocompleteLoadingByOverridingFetch<T extends AutocompleteItem>(inputElm: HTMLInputElement, autocompleterOptions: Partial<AutocompleterOption<T>>): void {
   const previousFetch = autocompleterOptions.fetch;
 
   if (previousFetch) {
@@ -33,7 +33,7 @@ export function addAutocompleteLoadingByOverridingFetch<T extends AutocompleteIt
   }
 }
 
-export function setPickerDates(dateInputElm: HTMLInputElement, pickerOptions: IOptions, dateValues: Date | Date[] | string | string[] | undefined, columnDef: Column, colEditorOrFilter: ColumnEditor | ColumnFilter) {
+export function setPickerDates(dateInputElm: HTMLInputElement, pickerOptions: IOptions, dateValues: Date | Date[] | string | string[] | undefined, columnDef: Column, colEditorOrFilter: ColumnEditor | ColumnFilter): void {
   const currentDateOrDates = dateValues;
   const outputFieldType = columnDef.outputType || colEditorOrFilter.type || columnDef.type || FieldType.dateUtc;
   const inputFieldType = colEditorOrFilter.type || columnDef.type;

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -56,7 +56,7 @@ export class SlickEventData<ArgType = any> {
     return this._isDefaultPrevented;
   }
 
-  constructor(protected event?: Event | null, protected args?: ArgType) {
+  constructor(protected event?: Event | null | undefined, protected args?: ArgType | undefined) {
     this.nativeEvent = event;
     this._arguments = args;
 
@@ -165,7 +165,7 @@ export class SlickEvent<ArgType = any> {
    * @param {String} [eventName] - event name that could be used for dispatching CustomEvent (when enabled)
    * @param {BasePubSub} [pubSubService] - event name that could be used for dispatching CustomEvent (when enabled)
    */
-  constructor(protected readonly eventName?: string, protected readonly pubSub?: BasePubSub) {
+  constructor(protected readonly eventName?: string | undefined, protected readonly pubSub?: BasePubSub | undefined) {
     this._pubSubService = pubSub;
   }
 

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -52,7 +52,7 @@ export class SlickEventData<ArgType = any> {
   readonly x?: number;
   readonly y?: number;
 
-  get defaultPrevented() {
+  get defaultPrevented(): boolean {
     return this._isDefaultPrevented;
   }
 
@@ -76,7 +76,7 @@ export class SlickEventData<ArgType = any> {
    * Stops event from propagating up the DOM tree.
    * @method stopPropagation
    */
-  stopPropagation() {
+  stopPropagation(): void {
     this._isPropagationStopped = true;
     this.nativeEvent?.stopPropagation();
   }
@@ -86,7 +86,7 @@ export class SlickEventData<ArgType = any> {
    * @method isPropagationStopped
    * @return {Boolean}
    */
-  isPropagationStopped() {
+  isPropagationStopped(): boolean {
     return this._isPropagationStopped;
   }
 
@@ -94,7 +94,7 @@ export class SlickEventData<ArgType = any> {
    * Prevents the rest of the handlers from being executed.
    * @method stopImmediatePropagation
    */
-  stopImmediatePropagation() {
+  stopImmediatePropagation(): void {
     this._isImmediatePropagationStopped = true;
     if (this.nativeEvent) {
       this.nativeEvent.stopImmediatePropagation();
@@ -106,7 +106,7 @@ export class SlickEventData<ArgType = any> {
    * @method isImmediatePropagationStopped
    * @return {Boolean}
    */
-  isImmediatePropagationStopped() {
+  isImmediatePropagationStopped(): boolean {
     return this._isImmediatePropagationStopped;
   }
 
@@ -114,35 +114,35 @@ export class SlickEventData<ArgType = any> {
     return this.nativeEvent as E;
   }
 
-  preventDefault() {
+  preventDefault(): void {
     if (this.nativeEvent) {
       this.nativeEvent.preventDefault();
     }
     this._isDefaultPrevented = true;
   }
 
-  isDefaultPrevented() {
+  isDefaultPrevented(): boolean {
     if (this.nativeEvent) {
       return this.nativeEvent.defaultPrevented;
     }
     return this._isDefaultPrevented;
   }
 
-  addReturnValue(value: any) {
+  addReturnValue(value: any): void {
     if (this.returnValue === undefined && value !== undefined) {
       this.returnValue = value;
     }
   }
 
-  getReturnValue() {
+  getReturnValue(): any {
     return this.returnValue;
   }
 
-  getArguments() {
+  getArguments(): ArgType | undefined {
     return this._arguments;
   }
 
-  resetReturnValue() {
+  resetReturnValue(): void {
     this.returnValue = undefined;
   }
 }
@@ -156,7 +156,7 @@ export class SlickEvent<ArgType = any> {
   protected _handlers: Handler<ArgType>[] = [];
   protected _pubSubService?: BasePubSub;
 
-  get subscriberCount() {
+  get subscriberCount(): number {
     return this._handlers.length;
   }
 
@@ -176,7 +176,7 @@ export class SlickEvent<ArgType = any> {
    * @method subscribe
    * @param {Function} fn - Event handler.
    */
-  subscribe(fn: Handler<ArgType>) {
+  subscribe(fn: Handler<ArgType>): void {
     this._handlers.push(fn);
   }
 
@@ -185,7 +185,7 @@ export class SlickEvent<ArgType = any> {
    * @method unsubscribe
    * @param {Function} [fn] - Event handler to be removed.
    */
-  unsubscribe(fn?: Handler<ArgType>) {
+  unsubscribe(fn?: Handler<ArgType>): void {
     for (let i = this._handlers.length - 1; i >= 0; i--) {
       if (this._handlers[i] === fn) {
         this._handlers.splice(i, 1);
@@ -202,7 +202,7 @@ export class SlickEvent<ArgType = any> {
    * @param {Object} [scope] - The scope ("this") within which the handler will be executed.
    *      If not specified, the scope will be set to the <code>Event</code> instance.
    */
-  notify(args: ArgType, evt?: SlickEventData<ArgType> | Event | MergeTypes<SlickEventData, Event> | null, scope?: any, ignorePrevEventDataValue = false) {
+  notify(args: ArgType, evt?: SlickEventData<ArgType> | Event | MergeTypes<SlickEventData, Event> | null, scope?: any, ignorePrevEventDataValue = false): SlickEventData<ArgType> {
     const sed = evt instanceof SlickEventData ? evt : new SlickEventData<ArgType>(evt, args);
     if (ignorePrevEventDataValue) {
       sed.resetReturnValue();
@@ -229,7 +229,7 @@ export class SlickEvent<ArgType = any> {
     return sed;
   }
 
-  setPubSubService(pubSub: BasePubSub) {
+  setPubSubService(pubSub: BasePubSub): void {
     this._pubSubService = pubSub;
   }
 }
@@ -237,18 +237,18 @@ export class SlickEvent<ArgType = any> {
 export class SlickEventHandler {
   protected handlers: Array<{ event: SlickEvent; handler: Handler<any>; }> = [];
 
-  get subscriberCount() {
+  get subscriberCount(): number {
     return this.handlers.length;
   }
 
-  subscribe<T = any>(event: SlickEvent<T>, handler: Handler<T>) {
+  subscribe<T = any>(event: SlickEvent<T>, handler: Handler<T>): SlickEventHandler {
     this.handlers.push({ event, handler });
     event.subscribe(handler);
 
     return this as SlickEventHandler;  // allow chaining
   }
 
-  unsubscribe<T = any>(event: SlickEvent, handler: Handler<T>) {
+  unsubscribe<T = any>(event: SlickEvent, handler: Handler<T>): SlickEventHandler | void {
     let i = this.handlers.length;
     while (i--) {
       if (this.handlers[i].event === event &&
@@ -262,7 +262,7 @@ export class SlickEventHandler {
     return this as SlickEventHandler;  // allow chaining
   }
 
-  unsubscribeAll() {
+  unsubscribeAll(): SlickEventHandler {
     let i = this.handlers.length;
     while (i--) {
       this.handlers[i].event.unsubscribe(this.handlers[i].handler);
@@ -324,7 +324,7 @@ export class SlickRange {
    * @method isSingleCell
    * @return {Boolean}
    */
-  isSingleCell() {
+  isSingleCell(): boolean {
     return this.fromRow === this.toRow && this.fromCell === this.toCell;
   }
 
@@ -333,7 +333,7 @@ export class SlickRange {
    * @method isSingleRow
    * @return {Boolean}
    */
-  isSingleRow() {
+  isSingleRow(): boolean {
     return this.fromRow === this.toRow;
   }
 
@@ -344,7 +344,7 @@ export class SlickRange {
    * @param cell {Integer}
    * @return {Boolean}
    */
-  contains(row: number, cell: number) {
+  contains(row: number, cell: number): boolean {
     return row >= this.fromRow && row <= this.toRow &&
       cell >= this.fromCell && cell <= this.toCell;
   }
@@ -354,7 +354,7 @@ export class SlickRange {
    * @method toString
    * @return {String}
    */
-  toString() {
+  toString(): string {
     if (this.isSingleCell()) {
       return `(${this.fromRow}:${this.fromCell})`;
     }
@@ -533,7 +533,7 @@ export class SlickEditorLock {
    * @method activate
    * @param editController {EditController} edit controller acquiring the lock
    */
-  activate(editController: EditController) {
+  activate(editController: EditController): void {
     if (editController === this.activeEditController) { // already activated?
       return;
     }
@@ -555,7 +555,7 @@ export class SlickEditorLock {
    * @method deactivate
    * @param editController {EditController} edit controller releasing the lock
    */
-  deactivate(editController: EditController) {
+  deactivate(editController: EditController): void {
     if (!this.activeEditController) {
       return;
     }
@@ -590,30 +590,35 @@ export class SlickEditorLock {
 }
 
 export class Utils {
-  public static storage = {
-    // https://stackoverflow.com/questions/29222027/vanilla-alternative-to-jquery-data-function-any-native-javascript-alternati
-    _storage: new WeakMap(),
-    put: function (element: any, key: string, obj: any) {
-      if (!this._storage.has(element)) {
-        this._storage.set(element, new Map());
+  public static storage: {
+    _storage: WeakMap<object, any>;
+    put: (element: any, key: string, obj: any) => void;
+    get: (element: any, key: string) => any;
+    remove: (element: any, key: string) => any;
+  } = {
+      // https://stackoverflow.com/questions/29222027/vanilla-alternative-to-jquery-data-function-any-native-javascript-alternati
+      _storage: new WeakMap(),
+      put: function (element: any, key: string, obj: any): void {
+        if (!this._storage.has(element)) {
+          this._storage.set(element, new Map());
+        }
+        this._storage.get(element).set(key, obj);
+      },
+      get: function (element: any, key: string): any {
+        const el = this._storage.get(element);
+        if (el) {
+          return el.get(key);
+        }
+        return null;
+      },
+      remove: function (element: any, key: string): any {
+        const ret = this._storage.get(element).delete(key);
+        if (!(this._storage.get(element).size === 0)) {
+          this._storage.delete(element);
+        }
+        return ret;
       }
-      this._storage.get(element).set(key, obj);
-    },
-    get: function (element: any, key: string) {
-      const el = this._storage.get(element);
-      if (el) {
-        return el.get(key);
-      }
-      return null;
-    },
-    remove: function (element: any, key: string) {
-      const ret = this._storage.get(element).delete(key);
-      if (!(this._storage.get(element).size === 0)) {
-        this._storage.delete(element);
-      }
-      return ret;
-    }
-  };
+    };
 
   public static height(el: HTMLElement, value?: number | string): number | void {
     if (!el) {
@@ -635,18 +640,18 @@ export class Utils {
     Utils.setStyleSize(el, 'width', value);
   }
 
-  public static setStyleSize(el: HTMLElement, style: string, val?: number | string | Function) {
+  public static setStyleSize(el: HTMLElement, style: string, val?: number | string | Function): void {
     if (typeof val === 'function') {
       val = val();
     }
     el.style[style as CSSStyleDeclarationWritable] = (typeof val === 'string') ? val : `${val}px`;
   }
 
-  public static isHidden(el: HTMLElement) {
+  public static isHidden(el: HTMLElement): boolean {
     return el.offsetWidth === 0 && el.offsetHeight === 0;
   }
 
-  public static parents(el: HTMLElement | ParentNode, selector?: string) {
+  public static parents(el: HTMLElement | ParentNode, selector?: string): Array<HTMLElement | ParentNode> {
     const parents: Array<HTMLElement | ParentNode> = [];
     const visible = selector === ':visible';
     const hidden = selector === ':hidden';
@@ -670,7 +675,7 @@ export class Utils {
     return parents;
   }
 
-  public static toFloat(value: string | number) {
+  public static toFloat(value: string | number): number {
     const x = parseFloat(value as string);
     if (isNaN(x)) {
       return 0;
@@ -678,7 +683,7 @@ export class Utils {
     return x;
   }
 
-  public static show(el: HTMLElement | HTMLElement[], type = '') {
+  public static show(el: HTMLElement | HTMLElement[], type = ''): void {
     if (Array.isArray(el)) {
       el.forEach((e) => e.style.display = type);
     } else {
@@ -686,7 +691,7 @@ export class Utils {
     }
   }
 
-  public static hide(el: HTMLElement | HTMLElement[]) {
+  public static hide(el: HTMLElement | HTMLElement[]): void {
     if (Array.isArray(el)) {
       el.forEach((e) => e.style.display = 'none');
     } else {
@@ -694,7 +699,7 @@ export class Utils {
     }
   }
 
-  public static applyDefaults(targetObj: any, srcObj: any) {
+  public static applyDefaults(targetObj: any, srcObj: any): void {
     if (typeof srcObj === 'object') {
       Object.keys(srcObj).forEach(key => {
         if (srcObj.hasOwnProperty(key) && !targetObj.hasOwnProperty(key)) {
@@ -710,7 +715,7 @@ export class Utils {
    * @param {BasePubSub} [pubSubService]
    * @param {*} scope
    */
-  public static addSlickEventPubSubWhenDefined<T = any>(pubSub: BasePubSub, scope: T) {
+  public static addSlickEventPubSubWhenDefined<T = any>(pubSub: BasePubSub, scope: T): void {
     if (pubSub) {
       for (const prop in scope) {
         if (scope[prop] instanceof SlickEvent && typeof (scope[prop] as SlickEvent).setPubSubService === 'function') {
@@ -721,6 +726,6 @@ export class Utils {
   }
 }
 
-export const SlickGlobalEditorLock = new SlickEditorLock();
+export const SlickGlobalEditorLock: SlickEditorLock = new SlickEditorLock();
 export const preClickClassName = 'slick-edit-preclick';
 

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -68,7 +68,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected idProperty = 'id';          // property holding a unique row id
   protected items: TData[] = [];            // data by index
   protected rows: TData[] = [];             // data by row
-  protected idxById = new Map<DataIdType, number>();   // indexes by id
+  protected idxById: Map<DataIdType, number> = new Map<DataIdType, number>();   // indexes by id
   protected rowsById: { [id: DataIdType]: number; } | undefined = undefined;       // rows by id; lazy-calculated
   protected filter: FilterFn<TData> | null = null;         // filter function
   protected filterCSPSafe: FilterFn<TData> | null = null;         // filter function
@@ -77,7 +77,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected isBulkSuspend = false;      // delays protectedious operations like the
   // index update and delete to efficient
   // versions at endUpdate
-  protected bulkDeleteIds = new Map<DataIdType, boolean>();
+  protected bulkDeleteIds: Map<DataIdType, boolean> = new Map<DataIdType, boolean>();
   protected sortAsc: boolean | undefined = true;
   protected sortComparer!: ((a: TData, b: TData) => number);
   protected refreshHints: DataViewHints = {};
@@ -149,12 +149,12 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * deliver fully consistent information.
    * @param {Boolean} [bulkUpdate] - if set to true, most data view modifications
    */
-  beginUpdate(bulkUpdate?: boolean) {
+  beginUpdate(bulkUpdate?: boolean): void {
     this.suspend = true;
     this.isBulkSuspend = bulkUpdate === true;
   }
 
-  endUpdate() {
+  endUpdate(): void {
     const wasBulkSuspend = this.isBulkSuspend;
     this.isBulkSuspend = false;
     this.suspend = false;
@@ -165,7 +165,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     this.refresh();
   }
 
-  destroy() {
+  destroy(): void {
     this.items = [];
     this.idProperty = 'id';
     this.idxById = null as any;
@@ -188,17 +188,17 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** provide some refresh hints as to what to rows needs refresh */
-  setRefreshHints(hints: DataViewHints) {
+  setRefreshHints(hints: DataViewHints): void {
     this.refreshHints = hints;
   }
 
   /** get extra filter arguments of the filter method */
-  getFilterArgs() {
+  getFilterArgs(): any {
     return this.filterArgs;
   }
 
   /** add extra filter arguments to the filter method */
-  setFilterArgs(args: unknown) {
+  setFilterArgs(args: unknown): void {
     this.filterArgs = args;
   }
 
@@ -206,7 +206,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Processes all delete requests placed during bulk update
    * by recomputing the items and idxById members.
    */
-  protected processBulkDelete() {
+  protected processBulkDelete(): void {
     if (!this.idxById) {
       return;
     }
@@ -248,7 +248,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     this.bulkDeleteIds = new Map();
   }
 
-  protected updateIdxById(startingIndex?: number) {
+  protected updateIdxById(startingIndex?: number): void {
     if (this.isBulkSuspend || !this.idxById) { // during bulk update we do not reorganize
       return;
     }
@@ -263,7 +263,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     }
   }
 
-  protected ensureIdUniqueness() {
+  protected ensureIdUniqueness(): void {
     if (this.isBulkSuspend || !this.idxById) { // during bulk update we do not reorganize
       return;
     }
@@ -277,12 +277,12 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Get all DataView Items */
-  getItems() {
+  getItems(): TData[] {
     return this.items;
   }
 
   /** Get the DataView Id property name to use (defaults to "Id" but could be customized to something else when instantiating the DataView) */
-  getIdPropertyName() {
+  getIdPropertyName(): string {
     return this.idProperty;
   }
 
@@ -291,7 +291,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param {Array<*>} data - array of data
    * @param {String} [objectIdProperty] - optional id property to use as primary id
    */
-  setItems(data: TData[], objectIdProperty?: string) {
+  setItems(data: TData[], objectIdProperty?: string): void {
     if (objectIdProperty !== undefined) {
       this.idProperty = objectIdProperty;
     }
@@ -304,7 +304,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Set Paging Options */
-  setPagingOptions(args: Partial<PagingInfo>) {
+  setPagingOptions(args: Partial<PagingInfo>): void {
     if (this.onBeforePagingInfoChanged.notify(this.getPagingInfo(), null, this).getReturnValue() !== false) {
       if (isDefined(args.pageSize)) {
         this.pagesize = args.pageSize;
@@ -328,7 +328,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Sort Method to use by the DataView */
-  sort(comparer: (a: TData, b: TData) => number, ascending?: boolean) {
+  sort(comparer: (a: TData, b: TData) => number, ascending?: boolean): void {
     this.sortAsc = ascending;
     this.sortComparer = comparer;
     if (ascending === false) {
@@ -344,7 +344,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Re-Sort the dataset */
-  reSort() {
+  reSort(): void {
     if (this.sortComparer) {
       this.sort(this.sortComparer, this.sortAsc);
     }
@@ -356,12 +356,12 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Get the array length (count) of only the DataView filtered items */
-  getFilteredItemCount() {
+  getFilteredItemCount(): number {
     return this.filteredItems.length;
   }
 
   /** Get current Filter used by the DataView */
-  getFilter() {
+  getFilter(): FilterFn<TData> | null {
     return this._options.useCSPSafeFilter ? this.filterCSPSafe : this.filter;
   }
 
@@ -369,7 +369,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Set a Filter that will be used by the DataView
    * @param {Function} fn - filter callback function
    */
-  setFilter(filterFn: FilterFn<TData>) {
+  setFilter(filterFn: FilterFn<TData>): void {
     this.filterCSPSafe = filterFn;
     this.filter = filterFn;
     if (this._options.inlineFilters) {
@@ -387,7 +387,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Set some Grouping */
-  setGrouping(groupingInfo: Grouping | Grouping[]) {
+  setGrouping(groupingInfo: Grouping | Grouping[]): void {
     if (!this._options.groupItemMetadataProvider) {
       this._options.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
     }
@@ -415,16 +415,16 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Get an item in the DataView by its row index */
-  getItemByIdx<T extends TData>(i: number) {
+  getItemByIdx<T extends TData>(i: number): T {
     return this.items[i] as T;
   }
 
   /** Get row index in the DataView by its Id */
-  getIdxById(id: DataIdType) {
+  getIdxById(id: DataIdType): number | undefined {
     return this.idxById?.get(id);
   }
 
-  protected ensureRowsByIdCache() {
+  protected ensureRowsByIdCache(): void {
     if (!this.rowsById) {
       this.rowsById = {};
       for (let i = 0, l = this.rows.length; i < l; i++) {
@@ -434,13 +434,13 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Get row number in the grid by its item object */
-  getRowByItem(item: TData) {
+  getRowByItem(item: TData): number | undefined {
     this.ensureRowsByIdCache();
     return this.rowsById?.[item[this.idProperty as keyof TData] as DataIdType];
   }
 
   /** Get row number in the grid by its Id */
-  getRowById(id: DataIdType) {
+  getRowById(id: DataIdType): number | undefined {
     this.ensureRowsByIdCache();
     return this.rowsById?.[id];
   }
@@ -451,7 +451,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** From the items array provided, return the mapped rows */
-  mapItemsToRows(itemArray: TData[]) {
+  mapItemsToRows(itemArray: TData[]): number[] {
     const rows: number[] = [];
     this.ensureRowsByIdCache();
     for (let i = 0, l = itemArray.length; i < l; i++) {
@@ -464,7 +464,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** From the Ids array provided, return the mapped rows */
-  mapIdsToRows(idArray: DataIdType[]) {
+  mapIdsToRows(idArray: DataIdType[]): number[] {
     const rows: number[] = [];
     this.ensureRowsByIdCache();
     for (let i = 0, l = idArray.length; i < l; i++) {
@@ -477,7 +477,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** From the rows array provided, return the mapped Ids */
-  mapRowsToIds(rowArray: number[]) {
+  mapRowsToIds(rowArray: number[]): DataIdType[] {
     const ids: DataIdType[] = [];
     for (let i = 0, l = rowArray.length; i < l; i++) {
       if (rowArray[i] < this.rows.length) {
@@ -494,7 +494,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param id The new id of the item.
    * @param item The item which should be the new value for the given id.
    */
-  updateSingleItem(id: DataIdType, item: TData) {
+  updateSingleItem(id: DataIdType, item: TData): void {
     if (!this.idxById) {
       return;
     }
@@ -540,7 +540,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param id The new id of the item.
    * @param item The item which should be the new value for the given id.
    */
-  updateItem<T extends TData>(id: DataIdType, item: T) {
+  updateItem<T extends TData>(id: DataIdType, item: T): void {
     this.updateSingleItem(id, item);
     this.refresh();
   }
@@ -550,7 +550,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param id {Array} The array of new ids which is in the same order as the items.
    * @param newItems {Array} The new items that should be set in the data view for the given ids.
    */
-  updateItems<T extends TData>(ids: DataIdType[], newItems: T[]) {
+  updateItems<T extends TData>(ids: DataIdType[], newItems: T[]): void {
     if (ids.length !== newItems.length) {
       throw new Error('[SlickGrid DataView] Mismatch on the length of ids and items provided to update');
     }
@@ -565,7 +565,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param insertBefore {Number} The 0-based index before which the item should be inserted.
    * @param item The item to insert.
    */
-  insertItem(insertBefore: number, item: TData) {
+  insertItem(insertBefore: number, item: TData): void {
     this.items.splice(insertBefore, 0, item);
     this.updateIdxById(insertBefore);
     this.refresh();
@@ -576,7 +576,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param insertBefore {Number} The 0-based index before which the items should be inserted.
    * @param newItems {Array}  The items to insert.
    */
-  insertItems(insertBefore: number, newItems: TData[]) {
+  insertItems(insertBefore: number, newItems: TData[]): void {
     // @ts-ignore
     Array.prototype.splice.apply(this.items, [insertBefore, 0].concat(newItems));
     this.updateIdxById(insertBefore);
@@ -587,7 +587,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Adds a single item at the end of the data view.
    * @param item The item to add at the end.
    */
-  addItem(item: TData) {
+  addItem(item: TData): void {
     this.items.push(item);
     this.updateIdxById(this.items.length - 1);
     this.refresh();
@@ -597,7 +597,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Adds multiple items at the end of the data view.
    * @param {Array} newItems The items to add at the end.
    */
-  addItems(newItems: TData[]) {
+  addItems(newItems: TData[]): void {
     this.items = this.items.concat(newItems);
     this.updateIdxById(this.items.length - newItems.length);
     this.refresh();
@@ -607,7 +607,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Deletes a single item identified by the given id from the data view.
    * @param {String|Number} id The id identifying the object to delete.
    */
-  deleteItem(id: DataIdType) {
+  deleteItem(id: DataIdType): void {
     if (!this.idxById) {
       return;
     }
@@ -629,7 +629,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Deletes multiple item identified by the given ids from the data view.
    * @param {Array} ids The ids of the items to delete.
    */
-  deleteItems(ids: DataIdType[]) {
+  deleteItems(ids: DataIdType[]): void {
     if (ids.length === 0 || !this.idxById) {
       return;
     }
@@ -669,7 +669,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Add an item in a sorted dataset (a Sort function must be defined) */
-  sortedAddItem(item: TData) {
+  sortedAddItem(item: TData): void {
     if (!this.sortComparer) {
       throw new Error('[SlickGrid DataView] sortedAddItem() requires a sort comparer, use sort()');
     }
@@ -677,7 +677,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Update an item in a sorted dataset (a Sort function must be defined) */
-  sortedUpdateItem(id: string | number, item: TData) {
+  sortedUpdateItem(id: string | number, item: TData): void {
     if (!this.idxById) {
       return;
     }
@@ -697,7 +697,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     }
   }
 
-  protected sortedIndex(searchItem: TData) {
+  protected sortedIndex(searchItem: TData): number {
     let low = 0;
     let high = this.items.length;
 
@@ -713,17 +713,17 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** Get item count, that is the full dataset lenght of the DataView */
-  getItemCount() {
+  getItemCount(): number {
     return this.items.length;
   }
 
   /** Get row count (rows displayed in current page) */
-  getLength() {
+  getLength(): number {
     return this.rows.length;
   }
 
   /** Retrieve an item from the DataView at specific index */
-  getItem<T extends TData>(i: number) {
+  getItem<T extends TData>(i: number): T {
     const item = this.rows[i] as T;
 
     // if this is a group row, make sure totals are calculated and update the title
@@ -761,7 +761,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return null;
   }
 
-  protected expandCollapseAllGroups(level?: number, collapse?: boolean) {
+  protected expandCollapseAllGroups(level?: number, collapse?: boolean): void {
     if (!isDefined(level)) {
       for (let i = 0; i < this.groupingInfos.length; i++) {
         this.toggledGroupsByLevel[i] = {};
@@ -789,18 +789,18 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   /**
    * @param {Number} [level] Optional level to collapse.  If not specified, applies to all levels.
    */
-  collapseAllGroups(level?: number) {
+  collapseAllGroups(level?: number): void {
     this.expandCollapseAllGroups(level, true);
   }
 
   /**
    * @param {Number} [level] Optional level to expand.  If not specified, applies to all levels.
    */
-  expandAllGroups(level?: number) {
+  expandAllGroups(level?: number): void {
     this.expandCollapseAllGroups(level, false);
   }
 
-  expandCollapseGroup(level: number, groupingKey: string, collapse?: boolean) {
+  expandCollapseGroup(level: number, groupingKey: string, collapse?: boolean): void {
     if (this.toggledGroupsByLevel[level]) {
       // @ts-ignore
       this.toggledGroupsByLevel[level][groupingKey] = this.groupingInfos[level].collapsed ^ collapse;
@@ -814,7 +814,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    *     example, calling collapseGroup('high', '10%') will collapse the '10%' subgroup of
    *     the 'high' group.
    */
-  collapseGroup(...args: any) {
+  collapseGroup(...args: any): void {
     const calledArgs = Array.prototype.slice.call(args);
     const arg0 = calledArgs[0];
     let groupingKey: string;
@@ -838,7 +838,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    *     example, calling expandGroup('high', '10%') will expand the '10%' subgroup of
    *     the 'high' group.
    */
-  expandGroup(...args: any) {
+  expandGroup(...args: any): void {
     const calledArgs = Array.prototype.slice.call(args);
     const arg0 = calledArgs[0];
     let groupingKey: string;
@@ -856,11 +856,11 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     this.onGroupExpanded.notify({ level, groupingKey });
   }
 
-  getGroups() {
+  getGroups(): SlickGroup[] {
     return this.groups;
   }
 
-  protected extractGroups(rows: any[], parentGroup?: SlickGroup) {
+  protected extractGroups(rows: any[], parentGroup?: SlickGroup): SlickGroup[] {
     let group: SlickGroup;
     let val: any;
     const groups: SlickGroup[] = [];
@@ -915,7 +915,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   /** claculate Group Totals */
-  protected calculateTotals(totals: SlickGroupTotals) {
+  protected calculateTotals(totals: SlickGroupTotals): void {
     const group = totals.group as SlickGroup;
     const gi = this.groupingInfos[group?.level ?? 0];
     const isLeafLevel = (group.level === this.groupingInfos.length);
@@ -945,7 +945,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     totals.initialized = true;
   }
 
-  protected addGroupTotals(group: SlickGroup) {
+  protected addGroupTotals(group: SlickGroup): void {
     const gi = this.groupingInfos[group.level];
     const totals = new SlickGroupTotals();
     totals.group = group;
@@ -955,7 +955,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     }
   }
 
-  protected addTotals(groups: SlickGroup[], level?: number) {
+  protected addTotals(groups: SlickGroup[], level?: number): void {
     level = level || 0;
     const gi = this.groupingInfos[level];
     const groupCollapsed = gi.collapsed;
@@ -984,7 +984,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     }
   }
 
-  protected flattenGroupedRows(groups: SlickGroup[], level?: number) {
+  protected flattenGroupedRows(groups: SlickGroup[], level?: number): any[] {
     level = level || 0;
     const gi = this.groupingInfos[level];
     const groupedRows: any[] = [];
@@ -1009,7 +1009,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return groupedRows;
   }
 
-  protected compileAccumulatorLoopCSPSafe(aggregator: Aggregator) {
+  protected compileAccumulatorLoopCSPSafe(aggregator: Aggregator): (items: any[]) => void {
     if (aggregator.accumulate) {
       return function (items: any[]) {
         let result;
@@ -1156,7 +1156,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param {*} fn
    * @param {string} fnName
    */
-  protected setFunctionName(fn: any, fnName: string) {
+  protected setFunctionName(fn: any, fnName: string): void {
     try {
       Object.defineProperty(fn, 'name', { writable: true, value: fnName });
     } catch (err) /* istanbul ignore next */ {
@@ -1164,7 +1164,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     }
   }
 
-  protected uncompiledFilter(items: TData[], args: any) {
+  protected uncompiledFilter(items: TData[], args: any): any[] {
     const retval: any[] = [];
     let idx = 0;
 
@@ -1177,7 +1177,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return retval;
   }
 
-  protected uncompiledFilterWithCaching(items: TData[], args: any, cache: any) {
+  protected uncompiledFilterWithCaching(items: TData[], args: any, cache: any): any[] {
     const retval: any[] = [];
     let idx = 0;
     let item: TData;
@@ -1195,7 +1195,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return retval;
   }
 
-  protected getFilteredAndPagedItems(items: TData[]) {
+  protected getFilteredAndPagedItems(items: TData[]): { totalRows: number; rows: TData[]; } {
     if (this._options.useCSPSafeFilter ? this.filterCSPSafe : this.filter) {
       let batchFilter: AnyFunction;
       let batchFilterWithCaching: AnyFunction;
@@ -1237,7 +1237,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return { totalRows: this.filteredItems.length, rows: paged };
   }
 
-  protected getRowDiffs(rows: TData[], newRows: TData[]) {
+  protected getRowDiffs(rows: TData[], newRows: TData[]): number[] {
     let item: TData | SlickNonDataItem | SlickDataItem | SlickGroup;
     let r;
     let eitherIsNonData;
@@ -1280,7 +1280,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return diff;
   }
 
-  protected recalc(_items: TData[]) {
+  protected recalc(_items: TData[]): number[] {
     this.rowsById = undefined;
 
     if (this.refreshHints.isFilterNarrowing !== this.prevRefreshHints.isFilterNarrowing ||
@@ -1307,7 +1307,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return diff;
   }
 
-  refresh() {
+  refresh(): void {
     if (this.suspend) {
       return;
     }
@@ -1372,7 +1372,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    *     access to the full list selected row ids, and not just the ones visible to the grid.
    * @method syncGridSelection
    */
-  syncGridSelection(grid: SlickGrid, preserveHidden: boolean, preserveHiddenOnSelectionChange?: boolean) {
+  syncGridSelection(grid: SlickGrid, preserveHidden: boolean, preserveHiddenOnSelectionChange?: boolean): SlickEvent<OnSelectedRowIdsChangedEventArgs> {
     this._grid = grid;
     let inHandler: boolean;
     this.selectedRowIds = this.mapRowsToIds(grid.getSelectedRows());
@@ -1472,7 +1472,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Get all selected IDs
    * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
    */
-  getAllSelectedIds() {
+  getAllSelectedIds(): DataIdType[] {
     return this.selectedRowIds;
   }
 
@@ -1480,7 +1480,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Get all selected filtered IDs (similar to "getAllSelectedIds" but only return filtered data)
    * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
    */
-  getAllSelectedFilteredIds() {
+  getAllSelectedFilteredIds(): TData[keyof TData][] {
     return this.getAllSelectedFilteredItems().map((item) => item[this.idProperty as keyof TData]);
   }
 
@@ -1494,7 +1494,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    *  - `shouldTriggerEvent`: defaults to true, should we trigger `onSelectedRowIdsChanged` event
    *  - `applyRowSelectionToGrid`: defaults to true, should we apply the row selections to the grid in the UI
    */
-  setSelectedIds(selectedIds: Array<number | string>, options?: Partial<{ isRowBeingAdded: boolean; shouldTriggerEvent: boolean; applyRowSelectionToGrid: boolean; }>) {
+  setSelectedIds(selectedIds: Array<number | string>, options?: Partial<{ isRowBeingAdded: boolean; shouldTriggerEvent: boolean; applyRowSelectionToGrid: boolean; }>): void {
     let isRowBeingAdded = options?.isRowBeingAdded;
     const shouldTriggerEvent = options?.shouldTriggerEvent;
     const applyRowSelectionToGrid = options?.applyRowSelectionToGrid;
@@ -1529,7 +1529,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * Get all selected dataContext items
    * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
    */
-  getAllSelectedItems<T extends TData>() {
+  getAllSelectedItems<T extends TData>(): T[] {
     const selectedData: TData[] = [];
     const selectedIds = this.getAllSelectedIds();
     selectedIds!.forEach((id) => {
@@ -1542,7 +1542,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   * Get all selected filtered dataContext items (similar to "getAllSelectedItems" but only return filtered data)
   * Note: when using Pagination it will also include hidden selections assuming `preserveHiddenOnSelectionChange` is set to true.
   */
-  getAllSelectedFilteredItems<T extends TData>() {
+  getAllSelectedFilteredItems<T extends TData>(): T[] {
     /* istanbul ignore if */
     if (!Array.isArray(this.selectedRowIds)) {
       return [];
@@ -1552,7 +1552,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return (intersection || []) as T[];
   }
 
-  syncGridCellCssStyles(grid: SlickGrid, key: string) {
+  syncGridCellCssStyles(grid: SlickGrid, key: string): void {
     let hashById: any;
     let inHandler: boolean;
 

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -128,7 +128,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   onSelectedRowIdsChanged: SlickEvent<OnSelectedRowIdsChangedEventArgs>;
   onSetItemsCalled: SlickEvent<OnSetItemsCalledEventArgs>;
 
-  constructor(options?: Partial<DataViewOption>, protected externalPubSub?: BasePubSub) {
+  constructor(options?: Partial<DataViewOption> | undefined, protected externalPubSub?: BasePubSub | undefined) {
     this.onBeforePagingInfoChanged = new SlickEvent<PagingInfo>('onBeforePagingInfoChanged', externalPubSub);
     this.onGroupExpanded = new SlickEvent<OnGroupExpandedEventArgs>('onGroupExpanded', externalPubSub);
     this.onGroupCollapsed = new SlickEvent<OnGroupCollapsedEventArgs>('onGroupCollapsed', externalPubSub);

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -88,6 +88,7 @@ import type {
   PagingInfo,
   SingleColumnSort,
   SlickPlugin,
+  ElementPosition,
 } from '../interfaces';
 import type { SlickDataView } from './slickDataview';
 
@@ -308,7 +309,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected page = 0;       // current page
   protected offset = 0;     // current page offset
   protected vScrollDir = 1;
-  protected _bindingEventService = new BindingEventService();
+  protected _bindingEventService: BindingEventService = new BindingEventService();
   protected initialized = false;
   protected _container!: HTMLElement;
   protected uid = `slickgrid_${Math.round(1000000 * Math.random())}`;
@@ -562,7 +563,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // Initialization
 
   /** Initializes the grid. */
-  init() {
+  init(): void {
     this.finishInitialization();
   }
 
@@ -578,7 +579,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    *   `sanitizerOptions` is to provide extra options when using `innerHTML` and the sanitizer.
    *   `skipEmptyReassignment`, defaults to true, when enabled it will not try to reapply an empty value when the target is already empty
    */
-  applyHtmlCode(target: HTMLElement, val: string | boolean | number | HTMLElement | DocumentFragment = '', options?: { emptyTarget?: boolean; sanitizerOptions?: unknown; skipEmptyReassignment?: boolean; cloneNode?: boolean; }) {
+  applyHtmlCode(target: HTMLElement, val: string | boolean | number | HTMLElement | DocumentFragment = '', options?: { emptyTarget?: boolean; sanitizerOptions?: unknown; skipEmptyReassignment?: boolean; cloneNode?: boolean; }): void {
     if (target) {
       if (val instanceof HTMLElement || val instanceof DocumentFragment) {
         // first empty target and then append new HTML element
@@ -612,7 +613,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected initialize(options: Partial<O>) {
+  protected initialize(options: Partial<O>): void {
     // calculate these only once and share between grid instances
     if (options?.mixinDefaults) {
       // use provided options and then assign defaults
@@ -830,7 +831,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected finishInitialization() {
+  protected finishInitialization(): void {
     if (!this.initialized) {
       this.initialized = true;
 
@@ -948,7 +949,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** handles "display:none" on container or container parents, related to issue: https://github.com/6pac/SlickGrid/issues/568 */
-  cacheCssForHiddenInit() {
+  cacheCssForHiddenInit(): void {
     this._hiddenParents = Utils.parents(this._container, ':hidden') as HTMLElement[];
     this._hiddenParents.forEach(el => {
       const old: Partial<CSSStyleDeclaration> = {};
@@ -962,7 +963,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     });
   }
 
-  restoreCssFromHiddenInit() {
+  restoreCssFromHiddenInit(): void {
     // finish handle display:none on container or container parents
     // - put values back the way they were
     let i = 0;
@@ -978,18 +979,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected hasFrozenColumns() {
+  protected hasFrozenColumns(): boolean {
     return this._options.frozenColumn! > -1;
   }
 
   /** Register an external Plugin */
-  registerPlugin<T extends SlickPlugin>(plugin: T) {
+  registerPlugin<T extends SlickPlugin>(plugin: T): void {
     this.plugins.unshift(plugin);
     plugin.init(this as unknown as SlickGrid);
   }
 
   /** Unregister (destroy) an external Plugin */
-  unregisterPlugin(plugin: SlickPlugin) {
+  unregisterPlugin(plugin: SlickPlugin): void {
     for (let i = this.plugins.length; i >= 0; i--) {
       if (this.plugins[i] === plugin) {
         this.plugins[i]?.destroy();
@@ -1000,7 +1001,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get a Plugin (addon) by its name */
-  getPluginByName<P extends SlickPlugin | undefined = undefined>(name: string) {
+  getPluginByName<P extends SlickPlugin | undefined = undefined>(name: string): P | undefined {
     for (let i = this.plugins.length - 1; i >= 0; i--) {
       if (this.plugins[i]?.pluginName === name) {
         return this.plugins[i] as P;
@@ -1017,7 +1018,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Unregisters a current selection model and registers a new one. See the definition of SelectionModel for more information.
    * @param {Object} selectionModel A SelectionModel.
    */
-  setSelectionModel(model: SelectionModel) {
+  setSelectionModel(model: SelectionModel): void {
     if (this.selectionModel) {
       this.selectionModel.onSelectedRangesChanged.unsubscribe(this.handleSelectedRangesChanged.bind(this));
       if (this.selectionModel.destroy) {
@@ -1033,17 +1034,17 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns the current SelectionModel. See here for more information about SelectionModels. */
-  getSelectionModel() {
+  getSelectionModel(): SelectionModel | undefined {
     return this.selectionModel;
   }
 
   /** Get Grid Canvas Node DOM Element */
-  getCanvasNode(columnIdOrIdx?: number | string, rowIndex?: number) {
+  getCanvasNode(columnIdOrIdx?: number | string, rowIndex?: number): HTMLDivElement {
     return this._getContainerElement(this.getCanvases(), columnIdOrIdx, rowIndex) as HTMLDivElement;
   }
 
   /** Get the canvas DOM element */
-  getActiveCanvasNode(e?: Event | SlickEventData) {
+  getActiveCanvasNode(e?: Event | SlickEventData): HTMLDivElement {
     if (e === undefined) {
       return this._activeCanvasNode;
     }
@@ -1057,28 +1058,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get the canvas DOM element */
-  getCanvases() {
+  getCanvases(): HTMLDivElement[] {
     return this._canvas;
   }
 
   /** Get the Viewport DOM node element */
-  getViewportNode(columnIdOrIdx?: number | string, rowIndex?: number) {
+  getViewportNode(columnIdOrIdx?: number | string, rowIndex?: number): HTMLElement | undefined {
     return this._getContainerElement(this.getViewports(), columnIdOrIdx, rowIndex);
   }
 
   /** Get all the Viewport node elements */
-  getViewports() {
+  getViewports(): HTMLDivElement[] {
     return this._viewport;
   }
 
-  getActiveViewportNode(e: Event | SlickEventData) {
+  getActiveViewportNode(e: Event | SlickEventData): HTMLDivElement {
     this.setActiveViewportNode(e);
 
     return this._activeViewportNode;
   }
 
   /** Sets an active viewport node */
-  setActiveViewportNode(e: Event | SlickEventData) {
+  setActiveViewportNode(e: Event | SlickEventData): HTMLDivElement {
     if (e instanceof SlickEventData) {
       e = e.getNativeEvent<Event>();
     }
@@ -1086,7 +1087,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this._activeViewportNode;
   }
 
-  protected _getContainerElement(targetContainers: HTMLElement[], columnIdOrIdx?: number | string, rowIndex?: number) {
+  protected _getContainerElement(targetContainers: HTMLElement[], columnIdOrIdx?: number | string, rowIndex?: number): HTMLElement | undefined {
     if (!targetContainers) { return; }
     if (!columnIdOrIdx) { columnIdOrIdx = 0; }
     if (!rowIndex) { rowIndex = 0; }
@@ -1099,7 +1100,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return targetContainers[(isBottomSide ? 2 : 0) + (isRightSide ? 1 : 0)];
   }
 
-  protected measureScrollbar() {
+  protected measureScrollbar(): { width: number; height: number; } {
     let className = '';
     this._viewport.forEach(v => className += v.className);
     const outerdiv = createDomElement('div', { className, style: { position: 'absolute', top: '-10000px', left: '-10000px', overflow: 'auto', width: '100px', height: '100px' } }, document.body);
@@ -1114,7 +1115,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get the headers width in pixel */
-  getHeadersWidth() {
+  getHeadersWidth(): number {
     this.headersWidth = this.headersWidthL = this.headersWidthR = 0;
     const includeScrollbar = !this._options.autoHeight;
 
@@ -1184,7 +1185,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return totalRowWidth;
   }
 
-  protected updateCanvasWidth(forceColumnWidthsUpdate?: boolean) {
+  protected updateCanvasWidth(forceColumnWidthsUpdate?: boolean): void {
     const oldCanvasWidth = this.canvasWidth;
     const oldCanvasWidthL = this.canvasWidthL;
     const oldCanvasWidthR = this.canvasWidthR;
@@ -1288,7 +1289,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected disableSelection(target: HTMLElement[]) {
+  protected disableSelection(target: HTMLElement[]): void {
     target.forEach((el) => {
       el.setAttribute('unselectable', 'on');
       (el.style as any).mozUserSelect = 'none';
@@ -1297,7 +1298,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     });
   }
 
-  protected getMaxSupportedCssHeight() {
+  protected getMaxSupportedCssHeight(): number {
     let supportedHeight = 1000000;
     // FF reports the height back but still renders blank after ~6M px
     // let testUpTo = navigator.userAgent.toLowerCase().match(/firefox/) ? 6000000 : 1000000000;
@@ -1324,22 +1325,22 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get grid unique identifier */
-  getUID() {
+  getUID(): string {
     return this.uid;
   }
 
   /** Get Header Column Width Difference in pixel */
-  getHeaderColumnWidthDiff() {
+  getHeaderColumnWidthDiff(): number {
     return this.headerColumnWidthDiff;
   }
 
   /** Get scrollbar dimensions */
-  getScrollbarDimensions() {
+  getScrollbarDimensions(): { height: number; width: number; } | undefined {
     return this.scrollbarDimensions;
   }
 
   /** Get the displayed scrollbar dimensions */
-  getDisplayedScrollbarDimensions() {
+  getDisplayedScrollbarDimensions(): { width: number; height: number; } {
     return {
       width: this.viewportHasVScroll ? (this.scrollbarDimensions?.width || 0) : 0,
       height: this.viewportHasHScroll ? (this.scrollbarDimensions?.height || 0) : 0
@@ -1352,7 +1353,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   // TODO:  this is static. we need to handle page mutation.
-  protected bindAncestorScrollEvents() {
+  protected bindAncestorScrollEvents(): void {
     let elem: HTMLElement | null = (this.hasFrozenRows && !this._options.frozenBottom) ? this._canvasBottomL : this._canvasTopL;
     while ((elem = elem!.parentNode as HTMLElement) !== document.body && elem) {
       // bind to scroll containers only
@@ -1363,7 +1364,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected unbindAncestorScrollEvents() {
+  protected unbindAncestorScrollEvents(): void {
     this._boundAncestors.forEach((ancestor) => {
       this._bindingEventService.unbindByEventName(ancestor, 'scroll');
     });
@@ -1419,7 +1420,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Get the Header DOM element
    * @param {C} columnDef - column definition
    */
-  getHeader(columnDef?: C) {
+  getHeader(columnDef?: C): HTMLDivElement | HTMLDivElement[] {
     if (!columnDef) {
       return this.hasFrozenColumns() ? this._headers : this._headerL;
     }
@@ -1431,7 +1432,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Get a specific Header Column DOM element by its column Id or index
    * @param {Number|String} columnIdOrIdx - column Id or index
    */
-  getHeaderColumn(columnIdOrIdx: number | string) {
+  getHeaderColumn(columnIdOrIdx: number | string): HTMLDivElement {
     const idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
     const targetHeader = this.hasFrozenColumns() ? ((idx <= this._options.frozenColumn!) ? this._headerL : this._headerR) : this._headerL;
     const targetIndex = this.hasFrozenColumns() ? ((idx <= this._options.frozenColumn!) ? idx : idx - this._options.frozenColumn! - 1) : idx;
@@ -1440,32 +1441,32 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get the Header Row DOM element */
-  getHeaderRow() {
+  getHeaderRow(): HTMLDivElement | HTMLDivElement[] {
     return this.hasFrozenColumns() ? this._headerRows : this._headerRows?.[0];
   }
 
   /** Get the Footer DOM element */
-  getFooterRow() {
+  getFooterRow(): HTMLDivElement | HTMLDivElement[] {
     return this.hasFrozenColumns() ? this._footerRow : this._footerRow?.[0];
   }
 
   /** @alias `getPreHeaderPanelLeft` */
-  getPreHeaderPanel() {
+  getPreHeaderPanel(): HTMLDivElement {
     return this._preHeaderPanel;
   }
 
   /** Get the Pre-Header Panel Left DOM node element */
-  getPreHeaderPanelLeft() {
+  getPreHeaderPanelLeft(): HTMLDivElement {
     return this._preHeaderPanel;
   }
 
   /** Get the Pre-Header Panel Right DOM node element */
-  getPreHeaderPanelRight() {
+  getPreHeaderPanelRight(): HTMLDivElement {
     return this._preHeaderPanelR;
   }
 
   /** Get the Top-Header Panel DOM node element */
-  getTopHeaderPanel() {
+  getTopHeaderPanel(): HTMLDivElement {
     return this._topHeaderPanel;
   }
 
@@ -1473,7 +1474,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Get Header Row Column DOM element by its column Id or index
    * @param {Number|String} columnIdOrIdx - column Id or index
    */
-  getHeaderRowColumn(columnIdOrIdx: number | string) {
+  getHeaderRowColumn(columnIdOrIdx: number | string): HTMLDivElement {
     let idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
     let headerRowTarget: HTMLDivElement;
 
@@ -1495,7 +1496,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Get the Footer Row Column DOM element by its column Id or index
    * @param {Number|String} columnIdOrIdx - column Id or index
    */
-  getFooterRowColumn(columnIdOrIdx: number | string) {
+  getFooterRowColumn(columnIdOrIdx: number | string): HTMLDivElement {
     let idx = (typeof columnIdOrIdx === 'number' ? columnIdOrIdx : this.getColumnIndex(columnIdOrIdx));
     let footerRowTarget: HTMLDivElement | null;
 
@@ -1513,7 +1514,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return footerRowTarget?.children[idx] as HTMLDivElement;
   }
 
-  protected createColumnFooter() {
+  protected createColumnFooter(): void {
     if (this._options.createFooterRow) {
       this._footerRow.forEach((footer) => {
         const columnElements = footer.querySelectorAll('.slick-footerrow-column');
@@ -1553,15 +1554,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleHeaderMouseHoverOn(e: Event | SlickEventData) {
+  protected handleHeaderMouseHoverOn(e: Event | SlickEventData): void {
     (e as any)?.target.classList.add('slick-state-hover');
   }
 
-  protected handleHeaderMouseHoverOff(e: Event | SlickEventData) {
+  protected handleHeaderMouseHoverOff(e: Event | SlickEventData): void {
     (e as any)?.target.classList.remove('slick-state-hover');
   }
 
-  protected createColumnHeaders() {
+  protected createColumnHeaders(): void {
     this._headers.forEach((header) => {
       const columnElements = header.querySelectorAll('.slick-header-column');
       columnElements.forEach((column) => {
@@ -1739,7 +1740,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected setupColumnSort() {
+  protected setupColumnSort(): void {
     this._headers.forEach((header) => {
       this._bindingEventService.bind(header, 'click', (e: any) => {
         if (this.columnResizeDragging || e.target.classList.contains('slick-resizable-handle')) {
@@ -1833,7 +1834,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     });
   }
 
-  protected setupColumnReorder() {
+  protected setupColumnReorder(): void {
     this.sortableSideLeftInstance?.destroy();
     this.sortableSideRightInstance?.destroy();
 
@@ -1905,18 +1906,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.sortableSideRightInstance = Sortable.create(this._headerR, sortableOptions);
   }
 
-  protected getHeaderChildren() {
+  protected getHeaderChildren(): HTMLElement[] {
     const a = Array.from(this._headers[0].children);
     const b = Array.from(this._headers[1].children);
     return a.concat(b) as HTMLElement[];
   }
 
-  protected handleResizeableDoubleClick(evt: MouseEvent & { target: HTMLDivElement; }) {
+  protected handleResizeableDoubleClick(evt: MouseEvent & { target: HTMLDivElement; }): void {
     const triggeredByColumn = evt.target.parentElement!.id.replace(this.uid, '');
     this.triggerEvent(this.onColumnsResizeDblClick, { triggeredByColumn });
   }
 
-  protected setupColumnResize() {
+  protected setupColumnResize(): void {
     /* istanbul ignore if */
     if (typeof Resizable === 'undefined') {
       throw new Error(`SlickResizable is undefined, make sure to import "slick.interactions.js"`);
@@ -2242,7 +2243,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected getVBoxDelta(el: HTMLElement) {
+  protected getVBoxDelta(el: HTMLElement): number {
     const p = ['borderTopWidth', 'borderBottomWidth', 'paddingTop', 'paddingBottom'];
     const styles = getComputedStyle(el);
     let delta = 0;
@@ -2250,7 +2251,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return delta;
   }
 
-  protected setFrozenOptions() {
+  protected setFrozenOptions(): void {
     this._options.frozenColumn = (this._options.frozenColumn! >= 0 && this._options.frozenColumn! < this.columns.length)
       ? parseInt(this._options.frozenColumn as unknown as string, 10)
       : -1;
@@ -2268,7 +2269,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected setPaneVisibility() {
+  protected setPaneVisibility(): void {
     if (this.hasFrozenColumns()) {
       Utils.show(this._paneHeaderR);
       Utils.show(this._paneTopR);
@@ -2294,7 +2295,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected setOverflow() {
+  protected setOverflow(): void {
     this._viewportTopL.style.overflowX = (this.hasFrozenColumns()) ? (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'hidden' : 'scroll') : (this.hasFrozenRows && !this._options.alwaysAllowHorizontalScroll ? 'hidden' : 'auto');
     this._viewportTopL.style.overflowY = (!this.hasFrozenColumns() && this._options.alwaysShowVerticalScroll) ? 'scroll' : ((this.hasFrozenColumns()) ? (this.hasFrozenRows ? 'hidden' : 'hidden') : (this.hasFrozenRows ? 'scroll' : 'auto'));
 
@@ -2316,7 +2317,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected setScroller() {
+  protected setScroller(): void {
     if (this.hasFrozenColumns()) {
       this._headerScrollContainer = this._headerScrollerR;
       this._headerRowScrollContainer = this._headerRowScrollerR;
@@ -2350,7 +2351,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected measureCellPaddingAndBorder() {
+  protected measureCellPaddingAndBorder(): void {
     const h = ['borderLeftWidth', 'borderRightWidth', 'paddingLeft', 'paddingRight'];
     const v = ['borderTopWidth', 'borderBottomWidth', 'paddingTop', 'paddingBottom'];
     const header = this._headers[0];
@@ -2378,7 +2379,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.absoluteColumnMinWidth = Math.max(this.headerColumnWidthDiff, this.cellWidthDiff);
   }
 
-  protected createCssRules() {
+  protected createCssRules(): void {
     this._style = document.createElement('style');
     this._style.nonce = this._options.nonce || '';
     (this._options.shadowRoot || document.head).appendChild(this._style);
@@ -2418,7 +2419,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Create CSS rules via template in case the first approach with createElement('style') doesn't work */
   /* istanbul ignore next */
-  protected createCssRulesAlternative(rules: string[]) {
+  protected createCssRulesAlternative(rules: string[]): void {
     const template = document.createElement('template');
     template.innerHTML = '<style type="text/css" rel="stylesheet" />';
     this._style = template.content.firstChild as HTMLStyleElement;
@@ -2438,7 +2439,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected getColumnCssRules(idx: number) {
+  protected getColumnCssRules(idx: number): { left: { selectorText: string; }; right: { selectorText: string; }; } {
     let i: number;
     if (!this.stylesheet) {
       const sheets: any = (this._options.shadowRoot || document).styleSheets;
@@ -2484,13 +2485,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     };
   }
 
-  protected removeCssRules() {
+  protected removeCssRules(): void {
     this._style?.remove();
     this.stylesheet = null;
   }
 
   /** Clear all highlight timers that might have been left opened */
-  protected clearAllTimers() {
+  protected clearAllTimers(): void {
     clearTimeout(this._columnResizeTimer);
     clearTimeout(this._executionBlockTimer);
     clearTimeout(this._flashCellTimer);
@@ -2502,7 +2503,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Destroy (dispose) of SlickGrid
    * @param {boolean} shouldDestroyAllElements - do we want to destroy (nullify) all DOM elements as well? This help in avoiding mem leaks
    */
-  destroy(shouldDestroyAllElements?: boolean) {
+  destroy(shouldDestroyAllElements?: boolean): void {
     this._bindingEventService.unbindAll();
     this.slickDraggableInstance = this.destroyAllInstances(this.slickDraggableInstance) as null;
     this.slickMouseWheelInstances = this.destroyAllInstances(this.slickMouseWheelInstances) as InteractionBase[];
@@ -2599,7 +2600,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * call destroy method, when exists, on all the instance(s) it found
    * @params instances - can be a single instance or a an array of instances
    */
-  protected destroyAllInstances(inputInstances: null | InteractionBase | Array<InteractionBase>) {
+  protected destroyAllInstances(inputInstances: null | InteractionBase | Array<InteractionBase>): InteractionBase[] | null {
     if (inputInstances) {
       const instances = Array.isArray(inputInstances) ? inputInstances : [inputInstances];
       let instance: InteractionBase | undefined;
@@ -2616,7 +2617,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // Column Autosizing
 
-  autosizeColumns() {
+  autosizeColumns(): void {
     this.legacyAutosizeColumns();
   }
 
@@ -2625,7 +2626,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * We could simply rename the method to autosizeColumns() but let's keep separate for now
    * to make it easier to compare against 6pac/SlickGrid fork
    */
-  protected legacyAutosizeColumns() {
+  protected legacyAutosizeColumns(): void {
     let i;
     let c: C | undefined;
     let shrinkLeeway = 0;
@@ -2714,7 +2715,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Apply Columns Widths in the UI and optionally invalidate & re-render the columns when specified
    * @param {Boolean} shouldReRender - should we invalidate and re-render the grid?
    */
-  reRenderColumns(reRender?: boolean) {
+  reRenderColumns(reRender?: boolean): void {
     this.applyColumnHeaderWidths();
     this.updateCanvasWidth(true);
 
@@ -2726,13 +2727,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  getVisibleColumns() {
+  getVisibleColumns(): C[] {
     return this.columns.filter(c => !c.hidden);
   }
 
   // General
 
-  triggerEvent<ArgType = any>(evt: SlickEvent, args?: ArgType, e?: Event | SlickEventData) {
+  triggerEvent<ArgType = any>(evt: SlickEvent, args?: ArgType, e?: Event | SlickEventData): SlickEventData<any> {
     const sed: SlickEventData = (e || new SlickEventData(e, args)) as SlickEventData;
     const eventArgs = (args || {}) as ArgType & { grid: SlickGrid<TData, C, O>; };
     eventArgs.grid = this;
@@ -2745,7 +2746,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get Editor Controller */
-  getEditController() {
+  getEditController(): EditController | undefined {
     return this.editController;
   }
 
@@ -2757,7 +2758,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this.columnsById[id];
   }
 
-  protected applyColumnHeaderWidths() {
+  protected applyColumnHeaderWidths(): void {
     if (this.initialized) {
       let columnIndex = 0;
       const vc = this.getVisibleColumns();
@@ -2776,7 +2777,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected applyColumnWidths() {
+  protected applyColumnWidths(): void {
     let x = 0;
     let w = 0;
     let rule: any;
@@ -2805,7 +2806,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {String | Number} columnId
    * @param {Boolean} ascending
    */
-  setSortColumn(columnId: number | string, ascending: boolean) {
+  setSortColumn(columnId: number | string, ascending: boolean): void {
     this.setSortColumns([{ columnId, sortAsc: ascending }]);
   }
 
@@ -2814,7 +2815,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} id - column index
    * @returns
    */
-  getColumnByIndex(id: number) {
+  getColumnByIndex(id: number): HTMLElement | undefined {
     let result: HTMLElement | undefined;
     this._headers.every((header) => {
       const length = header.children.length;
@@ -2833,7 +2834,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Accepts an array of objects in the form [ { columnId: [string], sortAsc: [boolean] }, ... ]. When called, this will apply a sort glyph in either ascending or descending form to the header of each column specified in the array. Note that this does not actually sort the column. It only adds the sort glyph to the header
    * @param {ColumnSort[]} cols - column sort
    */
-  setSortColumns(cols: ColumnSort[]) {
+  setSortColumns(cols: ColumnSort[]): void {
     this.sortColumns = cols;
 
     const numberCols = this._options.numberedMultiColumnSort && this.sortColumns.length > 1;
@@ -2879,7 +2880,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this.sortColumns;
   }
 
-  protected handleSelectedRangesChanged(e: SlickEventData, ranges: SlickRange[]) {
+  protected handleSelectedRangesChanged(e: SlickEventData, ranges: SlickRange[]): void {
     const ne = e.getNativeEvent<CustomEvent>();
     const previousSelectedRows = this.selectedRows.slice(0); // shallow copy previously selected rows for later comparison
     this.selectedRows = [];
@@ -2916,16 +2917,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   // compare 2 simple arrays (integers or strings only, do not use to compare object arrays)
-  simpleArrayEquals(arr1: any[], arr2: any[]) {
+  simpleArrayEquals(arr1: any[], arr2: any[]): boolean {
     return Array.isArray(arr1) && Array.isArray(arr2) && arr2.sort().toString() !== arr1.sort().toString();
   }
 
   /** Returns an array of column definitions. */
-  getColumns() {
+  getColumns(): C[] {
     return this.columns;
   }
 
-  protected updateColumnCaches() {
+  protected updateColumnCaches(): void {
     // Pre-calculate cell boundaries.
     this.columnPosLeft = [];
     this.columnPosRight = [];
@@ -2944,7 +2945,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected updateColumnProps() {
+  protected updateColumnProps(): void {
     this.columnsById = {};
     for (let i = 0; i < this.columns.length; i++) {
       let m: C = this.columns[i] || {};
@@ -2972,7 +2973,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Sets grid columns. Column headers will be recreated and all rendered rows will be removed. To rerender the grid (if necessary), call render().
    * @param {Column[]} columnDefinitions An array of column definitions.
    */
-  setColumns(columnDefinitions: C[]) {
+  setColumns(columnDefinitions: C[]): void {
     this.triggerEvent(this.onBeforeSetColumns, { previousColumns: this.columns, newColumns: columnDefinitions, grid: this });
     this.columns = columnDefinitions;
     this.updateColumnsInternal();
@@ -2980,12 +2981,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Update columns for when a hidden property has changed but the column list itself has not changed. */
-  updateColumns() {
+  updateColumns(): void {
     this.triggerEvent(this.onBeforeUpdateColumns, { columns: this.columns, grid: this });
     this.updateColumnsInternal();
   }
 
-  protected updateColumnsInternal() {
+  protected updateColumnsInternal(): void {
     this.updateColumnProps();
     this.updateColumnCaches();
 
@@ -3006,7 +3007,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns an object containing all of the Grid options set on the grid. See a list of Grid Options here.  */
-  getOptions() {
+  getOptions(): O {
     return this._options;
   }
 
@@ -3054,7 +3055,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.internal_setOptions(suppressRender, suppressColumnSet, suppressSetOverflow);
   }
 
-  protected prepareForOptionsChange() {
+  protected prepareForOptionsChange(): void {
     if (!this.getEditorLock()?.commitCurrentEdit()) {
       return;
     }
@@ -3113,7 +3114,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {CustomDataView|Array<*>} newData New databinding source using a regular JavaScript array.. or a custom object exposing getItem(index) and getLength() functions.
    * @param {Number} [scrollToTop] If true, the grid will reset the vertical scroll position to the top of the grid.
    */
-  setData(newData: CustomDataView<TData> | TData[], scrollToTop?: boolean) {
+  setData(newData: CustomDataView<TData> | TData[], scrollToTop?: boolean): void {
     this.data = newData;
     this.invalidateAllRows();
     this.updateRowCount();
@@ -3128,7 +3129,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns the size of the databinding source. */
-  getDataLength() {
+  getDataLength(): number {
     if ((this.data as CustomDataView<TData>).getLength) {
       return (this.data as CustomDataView<TData>).getLength();
     } else {
@@ -3136,7 +3137,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected getDataLengthIncludingAddNew() {
+  protected getDataLengthIncludingAddNew(): number {
     return this.getDataLength() + (
       !this._options.enableAddRow
         ? 0
@@ -3157,21 +3158,21 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get Top Panel DOM element */
-  getTopPanel() {
+  getTopPanel(): HTMLDivElement {
     return this._topPanels[0];
   }
 
   /** Get Top Panels (left/right) DOM element */
-  getTopPanels() {
+  getTopPanels(): HTMLDivElement[] {
     return this._topPanels;
   }
 
   /** Are we using a DataView? */
-  hasDataView() {
+  hasDataView(): boolean {
     return !Array.isArray(this.data);
   }
 
-  protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel' | 'showTopHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean) {
+  protected togglePanelVisibility(option: 'showTopPanel' | 'showHeaderRow' | 'showColumnHeader' | 'showFooterRow' | 'showPreHeaderPanel' | 'showTopHeaderPanel', container: HTMLElement | HTMLElement[], visible?: boolean): void {
     if (this._options[option] !== visible) {
       this._options[option] = visible as boolean;
       if (visible) {
@@ -3187,7 +3188,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Set the Top Panel Visibility
    * @param {Boolean} [visible] - optionally set if top panel is visible or not
    */
-  setTopPanelVisibility(visible?: boolean) {
+  setTopPanelVisibility(visible?: boolean): void {
     this.togglePanelVisibility('showTopPanel', this._topPanelScrollers, visible);
   }
 
@@ -3195,7 +3196,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Set the Header Row Visibility
    * @param {Boolean} [visible] - optionally set if header row panel is visible or not
    */
-  setHeaderRowVisibility(visible?: boolean) {
+  setHeaderRowVisibility(visible?: boolean): void {
     this.togglePanelVisibility('showHeaderRow', this._headerRowScroller, visible);
   }
 
@@ -3203,7 +3204,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Set the Column Header Visibility
    * @param {Boolean} [visible] - optionally set if column header is visible or not
    */
-  setColumnHeaderVisibility(visible?: boolean) {
+  setColumnHeaderVisibility(visible?: boolean): void {
     this.togglePanelVisibility('showColumnHeader', this._headerScroller, visible);
   }
 
@@ -3211,7 +3212,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Set the Footer Visibility
    * @param {Boolean} [visible] - optionally set if footer row panel is visible or not
    */
-  setFooterRowVisibility(visible?: boolean) {
+  setFooterRowVisibility(visible?: boolean): void {
     this.togglePanelVisibility('showFooterRow', this._footerRowScroller, visible);
   }
 
@@ -3219,7 +3220,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Set the Pre-Header Visibility
    * @param {Boolean} [visible] - optionally set if pre-header panel is visible or not
    */
-  setPreHeaderPanelVisibility(visible?: boolean) {
+  setPreHeaderPanelVisibility(visible?: boolean): void {
     this.togglePanelVisibility('showPreHeaderPanel', [this._preHeaderPanelScroller, this._preHeaderPanelScrollerR], visible);
   }
 
@@ -3227,22 +3228,22 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Set the Top-Header Visibility
    * @param {Boolean} [visible] - optionally set if top-header panel is visible or not
    */
-  setTopHeaderPanelVisibility(visible?: boolean) {
+  setTopHeaderPanelVisibility(visible?: boolean): void {
     this.togglePanelVisibility('showTopHeaderPanel', this._topHeaderPanelScroller, visible);
   }
 
   /** Get Grid Canvas Node DOM Element */
-  getContainerNode() {
+  getContainerNode(): HTMLElement {
     return this._container;
   }
 
   // Rendering / Scrolling
 
-  protected getRowTop(row: number) {
+  protected getRowTop(row: number): number {
     return this._options.rowHeight! * row - this.offset;
   }
 
-  protected getRowFromPosition(y: number) {
+  protected getRowFromPosition(y: number): number {
     return Math.floor((y + this.offset) / this._options.rowHeight!);
   }
 
@@ -3250,7 +3251,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Scroll to an Y coordinate position in the grid
    * @param {Number} y
    */
-  scrollTo(y: number) {
+  scrollTo(y: number): void {
     y = Math.max(y, 0);
     y = Math.min(y, (this.th || 0) - (Utils.height(this._viewportScrollContainerY) as number) + ((this.viewportHasHScroll || this.hasFrozenColumns()) ? (this.scrollbarDimensions?.height || 0) : 0));
 
@@ -3285,7 +3286,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected defaultFormatter(_row: number, _cell: number, value: any) {
+  protected defaultFormatter(_row: number, _cell: number, value: any): string {
     if (!isDefined(value)) {
       return '';
     } else {
@@ -3322,14 +3323,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return (column.editorClass || (this._options?.editorFactory?.getEditor(column)));
   }
 
-  protected getDataItemValueForColumn(item: TData, columnDef: C) {
+  protected getDataItemValueForColumn(item: TData, columnDef: C): TData | TData[keyof TData] {
     if (this._options.dataItemColumnValueExtractor) {
       return this._options.dataItemColumnValueExtractor(item, columnDef) as TData;
     }
     return item[columnDef.field as keyof TData];
   }
 
-  protected appendRowHtml(divArrayL: HTMLElement[], divArrayR: HTMLElement[], row: number, range: CellViewportRange, dataLength: number) {
+  protected appendRowHtml(divArrayL: HTMLElement[], divArrayR: HTMLElement[], row: number, range: CellViewportRange, dataLength: number): void {
     const d = this.getDataItem(row);
     const dataLoading = row < dataLength && !d;
     let rowCss = 'slick-row' +
@@ -3398,7 +3399,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected appendCellHtml(divRow: HTMLElement, row: number, cell: number, colspan: number, item: TData) {
+  protected appendCellHtml(divRow: HTMLElement, row: number, cell: number, colspan: number, item: TData): void {
     // divRow: the html element to append items too
     // row, cell: row and column index
     // colspan: HTML colspan
@@ -3477,7 +3478,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.rowsCache[row].cellColSpans[cell] = colspan;
   }
 
-  protected cleanupRows(rangeToKeep: { bottom: number; top: number; }) {
+  protected cleanupRows(rangeToKeep: { bottom: number; top: number; }): void {
     Object.keys(this.rowsCache).forEach(rowId => {
       if (this.rowsCache) {
         let i = +rowId;
@@ -3505,14 +3506,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Invalidate all grid rows and re-render the grid rows */
-  invalidate() {
+  invalidate(): void {
     this.updateRowCount();
     this.invalidateAllRows();
     this.render();
   }
 
   /** Invalidate all grid rows */
-  invalidateAllRows() {
+  invalidateAllRows(): void {
     if (this.currentEditor) {
       this.makeActiveCellNormal();
     }
@@ -3534,7 +3535,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Invalidate a specific set of row numbers
    * @param {Number[]} rows
    */
-  invalidateRows(rows: number[]) {
+  invalidateRows(rows: number[]): void {
     if (rows?.length) {
       this.vScrollDir = 0;
       const rl = rows.length;
@@ -3556,13 +3557,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Invalidate a specific row number
    * @param {Number} row
    */
-  invalidateRow(row: number) {
+  invalidateRow(row: number): void {
     if (row >= 0) {
       this.invalidateRows([row]);
     }
   }
 
-  protected queuePostProcessedRowForCleanup(cacheEntry: RowCaching, postProcessedRow: any, rowIdx: number) {
+  protected queuePostProcessedRowForCleanup(cacheEntry: RowCaching, postProcessedRow: any, rowIdx: number): void {
     this.postProcessgroupId++;
 
     // store and detach node for later async cleanup
@@ -3592,7 +3593,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     cacheEntry.rowNode?.forEach((node) => node.remove());
   }
 
-  protected queuePostProcessedCellForCleanup(cellnode: HTMLElement, columnIdx: number, rowIdx: number) {
+  protected queuePostProcessedCellForCleanup(cellnode: HTMLElement, columnIdx: number, rowIdx: number): void {
     this.postProcessedCleanupQueue.push({
       actionType: 'C',
       groupId: this.postProcessgroupId,
@@ -3603,7 +3604,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     cellnode.remove();
   }
 
-  protected removeRowFromCache(row: number) {
+  protected removeRowFromCache(row: number): void {
     const cacheEntry = this.rowsCache[row];
     if (cacheEntry?.rowNode) {
       if (this._options.enableAsyncPostRenderCleanup && this.postProcessedRows[row]) {
@@ -3620,7 +3621,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Apply a Formatter Result to a Cell DOM Node */
-  applyFormatResultToCellNode(formatterResult: FormatterResultWithHtml | FormatterResultWithText | string | HTMLElement | DocumentFragment, cellNode: HTMLElement, suppressRemove?: boolean) {
+  applyFormatResultToCellNode(formatterResult: FormatterResultWithHtml | FormatterResultWithText | string | HTMLElement | DocumentFragment, cellNode: HTMLElement, suppressRemove?: boolean): void {
     if (formatterResult === null || formatterResult === undefined) {
       formatterResult = '';
     }
@@ -3648,7 +3649,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - grid row number
    * @param {Number} cell - grid cell column number
    */
-  updateCell(row: number, cell: number) {
+  updateCell(row: number, cell: number): void {
     const cellNode = this.getCellNode(row, cell);
     if (cellNode) {
       const m = this.columns[cell];
@@ -3667,7 +3668,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Update a specific row by its row index
    * @param {Number} row - grid row number
    */
-  updateRow(row: number) {
+  updateRow(row: number): void {
     const cacheEntry = this.rowsCache[row];
     if (!cacheEntry) {
       return;
@@ -3707,13 +3708,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * the viewport must also be displayed for this calculation to work.
    * @return {Number} rowCount
    */
-  getViewportRowCount() {
+  getViewportRowCount(): number {
     const vh = this.getViewportHeight();
     const scrollbarHeight = this.getScrollbarDimensions()?.height || 0;
     return Math.floor((vh - scrollbarHeight) / this._options.rowHeight!);
   }
 
-  getViewportHeight() {
+  getViewportHeight(): number {
     if (!this._options.autoHeight || this._options.frozenColumn !== -1) {
       this.topPanelH = (this._options.showTopPanel) ? this._options.topPanelHeight! + this.getVBoxDelta(this._topPanelScrollers[0]) : 0;
       this.headerRowH = (this._options.showHeaderRow) ? this._options.headerRowHeight! + this.getVBoxDelta(this._headerRowScroller[0]) : 0;
@@ -3750,13 +3751,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this.viewportH;
   }
 
-  getViewportWidth() {
+  getViewportWidth(): number {
     this.viewportW = parseFloat(getInnerSize(this._container, 'width') as unknown as string) || (this._options.devMode && this._options.devMode.containerClientWidth) || 0;
     return this.viewportW;
   }
 
   /** Execute a Resize of the Grid Canvas */
-  resizeCanvas() {
+  resizeCanvas(): void {
     if (this.initialized) {
       this.paneTopH = 0;
       this.paneBottomH = 0;
@@ -3877,13 +3878,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Update paging information status from the View
    * @param {PagingInfo} pagingInfo
    */
-  updatePagingStatusFromView(pagingInfo: Pick<PagingInfo, 'pageSize' | 'pageNum' | 'totalPages'>) {
+  updatePagingStatusFromView(pagingInfo: Pick<PagingInfo, 'pageSize' | 'pageNum' | 'totalPages'>): void {
     this.pagingActive = (pagingInfo.pageSize !== 0);
     this.pagingIsLastPage = (pagingInfo.pageNum === pagingInfo.totalPages - 1);
   }
 
   /** Update the dataset row count */
-  updateRowCount() {
+  updateRowCount(): void {
     if (this.initialized) {
       const dataLength = this.getDataLength();
       const dataLengthIncludingAddNew = this.getDataLengthIncludingAddNew();
@@ -3982,11 +3983,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** @alias `getVisibleRange` */
-  getViewport(viewportTop?: number, viewportLeft?: number) {
+  getViewport(viewportTop?: number, viewportLeft?: number): CellViewportRange {
     return this.getVisibleRange(viewportTop, viewportLeft);
   }
 
-  getVisibleRange(viewportTop?: number, viewportLeft?: number) {
+  getVisibleRange(viewportTop?: number, viewportLeft?: number): CellViewportRange {
     viewportTop ??= this.scrollTop;
     viewportLeft ??= this.scrollLeft;
 
@@ -3999,7 +4000,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Get rendered range */
-  getRenderedRange(viewportTop?: number, viewportLeft?: number) {
+  getRenderedRange(viewportTop?: number, viewportLeft?: number): CellViewportRange {
     const range = this.getVisibleRange(viewportTop, viewportLeft);
     const buffer = Math.round(this.viewportH / this._options.rowHeight!);
     const minBuffer = this._options.minRowBuffer as number;
@@ -4027,7 +4028,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return range;
   }
 
-  protected ensureCellNodesInRowsCache(row: number) {
+  protected ensureCellNodesInRowsCache(row: number): void {
     const cacheEntry = this.rowsCache[row];
     if (cacheEntry?.cellRenderQueue.length && cacheEntry.rowNode?.length) {
       const rowNode = cacheEntry.rowNode as HTMLElement[];
@@ -4044,7 +4045,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected cleanUpCells(range: CellViewportRange, row: number) {
+  protected cleanUpCells(range: CellViewportRange, row: number): void {
     // Ignore frozen rows
     if (this.hasFrozenRows
       && ((this._options.frozenBottom && row > this.actualFrozenRow) // Frozen bottom rows
@@ -4109,7 +4110,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected cleanUpAndRenderCells(range: CellViewportRange) {
+  protected cleanUpAndRenderCells(range: CellViewportRange): void {
     let cacheEntry;
     const divRow: HTMLElement = document.createElement('div');
     const processedRows: number[] = [];
@@ -4201,7 +4202,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected renderRows(range: { top: number; bottom: number; leftPx: number; rightPx: number; }) {
+  protected renderRows(range: { top: number; bottom: number; leftPx: number; rightPx: number; }): void {
     const divArrayL: HTMLElement[] = [];
     const divArrayR: HTMLElement[] = [];
     const rows: number[] = [];
@@ -4280,7 +4281,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected startPostProcessing() {
+  protected startPostProcessing(): void {
     if (!this._options.enableAsyncPostRender) {
       return;
     }
@@ -4288,14 +4289,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.h_postrender = setTimeout(this.asyncPostProcessRows.bind(this), this._options.asyncPostRenderDelay);
   }
 
-  protected startPostProcessingCleanup() {
+  protected startPostProcessingCleanup(): void {
     if (this._options.enableAsyncPostRenderCleanup) {
       clearTimeout(this.h_postrenderCleanup);
       this.h_postrenderCleanup = setTimeout(this.asyncPostProcessCleanupRows.bind(this), this._options.asyncPostRenderCleanupDelay);
     }
   }
 
-  protected invalidatePostProcessingResults(row: number) {
+  protected invalidatePostProcessingResults(row: number): void {
     // change status of columns to be re-rendered
     if (typeof this.postProcessedRows[row] === 'object') {
       Object.keys(this.postProcessedRows[row]).forEach(columnIdx => {
@@ -4309,7 +4310,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.startPostProcessing();
   }
 
-  protected updateRowPositions() {
+  protected updateRowPositions(): void {
     if (this.rowsCache && typeof this.rowsCache === 'object') {
       Object.keys(this.rowsCache).forEach(row => {
         const rowNumber = row ? parseInt(row, 10) : 0;
@@ -4319,7 +4320,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** (re)Render the grid */
-  render() {
+  render(): void {
     if (this.initialized) {
       this.scrollThrottle.dequeue();
 
@@ -4373,42 +4374,42 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleHeaderRowScroll() {
+  protected handleHeaderRowScroll(): void {
     const scrollLeft = this._headerRowScrollContainer.scrollLeft;
     if (scrollLeft !== this._viewportScrollContainerX.scrollLeft) {
       this._viewportScrollContainerX.scrollLeft = scrollLeft;
     }
   }
 
-  protected handleFooterRowScroll() {
+  protected handleFooterRowScroll(): void {
     const scrollLeft = this._footerRowScrollContainer.scrollLeft;
     if (scrollLeft !== this._viewportScrollContainerX.scrollLeft) {
       this._viewportScrollContainerX.scrollLeft = scrollLeft;
     }
   }
 
-  protected handlePreHeaderPanelScroll() {
+  protected handlePreHeaderPanelScroll(): void {
     this.handleElementScroll(this._preHeaderPanelScroller);
   }
 
-  protected handleTopHeaderPanelScroll() {
+  protected handleTopHeaderPanelScroll(): void {
     this.handleElementScroll(this._topHeaderPanelScroller);
   }
 
-  protected handleElementScroll(element: HTMLElement) {
+  protected handleElementScroll(element: HTMLElement): void {
     const scrollLeft = element.scrollLeft;
     if (scrollLeft !== this._viewportScrollContainerX.scrollLeft) {
       this._viewportScrollContainerX.scrollLeft = scrollLeft;
     }
   }
 
-  protected handleScroll() {
+  protected handleScroll(): boolean {
     this.scrollTop = this._viewportScrollContainerY.scrollTop;
     this.scrollLeft = this._viewportScrollContainerX.scrollLeft;
     return this._handleScroll(false);
   }
 
-  protected _handleScroll(isMouseWheel: boolean) {
+  protected _handleScroll(isMouseWheel: boolean): boolean {
     let maxScrollDistanceY = this._viewportScrollContainerY.scrollHeight - this._viewportScrollContainerY.clientHeight;
     let maxScrollDistanceX = this._viewportScrollContainerY.scrollWidth - this._viewportScrollContainerY.clientWidth;
 
@@ -4527,7 +4528,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * call enqueue to execute the action - it will execute either immediately or, if it was executed less than minPeriod_ms in the past, as soon as minPeriod_ms has expired.
    * call dequeue to cancel any pending action.
    */
-  protected actionThrottle(action: () => void, minPeriod_ms: number) {
+  protected actionThrottle(action: () => void, minPeriod_ms: number): { enqueue: () => void; dequeue: () => void; } {
     let blocked = false;
     let queued = false;
 
@@ -4565,7 +4566,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     };
   }
 
-  protected asyncPostProcessRows() {
+  protected asyncPostProcessRows(): void {
     const dataLength = this.getDataLength();
     while (this.postProcessFromRow <= this.postProcessToRow) {
       const row = (this.vScrollDir >= 0) ? this.postProcessFromRow++ : this.postProcessToRow--;
@@ -4599,7 +4600,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected asyncPostProcessCleanupRows() {
+  protected asyncPostProcessCleanupRows(): void {
     if (this.postProcessedCleanupQueue.length > 0) {
       const groupId = this.postProcessedCleanupQueue[0].groupId;
 
@@ -4625,7 +4626,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected updateCellCssStylesOnRenderedRows(addedHash?: CssStyleHash | null, removedHash?: CssStyleHash | null) {
+  protected updateCellCssStylesOnRenderedRows(addedHash?: CssStyleHash | null, removedHash?: CssStyleHash | null): void {
     let node: HTMLElement | null;
     let addedRowHash: any;
     let removedRowHash: any;
@@ -4671,7 +4672,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * 	 4: { percent_column: SlickEvent; }
    * }`
    */
-  addCellCssStyles(key: string, hash: CssStyleHash) {
+  addCellCssStyles(key: string, hash: CssStyleHash): void {
     if (this.cellCssClasses[key]) {
       throw new Error(`SlickGrid addCellCssStyles: cell CSS hash with key "${key}" already exists.`);
     }
@@ -4685,7 +4686,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Removes an "overlay" of CSS classes from cell DOM elements. See setCellCssStyles for more.
    * @param {String} key A string key.
    */
-  removeCellCssStyles(key: string) {
+  removeCellCssStyles(key: string): void {
     if (!this.cellCssClasses[key]) {
       return;
     }
@@ -4703,7 +4704,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {String} key A string key. Will overwrite any data already associated with this key.
    * @param {Object} hash A hash of additional cell CSS classes keyed by row number and then by column id. Multiple CSS classes can be specified and separated by space.
    */
-  setCellCssStyles(key: string, hash: CssStyleHash) {
+  setCellCssStyles(key: string, hash: CssStyleHash): void {
     const prevHash = this.cellCssClasses[key];
 
     this.cellCssClasses[key] = hash;
@@ -4725,7 +4726,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} cell A column index.
    * @param {Number} [speed] (optional) - The milliseconds delay between the toggling calls. Defaults to 250 ms.
    */
-  flashCell(row: number, cell: number, speed = 250) {
+  flashCell(row: number, cell: number, speed = 250): void {
     const toggleCellClass = (cellNode: HTMLElement, times: number) => {
       if (times < 1) {
         return;
@@ -4755,7 +4756,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - grid row number
    * @param {Number} [duration] - duration (ms), defaults to 400ms
    */
-  highlightRow(row: number, duration?: number) {
+  highlightRow(row: number, duration?: number): void {
     const rowCache = this.rowsCache[row];
     duration ||= this._options.rowHighlightDuration;
 
@@ -4770,7 +4771,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // Interactivity
 
-  protected handleMouseWheel(e: MouseEvent, _delta: number, deltaX: number, deltaY: number) {
+  protected handleMouseWheel(e: MouseEvent, _delta: number, deltaX: number, deltaY: number): void {
     this.scrollTop = Math.max(0, this._viewportScrollContainerY.scrollTop - (deltaY * this._options.rowHeight!));
     this.scrollLeft = this._viewportScrollContainerX.scrollLeft + (deltaX * 10);
     const handled = this._handleScroll(true);
@@ -4779,7 +4780,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleDragInit(e: DragEvent, dd: DragPosition) {
+  protected handleDragInit(e: DragEvent, dd: DragPosition): boolean {
     const cell = this.getCellFromEvent(e);
     if (!cell || !this.cellExists(cell.row, cell.cell)) {
       return false;
@@ -4795,7 +4796,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return false;
   }
 
-  protected handleDragStart(e: DragEvent, dd: DragPosition) {
+  protected handleDragStart(e: DragEvent, dd: DragPosition): boolean {
     const cell = this.getCellFromEvent(e);
     if (!cell || !this.cellExists(cell.row, cell.cell)) {
       return false;
@@ -4809,15 +4810,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return false;
   }
 
-  protected handleDrag(e: DragEvent, dd: DragPosition) {
+  protected handleDrag(e: DragEvent, dd: DragPosition): void {
     return this.triggerEvent(this.onDrag, dd, e).getReturnValue();
   }
 
-  protected handleDragEnd(e: DragEvent, dd: DragPosition) {
+  protected handleDragEnd(e: DragEvent, dd: DragPosition): void {
     this.triggerEvent(this.onDragEnd, dd, e);
   }
 
-  protected handleKeyDown(e: KeyboardEvent & { originalEvent: Event; }) {
+  protected handleKeyDown(e: KeyboardEvent & { originalEvent: Event; }): void {
     const retval = this.triggerEvent(this.onKeyDown, { row: this.activeRow, cell: this.activeCell }, e);
     let handled: boolean | undefined | void = retval.isImmediatePropagationStopped();
 
@@ -4888,7 +4889,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleClick(evt: DOMEvent<HTMLDivElement> | SlickEventData) {
+  protected handleClick(evt: DOMEvent<HTMLDivElement> | SlickEventData): void {
     const e = evt instanceof SlickEventData ? evt.getNativeEvent() : evt;
 
     if (!this.currentEditor) {
@@ -4926,7 +4927,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleContextMenu(e: Event & { target: HTMLElement; }) {
+  protected handleContextMenu(e: Event & { target: HTMLElement; }): void {
     const cell = e.target.closest('.slick-cell');
     if (!cell) {
       return;
@@ -4940,7 +4941,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onContextMenu, {}, e);
   }
 
-  protected handleDblClick(e: MouseEvent) {
+  protected handleDblClick(e: MouseEvent): void {
     const cell = this.getCellFromEvent(e);
     if (!cell || (this.currentEditor !== null && this.activeRow === cell.row && this.activeCell === cell.cell)) {
       return;
@@ -4956,7 +4957,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleHeaderMouseEnter(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderMouseEnter(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-header-column'), 'column');
     if (!c) {
       return;
@@ -4964,7 +4965,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderMouseEnter, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderMouseOver(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderMouseOver(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-header-column'), 'column');
     if (!c) {
       return;
@@ -4972,7 +4973,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderMouseOver, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderMouseLeave(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderMouseLeave(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-header-column'), 'column');
     if (!c) {
       return;
@@ -4980,7 +4981,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderMouseLeave, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderMouseOut(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderMouseOut(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-header-column'), 'column');
     if (!c) {
       return;
@@ -4988,7 +4989,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderMouseOut, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderRowMouseEnter(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderRowMouseEnter(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-headerrow-column'), 'column');
     if (!c) {
       return;
@@ -4996,7 +4997,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderRowMouseEnter, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderRowMouseOver(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderRowMouseOver(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-headerrow-column'), 'column');
     if (!c) {
       return;
@@ -5004,7 +5005,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderRowMouseOver, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderRowMouseLeave(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderRowMouseLeave(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-headerrow-column'), 'column');
     if (!c) {
       return;
@@ -5012,7 +5013,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderRowMouseLeave, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderRowMouseOut(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderRowMouseOut(e: MouseEvent & { target: HTMLElement; }): void {
     const c = Utils.storage.get(e.target.closest('.slick-headerrow-column'), 'column');
     if (!c) {
       return;
@@ -5020,13 +5021,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.triggerEvent(this.onHeaderRowMouseOut, { column: c, grid: this }, e);
   }
 
-  protected handleHeaderContextMenu(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderContextMenu(e: MouseEvent & { target: HTMLElement; }): void {
     const header = e.target.closest('.slick-header-column');
     const column = header && Utils.storage.get(header, 'column');
     this.triggerEvent(this.onHeaderContextMenu, { column }, e);
   }
 
-  protected handleHeaderClick(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleHeaderClick(e: MouseEvent & { target: HTMLElement; }): void {
     if (this.columnResizeDragging) {
       return;
     }
@@ -5038,27 +5039,27 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected handleFooterContextMenu(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleFooterContextMenu(e: MouseEvent & { target: HTMLElement; }): void {
     const footer = e.target.closest('.slick-footerrow-column');
     const column = footer && Utils.storage.get(footer, 'column');
     this.triggerEvent(this.onFooterContextMenu, { column }, e);
   }
 
-  protected handleFooterClick(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleFooterClick(e: MouseEvent & { target: HTMLElement; }): void {
     const footer = e.target.closest('.slick-footerrow-column');
     const column = footer && Utils.storage.get(footer, 'column');
     this.triggerEvent(this.onFooterClick, { column }, e);
   }
 
-  protected handleCellMouseOver(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleCellMouseOver(e: MouseEvent & { target: HTMLElement; }): void {
     this.triggerEvent(this.onMouseEnter, {}, e);
   }
 
-  protected handleCellMouseOut(e: MouseEvent & { target: HTMLElement; }) {
+  protected handleCellMouseOut(e: MouseEvent & { target: HTMLElement; }): void {
     this.triggerEvent(this.onMouseLeave, {}, e);
   }
 
-  protected cellExists(row: number, cell: number) {
+  protected cellExists(row: number, cell: number): boolean {
     return !(row < 0 || row >= this.getDataLength() || cell < 0 || cell >= this.columns.length);
   }
 
@@ -5068,7 +5069,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param x An x coordinate.
    * @param y A y coordinate.
    */
-  getCellFromPoint(x: number, y: number) {
+  getCellFromPoint(x: number, y: number): { row: number; cell: number; } {
     let row = this.getRowFromPosition(y);
     let cell = 0;
 
@@ -5090,7 +5091,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return { row, cell };
   }
 
-  protected getCellFromNode(cellNode: HTMLElement) {
+  protected getCellFromNode(cellNode: HTMLElement): number {
     // read column number from .l<columnNumber> CSS class
     const cls = /l\d+/.exec(cellNode.className);
     if (!cls) {
@@ -5116,7 +5117,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Get frozen (pinned) row offset
    * @param {Number} row - grid row number
    */
-  getFrozenRowOffset(row: number) {
+  getFrozenRowOffset(row: number): number {
     // let offset = ( hasFrozenRows ) ? ( this._options.frozenBottom ) ? ( row >= actualFrozenRow ) ? ( h < viewportTopH ) ? ( actualFrozenRow * this._options.rowHeight ) : h : 0 : ( row >= actualFrozenRow ) ? frozenRowsHeight : 0 : 0; // WTF?
     let offset = 0;
     if (this.hasFrozenRows) {
@@ -5149,7 +5150,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Returns row and cell indexes by providing a standard W3C event.
    * @param {*} event A standard W3C event.
    */
-  getCellFromEvent(evt: Event | SlickEventData) {
+  getCellFromEvent(evt: Event | SlickEventData): { row: number; cell: number; } | null {
     const e = evt instanceof SlickEventData ? evt.getNativeEvent() : evt;
     if (!e) {
       return null;
@@ -5191,7 +5192,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - A row number.
    * @param {Number} cell - A column number.
    */
-  getCellNodeBox(row: number, cell: number) {
+  getCellNodeBox(row: number, cell: number): { top: number; left: number; bottom: number; right: number; } | null {
     if (!this.cellExists(row, cell)) {
       return null;
     }
@@ -5225,16 +5226,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // Cell switching
 
   /**  Resets active cell. */
-  resetActiveCell() {
+  resetActiveCell(): void {
     this.setActiveCellInternal(null, false);
   }
 
   /** @alias `setFocus` */
-  focus() {
+  focus(): void {
     this.setFocus();
   }
 
-  protected setFocus() {
+  protected setFocus(): void {
     if (this.tabbingDirection === -1) {
       this._focusSink.focus();
     } else {
@@ -5243,7 +5244,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Scroll to a specific cell and make it into the view */
-  scrollCellIntoView(row: number, cell: number, doPaging?: boolean) {
+  scrollCellIntoView(row: number, cell: number, doPaging?: boolean): void {
     this.scrollRowIntoView(row, doPaging);
 
     if (cell <= this._options.frozenColumn!) {
@@ -5254,7 +5255,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.internalScrollColumnIntoView(this.columnPosLeft[cell], this.columnPosRight[cell + (colspan > 1 ? colspan - 1 : 0)]);
   }
 
-  protected internalScrollColumnIntoView(left: number, right: number) {
+  protected internalScrollColumnIntoView(left: number, right: number): void {
     const scrollRight = this.scrollLeft + (Utils.width(this._viewportScrollContainerX) as number) - (this.viewportHasVScroll ? (this.scrollbarDimensions?.width || 0) : 0);
 
     if (left < this.scrollLeft) {
@@ -5272,11 +5273,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Scroll to a specific column and show it into the viewport
    * @param {Number} cell - cell column number
    */
-  scrollColumnIntoView(cell: number) {
+  scrollColumnIntoView(cell: number): void {
     this.internalScrollColumnIntoView(this.columnPosLeft[cell], this.columnPosRight[cell]);
   }
 
-  protected setActiveCellInternal(newCell: HTMLDivElement | null, opt_editMode?: boolean | null, preClickModeOn?: boolean | null, suppressActiveCellChangedEvent?: boolean, e?: Event | SlickEvent) {
+  protected setActiveCellInternal(newCell: HTMLDivElement | null, opt_editMode?: boolean | null, preClickModeOn?: boolean | null, suppressActiveCellChangedEvent?: boolean, e?: Event | SlickEvent): void {
     if (isDefined(this.activeCellNode)) {
       this.makeActiveCellNormal();
       this.activeCellNode.classList.remove('active');
@@ -5332,7 +5333,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // }
   }
 
-  protected clearTextSelection() {
+  protected clearTextSelection(): void {
     if ((document as any).selection?.empty) {
       try {
         // IE fails here if selected element is not in DOM
@@ -5347,7 +5348,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected isCellPotentiallyEditable(row: number, cell: number) {
+  protected isCellPotentiallyEditable(row: number, cell: number): boolean {
     const dataLength = this.getDataLength();
     // is the data for this row actually loaded?
     if (row < dataLength && !this.getDataItem(row)) {
@@ -5372,7 +5373,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * we can also optionally refocus on the current active cell (again possibly after closing cell editor)
    * @param {Boolean} [refocusActiveCell]
    */
-  protected makeActiveCellNormal(refocusActiveCell = false) {
+  protected makeActiveCellNormal(refocusActiveCell = false): void {
     if (!this.currentEditor) {
       return;
     }
@@ -5406,11 +5407,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
 
-  editActiveCell(editor: Editor | EditorConstructor, preClickModeOn?: boolean | null, e?: Event) {
+  editActiveCell(editor: Editor | EditorConstructor, preClickModeOn?: boolean | null, e?: Event): void {
     this.makeActiveCellEditable(editor, preClickModeOn, e);
   }
 
-  protected makeActiveCellEditable(editor?: Editor | EditorConstructor, preClickModeOn?: boolean | null, e?: Event | SlickEvent) {
+  protected makeActiveCellEditable(editor?: Editor | EditorConstructor, preClickModeOn?: boolean | null, e?: Event | SlickEvent): void {
     if (!this.activeCellNode) {
       return;
     }
@@ -5479,7 +5480,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected commitEditAndSetFocus() {
+  protected commitEditAndSetFocus(): void {
     // if the commit fails, it would do so due to a validation error
     // if so, do not steal the focus from the editor
     if (this.getEditorLock()?.commitCurrentEdit()) {
@@ -5490,13 +5491,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected cancelEditAndSetFocus() {
+  protected cancelEditAndSetFocus(): void {
     if (this.getEditorLock()?.cancelCurrentEdit()) {
       this.setFocus();
     }
   }
 
-  protected absBox(elem: HTMLElement) {
+  protected absBox(elem: HTMLElement): ElementPosition {
     const box = {
       top: elem.offsetTop,
       left: elem.offsetLeft,
@@ -5542,16 +5543,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns an object representing information about the active cell's position. All coordinates are absolute and take into consideration the visibility and scrolling position of all ancestors. */
-  getActiveCellPosition() {
+  getActiveCellPosition(): ElementPosition {
     return this.absBox(this.activeCellNode as HTMLElement);
   }
 
   /** Get the Grid Position */
-  getGridPosition() {
+  getGridPosition(): ElementPosition {
     return this.absBox(this._container);
   }
 
-  protected handleActiveCellPositionChange() {
+  protected handleActiveCellPositionChange(): void {
     if (this.activeCellNode) {
       this.triggerEvent(this.onActiveCellPositionChanged, {});
 
@@ -5573,7 +5574,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns the active cell editor. If there is no actively edited cell, null is returned.   */
-  getCellEditor() {
+  getCellEditor(): Editor | null {
     return this.currentEditor;
   }
 
@@ -5581,7 +5582,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Returns an object representing the coordinates of the currently active cell:
    * @example	`{ row: activeRow, cell: activeCell }`
    */
-  getActiveCell() {
+  getActiveCell(): { row: number; cell: number; } | null {
     if (!this.activeCellNode) {
       return null;
     }
@@ -5589,13 +5590,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns the DOM element containing the currently active cell. If no cell is active, null is returned. */
-  getActiveCellNode() {
+  getActiveCellNode(): HTMLDivElement | null {
     return this.activeCellNode;
   }
 
   // This get/set methods are used for keeping text-selection. These don't consider IE because they don't loose text-selection.
   // Fix for firefox selection. See https://github.com/mleibman/SlickGrid/pull/746/files
-  protected getTextSelection() {
+  protected getTextSelection(): Range | null {
     let textSelection: Range | null = null;
     if (window.getSelection) {
       const selection = window.getSelection();
@@ -5606,7 +5607,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return textSelection;
   }
 
-  protected setTextSelection(selection: Range) {
+  protected setTextSelection(selection: Range): void {
     if (window.getSelection && selection) {
       const target = window.getSelection();
       if (target) {
@@ -5621,7 +5622,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - grid row number
    * @param {Boolean} doPaging - scroll when pagination is enabled
    */
-  scrollRowIntoView(row: number, doPaging?: boolean) {
+  scrollRowIntoView(row: number, doPaging?: boolean): void {
     if (!this.hasFrozenRows ||
       (!this._options.frozenBottom && row > this.actualFrozenRow - 1) ||
       (this._options.frozenBottom && row < this.actualFrozenRow - 1)) {
@@ -5654,12 +5655,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * Scroll to the top row and make it into the view
    * @param {Number} row - grid row number
    */
-  scrollRowToTop(row: number) {
+  scrollRowToTop(row: number): void {
     this.scrollTo(row * this._options.rowHeight!);
     this.render();
   }
 
-  protected scrollPage(dir: number) {
+  protected scrollPage(dir: number): void {
     const deltaRows = dir * this.numVisibleRows;
     /// First fully visible row crosses the line with
     /// y === bottomOfTopmostFullyVisibleRow
@@ -5697,26 +5698,26 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Navigate (scroll) by a page down */
-  navigatePageDown() {
+  navigatePageDown(): void {
     this.scrollPage(1);
   }
 
   /** Navigate (scroll) by a page up */
-  navigatePageUp() {
+  navigatePageUp(): void {
     this.scrollPage(-1);
   }
 
   /** Navigate to the top of the grid */
-  navigateTop() {
+  navigateTop(): void {
     this.navigateToRow(0);
   }
 
   /** Navigate to the bottom of the grid */
-  navigateBottom() {
+  navigateBottom(): boolean {
     return this.navigateToRow(this.getDataLength() - 1);
   }
 
-  protected navigateToRow(row: number) {
+  protected navigateToRow(row: number): boolean {
     const num_rows = this.getDataLength();
     if (!num_rows) {
       return true;
@@ -5768,7 +5769,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return colspan as number;
   }
 
-  protected findFirstFocusableCell(row: number) {
+  protected findFirstFocusableCell(row: number): number | null {
     let cell = 0;
     while (cell < this.columns.length) {
       if (this.canCellBeActive(row, cell)) {
@@ -5779,7 +5780,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return null;
   }
 
-  protected findLastFocusableCell(row: number) {
+  protected findLastFocusableCell(row: number): number | null {
     let cell = 0;
     let lastFocusableCell: number | null = null;
     while (cell < this.columns.length) {
@@ -5791,7 +5792,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return lastFocusableCell;
   }
 
-  protected gotoRight(row: number, cell: number, _posX?: number) {
+  protected gotoRight(row: number, cell: number, _posX?: number): { row: number; cell: number; posX: number; } | null {
     /* istanbul ignore if */
     if (cell >= this.columns.length) {
       return null;
@@ -5896,7 +5897,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
-  protected gotoNext(row: number, cell: number, posX?: number) {
+  protected gotoNext(row: number, cell: number, posX?: number): { row: number; cell: number; posX: number; } | null {
     if (!isDefinedNumber(row) && !isDefinedNumber(cell)) {
       row = cell = posX = 0;
       if (this.canCellBeActive(row, cell)) {
@@ -5934,7 +5935,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return null;
   }
 
-  protected gotoPrev(row: number, cell: number, posX?: number) {
+  protected gotoPrev(row: number, cell: number, posX?: number): { row: number; cell: number; posX: number; } | null {
     if (!isDefinedNumber(row) && !isDefinedNumber(cell)) {
       row = this.getDataLengthIncludingAddNew() - 1;
       cell = posX = this.columns.length - 1;
@@ -5971,7 +5972,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return pos;
   }
 
-  protected gotoRowStart(row: number, _cell: number, _posX?: number) {
+  protected gotoRowStart(row: number, _cell: number, _posX?: number): { row: number; cell: number; posX: number; } | null {
     const newCell = this.findFirstFocusableCell(row);
     if (newCell === null) { return null; }
 
@@ -5982,7 +5983,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     };
   }
 
-  protected gotoRowEnd(row: number, _cell: number, _posX?: number) {
+  protected gotoRowEnd(row: number, _cell: number, _posX?: number): { row: number; cell: number; posX: number; } | null {
     const newCell = this.findLastFocusableCell(row);
     if (newCell === null) { return null; }
 
@@ -5994,42 +5995,42 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Switches the active cell one cell right skipping unselectable cells. Unline navigateNext, navigateRight stops at the last cell of the row. Returns a boolean saying whether it was able to complete or not. */
-  navigateRight() {
+  navigateRight(): boolean | undefined {
     return this.navigate('right');
   }
 
   /** Switches the active cell one cell left skipping unselectable cells. Unline navigatePrev, navigateLeft stops at the first cell of the row. Returns a boolean saying whether it was able to complete or not. */
-  navigateLeft() {
+  navigateLeft(): boolean | undefined {
     return this.navigate('left');
   }
 
   /** Switches the active cell one row down skipping unselectable cells. Returns a boolean saying whether it was able to complete or not. */
-  navigateDown() {
+  navigateDown(): boolean | undefined {
     return this.navigate('down');
   }
 
   /** Switches the active cell one row up skipping unselectable cells. Returns a boolean saying whether it was able to complete or not. */
-  navigateUp() {
+  navigateUp(): boolean | undefined {
     return this.navigate('up');
   }
 
   /** Tabs over active cell to the next selectable cell. Returns a boolean saying whether it was able to complete or not. */
-  navigateNext() {
+  navigateNext(): boolean | undefined {
     return this.navigate('next');
   }
 
   /** Tabs over active cell to the previous selectable cell. Returns a boolean saying whether it was able to complete or not. */
-  navigatePrev() {
+  navigatePrev(): boolean | undefined {
     return this.navigate('prev');
   }
 
   /** Navigate to the start row in the grid */
-  navigateRowStart() {
+  navigateRowStart(): boolean | undefined {
     return this.navigate('home');
   }
 
   /** Navigate to the end row in the grid */
-  navigateRowEnd() {
+  navigateRowEnd(): boolean | undefined {
     return this.navigate('end');
   }
 
@@ -6037,7 +6038,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {string} dir Navigation direction.
    * @return {boolean} Whether navigation resulted in a change of active cell.
    */
-  protected navigate(dir: 'up' | 'down' | 'left' | 'right' | 'prev' | 'next' | 'home' | 'end') {
+  protected navigate(dir: 'up' | 'down' | 'left' | 'right' | 'prev' | 'next' | 'home' | 'end'): boolean | undefined {
     if (!this._options.enableCellNavigation || (!this.activeCellNode && dir !== 'prev' && dir !== 'next')) {
       return false;
     }
@@ -6122,7 +6123,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {boolean} [preClickModeOn] Pre-Click Mode is Enabled?
    * @param {boolean} [suppressActiveCellChangedEvent] Are we suppressing Active Cell Changed Event (defaults to false)
    */
-  setActiveCell(row: number, cell: number, opt_editMode?: boolean, preClickModeOn?: boolean, suppressActiveCellChangedEvent?: boolean) {
+  setActiveCell(row: number, cell: number, opt_editMode?: boolean, preClickModeOn?: boolean, suppressActiveCellChangedEvent?: boolean): void {
     if (!this.initialized || !this._options.enableCellNavigation
       || row > this.getDataLength() || row < 0 || cell >= this.columns.length || cell < 0
     ) {
@@ -6139,7 +6140,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {number} cell - A column index.
    * @param {boolean} [suppressScrollIntoView] - optionally suppress the ScrollIntoView that happens by default (defaults to false)
    */
-  setActiveRow(row: number, cell?: number, suppressScrollIntoView?: boolean) {
+  setActiveRow(row: number, cell?: number, suppressScrollIntoView?: boolean): void {
     cell ??= 0;
 
     if (!this.initialized || row > this.getDataLength() || row < 0 || cell >= this.columns.length || cell < 0) {
@@ -6157,7 +6158,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {number} row A row index.
    * @param {number} col A column index.
    */
-  canCellBeActive(row: number, cell: number) {
+  canCellBeActive(row: number, cell: number): boolean {
     if (!this._options.enableCellNavigation || row >= this.getDataLengthIncludingAddNew()
       || row < 0 || cell >= this.columns.length || cell < 0) {
       return false;
@@ -6188,7 +6189,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {number} row A row index.
    * @param {number} col A column index.
    */
-  canCellBeSelected(row: number, cell: number) {
+  canCellBeSelected(row: number, cell: number): boolean {
     if (row >= this.getDataLength() || row < 0 || cell >= this.columns.length || cell < 0) {
       return false;
     }
@@ -6217,7 +6218,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} cell A column index.
    * @param {Boolean} [forceEdit] If true, will attempt to initiate the edit dialogue for the field in the specified cell.
    */
-  gotoCell(row: number, cell: number, forceEdit?: boolean, e?: Event | SlickEvent) {
+  gotoCell(row: number, cell: number, forceEdit?: boolean, e?: Event | SlickEvent): void {
     if (!this.initialized
       || !this.canCellBeActive(row, cell)
       || !this.getEditorLock()?.commitCurrentEdit()
@@ -6242,7 +6243,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // IEditor implementation for the editor lock
 
-  protected commitCurrentEdit() {
+  protected commitCurrentEdit(): boolean {
     const self = this as SlickGrid<TData, C, O>;
     const item = self.getDataItem(self.activeRow);
     const column = self.columns[self.activeCell];
@@ -6322,12 +6323,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return true;
   }
 
-  protected cancelCurrentEdit() {
+  protected cancelCurrentEdit(): boolean {
     this.makeActiveCellNormal();
     return true;
   }
 
-  protected rowsToRanges(rows: number[]) {
+  protected rowsToRanges(rows: number[]): SlickRange[] {
     const ranges: SlickRange[] = [];
     const lastCell = this.columns.length - 1;
     for (let i = 0; i < rows.length; i++) {
@@ -6337,7 +6338,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /** Returns an array of row indices corresponding to the currently selected rows. */
-  getSelectedRows() {
+  getSelectedRows(): number[] {
     if (!this.selectionModel) {
       throw new Error('SlickGrid Selection model is not set');
     }
@@ -6349,7 +6350,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Array<number>} rowsArray - an array of row numbers.
    * @param {String} [caller] - an optional string to identify who called the method
    */
-  setSelectedRows(rows: number[], caller?: string) {
+  setSelectedRows(rows: number[], caller?: string): void {
     if (!this.selectionModel) {
       throw new Error('SlickGrid Selection model is not set');
     }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -490,7 +490,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Object} [options] - Grid Options
    * @param {Object} [externalPubSub] - optional External PubSub Service to use by SlickEvent
    **/
-  constructor(protected readonly container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], options: Partial<O>, protected readonly externalPubSub?: BasePubSub) {
+  constructor(protected readonly container: HTMLElement | string, protected data: CustomDataView<TData> | TData[], protected columns: C[], options: Partial<O>, protected readonly externalPubSub?: BasePubSub | undefined) {
     this._container = typeof this.container === 'string'
       ? document.querySelector(this.container) as HTMLDivElement
       : this.container;

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -26,7 +26,9 @@ import type { DragItem, DragPosition, DraggableOption, MouseWheelOption, Resizab
  * @returns - Draggable instance which includes destroy method
  * @class Draggable
  */
-export function Draggable(options: DraggableOption) {
+export function Draggable(options: DraggableOption): {
+  destroy: () => void;
+} {
   let { containerElement } = options;
   const { onDragInit, onDragStart, onDrag, onDragEnd, preventDragFromKeys } = options;
   let element: HTMLElement | null;
@@ -45,20 +47,20 @@ export function Draggable(options: DraggableOption) {
     dragHandle: null,
   };
 
-  function init() {
+  function init(): void {
     if (containerElement) {
       containerElement.addEventListener('mousedown', userPressed as EventListener);
       containerElement.addEventListener('touchstart', userPressed as EventListener);
     }
   }
 
-  function executeDragCallbackWhenDefined(callback?: (e: DragEvent, dd: DragPosition) => boolean | void, evt?: MouseEvent | Touch | TouchEvent | KeyboardEvent, dd?: DragItem) {
+  function executeDragCallbackWhenDefined(callback?: (e: DragEvent, dd: DragPosition) => boolean | void, evt?: MouseEvent | Touch | TouchEvent | KeyboardEvent, dd?: DragItem): boolean | void {
     if (typeof callback === 'function') {
       return callback(evt as DragEvent, dd as DragItem);
     }
   }
 
-  function destroy() {
+  function destroy(): void {
     if (containerElement) {
       containerElement.removeEventListener('mousedown', userPressed as EventListener);
       containerElement.removeEventListener('touchstart', userPressed as EventListener);
@@ -66,7 +68,7 @@ export function Draggable(options: DraggableOption) {
   }
 
   /** Do we want to prevent Drag events from happening (for example prevent onDrag when Ctrl key is pressed while dragging) */
-  function preventDrag(event: MouseEvent | TouchEvent | KeyboardEvent) {
+  function preventDrag(event: MouseEvent | TouchEvent | KeyboardEvent): boolean {
     let eventPrevented = false;
     if (preventDragFromKeys) {
       preventDragFromKeys.forEach(key => {
@@ -78,7 +80,7 @@ export function Draggable(options: DraggableOption) {
     return eventPrevented;
   }
 
-  function userPressed(event: MouseEvent | TouchEvent | KeyboardEvent) {
+  function userPressed(event: MouseEvent | TouchEvent | KeyboardEvent): void {
     element = event.target as HTMLElement;
     if (!preventDrag(event)) {
       const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
@@ -105,7 +107,7 @@ export function Draggable(options: DraggableOption) {
     }
   }
 
-  function userMoved(event: MouseEvent | TouchEvent | KeyboardEvent) {
+  function userMoved(event: MouseEvent | TouchEvent | KeyboardEvent): void {
     const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
     if (!preventDrag(event)) {
       deltaX = targetEvent.clientX - startX;
@@ -123,7 +125,7 @@ export function Draggable(options: DraggableOption) {
     }
   }
 
-  function userReleased(event: MouseEvent | TouchEvent) {
+  function userReleased(event: MouseEvent | TouchEvent): void {
     document.body.removeEventListener('mousemove', userMoved);
     document.body.removeEventListener('touchmove', userMoved);
     document.body.removeEventListener('mouseup', userReleased);
@@ -155,7 +157,9 @@ export function Draggable(options: DraggableOption) {
  * @returns - MouseWheel instance which includes destroy method
  * @class MouseWheel
  */
-export function MouseWheel(options: MouseWheelOption) {
+export function MouseWheel(options: MouseWheelOption): {
+  destroy: () => void;
+} {
   const { element, onMouseWheel } = options;
 
   function destroy() {
@@ -163,13 +167,13 @@ export function MouseWheel(options: MouseWheelOption) {
     element.removeEventListener('mousewheel', wheelHandler as EventListener);
   }
 
-  function init() {
+  function init(): void {
     element.addEventListener('wheel', wheelHandler as EventListener);
     element.addEventListener('mousewheel', wheelHandler as EventListener);
   }
 
   // copy over the same event handler code used in jquery.mousewheel
-  function wheelHandler(event: WheelEvent & { axis: number; wheelDelta: number; wheelDeltaX: number; wheelDeltaY: number; HORIZONTAL_AXIS: number; }) {
+  function wheelHandler(event: WheelEvent & { axis: number; wheelDelta: number; wheelDeltaX: number; wheelDeltaY: number; HORIZONTAL_AXIS: number; }): void {
     const orgEvent = event || window.event;
     let delta = 0;
     let deltaX = 0;
@@ -227,32 +231,34 @@ export function MouseWheel(options: MouseWheelOption) {
  * @returns - Resizable instance which includes destroy method
  * @class Resizable
  */
-export function Resizable(options: ResizableOption) {
+export function Resizable(options: ResizableOption): {
+  destroy: () => void;
+} {
   const { resizeableElement, resizeableHandleElement, onResizeStart, onResize, onResizeEnd } = options;
   if (!resizeableHandleElement || typeof resizeableHandleElement.addEventListener !== 'function') {
     throw new Error('[SlickResizable] You did not provide a valid html element that will be used for the handle to resize.');
   }
 
-  function init() {
+  function init(): void {
     // add event listeners on the draggable element
     resizeableHandleElement.addEventListener('mousedown', resizeStartHandler);
     resizeableHandleElement.addEventListener('touchstart', resizeStartHandler);
   }
 
-  function destroy() {
+  function destroy(): void {
     if (typeof resizeableHandleElement?.removeEventListener === 'function') {
       resizeableHandleElement.removeEventListener('mousedown', resizeStartHandler);
       resizeableHandleElement.removeEventListener('touchstart', resizeStartHandler);
     }
   }
 
-  function executeResizeCallbackWhenDefined(callback?: (e: MouseEvent | TouchEvent, resizeElms: { resizeableElement: HTMLElement; resizeableHandleElement: HTMLElement; }) => boolean | void, e?: MouseEvent | TouchEvent | Touch) {
+  function executeResizeCallbackWhenDefined(callback?: (e: MouseEvent | TouchEvent, resizeElms: { resizeableElement: HTMLElement; resizeableHandleElement: HTMLElement; }) => boolean | void, e?: MouseEvent | TouchEvent | Touch): boolean | void {
     if (typeof callback === 'function') {
       return callback(e as any, { resizeableElement, resizeableHandleElement });
     }
   }
 
-  function resizeStartHandler(e: MouseEvent | TouchEvent) {
+  function resizeStartHandler(e: MouseEvent | TouchEvent): void {
     e.preventDefault();
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
     const result = executeResizeCallbackWhenDefined(onResizeStart, event);
@@ -264,7 +270,7 @@ export function Resizable(options: ResizableOption) {
     }
   }
 
-  function resizingHandler(e: MouseEvent | TouchEvent) {
+  function resizingHandler(e: MouseEvent | TouchEvent): void {
     if (e.preventDefault && e.type !== 'touchmove') {
       e.preventDefault();
     }
@@ -275,7 +281,7 @@ export function Resizable(options: ResizableOption) {
   }
 
   /** Remove all mouse/touch handlers */
-  function resizeEndHandler(e: MouseEvent | TouchEvent) {
+  function resizeEndHandler(e: MouseEvent | TouchEvent): void {
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
     executeResizeCallbackWhenDefined(onResizeEnd, event);
     document.body.removeEventListener('mousemove', resizingHandler);

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -165,7 +165,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     return this.columnEditor?.validator ?? this.columnDef?.validator;
   }
 
-  init() {
+  init(): void {
     this.labelName = this.customStructure?.label ?? 'label';
     this.valueName = this.customStructure?.value ?? 'value';
     this.labelPrefixName = this.customStructure?.labelPrefix ?? 'labelPrefix';
@@ -186,7 +186,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     if (typeof this._instance?.destroy === 'function') {
       this._instance.destroy();
@@ -195,7 +195,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     this._elementCollection = null;
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -214,7 +214,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  focus() {
+  focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
 
@@ -224,7 +224,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (isCompositeEditor) {
       // when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor
@@ -232,11 +232,11 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  getValue() {
+  getValue(): string {
     return this._inputElm.value;
   }
 
-  setValue(inputValue: any, isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(inputValue: any, isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     // if user provided a custom structure, we will serialize the value returned from the object with custom structure
     this._inputElm.value = (inputValue?.hasOwnProperty(this.labelName))
       ? inputValue[this.labelName]
@@ -255,7 +255,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     let newValue = state;
     const fieldName = this.columnDef?.field;
 
@@ -305,7 +305,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     return this._isValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef?.field;
 
     if (item && fieldName !== undefined) {
@@ -321,7 +321,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  clear(clearByDisableCommand = false) {
+  clear(clearByDisableCommand = false): void {
     if (this._inputElm) {
       this._currentValue = '';
       this._defaultTextValue = '';
@@ -343,7 +343,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
    * You can reset the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: any, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: any, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this._originalValue ?? '';
     if (this._inputElm) {
       this._currentValue = inputValue;
@@ -359,7 +359,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = validation?.valid ?? false;
 
@@ -425,7 +425,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
   // ------------------
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -433,7 +433,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     this.disable(isCellEditable === false);
   }
 
-  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';
@@ -459,7 +459,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
 
   // this function should be protected but for unit tests purposes we'll make it public until a better solution is found
   // a better solution would be to get the autocomplete DOM element to work with selection but I couldn't find how to do that in Jest
-  handleSelect(item: AutocompleteSearchItem) {
+  handleSelect(item: AutocompleteSearchItem): boolean {
     if (item !== undefined) {
       const event = null; // TODO do we need the event?
       const selectedItem = item;
@@ -492,12 +492,12 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     return false;
   }
 
-  protected renderRegularItem(item: T) {
+  protected renderRegularItem(item: T): HTMLDivElement {
     const itemLabel = (typeof item === 'string' ? item : item?.label ?? '') as string;
     return createDomElement('div', { textContent: itemLabel || '' });
   }
 
-  protected renderCustomItem(item: T) {
+  protected renderCustomItem(item: T): HTMLDivElement {
     const templateString = this._autocompleterOptions?.renderItem?.templateCallback(item) ?? '';
 
     // sanitize any unauthorized html tags like script and others
@@ -506,7 +506,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     return tmpElm;
   }
 
-  protected renderCollectionItem(item: any) { // CollectionCustomStructure
+  protected renderCollectionItem(item: any): HTMLDivElement {
     const isRenderHtmlEnabled = this.columnEditor?.enableRenderHtml ?? false;
     const prefixText = item.labelPrefix || '';
     const labelText = item.label || '';
@@ -522,7 +522,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     return div;
   }
 
-  renderDomElement(collection?: any[]) {
+  renderDomElement(collection?: any[]): void {
     const columnId = this.columnDef?.id ?? '';
     const placeholder = this.columnEditor?.placeholder ?? '';
     const title = this.columnEditor?.title ?? '';

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -264,7 +264,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
       if (Array.isArray(this.collection) && this.collection.length > 0) {
         newValue = findOrDefault(this.collection, (collectionItem: any) => {
           if (collectionItem && isObject(state) && collectionItem.hasOwnProperty(this.valueName)) {
-            return (collectionItem[this.valueName].toString()) === (state.hasOwnProperty(this.valueName) && state[this.valueName].toString());
+            return (collectionItem[this.valueName].toString()) === (state.hasOwnProperty(this.valueName) && (state as any)[this.valueName].toString());
           } else if (collectionItem && typeof state === 'string' && collectionItem.hasOwnProperty(this.valueName)) {
             return (collectionItem[this.valueName].toString()) === state;
           }

--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -106,12 +106,12 @@ export class CheckboxEditor implements Editor {
     }
   }
 
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this._input?.remove?.();
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -139,13 +139,13 @@ export class CheckboxEditor implements Editor {
   }
 
   /** pre-click, when enabled, will simply toggle the checkbox without requiring to double-click */
-  preClick() {
+  preClick(): void {
     if (this._input) {
       this._input.checked = !this._input.checked;
     }
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (isCompositeEditor) {
       // when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor
@@ -153,11 +153,11 @@ export class CheckboxEditor implements Editor {
     }
   }
 
-  getValue() {
+  getValue(): boolean {
     return this._input?.checked ?? false;
   }
 
-  setValue(val: boolean | string, isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(val: boolean | string, isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     const isChecked = val ? true : false;
     if (this._input) {
       this._input.checked = isChecked;
@@ -174,7 +174,7 @@ export class CheckboxEditor implements Editor {
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     const fieldName = this.columnDef && this.columnDef.field;
     if (fieldName !== undefined) {
       const isComplexObject = fieldName?.indexOf('.') > 0; // is the field a complex object, "address.streetNumber"
@@ -202,7 +202,7 @@ export class CheckboxEditor implements Editor {
     return this._isValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef && this.columnDef.field;
 
     if (item && fieldName !== undefined && this._input) {
@@ -219,7 +219,7 @@ export class CheckboxEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: boolean, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: boolean, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this._originalValue ?? false;
     if (this._input) {
       this._originalValue = inputValue;
@@ -234,7 +234,7 @@ export class CheckboxEditor implements Editor {
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = (validation && validation.valid) || false;
 
@@ -289,7 +289,7 @@ export class CheckboxEditor implements Editor {
   // ------------------
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -297,7 +297,7 @@ export class CheckboxEditor implements Editor {
     this.disable(isCellEditable === false);
   }
 
-  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -102,7 +102,7 @@ export class DateEditor implements Editor {
     return this.columnEditor?.validator ?? this.columnDef?.validator;
   }
 
-  async init() {
+  async init(): Promise<void> {
     if (this.args && this.columnDef) {
       const compositeEditorOptions = this.args.compositeEditorOptions;
       const columnId = this.columnDef?.id ?? '';
@@ -221,7 +221,7 @@ export class DateEditor implements Editor {
     }
   }
 
-  destroy() {
+  destroy(): void {
     queueMicrotask(() => {
       this.hide();
       this.calendarInstance?.destroy();
@@ -234,7 +234,7 @@ export class DateEditor implements Editor {
     this._bindEventService.unbindAll();
   }
 
-  clear() {
+  clear(): void {
     this._lastTriggeredByClearDate = true;
     if (this.calendarInstance) {
       this.calendarInstance.settings.selected.dates = [];
@@ -242,7 +242,7 @@ export class DateEditor implements Editor {
     }
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -269,7 +269,7 @@ export class DateEditor implements Editor {
    * @param {string} optionName
    * @param {newValue} newValue
    */
-  changeEditorOption<T extends keyof VanillaCalendarOption, K extends Partial<VanillaCalendarOption[T]>>(optionName: T, newValue: K) {
+  changeEditorOption<T extends keyof VanillaCalendarOption, K extends Partial<VanillaCalendarOption[T]>>(optionName: T, newValue: K): void {
     if (!this.columnEditor.editorOptions) {
       this.columnEditor.editorOptions = {};
     }
@@ -277,7 +277,7 @@ export class DateEditor implements Editor {
     this._pickerMergedOptions = extend(true, {}, this._pickerMergedOptions, { settings: { [optionName]: newValue } });
   }
 
-  focus() {
+  focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
 
@@ -285,11 +285,11 @@ export class DateEditor implements Editor {
     this._inputElm?.focus();
   }
 
-  hide() {
+  hide(): void {
     this.calendarInstance?.hide();
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (!isCompositeEditor && this.calendarInstance) {
       this.calendarInstance.show();
@@ -303,7 +303,7 @@ export class DateEditor implements Editor {
     return this._inputElm.value;
   }
 
-  setValue(val: string, isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(val: string, isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     if (this.calendarInstance) {
       setPickerDates(this._inputElm, this.calendarInstance, val, this.columnDef, this.columnEditor);
     }
@@ -319,7 +319,7 @@ export class DateEditor implements Editor {
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     const fieldName = this.columnDef?.field;
     if (this.columnDef && fieldName !== undefined) {
       const saveFieldType = this.columnDef.saveOutputType || this.columnDef.outputType || this.columnEditor.type || this.columnDef.type || FieldType.dateUtc;
@@ -357,7 +357,7 @@ export class DateEditor implements Editor {
     return this._isValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef?.field;
 
     if (item && this.columnDef && fieldName !== undefined) {
@@ -376,7 +376,7 @@ export class DateEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this._originalDate ?? '';
     if (this.calendarInstance) {
       this._originalDate = inputValue;
@@ -395,7 +395,7 @@ export class DateEditor implements Editor {
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = validation?.valid ?? false;
 
@@ -408,7 +408,7 @@ export class DateEditor implements Editor {
     }
   }
 
-  serializeValue() {
+  serializeValue(): string {
     const domValue = this.getValue();
     if (!domValue) {
       return '';
@@ -449,7 +449,7 @@ export class DateEditor implements Editor {
   // ------------------
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -457,7 +457,7 @@ export class DateEditor implements Editor {
     this.disable(isCellEditable === false);
   }
 
-  protected handleOnDateChange() {
+  protected handleOnDateChange(): void {
     this._isValueTouched = true;
 
     if (this.args) {
@@ -471,7 +471,7 @@ export class DateEditor implements Editor {
     setTimeout(() => this._lastTriggeredByClearDate = false); // reset flag after a cycle
   }
 
-  protected handleChangeOnCompositeEditor(compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -100,7 +100,7 @@ export class DualInputEditor implements Editor {
     return this.columnEditor?.validator ?? this.columnDef?.validator;
   }
 
-  init() {
+  init(): void {
     if (!this.editorParams || !this.editorParams.leftInput || !this.editorParams.leftInput.field || !this.editorParams.rightInput || !this.editorParams.rightInput.field) {
       throw new Error(`[Slickgrid-Universal] Please make sure that your Combo Input Editor has params defined with "leftInput" and "rightInput" (example: { editor: { model: Editors.comboInput, params: { leftInput: { field: 'firstName' }, { rightSide: { field: 'lastName' } }}}`);
     }
@@ -133,7 +133,7 @@ export class DualInputEditor implements Editor {
     }
   }
 
-  handleFocusOut(event: DOMEvent<HTMLInputElement>, position: 'leftInput' | 'rightInput') {
+  handleFocusOut(event: DOMEvent<HTMLInputElement>, position: 'leftInput' | 'rightInput'): void {
     // when clicking outside the editable cell OR when focusing out of it
     const targetClassNames = event.relatedTarget?.className || '';
     const compositeEditorOptions = this.args.compositeEditorOptions;
@@ -152,7 +152,7 @@ export class DualInputEditor implements Editor {
     this._lastEventType = `${event?.type}-${side}`;
   }
 
-  handleKeyDown(event: KeyboardEvent, position: 'leftInput' | 'rightInput') {
+  handleKeyDown(event: KeyboardEvent, position: 'leftInput' | 'rightInput'): void {
     if (position === 'leftInput') {
       this._isLeftValueTouched = true;
     } else {
@@ -164,7 +164,7 @@ export class DualInputEditor implements Editor {
     }
   }
 
-  destroy() {
+  destroy(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
     this._bindEventService.unbindAll();
@@ -204,7 +204,7 @@ export class DualInputEditor implements Editor {
     return input;
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -224,12 +224,12 @@ export class DualInputEditor implements Editor {
     }
   }
 
-  focus() {
+  focus(): void {
     // always set focus on grid first, then do nothing since we have 2 inputs and we might focus on left/right depending on which is invalid and/or new
     this.grid.focus();
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (isCompositeEditor) {
       // when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor
@@ -251,19 +251,19 @@ export class DualInputEditor implements Editor {
     return obj;
   }
 
-  setValues(values: Array<number | string>) {
+  setValues(values: Array<number | string>): void {
     if (Array.isArray(values) && values.length === 2) {
       this._leftInput.value = `${values[0]}`;
       this._rightInput.value = `${values[1]}`;
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     this.applyValueByPosition(item, state, 'leftInput');
     this.applyValueByPosition(item, state, 'rightInput');
   }
 
-  applyValueByPosition(item: any, state: any, position: 'leftInput' | 'rightInput') {
+  applyValueByPosition(item: any, state: any, position: 'leftInput' | 'rightInput'): void {
     const fieldName = position === 'leftInput' ? this._leftFieldName : this._rightFieldName;
     if (fieldName !== undefined) {
       const isComplexObject = fieldName?.indexOf('.') > 0; // is the field a complex object, "address.streetNumber"
@@ -310,13 +310,13 @@ export class DualInputEditor implements Editor {
     return this._isLeftValueTouched || this._isRightValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     this.loadValueByPosition(item, 'leftInput');
     this.loadValueByPosition(item, 'rightInput');
     this._leftInput.select();
   }
 
-  loadValueByPosition(item: any, position: 'leftInput' | 'rightInput') {
+  loadValueByPosition(item: any, position: 'leftInput' | 'rightInput'): void {
     // is the field a complex object, "address.streetNumber"
     const fieldName = (position === 'leftInput') ? this._leftFieldName : this._rightFieldName;
     const originalValuePosition = (position === 'leftInput') ? '_originalLeftValue' : '_originalRightValue';
@@ -343,7 +343,7 @@ export class DualInputEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: number | string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: number | string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputLeftValue = value ?? this._originalLeftValue ?? '';
     const inputRightValue = value ?? this._originalRightValue ?? '';
     if (this._leftInput && this._rightInput) {
@@ -362,7 +362,7 @@ export class DualInputEditor implements Editor {
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = (validation && validation.valid) || false;
 
@@ -387,7 +387,7 @@ export class DualInputEditor implements Editor {
     return obj;
   }
 
-  serializeValueByPosition(position: 'leftInput' | 'rightInput') {
+  serializeValueByPosition(position: 'leftInput' | 'rightInput'): string | number {
     const elmValue = position === 'leftInput' ? this._leftInput.value : this._rightInput.value;
     if (elmValue === '' || isNaN(+elmValue)) {
       return elmValue;
@@ -506,7 +506,7 @@ export class DualInputEditor implements Editor {
   }
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -514,7 +514,7 @@ export class DualInputEditor implements Editor {
     this.disable(isCellEditable === false);
   }
 
-  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const leftInputId = this.columnEditor.params?.leftInput?.field ?? '';
@@ -544,7 +544,7 @@ export class DualInputEditor implements Editor {
     );
   }
 
-  protected handleChangeOnCompositeEditorDebounce(event: KeyboardEvent) {
+  protected handleChangeOnCompositeEditorDebounce(event: KeyboardEvent): void {
     const compositeEditorOptions = this.args?.compositeEditorOptions;
     if (compositeEditorOptions) {
       const typingDelay = this.gridOptions?.editorTypingDebounce ?? 500;

--- a/packages/common/src/editors/editors.index.ts
+++ b/packages/common/src/editors/editors.index.ts
@@ -1,3 +1,4 @@
+import type { EditorConstructor } from '../interfaces';
 import { AutocompleterEditor } from './autocompleterEditor';
 import { CheckboxEditor } from './checkboxEditor';
 import { DateEditor } from './dateEditor';
@@ -11,7 +12,7 @@ import { MultipleSelectEditor } from './multipleSelectEditor';
 import { SingleSelectEditor } from './singleSelectEditor';
 import { SliderEditor } from './sliderEditor';
 
-export const Editors = {
+export const Editors: Record<string, EditorConstructor> = {
   /** Autocompleter Editor (using https://github.com/kraaden/autocomplete) */
   autocompleter: AutocompleterEditor,
 

--- a/packages/common/src/editors/floatEditor.ts
+++ b/packages/common/src/editors/floatEditor.ts
@@ -8,7 +8,7 @@ export class FloatEditor extends InputEditor {
     super(args, 'number');
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef && this.columnDef.field;
 
     if (fieldName !== undefined) {
@@ -29,7 +29,7 @@ export class FloatEditor extends InputEditor {
     }
   }
 
-  serializeValue() {
+  serializeValue(): string | number {
     const elmValue = this._input?.value;
     if (elmValue === undefined || elmValue === '' || isNaN(+elmValue)) {
       return elmValue as string;

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -75,7 +75,7 @@ export class InputEditor implements Editor {
   }
 
   /** Getter of input type (text, number, password) */
-  get inputType() {
+  get inputType(): string {
     return this._inputType;
   }
 
@@ -89,7 +89,7 @@ export class InputEditor implements Editor {
     return this.columnEditor?.validator ?? this.columnDef?.validator;
   }
 
-  init() {
+  init(): void {
     const columnId = this.columnDef?.id ?? '';
     const compositeEditorOptions = this.args.compositeEditorOptions;
 
@@ -138,12 +138,12 @@ export class InputEditor implements Editor {
     }
   }
 
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this._input?.remove?.();
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -192,7 +192,7 @@ export class InputEditor implements Editor {
     return '1';
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (isCompositeEditor) {
       // when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor
@@ -204,7 +204,7 @@ export class InputEditor implements Editor {
     return this._input?.value || '';
   }
 
-  setValue(value: number | string, isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(value: number | string, isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     if (this._input) {
       this._input.value = `${value}`;
 
@@ -220,7 +220,7 @@ export class InputEditor implements Editor {
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     const fieldName = this.columnDef && this.columnDef.field;
     if (fieldName !== undefined) {
       const isComplexObject = fieldName?.indexOf('.') > 0; // is the field a complex object, "address.streetNumber"
@@ -254,7 +254,7 @@ export class InputEditor implements Editor {
     return this._isValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef?.field;
 
     if (item && fieldName !== undefined && this._input) {
@@ -272,7 +272,7 @@ export class InputEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: number | string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: number | string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this._originalValue ?? '';
     if (this._input) {
       this._originalValue = inputValue;
@@ -287,7 +287,7 @@ export class InputEditor implements Editor {
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = (validation && validation.valid) || false;
 
@@ -332,7 +332,7 @@ export class InputEditor implements Editor {
   // ------------------
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -340,7 +340,7 @@ export class InputEditor implements Editor {
     this.disable(isCellEditable === false);
   }
 
-  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';
@@ -364,7 +364,7 @@ export class InputEditor implements Editor {
     );
   }
 
-  protected handleOnInputChange(event: KeyboardEvent) {
+  protected handleOnInputChange(event: KeyboardEvent): void {
     this._isValueTouched = true;
     const compositeEditorOptions = this.args.compositeEditorOptions;
     if (compositeEditorOptions) {
@@ -375,7 +375,7 @@ export class InputEditor implements Editor {
   }
 
   /** When the input value changes (this will cover the input spinner arrows on the right) */
-  protected handleOnMouseWheel(event: KeyboardEvent) {
+  protected handleOnMouseWheel(event: KeyboardEvent): void {
     this._isValueTouched = true;
     const compositeEditorOptions = this.args.compositeEditorOptions;
     if (compositeEditorOptions) {

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -9,7 +9,7 @@ export class IntegerEditor extends InputEditor {
   }
 
   loadValue(item: any): void {
-    const fieldName = this.columnDef && this.columnDef.field;
+    const fieldName = this.columnDef?.field;
 
     if (fieldName !== undefined) {
 

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -8,7 +8,7 @@ export class IntegerEditor extends InputEditor {
     super(args, 'number');
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef && this.columnDef.field;
 
     if (fieldName !== undefined) {
@@ -25,7 +25,7 @@ export class IntegerEditor extends InputEditor {
     }
   }
 
-  serializeValue() {
+  serializeValue(): string | number {
     const elmValue = this._input?.value;
     if (elmValue === undefined || elmValue === '' || isNaN(+elmValue)) {
       return elmValue as string;
@@ -62,7 +62,7 @@ export class IntegerEditor extends InputEditor {
   // ------------------
 
   /** When the input value changes (this will cover the input spinner arrows on the right) */
-  protected handleOnMouseWheel(event: KeyboardEvent) {
+  protected handleOnMouseWheel(event: KeyboardEvent): void {
     this._isValueTouched = true;
     const compositeEditorOptions = this.args.compositeEditorOptions;
     if (compositeEditorOptions) {

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -173,7 +173,7 @@ export class LongTextEditor implements Editor {
     this._bindEventService.bind(this._textareaElm, 'paste', this.handleOnInputChange.bind(this) as unknown as EventListener);
   }
 
-  cancel() {
+  cancel(): void {
     const value = this._defaultTextValue || '';
     this._textareaElm.value = value;
     this._currentLengthElm.textContent = `${value.length}`;
@@ -182,11 +182,11 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  hide() {
+  hide(): void {
     this._wrapperElm.style.display = 'none';
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (!isCompositeEditor) {
       this._wrapperElm.style.display = 'block';
@@ -196,12 +196,12 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this._wrapperElm?.remove?.();
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -222,7 +222,7 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  focus() {
+  focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
 
@@ -236,7 +236,7 @@ export class LongTextEditor implements Editor {
     return this._textareaElm.value;
   }
 
-  setValue(val: string, isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(val: string, isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     this._textareaElm.value = val;
     this._currentLengthElm.textContent = `${val.length}`;
 
@@ -251,7 +251,7 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     const fieldName = this.columnDef?.field;
     if (fieldName !== undefined) {
       const isComplexObject = fieldName?.indexOf('.') > 0; // is the field a complex object, "address.streetNumber"
@@ -281,7 +281,7 @@ export class LongTextEditor implements Editor {
     return this._isValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef?.field;
 
     if (item && fieldName !== undefined) {
@@ -305,7 +305,7 @@ export class LongTextEditor implements Editor {
    * Same goes for the top/bottom position, Most of the time positioning the editor to the "bottom" but we are clicking on a cell at the bottom of the grid then we might need to reposition to "top" instead.
    * NOTE: this only applies to Inline Editing and will not have any effect when using the Composite Editor modal window.
    */
-  position(parentPosition: Partial<HtmlElementPosition>) {
+  position(parentPosition: Partial<HtmlElementPosition>): void {
     const containerOffset = getOffset(this.args.container);
     const containerHeight = this.args.container.offsetHeight;
     const containerWidth = this.args.container.offsetWidth;
@@ -340,7 +340,7 @@ export class LongTextEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this._defaultTextValue ?? '';
     if (this._textareaElm) {
       this._defaultTextValue = inputValue;
@@ -356,7 +356,7 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = validation?.valid ?? false;
 
@@ -369,7 +369,7 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  serializeValue() {
+  serializeValue(): string {
     return this._textareaElm.value;
   }
 
@@ -401,7 +401,7 @@ export class LongTextEditor implements Editor {
   // ------------------
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -409,7 +409,7 @@ export class LongTextEditor implements Editor {
     this.disable(isCellEditable === false);
   }
 
-  protected handleKeyDown(e: KeyboardEvent) {
+  protected handleKeyDown(e: KeyboardEvent): void {
     const key = e.key;
     this._isValueTouched = true;
 
@@ -435,7 +435,7 @@ export class LongTextEditor implements Editor {
   }
 
   /** On every input change event, we'll update the current text length counter */
-  protected handleOnInputChange(event: Event & { clipboardData: DataTransfer, target: HTMLTextAreaElement; }) {
+  protected handleOnInputChange(event: Event & { clipboardData: DataTransfer, target: HTMLTextAreaElement; }): void {
     const compositeEditorOptions = this.args.compositeEditorOptions;
     const maxLength = this.columnEditor?.maxLength;
 
@@ -461,7 +461,7 @@ export class LongTextEditor implements Editor {
     }
   }
 
-  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -194,7 +194,7 @@ export class SelectEditor implements Editor {
   }
 
   /** Getter for the Editor DOM Element */
-  get editorDomElement() {
+  get editorDomElement(): HTMLElement | undefined {
     return this.editorElm;
   }
 
@@ -215,11 +215,11 @@ export class SelectEditor implements Editor {
     return this.gridOptions.autoCommitEdit ?? false;
   }
 
-  get msInstance() {
+  get msInstance(): MultipleSelectInstance | undefined {
     return this._msInstance;
   }
 
-  get selectOptions() {
+  get selectOptions(): Partial<MultipleSelectOption> {
     return this.defaultOptions;
   }
 
@@ -319,7 +319,7 @@ export class SelectEditor implements Editor {
     return this.columnEditor?.validator ?? this.columnDef?.validator;
   }
 
-  init() {
+  init(): void {
     if (!this.columnDef || !this.columnDef.editor || (!this.columnDef.editor.collection && !this.columnDef.editor.collectionAsync)) {
       throw new Error(`[Slickgrid-Universal] You need to pass a "collection" (or "collectionAsync") inside Column Definition Editor for the MultipleSelect/SingleSelect Editor to work correctly.
       Also each option should include a value/label pair (or value/labelKey when using Locale).
@@ -353,7 +353,7 @@ export class SelectEditor implements Editor {
     return (this.isMultipleSelect) ? this.currentValues : this.currentValue;
   }
 
-  setValue(value: any | any[], isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(value: any | any[], isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     if (this.isMultipleSelect && Array.isArray(value)) {
       this.loadMultipleValues(value);
     } else {
@@ -371,19 +371,19 @@ export class SelectEditor implements Editor {
     }
   }
 
-  cancel() {
+  cancel(): void {
     if (this.args?.cancelChanges) {
       this.args.cancelChanges();
     }
   }
 
-  hide() {
+  hide(): void {
     if (this._msInstance) {
       this._msInstance.close();
     }
   }
 
-  show(openDelay?: number | null) {
+  show(openDelay?: number | null): void {
     if (!this.isCompositeEditor && this._msInstance) {
       this._msInstance.open(openDelay);
     } else if (this.isCompositeEditor) {
@@ -428,7 +428,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  destroy() {
+  destroy(): void {
     // when autoCommitEdit is enabled, we might end up leaving an editor without it being saved, if so do call a save before destroying
     // this mainly happens doing a blur or focusing on another cell in the grid (it won't come here if we click outside the grid, in the body)
     if (this._msInstance && this.hasAutoCommitEdit && this.isValueChanged() && !this._isDisposingOrCallingSave && !this.isCompositeEditor) {
@@ -465,7 +465,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  loadMultipleValues(currentValues: any[]) {
+  loadMultipleValues(currentValues: any[]): void {
     // convert to string because that is how the DOM will return these values
     if (Array.isArray(currentValues)) {
       // keep the default values in memory for references
@@ -480,7 +480,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  loadSingleValue(currentValue: any) {
+  loadSingleValue(currentValue: any): void {
     // keep the default value in memory for references
     this.originalValue = (typeof currentValue === 'number' || typeof currentValue === 'boolean') ? `${currentValue}` : currentValue;
     this._msInstance?.setSelects([this.originalValue]);
@@ -496,7 +496,7 @@ export class SelectEditor implements Editor {
    * @param {string} optionName - MultipleSelect option name
    * @param {newValue} newValue - MultipleSelect new option value
    */
-  changeEditorOption(optionName: keyof MultipleSelectOption, newValue: any) {
+  changeEditorOption(optionName: keyof MultipleSelectOption, newValue: any): void {
     if (this.columnEditor) {
       if (!this.columnEditor.editorOptions) {
         this.columnEditor.editorOptions = {};
@@ -507,7 +507,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -527,7 +527,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  focus() {
+  focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
     this._msInstance?.focus();
@@ -551,7 +551,7 @@ export class SelectEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this.originalValue;
     if (this._msInstance) {
       this.originalValue = this.isMultipleSelect ? (inputValue !== undefined ? [inputValue] : []) : inputValue;
@@ -567,7 +567,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  save(forceCommitCurrentEdit = false) {
+  save(forceCommitCurrentEdit = false): void {
     const validation = this.validate();
     const isValid = validation?.valid ?? false;
 
@@ -619,7 +619,7 @@ export class SelectEditor implements Editor {
   // ------------------
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -662,7 +662,7 @@ export class SelectEditor implements Editor {
     return outputCollection;
   }
 
-  renderDomElement(inputCollection?: any[]) {
+  renderDomElement(inputCollection?: any[]): void {
     if (!Array.isArray(inputCollection) && this.collectionOptions?.collectionInsideObjectProperty) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty;
       inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
@@ -752,7 +752,7 @@ export class SelectEditor implements Editor {
    * From the Select DOM Element created earlier, create a Multiple/Single Select Editor using the multiple-select-vanilla.js lib
    * @param {Object} selectElement
    */
-  protected createDomElement(selectElement: HTMLSelectElement, dataCollection: OptionRowData[]) {
+  protected createDomElement(selectElement: HTMLSelectElement, dataCollection: OptionRowData[]): void {
     const cellContainer = this.args.container;
     if (selectElement && cellContainer && typeof cellContainer.appendChild === 'function') {
       emptyElement(cellContainer);
@@ -771,7 +771,7 @@ export class SelectEditor implements Editor {
     }
   }
 
-  protected handleChangeOnCompositeEditor(compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -121,21 +121,21 @@ export class SliderEditor implements Editor {
     }
   }
 
-  cancel() {
+  cancel(): void {
     if (this._inputElm) {
       this._inputElm.value = `${this._originalValue}`;
     }
     this.args.cancelChanges();
   }
 
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this._inputElm?.remove();
     this._editorElm?.remove();
     this._sliderTrackElm?.remove();
   }
 
-  disable(isDisabled = true) {
+  disable(isDisabled = true): void {
     const prevIsDisabled = this.disabled;
     this.disabled = isDisabled;
 
@@ -154,13 +154,13 @@ export class SliderEditor implements Editor {
     }
   }
 
-  focus() {
+  focus(): void {
     // always set focus on grid first so that plugin to copy range (SlickCellExternalCopyManager) would still be able to paste at that position
     this.grid.focus();
     this._inputElm?.focus();
   }
 
-  show() {
+  show(): void {
     const isCompositeEditor = !!this.args?.compositeEditorOptions;
     if (isCompositeEditor) {
       // when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor
@@ -172,7 +172,7 @@ export class SliderEditor implements Editor {
     return this._inputElm?.value ?? '';
   }
 
-  setValue(value: number | string, isApplyingValue = false, triggerOnCompositeEditorChange = true) {
+  setValue(value: number | string, isApplyingValue = false, triggerOnCompositeEditorChange = true): void {
     if (this._inputElm) {
       this._inputElm.value = `${value}`;
     }
@@ -191,7 +191,7 @@ export class SliderEditor implements Editor {
     }
   }
 
-  applyValue(item: any, state: any) {
+  applyValue(item: any, state: any): void {
     const fieldName = this.columnDef?.field ?? '';
     if (fieldName !== undefined) {
       const isComplexObject = fieldName?.indexOf('.') > 0; // is the field a complex object, "address.streetNumber"
@@ -220,7 +220,7 @@ export class SliderEditor implements Editor {
     return this._isValueTouched;
   }
 
-  loadValue(item: any) {
+  loadValue(item: any): void {
     const fieldName = this.columnDef?.field ?? '';
 
     if (item && fieldName !== undefined) {
@@ -247,7 +247,7 @@ export class SliderEditor implements Editor {
    * You can reset or clear the input value,
    * when no value is provided it will use the original value to reset (could be useful with Composite Editor Modal with edit/clone)
    */
-  reset(value?: number | string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false) {
+  reset(value?: number | string, triggerCompositeEventWhenExist = true, clearByDisableCommand = false): void {
     const inputValue = value ?? this._originalValue ?? 0;
     if (this._inputElm) {
       this._inputElm.value = `${inputValue}`;
@@ -264,7 +264,7 @@ export class SliderEditor implements Editor {
     }
   }
 
-  save() {
+  save(): void {
     const validation = this.validate();
     const isValid = (validation && validation.valid) || false;
 
@@ -277,7 +277,7 @@ export class SliderEditor implements Editor {
     }
   }
 
-  serializeValue() {
+  serializeValue(): string | number | undefined {
     const elmValue: string = this._inputElm?.value ?? '';
     return elmValue !== '' ? parseInt(elmValue, 10) : this._originalValue;
   }
@@ -351,7 +351,7 @@ export class SliderEditor implements Editor {
   }
 
   /** when it's a Composite Editor, we'll check if the Editor is editable (by checking onBeforeEditCell) and if not Editable we'll disable the Editor */
-  protected applyInputUsabilityState() {
+  protected applyInputUsabilityState(): void {
     const activeCell = this.grid.getActiveCell();
     const isCellEditable = this.grid.onBeforeEditCell.notify({
       ...activeCell, item: this.dataContext, column: this.args.column, grid: this.grid, target: 'composite', compositeEditorOptions: this.args.compositeEditorOptions
@@ -359,7 +359,7 @@ export class SliderEditor implements Editor {
     this.disable(isCellEditable === false);
   }
 
-  protected handleChangeEvent(event: MouseEvent) {
+  protected handleChangeEvent(event: MouseEvent): void {
     this._isValueTouched = true;
     const compositeEditorOptions = this.args.compositeEditorOptions;
 
@@ -370,7 +370,7 @@ export class SliderEditor implements Editor {
     }
   }
 
-  protected handleChangeSliderNumber(event: Event) {
+  protected handleChangeSliderNumber(event: Event): void {
     const value = (<HTMLInputElement>event.target)?.value ?? '';
     if (value !== '') {
       if (!this.editorOptions.hideSliderNumber && this._sliderNumberElm) {
@@ -389,7 +389,7 @@ export class SliderEditor implements Editor {
     this.updateTrackFilledColorWhenEnabled();
   }
 
-  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false) {
+  protected handleChangeOnCompositeEditor(event: Event | null, compositeEditorOptions: CompositeEditorOption, triggeredBy: 'user' | 'system' = 'user', isCalledByClearValue = false): void {
     const activeCell = this.grid.getActiveCell();
     const column = this.args.column;
     const columnId = this.columnDef?.id ?? '';
@@ -413,7 +413,7 @@ export class SliderEditor implements Editor {
     );
   }
 
-  protected sliderTrackClicked(e: MouseEvent) {
+  protected sliderTrackClicked(e: MouseEvent): void {
     e.preventDefault();
     const sliderTrackX = e.offsetX;
     const sliderTrackWidth = this._sliderTrackElm.offsetWidth;
@@ -427,7 +427,7 @@ export class SliderEditor implements Editor {
     }
   }
 
-  protected updateTrackFilledColorWhenEnabled() {
+  protected updateTrackFilledColorWhenEnabled(): void {
     if (this.editorOptions.enableSliderTrackColoring && this._inputElm) {
       const percent1 = 0;
       const percent2 = ((+this.getValue() - +this._inputElm.min) / (this.sliderOptions?.maxValue ?? 0 - +this._inputElm.min)) * 100;

--- a/packages/common/src/extensions/extensionCommonUtils.ts
+++ b/packages/common/src/extensions/extensionCommonUtils.ts
@@ -9,7 +9,7 @@ const PICKER_CHECK_ICON = 'mdi-icon-picker-check';
 const PICKER_UNCHECK_ICON = 'mdi-icon-picker-uncheck';
 
 /** Create a Close button element and add it to the Menu element */
-export function addCloseButtomElement(this: SlickColumnPicker | SlickGridMenu, menuElm: HTMLDivElement) {
+export function addCloseButtomElement(this: SlickColumnPicker | SlickGridMenu, menuElm: HTMLDivElement): void {
   const context: any = this;
   const closePickerButtonElm = createDomElement('button', {
     type: 'button', className: 'close',
@@ -21,7 +21,7 @@ export function addCloseButtomElement(this: SlickColumnPicker | SlickGridMenu, m
 }
 
 /** When "columnTitle" option is provided, let's create a div element to show "Columns" list title */
-export function addColumnTitleElementWhenDefined(this: SlickColumnPicker | SlickGridMenu, menuElm: HTMLDivElement) {
+export function addColumnTitleElementWhenDefined(this: SlickColumnPicker | SlickGridMenu, menuElm: HTMLDivElement): void {
   const context: any = this;
   if (context.addonOptions?.columnTitle) {
     context._columnTitleElm = createDomElement(
@@ -37,7 +37,7 @@ export function addColumnTitleElementWhenDefined(this: SlickColumnPicker | Slick
  * @param event - input checkbox event
  * @returns
  */
-export function handleColumnPickerItemClick(this: SlickColumnPicker | SlickGridMenu, event: DOMEvent<HTMLInputElement>) {
+export function handleColumnPickerItemClick(this: SlickColumnPicker | SlickGridMenu, event: DOMEvent<HTMLInputElement>): void {
   const context: any = this;
   const controlType = context instanceof SlickColumnPicker ? 'columnPicker' : 'gridMenu';
   const iconContainerElm = event.target?.closest('.icon-checkbox-container') as HTMLDivElement;
@@ -118,13 +118,17 @@ export function handleColumnPickerItemClick(this: SlickColumnPicker | SlickGridM
   }
 }
 
-function togglePickerCheckbox(iconElm: HTMLDivElement | null, checked = false) {
+function togglePickerCheckbox(iconElm: HTMLDivElement | null, checked = false): void {
   if (iconElm) {
     iconElm.className = `mdi ${checked ? PICKER_CHECK_ICON : PICKER_UNCHECK_ICON}`;
   }
 }
 
-function generatePickerCheckbox(columnLiElm: HTMLLIElement, inputId: string, inputData: any, checked = false) {
+function generatePickerCheckbox(columnLiElm: HTMLLIElement, inputId: string, inputData: any, checked = false): {
+  inputElm: HTMLInputElement;
+  labelElm: HTMLLabelElement;
+  labelSpanElm: HTMLSpanElement;
+} {
   const labelElm = createDomElement('label', { className: 'checkbox-picker-label', htmlFor: inputId });
   const divElm = createDomElement('div', { className: 'icon-checkbox-container' });
   const inputElm = createDomElement('input', { id: inputId, type: 'checkbox', dataset: inputData });
@@ -144,7 +148,7 @@ function generatePickerCheckbox(columnLiElm: HTMLLIElement, inputId: string, inp
   return { inputElm, labelElm, labelSpanElm };
 }
 
-export function populateColumnPicker(this: SlickColumnPicker | SlickGridMenu, addonOptions: ColumnPickerOption | GridMenuOption) {
+export function populateColumnPicker(this: SlickColumnPicker | SlickGridMenu, addonOptions: ColumnPickerOption | GridMenuOption): void {
   const context: any = this;
   const menuPrefix = context instanceof SlickGridMenu ? 'gridmenu-' : '';
 
@@ -194,7 +198,7 @@ export function populateColumnPicker(this: SlickColumnPicker | SlickGridMenu, ad
  * as it does not include columns currently hidden by the picker. We create a new `columns` structure by leaving currently-hidden
  * columns in their original ordinal position and interleaving the results of the current column sort.
  */
-export function updateColumnPickerOrder(this: SlickColumnPicker | SlickGridMenu) {
+export function updateColumnPickerOrder(this: SlickColumnPicker | SlickGridMenu): void {
   const context: any = this;
 
   const current = context.grid.getColumns().slice(0);

--- a/packages/common/src/extensions/extensionUtility.ts
+++ b/packages/common/src/extensions/extensionUtility.ts
@@ -18,7 +18,7 @@ export class ExtensionUtility {
    * 2- else if user provided a title key, use it to translate the output title
    * 3- else if nothing is provided use text defined as constants
    */
-  getPickerTitleOutputString(propName: string, pickerName: 'gridMenu' | 'columnPicker') {
+  getPickerTitleOutputString(propName: string, pickerName: 'gridMenu' | 'columnPicker'): string {
     if (this.sharedService.gridOptions?.enableTranslate && (!this.translaterService?.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
@@ -67,7 +67,7 @@ export class ExtensionUtility {
    * @param {Array<Object>} allColumns - all columns (including hidden ones)
    * @param {Array<Object>} visibleColumns - only visible columns (excluding hidden ones)
    */
-  readjustFrozenColumnIndexWhenNeeded(frozenColumnIndex: number, allColumns: Column[], visibleColumns: Column[]) {
+  readjustFrozenColumnIndexWhenNeeded(frozenColumnIndex: number, allColumns: Column[], visibleColumns: Column[]): void {
     if (frozenColumnIndex >= 0) {
       const recalculatedFrozenColumnIndex = visibleColumns.findIndex(col => col.id === this.sharedService.frozenVisibleColumnId);
       if (recalculatedFrozenColumnIndex >= 0 && recalculatedFrozenColumnIndex !== frozenColumnIndex) {
@@ -84,7 +84,7 @@ export class ExtensionUtility {
   }
 
   /** Refresh the dataset through the Backend Service */
-  refreshBackendDataset(inputGridOptions?: GridOption) {
+  refreshBackendDataset(inputGridOptions?: GridOption): void {
     // user can pass new set of grid options which will override current ones
     let gridOptions = this.sharedService.gridOptions;
     if (inputGridOptions) {
@@ -107,7 +107,7 @@ export class ExtensionUtility {
    * @param {Array<Object>} items array
    * @param {String} property name to sort with
    */
-  sortItems(items: any[], propertyName: string) {
+  sortItems(items: any[], propertyName: string): void {
     // sort the command items by their position in the list
     if (Array.isArray(items)) {
       items.sort((itemA: any, itemB: any) => {
@@ -120,7 +120,7 @@ export class ExtensionUtility {
   }
 
   /** Translate the array of items from an input key and assign them to their output key */
-  translateItems<T = any>(items: T[], inputKey: string, outputKey: string) {
+  translateItems<T = any>(items: T[], inputKey: string, outputKey: string): void {
     if (Array.isArray(items)) {
       for (const item of items) {
         if ((item as any).hasOwnProperty(inputKey)) {
@@ -135,7 +135,7 @@ export class ExtensionUtility {
    * @param {Array<MenuCommandItem | String>} items - Menu Command Items array
    * @param {Object} gridOptions - Grid Options
    */
-  translateMenuItemsFromTitleKey(items: Array<MenuCommandItem | MenuOptionItem | GridMenuItem | 'divider'>, subMenuItemsKey = 'commandItems') {
+  translateMenuItemsFromTitleKey(items: Array<MenuCommandItem | MenuOptionItem | GridMenuItem | 'divider'>, subMenuItemsKey = 'commandItems'): void {
     for (const item of items) {
       // translate `titleKey` and also `subMenuTitleKey` if exists
       if (typeof item === 'object') {

--- a/packages/common/src/extensions/extensionUtility.ts
+++ b/packages/common/src/extensions/extensionUtility.ts
@@ -8,8 +8,8 @@ import { getTranslationPrefix } from '../services/utilities';
 export class ExtensionUtility {
   constructor(
     private readonly sharedService: SharedService,
-    private readonly backendUtilities?: BackendUtilityService,
-    public readonly translaterService?: TranslaterService
+    private readonly backendUtilities?: BackendUtilityService | undefined,
+    public readonly translaterService?: TranslaterService | undefined
   ) { }
 
   /**

--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -1,6 +1,6 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
 import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import { createDomElement, emptyElement, hasData, classNameToList } from '@slickgrid-universal/utils';
+import { classNameToList, createDomElement, emptyElement, isDefined, } from '@slickgrid-universal/utils';
 
 import type {
   CellMenu,
@@ -77,7 +77,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
     return this.gridUid ? `.${this.gridUid}` : '';
   }
 
-  get menuCssClass() {
+  get menuCssClass(): string {
     return this._menuPluginCssPrefix || this._menuCssPrefix;
   }
 
@@ -86,7 +86,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
   }
 
   /** Dispose (destroy) of the plugin */
-  dispose() {
+  dispose(): void {
     this._eventHandler?.unsubscribeAll();
     this._bindEventService.unbindAll();
     this.pubSubService.unsubscribeAll();
@@ -99,7 +99,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
   }
 
   /** Remove/dispose all parent menus and any sub-menu(s) */
-  disposeAllMenus() {
+  disposeAllMenus(): void {
     this.disposeSubMenus();
 
     // remove all parent menu listeners before removing them from the DOM
@@ -112,13 +112,13 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
    * Remove/dispose all previously opened sub-menu(s),
    * it will first remove all sub-menu listeners then remove sub-menus from the DOM
    */
-  disposeSubMenus() {
+  disposeSubMenus(): void {
     this._bindEventService.unbindAll('sub-menu');
     document.querySelectorAll(`.${this.menuCssClass}.slick-submenu${this.gridUidSelector}`)
       .forEach(subElm => subElm.remove());
   }
 
-  setOptions(newOptions: M) {
+  setOptions(newOptions: M): void {
     this._addonOptions = { ...this._addonOptions, ...newOptions };
   }
 
@@ -126,7 +126,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
   // protected functions
   // ------------------
 
-  protected addSubMenuTitleWhenExists(item: ExtractMenuType<ExtendableItemTypes, MenuType>, commandOrOptionMenu: HTMLDivElement) {
+  protected addSubMenuTitleWhenExists(item: ExtractMenuType<ExtendableItemTypes, MenuType>, commandOrOptionMenu: HTMLDivElement): void {
     if (item !== 'divider' && (item as MenuCommandItem | MenuOptionItem | GridMenuItem)?.subMenuTitle) {
       const subMenuTitleElm = document.createElement('div');
       subMenuTitleElm.className = 'slick-menu-title';
@@ -148,7 +148,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
     args: unknown,
     itemClickCallback: (e: DOMMouseOrTouchEvent<HTMLDivElement>, type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number, columnDef?: Column) => void,
     itemMouseoverCallback?: (e: DOMMouseOrTouchEvent<HTMLElement>, type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number, columnDef?: Column) => void
-  ) {
+  ): void {
     if (args && commandOrOptionItems && menuOptions) {
       for (const item of commandOrOptionItems) {
         this.populateSingleCommandOrOptionItem(itemType, menuOptions, commandOrOptionMenuElm, item, args, itemClickCallback, itemMouseoverCallback);
@@ -218,7 +218,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
       }
 
       commandLiElm = createDomElement('li', { className: menuCssPrefix, role: 'menuitem' });
-      if (typeof item === 'object' && hasData((item as never)[itemType])) {
+      if (typeof item === 'object' && isDefined((item as never)[itemType])) {
         commandLiElm.dataset[itemType] = (item as never)?.[itemType];
       }
       if (commandOrOptionMenuElm) {

--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -157,7 +157,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
   }
 
   /** Add the Command/Options Title when necessary. */
-  protected populateCommandOrOptionTitle(itemType: MenuType, menuOptions: M, commandOrOptionMenuElm: HTMLElement, level: number) {
+  protected populateCommandOrOptionTitle(itemType: MenuType, menuOptions: M, commandOrOptionMenuElm: HTMLElement, level: number): void {
     if (menuOptions) {
       const isSubMenu = level > 0;
 

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -32,7 +32,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     super(extensionUtility, pubSubService, sharedService);
   }
 
-  createParentMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData) {
+  createParentMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData): HTMLDivElement | undefined {
     this.menuElement?.remove();
     this._menuElm = undefined;
     const cell = this.grid.getCellFromEvent(event);
@@ -89,7 +89,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
    * @param item - command, option or divider
    * @returns menu DOM element
    */
-  createMenu(commandItems: Array<MenuCommandItem | 'divider'>, optionItems: Array<MenuOptionItem | 'divider'>, level = 0, item?: ExtractMenuType<ExtendableItemTypes, MenuType>) {
+  createMenu(commandItems: Array<MenuCommandItem | 'divider'>, optionItems: Array<MenuOptionItem | 'divider'>, level = 0, item?: ExtractMenuType<ExtendableItemTypes, MenuType>): HTMLDivElement | undefined {
     const columnDef = this.grid.getColumns()[this._currentCell];
     const dataContext = this.grid.getDataItem(this._currentRow);
 
@@ -216,7 +216,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     return menuElm;
   }
 
-  closeMenu(e: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: { grid: SlickGrid; } | MenuFromCellCallbackArgs) {
+  closeMenu(e: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: { grid: SlickGrid; } | MenuFromCellCallbackArgs): void {
     if (this.menuElement) {
       if (typeof this.addonOptions?.onBeforeMenuClose === 'function' && (this.addonOptions as CellMenu | ContextMenu).onBeforeMenuClose!(e, args as MenuFromCellCallbackArgs) === false) {
         return;
@@ -226,7 +226,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
   }
 
   /** Hide the Menu */
-  hideMenu() {
+  hideMenu(): void {
     this.menuElement?.remove();
     this._menuElm = null;
     this.disposeSubMenus();
@@ -244,7 +244,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
   }
 
   /** Mouse down handler when clicking anywhere in the DOM body */
-  protected handleBodyMouseDown(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected handleBodyMouseDown(e: DOMMouseOrTouchEvent<HTMLDivElement>): void {
     if (this.menuElement) {
       let isMenuClicked = false;
       const parentMenuElm = e.target.closest(`.${this.menuCssClass}`);
@@ -260,13 +260,13 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     }
   }
 
-  protected handleCloseButtonClicked(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected handleCloseButtonClicked(e: DOMMouseOrTouchEvent<HTMLDivElement>): void {
     if (!e.defaultPrevented) {
       this.closeMenu(e, { cell: 0, row: 0, grid: this.grid, });
     }
   }
 
-  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0) {
+  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0): void {
     if ((item as never)?.[type] !== undefined && item !== 'divider' && !item.disabled && !(item as MenuCommandItem | MenuOptionItem).divider) {
       if ((item as MenuCommandItem).commandItems || (item as MenuOptionItem).optionItems) {
         this.repositionSubMenu(item, type, level, e);
@@ -277,7 +277,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     }
   }
 
-  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0) {
+  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0): void {
     if ((item as never)?.[type] !== undefined && item !== 'divider' && !item.disabled && !(item as MenuCommandItem | MenuOptionItem).divider && this._currentCell !== undefined && this._currentRow !== undefined) {
       if (type === 'option' && !this.grid.getEditorLock().commitCurrentEdit()) {
         return;
@@ -327,7 +327,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     }
   }
 
-  protected populateCommandOrOptionCloseBtn(itemType: MenuType, closeButtonElm: HTMLButtonElement, commandOrOptionMenuElm: HTMLDivElement) {
+  protected populateCommandOrOptionCloseBtn(itemType: MenuType, closeButtonElm: HTMLButtonElement, commandOrOptionMenuElm: HTMLDivElement): void {
     this._bindEventService.bind(closeButtonElm, 'click', ((e: DOMMouseOrTouchEvent<HTMLDivElement>) => this.handleCloseButtonClicked(e)) as EventListener, undefined, 'parent-menu');
     const commandOrOptionMenuHeaderElm = commandOrOptionMenuElm.querySelector<HTMLDivElement>(`.slick-${itemType}-header`) ?? createDomElement('div', { className: `slick-${itemType}-header` });
     commandOrOptionMenuHeaderElm?.appendChild(closeButtonElm);
@@ -335,7 +335,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     commandOrOptionMenuHeaderElm.classList.add('with-close');
   }
 
-  protected repositionSubMenu(item: ExtractMenuType<ExtendableItemTypes, MenuType>, type: MenuType, level: number, e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData) {
+  protected repositionSubMenu(item: ExtractMenuType<ExtendableItemTypes, MenuType>, type: MenuType, level: number, e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData): void {
     // when we're clicking a grid cell OR our last menu type (command/option) differs then we know that we need to start fresh and close any sub-menus that might still be open
     if (e.target!.classList.contains('slick-cell') || this._lastMenuTypeClicked !== type) {
       this.disposeSubMenus();
@@ -350,7 +350,7 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
     }
   }
 
-  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, menuElm?: HTMLElement) {
+  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, menuElm?: HTMLElement): void {
     const isSubMenu = menuElm?.classList.contains('slick-submenu');
     const parentElm = isSubMenu
       ? event.target!.closest(`.${this._menuCssPrefix}-item`) as HTMLDivElement

--- a/packages/common/src/extensions/slickAutoTooltip.ts
+++ b/packages/common/src/extensions/slickAutoTooltip.ts
@@ -39,7 +39,7 @@ export class SlickAutoTooltip {
   }
 
   /** Initialize plugin. */
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._addonOptions = { ...this._defaults, ...this.addonOptions };
     this._grid = grid;
     if (this._addonOptions.enableForCells) {
@@ -50,12 +50,12 @@ export class SlickAutoTooltip {
     }
   }
 
-  destroy() {
+  destroy(): void {
     this.dispose();
   }
 
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
-  dispose() {
+  dispose(): void {
     this._eventHandler?.unsubscribeAll();
   }
 
@@ -67,7 +67,7 @@ export class SlickAutoTooltip {
    * Handle mouse entering grid cell to add/remove tooltip.
    * @param {SlickEventData} event - The event
    */
-  protected handleMouseEnter(event: SlickEventData) {
+  protected handleMouseEnter(event: SlickEventData): void {
     const cell = this._grid.getCellFromEvent(event);
     if (cell) {
       let node: HTMLElement | null = this._grid.getCellNode(cell.row, cell.cell);
@@ -92,7 +92,7 @@ export class SlickAutoTooltip {
    * @param {SlickEventData} event - The event
    * @param {Object} args.column - The column definition
    */
-  protected handleHeaderMouseEnter(event: SlickEventData, args: { column: Column; }) {
+  protected handleHeaderMouseEnter(event: SlickEventData, args: { column: Column; }): void {
     const column = args.column;
     let node: HTMLDivElement | null;
     const targetElm = (event.target as HTMLDivElement);

--- a/packages/common/src/extensions/slickCellExcelCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExcelCopyManager.ts
@@ -58,7 +58,7 @@ export class SlickCellExcelCopyManager {
     return this._undoRedoBuffer;
   }
 
-  init(grid: SlickGrid, options?: ExcelCopyBufferOption) {
+  init(grid: SlickGrid, options?: ExcelCopyBufferOption): void {
     this._grid = grid;
     this.createUndoRedoBuffer();
     this._cellSelectionModel = new SlickCellSelectionModel();
@@ -88,7 +88,7 @@ export class SlickCellExcelCopyManager {
   }
 
   /** Dispose of the 3rd party addon (plugin) */
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
     this._bindingEventService.unbindAll();
@@ -101,7 +101,7 @@ export class SlickCellExcelCopyManager {
   // ---------------------
 
   /** Create an undo redo buffer used by the Excel like copy */
-  protected createUndoRedoBuffer() {
+  protected createUndoRedoBuffer(): void {
     let commandCtr = 0;
     this._commandQueue = [];
 
@@ -177,7 +177,7 @@ export class SlickCellExcelCopyManager {
   }
 
   /** Hook an undo shortcut key hook that will redo/undo the copy buffer using Ctrl+(Shift)+Z keyboard events */
-  protected handleBodyKeyDown(e: KeyboardEvent) {
+  protected handleBodyKeyDown(e: KeyboardEvent): void {
     if (e.key === 'Z' && (e.ctrlKey || e.metaKey)) {
       if (e.shiftKey) {
         this._undoRedoBuffer.redo(); // Ctrl + Shift + Z

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -20,13 +20,14 @@ const noop = () => { };
 */
 export class SlickCellExternalCopyManager {
   pluginName: 'CellExternalCopyManager' = 'CellExternalCopyManager' as const;
-  onCopyCells = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCells');
-  onCopyCancelled = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCancelled');
-  onPasteCells = new SlickEvent<{ ranges: SlickRange[]; }>('onPasteCells');
-  onBeforePasteCell = new SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>('onBeforePasteCell');
+  onCopyCells: SlickEvent<{ ranges: SlickRange[]; }> = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCells');
+  onCopyCancelled: SlickEvent<{ ranges: SlickRange[]; }> = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCancelled');
+  onPasteCells: SlickEvent<{ ranges: SlickRange[]; }> = new SlickEvent<{ ranges: SlickRange[]; }>('onPasteCells');
+  onBeforePasteCell: SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>
+    = new SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>('onBeforePasteCell');
 
   protected _addonOptions!: ExcelCopyBufferOption;
-  protected _bodyElement = document.body;
+  protected _bodyElement: HTMLElement = document.body;
   protected _clearCopyTI?: NodeJS.Timeout;
   protected _copiedCellStyle = 'copied';
   protected _copiedCellStyleLayerKey = 'copy-manager';

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -20,11 +20,10 @@ const noop = () => { };
 */
 export class SlickCellExternalCopyManager {
   pluginName: 'CellExternalCopyManager' = 'CellExternalCopyManager' as const;
-  onCopyCells: SlickEvent<{ ranges: SlickRange[]; }> = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCells');
-  onCopyCancelled: SlickEvent<{ ranges: SlickRange[]; }> = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCancelled');
-  onPasteCells: SlickEvent<{ ranges: SlickRange[]; }> = new SlickEvent<{ ranges: SlickRange[]; }>('onPasteCells');
-  onBeforePasteCell: SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>
-    = new SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>('onBeforePasteCell');
+  onCopyCells: SlickEvent<{ ranges: SlickRange[]; }>;
+  onCopyCancelled: SlickEvent<{ ranges: SlickRange[]; }>;
+  onPasteCells: SlickEvent<{ ranges: SlickRange[]; }>;
+  onBeforePasteCell: SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>;
 
   protected _addonOptions!: ExcelCopyBufferOption;
   protected _bodyElement: HTMLElement = document.body;
@@ -38,6 +37,10 @@ export class SlickCellExternalCopyManager {
   protected _onCopySuccess?: (rowCount: number) => void;
 
   constructor() {
+    this.onCopyCells = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCells');
+    this.onCopyCancelled = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCancelled');
+    this.onPasteCells = new SlickEvent<{ ranges: SlickRange[]; }>('onPasteCells');
+    this.onBeforePasteCell = new SlickEvent<{ cell: number; row: number; item: any; columnDef: Column; value: any; }>('onBeforePasteCell');
     this._eventHandler = new SlickEventHandler();
   }
 

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -40,7 +40,7 @@ export class SlickCellExternalCopyManager {
     this._eventHandler = new SlickEventHandler();
   }
 
-  get addonOptions() {
+  get addonOptions(): ExcelCopyBufferOption {
     return this._addonOptions;
   }
 
@@ -48,7 +48,7 @@ export class SlickCellExternalCopyManager {
     return this._eventHandler;
   }
 
-  init(grid: SlickGrid, options?: ExcelCopyBufferOption) {
+  init(grid: SlickGrid, options?: ExcelCopyBufferOption): void {
     this._grid = grid;
     this._addonOptions = { ...this._addonOptions, ...options };
     this._copiedCellStyleLayerKey = this._addonOptions.copiedCellStyleLayerKey || 'copy-manager';
@@ -100,11 +100,11 @@ export class SlickCellExternalCopyManager {
     }
   }
 
-  dispose() {
+  dispose(): void {
     this._eventHandler.unsubscribeAll();
   }
 
-  clearCopySelection() {
+  clearCopySelection(): void {
     this._grid.removeCellCssStyles(this._copiedCellStyleLayerKey);
   }
 
@@ -118,7 +118,7 @@ export class SlickCellExternalCopyManager {
     return getHtmlStringOutput(columnDef.name || '', 'innerHTML');
   }
 
-  getDataItemValueForColumn(item: any, columnDef: Column, row: number, cell: number, event: SlickEventData) {
+  getDataItemValueForColumn(item: any, columnDef: Column, row: number, cell: number, event: SlickEventData): string {
     if (typeof this._addonOptions.dataItemColumnValueExtractor === 'function') {
       const val = this._addonOptions.dataItemColumnValueExtractor(item, columnDef, row, cell) as string | HTMLElement;
       if (val) {
@@ -200,7 +200,7 @@ export class SlickCellExternalCopyManager {
     }
   }
 
-  setIncludeHeaderWhenCopying(includeHeaderWhenCopying: boolean) {
+  setIncludeHeaderWhenCopying(includeHeaderWhenCopying: boolean): void {
     this._addonOptions.includeHeaderWhenCopying = includeHeaderWhenCopying;
   }
 
@@ -208,7 +208,7 @@ export class SlickCellExternalCopyManager {
   // protected functions
   // ---------------------
 
-  protected createTextBox(innerText: string) {
+  protected createTextBox(innerText: string): HTMLTextAreaElement {
     const textAreaElm = createDomElement(
       'textarea',
       {
@@ -221,7 +221,7 @@ export class SlickCellExternalCopyManager {
     return textAreaElm;
   }
 
-  protected decodeTabularData(grid: SlickGrid, textAreaElement: HTMLTextAreaElement) {
+  protected decodeTabularData(grid: SlickGrid, textAreaElement: HTMLTextAreaElement): void {
     const columns = grid.getColumns();
     const clipText = textAreaElement.value;
     const clipRows = clipText.split(/[\n\f\r]/);
@@ -504,7 +504,7 @@ export class SlickCellExternalCopyManager {
     }
   }
 
-  protected markCopySelection(ranges: SlickRange[]) {
+  protected markCopySelection(ranges: SlickRange[]): void {
     this.clearCopySelection();
 
     const columns = this._grid.getColumns();

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -59,7 +59,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
   }
 
   /** Initialize plugin. */
-  init(cellMenuOptions?: CellMenu) {
+  init(cellMenuOptions?: CellMenu): void {
     this._addonOptions = { ...this._defaults, ...cellMenuOptions };
 
     // sort all menu items by their position order when defined
@@ -73,7 +73,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
   }
 
   /** Translate the Cell Menu titles, we need to loop through all column definition to re-translate all list titles & all commands/options */
-  translateCellMenu() {
+  translateCellMenu(): void {
     const gridOptions = this.sharedService?.gridOptions;
     const columnDefinitions = this.sharedService.allColumns;
 
@@ -104,7 +104,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
   // event handlers
   // ------------------
 
-  protected handleCellClick(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: OnClickEventArgs) {
+  protected handleCellClick(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: OnClickEventArgs): void {
     this.disposeAllMenus(); // make there's only 1 parent menu opened at a time
     const cell = this.grid.getCellFromEvent(event);
 
@@ -152,7 +152,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
   // protected functions
   // ------------------
 
-  protected sortMenuItems(columnDefinitions: Column[]) {
+  protected sortMenuItems(columnDefinitions: Column[]): void {
     // sort both items list
     columnDefinitions.forEach((columnDef: Column) => {
       if (columnDef?.cellMenu?.commandItems) {

--- a/packages/common/src/extensions/slickCellRangeDecorator.ts
+++ b/packages/common/src/extensions/slickCellRangeDecorator.ts
@@ -30,7 +30,7 @@ export class SlickCellRangeDecorator {
     this._options = deepMerge(this._defaults, options);
   }
 
-  get addonOptions() {
+  get addonOptions(): CellRangeDecoratorOption {
     return this._options;
   }
 

--- a/packages/common/src/extensions/slickCellRangeDecorator.ts
+++ b/packages/common/src/extensions/slickCellRangeDecorator.ts
@@ -39,18 +39,18 @@ export class SlickCellRangeDecorator {
   }
 
   /** Dispose the plugin. */
-  destroy() {
+  destroy(): void {
     this.hide();
   }
 
-  init() { }
+  init(): void { }
 
-  hide() {
+  hide(): void {
     this._elem?.remove();
     this._elem = null;
   }
 
-  show(range: SlickRange) {
+  show(range: SlickRange): HTMLDivElement {
     if (!this._elem) {
       this._elem = createDomElement('div', { className: this._options.selectionCssClass });
       Object.keys(this._options.selectionCss as CSSStyleDeclaration).forEach((cssStyleKey) => {

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -64,7 +64,7 @@ export class SlickCellRangeSelector {
     this._options = deepMerge(this._defaults, options);
   }
 
-  get addonOptions() {
+  get addonOptions(): CellRangeSelectorOption {
     return this._options;
   }
 
@@ -80,7 +80,7 @@ export class SlickCellRangeSelector {
     return this.gridUid ? `.${this.gridUid}` : '';
   }
 
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
     this._decorator = this._options.cellDecorator || new SlickCellRangeDecorator(grid, this._options);
     this._canvas = grid.getCanvasNode();
@@ -101,12 +101,12 @@ export class SlickCellRangeSelector {
       .subscribe(this._grid.onScroll, this.handleScroll.bind(this));
   }
 
-  destroy() {
+  destroy(): void {
     this.dispose();
   }
 
   /** Dispose the plugin. */
-  dispose() {
+  dispose(): void {
     this._eventHandler?.unsubscribeAll();
     emptyElement(this._activeCanvas);
     emptyElement(this._canvas);
@@ -114,11 +114,11 @@ export class SlickCellRangeSelector {
     this.stopIntervalTimer();
   }
 
-  getCellDecorator() {
+  getCellDecorator(): SlickCellRangeDecorator {
     return this._decorator;
   }
 
-  getCurrentRange() {
+  getCurrentRange(): DragRange | null {
     return this._currentlySelectedRange;
   }
 
@@ -164,7 +164,7 @@ export class SlickCellRangeSelector {
     return result;
   }
 
-  stopIntervalTimer() {
+  stopIntervalTimer(): void {
     if (this._autoScrollTimerId) {
       clearInterval(this._autoScrollTimerId);
       this._autoScrollTimerId = undefined;
@@ -175,7 +175,7 @@ export class SlickCellRangeSelector {
   // protected functions
   // ---------------------
 
-  protected handleDrag(evt: SlickEventData, dd: DragRowMove) {
+  protected handleDrag(evt: SlickEventData, dd: DragRowMove): void {
     if (!this._dragging && !this._gridOptions.enableRowMoveManager) {
       return;
     }
@@ -194,7 +194,7 @@ export class SlickCellRangeSelector {
     this.handleDragTo(e, dd);
   }
 
-  protected handleDragOutsideViewport() {
+  protected handleDragOutsideViewport(): void {
     this._xDelayForNextCell = this.addonOptions.maxIntervalToShowNextCell - Math.abs(this._draggingMouseOffset.offset.x) * this.addonOptions.accelerateInterval;
     this._yDelayForNextCell = this.addonOptions.maxIntervalToShowNextCell - Math.abs(this._draggingMouseOffset.offset.y) * this.addonOptions.accelerateInterval;
 
@@ -233,7 +233,7 @@ export class SlickCellRangeSelector {
     }
   }
 
-  protected handleDragToNewPosition(xNeedUpdate: boolean, yNeedUpdate: boolean) {
+  protected handleDragToNewPosition(xNeedUpdate: boolean, yNeedUpdate: boolean): void {
     let pageX = this._draggingMouseOffset.e.pageX;
     let pageY = this._draggingMouseOffset.e.pageY;
     const mouseOffsetX = this._draggingMouseOffset.offset.x;
@@ -258,7 +258,7 @@ export class SlickCellRangeSelector {
     this.handleDragTo({ pageX, pageY }, this._draggingMouseOffset.dd);
   }
 
-  protected handleDragTo(e: { pageX: number; pageY: number; }, dd: DragPosition) {
+  protected handleDragTo(e: { pageX: number; pageY: number; }, dd: DragPosition): void {
     const targetEvent: MouseEvent | Touch = (e as unknown as TouchEvent)?.touches?.[0] ?? e;
     const end = this._grid.getCellFromPoint(
       targetEvent.pageX - (getOffset(this._activeCanvas)?.left ?? 0) + this._columnOffset,
@@ -301,7 +301,7 @@ export class SlickCellRangeSelector {
     }
   }
 
-  protected handleDragEnd(e: any, dd: DragRowMove) {
+  protected handleDragEnd(e: any, dd: DragRowMove): void {
     this._decorator.hide();
 
     if (this._dragging) {
@@ -315,7 +315,7 @@ export class SlickCellRangeSelector {
     }
   }
 
-  protected handleDragInit(e: SlickEventData) {
+  protected handleDragInit(e: SlickEventData): void {
     // Set the active canvas node because the decorator needs to append its
     // box to the correct canvas
     this._activeCanvas = this._grid.getActiveCanvasNode(e);
@@ -359,7 +359,7 @@ export class SlickCellRangeSelector {
     }
   }
 
-  protected handleDragStart(e: SlickEventData, dd: DragRowMove) {
+  protected handleDragStart(e: SlickEventData, dd: DragRowMove): HTMLDivElement | undefined {
     const cellObj = this._grid.getCellFromEvent(e);
     if (cellObj && this.onBeforeCellRangeSelected.notify(cellObj).getReturnValue() !== false && this._grid.canCellBeSelected(cellObj.row, cellObj.cell)) {
       this._dragging = true;
@@ -389,7 +389,7 @@ export class SlickCellRangeSelector {
     return this._decorator.show(new SlickRange(start.row, start.cell));
   }
 
-  protected handleScroll(_e: SlickEventData, args: OnScrollEventArgs) {
+  protected handleScroll(_e: SlickEventData, args: OnScrollEventArgs): void {
     this._scrollTop = args.scrollTop;
     this._scrollLeft = args.scrollLeft;
   }

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -14,9 +14,9 @@ import { SlickEvent, type SlickEventData, SlickEventHandler, type SlickGrid, Sli
 
 export class SlickCellRangeSelector {
   pluginName: 'CellRangeSelector' = 'CellRangeSelector' as const;
-  onBeforeCellRangeSelected: SlickEvent<{ row: number; cell: number; }> = new SlickEvent<{ row: number; cell: number; }>('onBeforeCellRangeSelected');
-  onCellRangeSelecting: SlickEvent<{ range: SlickRange; }> = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelecting');
-  onCellRangeSelected: SlickEvent<{ range: SlickRange; }> = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelected');
+  onBeforeCellRangeSelected: SlickEvent<{ row: number; cell: number; }>;
+  onCellRangeSelecting: SlickEvent<{ range: SlickRange; }>;
+  onCellRangeSelected: SlickEvent<{ range: SlickRange; }>;
 
   protected _activeCanvas!: HTMLElement;
   protected _options!: CellRangeSelectorOption;
@@ -60,6 +60,9 @@ export class SlickCellRangeSelector {
   } as CellRangeSelectorOption;
 
   constructor(options?: Partial<CellRangeSelectorOption>) {
+    this.onBeforeCellRangeSelected = new SlickEvent<{ row: number; cell: number; }>('onBeforeCellRangeSelected');
+    this.onCellRangeSelecting = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelecting');
+    this.onCellRangeSelected = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelected');
     this._eventHandler = new SlickEventHandler();
     this._options = deepMerge(this._defaults, options);
   }

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -14,9 +14,9 @@ import { SlickEvent, type SlickEventData, SlickEventHandler, type SlickGrid, Sli
 
 export class SlickCellRangeSelector {
   pluginName: 'CellRangeSelector' = 'CellRangeSelector' as const;
-  onBeforeCellRangeSelected = new SlickEvent<{ row: number; cell: number; }>('onBeforeCellRangeSelected');
-  onCellRangeSelecting = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelecting');
-  onCellRangeSelected = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelected');
+  onBeforeCellRangeSelected: SlickEvent<{ row: number; cell: number; }> = new SlickEvent<{ row: number; cell: number; }>('onBeforeCellRangeSelected');
+  onCellRangeSelecting: SlickEvent<{ range: SlickRange; }> = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelecting');
+  onCellRangeSelected: SlickEvent<{ range: SlickRange; }> = new SlickEvent<{ range: SlickRange; }>('onCellRangeSelected');
 
   protected _activeCanvas!: HTMLElement;
   protected _options!: CellRangeSelectorOption;

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -49,7 +49,7 @@ export class SlickCellSelectionModel implements SelectionModel {
     return this._eventHandler;
   }
 
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
     if (grid.hasDataView()) {
       this._dataView = grid.getData<CustomDataView | SlickDataView>();
@@ -72,11 +72,11 @@ export class SlickCellSelectionModel implements SelectionModel {
     grid.registerPlugin(this._selector);
   }
 
-  destroy() {
+  destroy(): void {
     this.dispose();
   }
 
-  dispose() {
+  dispose(): void {
     if (this._selector) {
       this._selector.onBeforeCellRangeSelected.unsubscribe(this.handleBeforeCellRangeSelected.bind(this));
       this._selector.onCellRangeSelected.unsubscribe(this.handleCellRangeSelected.bind(this));
@@ -90,7 +90,7 @@ export class SlickCellSelectionModel implements SelectionModel {
     return this._ranges;
   }
 
-  rangesAreEqual(range1: SlickRange[], range2: SlickRange[]) {
+  rangesAreEqual(range1: SlickRange[], range2: SlickRange[]): boolean {
     let areDifferent = (range1.length !== range2.length);
     if (!areDifferent) {
       for (let i = 0; i < range1.length; i++) {
@@ -107,11 +107,11 @@ export class SlickCellSelectionModel implements SelectionModel {
     return !areDifferent;
   }
 
-  refreshSelections() {
+  refreshSelections(): void {
     this.setSelectedRanges(this.getSelectedRanges());
   }
 
-  removeInvalidRanges(ranges: SlickRange[]) {
+  removeInvalidRanges(ranges: SlickRange[]): SlickRange[] {
     const result = [];
     for (let i = 0; i < ranges.length; i++) {
       const r = ranges[i];
@@ -123,11 +123,11 @@ export class SlickCellSelectionModel implements SelectionModel {
   }
 
   /** Provide a way to force a recalculation of page row count (for example on grid resize) */
-  resetPageRowCount() {
+  resetPageRowCount(): void {
     this._cachedPageRowCount = 0;
   }
 
-  setSelectedRanges(ranges: SlickRange[], caller = 'SlickCellSelectionModel.setSelectedRanges') {
+  setSelectedRanges(ranges: SlickRange[], caller = 'SlickCellSelectionModel.setSelectedRanges'): void {
     // simple check for: empty selection didn't change, prevent firing onSelectedRangesChanged
     if ((!this._ranges || this._ranges.length === 0) && (!ranges || ranges.length === 0)) {
       return;
@@ -149,7 +149,7 @@ export class SlickCellSelectionModel implements SelectionModel {
   // protected functions
   // ---------------------
 
-  protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs) {
+  protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs): void {
     this._prevSelectedRow = undefined;
     const isCellDefined = isDefined(args.cell);
     const isRowDefined = isDefined(args.row);
@@ -174,16 +174,16 @@ export class SlickCellSelectionModel implements SelectionModel {
     }
   }
 
-  protected handleCellRangeSelected(_e: SlickEventData, args: { range: SlickRange; }) {
+  protected handleCellRangeSelected(_e: SlickEventData, args: { range: SlickRange; }): void {
     this._grid.setActiveCell(args.range.fromRow, args.range.fromCell, false, false, true);
     this.setSelectedRanges([args.range]);
   }
 
-  protected isKeyAllowed(key: string) {
+  protected isKeyAllowed(key: string): boolean {
     return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End'].some(k => k === key);
   }
 
-  protected handleKeyDown(e: SlickEventData) {
+  protected handleKeyDown(e: SlickEventData): void {
     let ranges: SlickRange[];
     let last: SlickRange;
     const colLn = this._grid.getColumns().length;

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -11,7 +11,7 @@ export interface CellSelectionModelOption {
 }
 
 export class SlickCellSelectionModel implements SelectionModel {
-  onSelectedRangesChanged = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
+  onSelectedRangesChanged: SlickEvent<SlickRange[]> = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
   pluginName: 'CellSelectionModel' = 'CellSelectionModel' as const;
 
   protected _addonOptions?: CellSelectionModelOption;
@@ -37,11 +37,11 @@ export class SlickCellSelectionModel implements SelectionModel {
     this._addonOptions = options;
   }
 
-  get addonOptions() {
+  get addonOptions(): CellSelectionModelOption | undefined {
     return this._addonOptions;
   }
 
-  get cellRangeSelector() {
+  get cellRangeSelector(): SlickCellRangeSelector {
     return this._selector;
   }
 

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -11,7 +11,7 @@ export interface CellSelectionModelOption {
 }
 
 export class SlickCellSelectionModel implements SelectionModel {
-  onSelectedRangesChanged: SlickEvent<SlickRange[]> = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
+  onSelectedRangesChanged: SlickEvent<SlickRange[]>;
   pluginName: 'CellSelectionModel' = 'CellSelectionModel' as const;
 
   protected _addonOptions?: CellSelectionModelOption;
@@ -28,12 +28,13 @@ export class SlickCellSelectionModel implements SelectionModel {
   };
 
   constructor(options?: { selectActiveCell: boolean; cellRangeSelector: SlickCellRangeSelector; }) {
+    this.onSelectedRangesChanged = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
     this._eventHandler = new SlickEventHandler();
-    if (options === undefined || options.cellRangeSelector === undefined) {
-      this._selector = new SlickCellRangeSelector({ selectionCss: { border: '2px solid black' } as CSSStyleDeclaration });
-    } else {
-      this._selector = options.cellRangeSelector;
-    }
+
+    this._selector = (options === undefined || options.cellRangeSelector === undefined)
+      ? new SlickCellRangeSelector({ selectionCss: { border: '2px solid black' } as CSSStyleDeclaration })
+      : this._selector = options.cellRangeSelector;
+
     this._addonOptions = options;
   }
 

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -48,7 +48,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     this._addonOptions = { ...this._defaults, ...options } as CheckboxSelectorOption;
   }
 
-  get addonOptions() {
+  get addonOptions(): CheckboxSelectorOption {
     return this._addonOptions;
   }
 

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -61,7 +61,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     return this._grid?.getOptions() ?? {};
   }
 
-  get selectAllUid() {
+  get selectAllUid(): number {
     return this._selectAll_UID;
   }
 
@@ -69,7 +69,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     this._selectedRowsLookup = selectedRows;
   }
 
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
     this._isUsingDataView = !Array.isArray(grid.getData());
     if (this._isUsingDataView) {
@@ -122,7 +122,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  dispose() {
+  dispose(): void {
     this._bindEventService.unbindAll();
     this._eventHandler.unsubscribeAll();
   }
@@ -154,11 +154,11 @@ export class SlickCheckboxSelectColumn<T = any> {
     return this;
   }
 
-  getOptions() {
+  getOptions(): CheckboxSelectorOption {
     return this._addonOptions;
   }
 
-  setOptions(options: CheckboxSelectorOption) {
+  setOptions(options: CheckboxSelectorOption): void {
     this._addonOptions = { ...this._addonOptions, ...options } as CheckboxSelectorOption;
 
     if (this._addonOptions.hideSelectAllCheckbox) {
@@ -192,7 +192,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  deSelectRows(rowArray: number[]) {
+  deSelectRows(rowArray: number[]): void {
     const removeRows: number[] = [];
     for (const row of rowArray) {
       if (this._selectedRowsLookup[row]) {
@@ -202,7 +202,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     this._grid.setSelectedRows(this._grid.getSelectedRows().filter((n) => removeRows.indexOf(n) < 0), 'SlickCheckboxSelectColumn.deSelectRows');
   }
 
-  selectRows(rowArray: number[]) {
+  selectRows(rowArray: number[]): void {
     const addRows = [];
     for (const row of rowArray) {
       if (this._selectedRowsLookup[row]) {
@@ -220,7 +220,7 @@ export class SlickCheckboxSelectColumn<T = any> {
    * @param {Boolean} checked - is the input checkbox checked?
    * @returns
    */
-  createCheckboxElement(inputId: string, checked = false) {
+  createCheckboxElement(inputId: string, checked = false): DocumentFragment {
     const fragmentElm = new DocumentFragment();
     const labelElm = createDomElement('label', { className: 'checkbox-selector-label', htmlFor: inputId });
     const divElm = createDomElement('div', { className: 'icon-checkbox-container' });
@@ -262,11 +262,11 @@ export class SlickCheckboxSelectColumn<T = any> {
     } as Column;
   }
 
-  hideSelectAllFromColumnHeaderTitleRow() {
+  hideSelectAllFromColumnHeaderTitleRow(): void {
     this._grid.updateColumnHeader(this._addonOptions.columnId || '', this._addonOptions.name || '', '');
   }
 
-  hideSelectAllFromColumnHeaderFilterRow() {
+  hideSelectAllFromColumnHeaderFilterRow(): void {
     const selectAllContainerElm = this.headerRowNode?.querySelector<HTMLSpanElement>('#filter-checkbox-selectall-container');
     if (selectAllContainerElm) {
       selectAllContainerElm.style.display = 'none';
@@ -277,7 +277,7 @@ export class SlickCheckboxSelectColumn<T = any> {
    * Toggle a row selection by providing a row number
    * @param {Number} row - grid row number to toggle
    */
-  toggleRowSelection(row: number) {
+  toggleRowSelection(row: number): void {
     this.toggleRowSelectionWithEvent(null, row);
   }
 
@@ -287,7 +287,7 @@ export class SlickCheckboxSelectColumn<T = any> {
    * @param {Number} row - grid row number to toggle
    * @returns
    */
-  toggleRowSelectionWithEvent(event: SlickEventData | null, row: number) {
+  toggleRowSelectionWithEvent(event: SlickEventData | null, row: number): void {
     const dataContext = this._grid.getDataItem(row);
     if (!this.checkSelectableOverride(row, dataContext, this._grid)) {
       return;
@@ -315,7 +315,7 @@ export class SlickCheckboxSelectColumn<T = any> {
    * In order word, user can choose which rows to be selectable or not by providing his own logic.
    * @param overrideFn: override function callback
    */
-  selectableOverride(overrideFn: SelectableOverrideCallback<T>) {
+  selectableOverride(overrideFn: SelectableOverrideCallback<T>): void {
     this._selectableOverride = overrideFn;
   }
 
@@ -323,7 +323,7 @@ export class SlickCheckboxSelectColumn<T = any> {
   // protected functions
   // ---------------------
 
-  protected addCheckboxToFilterHeaderRow(grid: SlickGrid) {
+  protected addCheckboxToFilterHeaderRow(grid: SlickGrid): void {
     this._eventHandler.subscribe(grid.onHeaderRowCellRendered, (_e, args) => {
       if (args.column.field === (this._addonOptions.field || '_checkbox_selector')) {
         emptyElement(args.node);
@@ -348,7 +348,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     });
   }
 
-  protected checkboxSelectionFormatter(row: number, _cell: number, _val: any, _columnDef: Column, dataContext: any, grid: SlickGrid) {
+  protected checkboxSelectionFormatter(row: number, _cell: number, _val: any, _columnDef: Column, dataContext: any, grid: SlickGrid): DocumentFragment | null {
     if (dataContext && this.checkSelectableOverride(row, dataContext, grid)) {
       const UID = this.createUID() + row;
       return this.createCheckboxElement(`selector${UID}`, !!this._selectedRowsLookup[row]);
@@ -356,7 +356,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     return null;
   }
 
-  protected checkSelectableOverride(row: number, dataContext: any, grid: SlickGrid) {
+  protected checkSelectableOverride(row: number, dataContext: any, grid: SlickGrid): boolean {
     if (typeof this._selectableOverride === 'function') {
       return this._selectableOverride(row, dataContext, grid);
     }
@@ -367,7 +367,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     return Math.round(10000000 * Math.random());
   }
 
-  protected getCheckboxColumnCellIndex() {
+  protected getCheckboxColumnCellIndex(): number {
     if (this._checkboxColumnCellIndex === null) {
       this._checkboxColumnCellIndex = 0;
       const colArr = this._grid.getColumns();
@@ -380,7 +380,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     return this._checkboxColumnCellIndex;
   }
 
-  protected handleDataViewSelectedIdsChanged() {
+  protected handleDataViewSelectedIdsChanged(): void {
     const selectedIds = this._dataView.getAllSelectedFilteredIds();
     const filteredItems = this._dataView.getFilteredItems();
     let disabledCount = 0;
@@ -415,7 +415,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleClick(e: SlickEventData, args: { row: number; cell: number; grid: SlickGrid; }) {
+  protected handleClick(e: SlickEventData, args: { row: number; cell: number; grid: SlickGrid; }): void {
     // clicking on a row select checkbox
     if (this._grid.getColumns()[args.cell].id === this._addonOptions.columnId && (e.target as HTMLInputElement).type === 'checkbox') {
       (e.target as HTMLInputElement).ariaChecked = String((e.target as HTMLInputElement).checked);
@@ -433,7 +433,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleHeaderClick(e: DOMMouseOrTouchEvent<HTMLInputElement> | SlickEventData, args: OnHeaderClickEventArgs) {
+  protected handleHeaderClick(e: DOMMouseOrTouchEvent<HTMLInputElement> | SlickEventData, args: OnHeaderClickEventArgs): void {
     if (args.column.id === this._addonOptions.columnId && (e.target as HTMLInputElement).type === 'checkbox') {
       (e.target as HTMLInputElement).ariaChecked = String((e.target as HTMLInputElement).checked);
 
@@ -496,7 +496,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleKeyDown(e: SlickEventData, args: OnKeyDownEventArgs) {
+  protected handleKeyDown(e: SlickEventData, args: OnKeyDownEventArgs): void {
     if (e.key === ' ') {
       if (this._grid.getColumns()[args.cell].id === this._addonOptions.columnId) {
         // if editing, try to commit
@@ -509,7 +509,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected handleSelectedRowsChanged() {
+  protected handleSelectedRowsChanged(): void {
     const selectedRows = this._grid.getSelectedRows();
     const lookup: RowLookup = {};
     let row = 0;
@@ -577,7 +577,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     }
   }
 
-  protected renderSelectAllCheckbox(isSelectAllChecked: boolean) {
+  protected renderSelectAllCheckbox(isSelectAllChecked: boolean): void {
     const colHeaderElm = this._grid.updateColumnHeader(
       this._addonOptions.columnId || '',
       this.createCheckboxElement(`header-selector${this._selectAll_UID}`, !!isSelectAllChecked),

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -87,7 +87,7 @@ export class SlickColumnPicker {
   }
 
   /** Initialize plugin. */
-  init() {
+  init(): void {
     this._gridUid = this.grid.getUID() ?? '';
     this.gridOptions.columnPicker = { ...this._defaults, ...this.gridOptions.columnPicker };
 
@@ -111,20 +111,20 @@ export class SlickColumnPicker {
   }
 
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
-  dispose() {
+  dispose(): void {
     this._eventHandler.unsubscribeAll();
     this._bindEventService.unbindAll();
     this.disposeMenu();
   }
 
-  disposeMenu() {
+  disposeMenu(): void {
     this._bindEventService.unbindAll('parent-menu');
     this._listElm?.remove();
     this._menuElm?.remove();
     this._menuElm = null;
   }
 
-  createPickerMenu() {
+  createPickerMenu(): HTMLDivElement {
     const menuElm = createDomElement('div', {
       ariaExpanded: 'true',
       className: `slick-column-picker ${this._gridUid}`,
@@ -148,7 +148,7 @@ export class SlickColumnPicker {
    * Get all columns including hidden columns.
    * @returns {Array<Object>} - all columns array
    */
-  getAllColumns() {
+  getAllColumns(): Column[] {
     return this._columns;
   }
 
@@ -156,12 +156,12 @@ export class SlickColumnPicker {
    * Get only the visible columns.
    * @returns {Array<Object>} - all columns array
    */
-  getVisibleColumns() {
+  getVisibleColumns(): Column[] {
     return this.grid.getColumns();
   }
 
   /** Translate the Column Picker headers and also the last 2 checkboxes */
-  translateColumnPicker() {
+  translateColumnPicker(): void {
     // update the properties by pointers, that is the only way to get Column Picker Control to see the new values
     if (this.addonOptions) {
       this.addonOptions.columnTitle = '';
@@ -184,14 +184,14 @@ export class SlickColumnPicker {
   // ------------------
 
   /** Mouse down handler when clicking anywhere in the DOM body */
-  protected handleBodyMouseDown(e: DOMMouseOrTouchEvent<HTMLDivElement>) {
+  protected handleBodyMouseDown(e: DOMMouseOrTouchEvent<HTMLDivElement>): void {
     if ((this._menuElm !== e.target && !this._menuElm?.contains(e.target)) || (e.target.className === 'close' && e.target.closest('.slick-column-picker'))) {
       this.disposeMenu();
     }
   }
 
   /** Mouse header context handler when doing a right+click on any of the header column title */
-  protected handleHeaderContextMenu(e: SlickEventData) {
+  protected handleHeaderContextMenu(e: SlickEventData): void {
     e.preventDefault();
     emptyElement(this._listElm);
     this._columnCheckboxes = [];
@@ -210,7 +210,7 @@ export class SlickColumnPicker {
     this.repositionMenu(e);
   }
 
-  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData) {
+  protected repositionMenu(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData): void {
     const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
     if (this._menuElm) {
       this._menuElm.style.top = `${targetEvent.pageY - 10}px`;

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -27,7 +27,7 @@ import { SlickEvent, type SlickEventData, SlickEventHandler, type SlickGrid } fr
  * @constructor
  */
 export class SlickColumnPicker {
-  onColumnsChanged: SlickEvent<OnColumnsChangedArgs> = new SlickEvent<OnColumnsChangedArgs>('onColumnsChanged');
+  onColumnsChanged: SlickEvent<OnColumnsChangedArgs>;
 
   protected _areVisibleColumnDifferent = false;
   protected _bindEventService: BindingEventService;
@@ -52,6 +52,7 @@ export class SlickColumnPicker {
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
   constructor(protected readonly extensionUtility: ExtensionUtility, protected readonly pubSubService: BasePubSubService, protected readonly sharedService: SharedService) {
     this._bindEventService = new BindingEventService();
+    this.onColumnsChanged = new SlickEvent<OnColumnsChangedArgs>('onColumnsChanged');
     this._eventHandler = new SlickEventHandler();
     this._columns = this.sharedService.allColumns ?? [];
     this._gridUid = this.grid?.getUID?.() ?? '';

--- a/packages/common/src/extensions/slickColumnPicker.ts
+++ b/packages/common/src/extensions/slickColumnPicker.ts
@@ -27,7 +27,7 @@ import { SlickEvent, type SlickEventData, SlickEventHandler, type SlickGrid } fr
  * @constructor
  */
 export class SlickColumnPicker {
-  onColumnsChanged = new SlickEvent<OnColumnsChangedArgs>('onColumnsChanged');
+  onColumnsChanged: SlickEvent<OnColumnsChangedArgs> = new SlickEvent<OnColumnsChangedArgs>('onColumnsChanged');
 
   protected _areVisibleColumnDifferent = false;
   protected _bindEventService: BindingEventService;
@@ -224,7 +224,7 @@ export class SlickColumnPicker {
   }
 
   /** Update the Titles of each sections (command, commandTitle, ...) */
-  protected translateTitleLabels(pickerOptions: ColumnPickerOption) {
+  protected translateTitleLabels(pickerOptions: ColumnPickerOption): void {
     if (pickerOptions) {
       pickerOptions.columnTitle = this.extensionUtility.getPickerTitleOutputString('columnTitle', 'gridMenu');
     }

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -62,7 +62,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
   }
 
   /** Initialize plugin. */
-  init(contextMenuOptions?: ContextMenu) {
+  init(contextMenuOptions?: ContextMenu): void {
     this._addonOptions = { ...this._defaults, ...contextMenuOptions };
 
     // merge the original commands with the built-in internal commands
@@ -83,7 +83,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
   }
 
   /** Translate the Context Menu titles, we need to loop through all column definition to re-translate all list titles & all commands/options */
-  translateContextMenu() {
+  translateContextMenu(): void {
     const gridOptions = this.sharedService?.gridOptions ?? {};
     const contextMenu = this.sharedService.gridOptions.contextMenu;
 
@@ -110,7 +110,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
   // event handlers
   // ------------------
 
-  protected handleOnContextMenu(event: SlickEventData, args: { grid: SlickGrid; }) {
+  protected handleOnContextMenu(event: SlickEventData, args: { grid: SlickGrid; }): void {
     this.disposeAllMenus(); // make there's only 1 parent menu opened at a time
     const cell = this.grid.getCellFromEvent(event);
 
@@ -157,7 +157,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
   // ------------------
 
   /** Create Context Menu with Custom Commands (copy cell value, export) */
-  protected addMenuCustomCommands(originalCommandItems: Array<MenuCommandItem | 'divider'>) {
+  protected addMenuCustomCommands(originalCommandItems: Array<MenuCommandItem | 'divider'>): (MenuCommandItem<MenuCommandItemCallbackArgs, MenuCallbackArgs<any>> | 'divider')[] {
     const menuCommandItems: Array<MenuCommandItem | 'divider'> = [];
     const gridOptions = this.sharedService && this.sharedService.gridOptions || {};
     const contextMenu = gridOptions?.contextMenu;
@@ -385,7 +385,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
    * and from there we can call the execCommand 'copy' command and expect the value to be in clipboard
    * @param args
    */
-  protected copyToClipboard(args: MenuCommandItemCallbackArgs) {
+  protected copyToClipboard(args: MenuCommandItemCallbackArgs): void {
     try {
       if (args && args.grid && args.command) {
         // get the value, if "exportWithFormatter" is set then we'll use the formatter output
@@ -430,7 +430,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
   }
 
   /** sort all menu items by their position order when defined */
-  protected sortMenuItems() {
+  protected sortMenuItems(): void {
     const contextMenu = this.sharedService?.gridOptions?.contextMenu;
     if (contextMenu) {
       this.extensionUtility.sortItems(contextMenu.commandItems || [], 'positionOrder');

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -120,7 +120,7 @@ export class SlickDraggableGrouping {
     return this._gridUid || (this.grid?.getUID() ?? '');
   }
 
-  get gridContainer() {
+  get gridContainer(): HTMLElement {
     return this.grid.getContainerNode();
   }
 
@@ -249,7 +249,7 @@ export class SlickDraggableGrouping {
     this._addonOptions = { ...this._addonOptions, ...options };
   }
 
-  setColumns(cols: Column[]) {
+  setColumns(cols: Column[]): void {
     this._gridColumns = cols;
   }
 

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -87,19 +87,19 @@ export class SlickDraggableGrouping {
     return this.grid?.getData<SlickDataView>() ?? {};
   }
 
-  get dropboxElement() {
+  get dropboxElement(): HTMLDivElement {
     return this._dropzoneElm;
   }
 
-  get droppableInstance() {
+  get droppableInstance(): Sortable | undefined {
     return this._droppableInstance;
   }
 
-  get sortableLeftInstance() {
+  get sortableLeftInstance(): Sortable | undefined {
     return this._sortableLeftInstance;
   }
 
-  get sortableRightInstance() {
+  get sortableRightInstance(): Sortable | undefined {
     return this._sortableRightInstance;
   }
 
@@ -125,7 +125,7 @@ export class SlickDraggableGrouping {
   }
 
   /** Initialize plugin. */
-  init(grid: SlickGrid, groupingOptions?: DraggableGrouping) {
+  init(grid: SlickGrid, groupingOptions?: DraggableGrouping): this {
     this._addonOptions = { ...this._defaults, ...groupingOptions };
     this._grid = grid;
     if (grid) {
@@ -207,7 +207,7 @@ export class SlickDraggableGrouping {
   }
 
   /** Dispose the plugin. */
-  dispose() {
+  dispose(): void {
     this.destroySortableInstances();
     if (this._droppableInstance?.el) {
       this._droppableInstance?.destroy();
@@ -219,7 +219,7 @@ export class SlickDraggableGrouping {
     emptyElement(this.gridContainer.querySelector(`.${this.gridUid} .slick-preheader-panel,.${this.gridUid} .slick-topheader-panel`));
   }
 
-  clearDroppedGroups() {
+  clearDroppedGroups(): void {
     this.columnsGroupBy = [];
     this.updateGroupBy('clear-all');
     const allDroppedGroupingElms = this._dropzoneElm.querySelectorAll('.slick-dropped-grouping');
@@ -236,7 +236,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  destroySortableInstances() {
+  destroySortableInstances(): void {
     if (this._sortableLeftInstance?.el) {
       this._sortableLeftInstance?.destroy();
     }
@@ -245,7 +245,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  setAddonOptions(options: Partial<DraggableGroupingOption>) {
+  setAddonOptions(options: Partial<DraggableGroupingOption>): void {
     this._addonOptions = { ...this._addonOptions, ...options };
   }
 
@@ -253,7 +253,7 @@ export class SlickDraggableGrouping {
     this._gridColumns = cols;
   }
 
-  setDroppedGroups(groupingInfo: Array<string | GroupingGetterFunction> | string) {
+  setDroppedGroups(groupingInfo: Array<string | GroupingGetterFunction> | string): void {
     this._dropzonePlaceholderElm.style.display = 'none';
     const groupingInfos = Array.isArray(groupingInfo) ? groupingInfo : [groupingInfo];
     for (const groupInfo of groupingInfos) {
@@ -275,7 +275,10 @@ export class SlickDraggableGrouping {
    * @param uid - grid UID
    * @param trigger - callback to execute when triggering a column grouping
    */
-  setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, _columns: Column[], getColumnIndex: (columnId: string) => number, _uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void) {
+  setupColumnReorder(grid: SlickGrid, headers: any, _headerColumnWidthDiff: any, setColumns: (columns: Column[]) => void, setupColumnResize: () => void, _columns: Column[], getColumnIndex: (columnId: string) => number, _uid: string, trigger: (slickEvent: SlickEvent, data?: any) => void): {
+    sortableLeftInstance: Sortable;
+    sortableRightInstance: Sortable;
+  } {
     this.destroySortableInstances();
     const dropzoneElm = grid.getTopHeaderPanel() || grid.getPreHeaderPanel();
     const draggablePlaceholderElm = dropzoneElm.querySelector<HTMLDivElement>('.slick-draggable-dropzone-placeholder');
@@ -368,14 +371,14 @@ export class SlickDraggableGrouping {
   // protected functions
   // ------------------
 
-  protected addColumnGroupBy(column: Column) {
+  protected addColumnGroupBy(column: Column): void {
     this.columnsGroupBy.push(column);
     this.updateGroupBy('add-group');
   }
 
-  protected addGroupByRemoveClickHandler(id: string | number, groupRemoveIconElm: HTMLDivElement, headerColumnElm: HTMLDivElement, entry: any) {
+  protected addGroupByRemoveClickHandler(id: string | number, groupRemoveIconElm: HTMLDivElement, headerColumnElm: HTMLDivElement, entry: any): void {
     this._bindingEventService.bind(groupRemoveIconElm, 'click', () => {
-      const boundedElms = this._bindingEventService.boundedEvents.filter(boundedEvent => boundedEvent.element === groupRemoveIconElm);
+      const boundedElms = this._bindingEventService.boundedEvents.filter((boundedEvent: any) => boundedEvent.element === groupRemoveIconElm);
       for (const boundedEvent of boundedElms) {
         this._bindingEventService.unbind(boundedEvent.element, 'click', boundedEvent.listener);
       }
@@ -383,7 +386,7 @@ export class SlickDraggableGrouping {
     });
   }
 
-  protected addGroupSortClickHandler(col: Column, groupSortContainerElm: HTMLDivElement) {
+  protected addGroupSortClickHandler(col: Column, groupSortContainerElm: HTMLDivElement): void {
     const { grouping, type } = col;
     this._bindingEventService.bind(groupSortContainerElm, 'click', () => {
       // group sorting requires all group to be opened, make sure that the Toggle All is also expanded
@@ -400,7 +403,7 @@ export class SlickDraggableGrouping {
     });
   }
 
-  protected getGroupBySortIcon(groupSortContainerElm: HTMLDivElement, sortAsc = true) {
+  protected getGroupBySortIcon(groupSortContainerElm: HTMLDivElement, sortAsc = true): void {
     if (sortAsc) {
       // ascending icon
       if (this._addonOptions.sortAscIconCssClass) {
@@ -424,7 +427,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  protected handleGroupByDrop(containerElm: HTMLDivElement, headerColumnElm: HTMLDivElement) {
+  protected handleGroupByDrop(containerElm: HTMLDivElement, headerColumnElm: HTMLDivElement): void {
     const columnId = headerColumnElm.getAttribute('data-id')?.replace(this._gridUid, '');
     let columnAllowed = true;
     for (const colGroupBy of this.columnsGroupBy) {
@@ -493,7 +496,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  protected toggleGroupAll({ grouping }: Column, collapsed?: boolean) {
+  protected toggleGroupAll({ grouping }: Column, collapsed?: boolean): void {
     const togglerIcon = this._groupToggler?.querySelector<HTMLSpanElement>('.slick-group-toggle-all-icon');
     if (collapsed === true || grouping?.collapsed) {
       togglerIcon?.classList.add('collapsed');
@@ -504,7 +507,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  protected removeFromArray(arrayToModify: any[], itemToRemove: any) {
+  protected removeFromArray(arrayToModify: any[], itemToRemove: any): any[] {
     if (Array.isArray(arrayToModify)) {
       const itemIdx = arrayToModify.findIndex(a => a.id === itemToRemove.id);
       if (itemIdx >= 0) {
@@ -514,7 +517,7 @@ export class SlickDraggableGrouping {
     return arrayToModify;
   }
 
-  protected removeGroupBy(id: string | number, _hdrColumnElm: HTMLDivElement, entry: any) {
+  protected removeGroupBy(id: string | number, _hdrColumnElm: HTMLDivElement, entry: any): void {
     entry.remove();
     const groupByColumns: Column[] = [];
     this._gridColumns.forEach(col => groupByColumns[col.id as number] = col);
@@ -529,17 +532,17 @@ export class SlickDraggableGrouping {
     this.updateGroupBy('remove-group');
   }
 
-  protected addDragOverDropzoneListeners() {
+  protected addDragOverDropzoneListeners(): void {
     const draggablePlaceholderElm = this._dropzoneElm.querySelector('.slick-draggable-dropzone-placeholder');
 
     if (draggablePlaceholderElm && this._dropzoneElm) {
-      this._bindingEventService.bind(draggablePlaceholderElm, 'dragover', (e) => e.preventDefault());
+      this._bindingEventService.bind(draggablePlaceholderElm, 'dragover', (e: Event) => e.preventDefault());
       this._bindingEventService.bind(draggablePlaceholderElm, 'dragenter', () => this._dropzoneElm.classList.add('slick-dropzone-hover'));
       this._bindingEventService.bind(draggablePlaceholderElm, 'dragleave', () => this._dropzoneElm.classList.remove('slick-dropzone-hover'));
     }
   }
 
-  protected setupColumnDropbox() {
+  protected setupColumnDropbox(): void {
     const dropzoneElm = this._dropzoneElm;
 
     this._droppableInstance = Sortable.create(dropzoneElm, {
@@ -581,7 +584,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  protected toggleGroupToggler(targetElm: Element | null, collapsing = true, shouldExecuteDataViewCommand = true) {
+  protected toggleGroupToggler(targetElm: Element | null, collapsing = true, shouldExecuteDataViewCommand = true): void {
     if (targetElm) {
       if (collapsing === true) {
         targetElm.classList.add('collapsed');
@@ -599,7 +602,7 @@ export class SlickDraggableGrouping {
     }
   }
 
-  protected updateGroupBy(originator: string) {
+  protected updateGroupBy(originator: string): void {
     if (this.columnsGroupBy.length === 0) {
       this.dataView.setGrouping([]);
       this._dropzonePlaceholderElm.style.display = 'inline-block';
@@ -614,7 +617,7 @@ export class SlickDraggableGrouping {
   }
 
   /** call notify on slickgrid event and execute onGroupChanged callback when defined as a function by the user */
-  protected triggerOnGroupChangedEvent(args: { caller?: string; groupColumns: Grouping[]; }) {
+  protected triggerOnGroupChangedEvent(args: { caller?: string; groupColumns: Grouping[]; }): void {
     if (this._addonOptions && typeof this._addonOptions.onGroupChanged === 'function') {
       this._addonOptions.onGroupChanged(new SlickEventData(), args);
     }

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -74,8 +74,8 @@ export class SlickDraggableGrouping {
     protected readonly sharedService: SharedService,
   ) {
     this._bindingEventService = new BindingEventService();
-    this._eventHandler = new SlickEventHandler();
     this.onGroupChanged = new SlickEvent<{ caller?: string; groupColumns: Grouping[]; }>('onGroupChanged');
+    this._eventHandler = new SlickEventHandler();
   }
 
   get addonOptions(): DraggableGroupingOption {

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -111,7 +111,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     return this.gridUid ? `.${this.gridUid}` : '';
   }
 
-  initEventHandlers() {
+  initEventHandlers(): void {
     // when grid columns are reordered then we also need to update/resync our picker column in the same order
     this._eventHandler.subscribe(this.grid.onColumnsReordered, updateColumnPickerOrder.bind(this));
     this._eventHandler.subscribe(this.grid.onClick, (e) => this.hideMenu(e as any));
@@ -133,7 +133,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Initialize plugin. */
-  init() {
+  init(): void {
     this._gridUid = this.grid.getUID() ?? '';
 
     // add PubSub instance to all SlickEvent
@@ -157,12 +157,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
-  dispose() {
+  dispose(): void {
     this.deleteMenu();
     super.dispose();
   }
 
-  deleteMenu() {
+  deleteMenu(): void {
     this._bindEventService.unbindAll();
     this._menuElm?.remove();
     this._menuElm = null;
@@ -173,7 +173,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
   }
 
-  createColumnPickerContainer() {
+  createColumnPickerContainer(): void {
     if (this._menuElm) {
       // user could pass a title on top of the columns list
       addColumnTitleElementWhenDefined.call(this, this._menuElm);
@@ -186,7 +186,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Create parent grid menu container */
-  createGridMenu() {
+  createGridMenu(): void {
     const gridUidSelector = this._gridUid ? `.${this._gridUid}` : '';
     const gridMenuWidth = this._addonOptions?.menuWidth || this._defaults.menuWidth;
     const headerSide = (this.gridOptions.hasOwnProperty('frozenColumn') && this.gridOptions.frozenColumn! >= 0) ? 'right' : 'left';
@@ -235,7 +235,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Create the menu or sub-menu(s) but without the column picker which is a separate single process */
-  createCommandMenu(commandItems: Array<GridMenuItem | 'divider'>, level = 0, item?: ExtractMenuType<ExtendableItemTypes, MenuType>) {
+  createCommandMenu(commandItems: Array<GridMenuItem | 'divider'>, level = 0, item?: ExtractMenuType<ExtendableItemTypes, MenuType>): HTMLDivElement {
     // to avoid having multiple sub-menu trees opened
     // we need to somehow keep trace of which parent menu the tree belongs to
     // and we should keep ref of only the first sub-menu parent, we can use the command name (remove any whitespaces though)
@@ -291,7 +291,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
    * Get all columns including hidden columns.
    * @returns {Array<Object>} - all columns array
    */
-  getAllColumns() {
+  getAllColumns(): Column[] {
     return this._columns;
   }
 
@@ -299,7 +299,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
    * Get only the visible columns.
    * @returns {Array<Object>} - only the visible columns array
    */
-  getVisibleColumns() {
+  getVisibleColumns(): Column[] {
     return this.grid.getColumns();
   }
 
@@ -308,7 +308,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
    * @param event
    * @returns
    */
-  hideMenu(event: Event) {
+  hideMenu(event: Event): void {
     const callbackArgs = {
       grid: this.grid,
       menu: this._menuElm,
@@ -343,12 +343,12 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** destroy and recreate the Grid Menu in the DOM */
-  recreateGridMenu() {
+  recreateGridMenu(): void {
     this.deleteMenu();
     this.init();
   }
 
-  repositionMenu(e: MouseEvent | TouchEvent, menuElm: HTMLElement, buttonElm?: HTMLButtonElement, addonOptions?: GridMenu) {
+  repositionMenu(e: MouseEvent | TouchEvent, menuElm: HTMLElement, buttonElm?: HTMLButtonElement, addonOptions?: GridMenu): void {
     const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
     const isSubMenu = menuElm.classList.contains('slick-submenu');
     const parentElm = isSubMenu
@@ -432,7 +432,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Open the Grid Menu */
-  openGridMenu() {
+  openGridMenu(): void {
     const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, composed: false });
     Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: createDomElement('button', { className: 'slick-grid-menu-button' }) });
     this.showGridMenu(clickEvent);
@@ -522,7 +522,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Translate the Grid Menu titles and column picker */
-  translateGridMenu() {
+  translateGridMenu(): void {
     // update the properties by pointers, that is the only way to get Grid Menu Control to see the new values
     // we also need to call the control init so that it takes the new Grid object with latest values
     if (this.sharedService.gridOptions.gridMenu) {
@@ -546,7 +546,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
   }
 
-  translateTitleLabels(gridMenuOptions: GridMenu | null) {
+  translateTitleLabels(gridMenuOptions: GridMenu | null): void {
     if (gridMenuOptions) {
       gridMenuOptions.commandTitle = this.extensionUtility.getPickerTitleOutputString('commandTitle', 'gridMenu');
       gridMenuOptions.columnTitle = this.extensionUtility.getPickerTitleOutputString('columnTitle', 'gridMenu');
@@ -730,7 +730,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
    * @param event
    * @param GridMenuItem args
    */
-  protected executeGridMenuInternalCustomCommands(_e: Event, args: GridMenuItem) {
+  protected executeGridMenuInternalCustomCommands(_e: Event, args: GridMenuItem): void {
     const registeredResources = this.sharedService?.externalRegisteredResources || [];
 
     if (args?.command) {
@@ -843,7 +843,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Mouse down handler when clicking anywhere in the DOM body */
-  protected handleBodyMouseDown(e: DOMEvent<HTMLElement>) {
+  protected handleBodyMouseDown(e: DOMEvent<HTMLElement>): void {
     if (this.menuElement) {
       let isMenuClicked = false;
       const parentMenuElm = e.target.closest(`.${this.menuCssClass}`);
@@ -859,7 +859,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
   }
 
-  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0) {
+  protected handleMenuItemCommandClick(event: DOMMouseOrTouchEvent<HTMLDivElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0): void {
     if (item !== 'divider' && !item.disabled && !(item as GridMenuItem).divider) {
       const command = (item as GridMenuItem).command || '';
 
@@ -900,7 +900,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     }
   }
 
-  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0) {
+  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement>, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0): void {
     if (item !== 'divider' && !item.disabled && !(item as GridMenuItem).divider) {
       if ((item as GridMenuItem).commandItems) {
         this.repositionSubMenu(e, item, level);
@@ -911,7 +911,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** Re/Create Command List by adding title, close & list of commands */
-  recreateCommandList(commandItems: Array<GridMenuItem | 'divider'>, menuElm: HTMLElement, callbackArgs: GridMenuEventWithElementCallbackArgs, item?: ExtractMenuType<ExtendableItemTypes, MenuType>) {
+  recreateCommandList(commandItems: Array<GridMenuItem | 'divider'>, menuElm: HTMLElement, callbackArgs: GridMenuEventWithElementCallbackArgs, item?: ExtractMenuType<ExtendableItemTypes, MenuType>): HTMLDivElement | null {
     // -- Command List section
     const level = callbackArgs.level || 0;
     if (commandItems.length > 0) {
@@ -943,7 +943,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     return null;
   }
 
-  protected repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement>, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number) {
+  protected repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement>, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number): void {
     // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
     const commandItems = (item as GridMenuItem)?.commandItems || [];
     const subMenuElm = this.createCommandMenu(commandItems as Array<GridMenuItem | 'divider'>, level + 1, item);

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -40,11 +40,11 @@ import { SlickEvent, Utils as SlickUtils } from '../core/index';
  */
 export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   // public events
-  onAfterMenuShow: SlickEvent<GridMenuEventWithElementCallbackArgs> = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onAfterMenuShow');
-  onBeforeMenuShow: SlickEvent<GridMenuEventWithElementCallbackArgs> = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onBeforeMenuShow');
-  onMenuClose: SlickEvent<GridMenuEventWithElementCallbackArgs> = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onMenuClose');
-  onCommand: SlickEvent<GridMenuCommandItemCallbackArgs> = new SlickEvent<GridMenuCommandItemCallbackArgs>('onCommand');
-  onColumnsChanged: SlickEvent<onGridMenuColumnsChangedCallbackArgs> = new SlickEvent<onGridMenuColumnsChangedCallbackArgs>('onColumnsChanged');
+  onAfterMenuShow: SlickEvent<GridMenuEventWithElementCallbackArgs>;
+  onBeforeMenuShow: SlickEvent<GridMenuEventWithElementCallbackArgs>;
+  onMenuClose: SlickEvent<GridMenuEventWithElementCallbackArgs>;
+  onCommand: SlickEvent<GridMenuCommandItemCallbackArgs>;
+  onColumnsChanged: SlickEvent<onGridMenuColumnsChangedCallbackArgs>;
 
   protected _areVisibleColumnDifferent = false;
   protected _columns: Column[] = [];
@@ -87,6 +87,11 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     this._camelPluginName = 'gridMenu';
     this._columns = this.sharedService.allColumns ?? [];
     this._gridUid = this.grid?.getUID() ?? '';
+    this.onAfterMenuShow = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onAfterMenuShow');
+    this.onBeforeMenuShow = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onBeforeMenuShow');
+    this.onMenuClose = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onMenuClose');
+    this.onCommand = new SlickEvent<GridMenuCommandItemCallbackArgs>('onCommand');
+    this.onColumnsChanged = new SlickEvent<onGridMenuColumnsChangedCallbackArgs>('onColumnsChanged');
 
     this.initEventHandlers();
     this.init();

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -40,11 +40,11 @@ import { SlickEvent, Utils as SlickUtils } from '../core/index';
  */
 export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   // public events
-  onAfterMenuShow = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onAfterMenuShow');
-  onBeforeMenuShow = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onBeforeMenuShow');
-  onMenuClose = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onMenuClose');
-  onCommand = new SlickEvent<GridMenuCommandItemCallbackArgs>('onCommand');
-  onColumnsChanged = new SlickEvent<onGridMenuColumnsChangedCallbackArgs>('onColumnsChanged');
+  onAfterMenuShow: SlickEvent<GridMenuEventWithElementCallbackArgs> = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onAfterMenuShow');
+  onBeforeMenuShow: SlickEvent<GridMenuEventWithElementCallbackArgs> = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onBeforeMenuShow');
+  onMenuClose: SlickEvent<GridMenuEventWithElementCallbackArgs> = new SlickEvent<GridMenuEventWithElementCallbackArgs>('onMenuClose');
+  onCommand: SlickEvent<GridMenuCommandItemCallbackArgs> = new SlickEvent<GridMenuCommandItemCallbackArgs>('onCommand');
+  onColumnsChanged: SlickEvent<onGridMenuColumnsChangedCallbackArgs> = new SlickEvent<onGridMenuColumnsChangedCallbackArgs>('onColumnsChanged');
 
   protected _areVisibleColumnDifferent = false;
   protected _columns: Column[] = [];
@@ -439,7 +439,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   }
 
   /** show Grid Menu from the click event, which in theory will recreate the grid menu in the DOM */
-  showGridMenu(e: MouseEvent | TouchEvent, options?: GridMenuOption) {
+  showGridMenu(e: MouseEvent | TouchEvent, options?: GridMenuOption): void {
     const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
     e.preventDefault();
 
@@ -560,7 +560,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
   // ------------------
 
   /** Create Grid Menu with Custom Commands if user has enabled Filters and/or uses a Backend Service (OData, GraphQL) */
-  protected addGridMenuCustomCommands(originalCommandItems: Array<GridMenuItem | 'divider'>) {
+  protected addGridMenuCustomCommands(originalCommandItems: Array<GridMenuItem | 'divider'>): Array<GridMenuItem | 'divider'> {
     const backendApi = this.gridOptions.backendServiceApi || null;
     const gridMenuCommandItems: Array<GridMenuItem | 'divider'> = [];
     const gridOptions = this.gridOptions;

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -151,7 +151,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
   }
 
   /** Handle a grid cell clicked, it could be a Group that is being collapsed/expanded or do nothing when it's not */
-  protected handleGridClick(e: SlickEventData, args: OnClickEventArgs) {
+  protected handleGridClick(e: SlickEventData, args: OnClickEventArgs): void {
     const target = e.target as HTMLElement;
     const item = this._grid?.getDataItem(args.row);
     if (item instanceof SlickGroup && target.classList.contains(this._options.toggleCssClass || '')) {

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -3,6 +3,7 @@ import { createDomElement, extend } from '@slickgrid-universal/utils';
 import { SlickEventHandler, type SlickDataView, SlickGroup, type SlickGrid, type SlickEventData } from '../core/index';
 import type {
   Column,
+  Formatter,
   GridOption,
   GroupingFormatterItem,
   GroupItemMetadataProviderOption,
@@ -59,7 +60,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     return this._grid?.getOptions() || {};
   }
 
-  init(grid: SlickGrid, inputOptions?: GroupItemMetadataProviderOption) {
+  init(grid: SlickGrid, inputOptions?: GroupItemMetadataProviderOption): void {
     this._grid = grid;
     this._options = { ...this._defaults, ...inputOptions };
 
@@ -67,11 +68,11 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     this._eventHandler.subscribe(grid.onKeyDown, this.handleGridKeyDown.bind(this));
   }
 
-  destroy() {
+  destroy(): void {
     this.dispose();
   }
 
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler?.unsubscribeAll();
   }
@@ -80,7 +81,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     return this._options;
   }
 
-  setOptions(inputOptions: GroupItemMetadataProviderOption) {
+  setOptions(inputOptions: GroupItemMetadataProviderOption): void {
     this._options = { ...this._options, ...inputOptions };
   }
 
@@ -100,7 +101,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     };
   }
 
-  getTotalsRowMetadata(item: { group: GroupingFormatterItem; }) {
+  getTotalsRowMetadata(item: { group: GroupingFormatterItem; }): { selectable: boolean; focusable: boolean | undefined; cssClasses: string; formatter: Formatter | undefined; editorClass: null; } {
     return {
       selectable: false,
       focusable: this._options.totalsFocusable,
@@ -114,7 +115,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
   // protected functions
   // -------------------
 
-  protected defaultGroupCellFormatter(_row: number, _cell: number, _value: any, _columnDef: Column, item: any) {
+  protected defaultGroupCellFormatter(_row: number, _cell: number, _value: any, _columnDef: Column, item: any): any {
     if (!this._options.enableExpandCollapse) {
       return item.title;
     }
@@ -145,7 +146,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     return containerElm;
   }
 
-  protected defaultTotalsCellFormatter(_row: number, _cell: number, _value: any, columnDef: Column, item: any, grid: SlickGrid) {
+  protected defaultTotalsCellFormatter(_row: number, _cell: number, _value: any, columnDef: Column, item: any, grid: SlickGrid): string | HTMLElement {
     return columnDef?.groupTotalsFormatter?.(item, columnDef, grid) ?? '';
   }
 
@@ -164,7 +165,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
    * Handle a keyboard down event on a grouping cell.
    * TODO:  add -/+ handling
    */
-  protected handleGridKeyDown(e: SlickEventData) {
+  protected handleGridKeyDown(e: SlickEventData): void {
     if (this._options.enableExpandCollapse && (e.key === ' ')) {
       const activeCell = this._grid?.getActiveCell();
       if (activeCell) {
@@ -178,7 +179,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     }
   }
 
-  protected handleDataViewExpandOrCollapse(item: any) {
+  protected handleDataViewExpandOrCollapse(item: any): void {
     const range = this._grid?.getRenderedRange();
     this.dataView.setRefreshHints({
       ignoreDiffsBefore: range.top,

--- a/packages/common/src/extensions/slickHeaderButtons.ts
+++ b/packages/common/src/extensions/slickHeaderButtons.ts
@@ -59,7 +59,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
   }
 
   /** Initialize plugin. */
-  init(headerButtonOptions?: HeaderButton) {
+  init(headerButtonOptions?: HeaderButton): void {
     this._addonOptions = { ...this._defaults, ...headerButtonOptions };
 
     this._eventHandler.subscribe(this.grid.onHeaderCellRendered, this.handleHeaderCellRendered.bind(this));
@@ -70,7 +70,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
   }
 
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
-  dispose() {
+  dispose(): void {
     super.dispose();
     this._buttonElms.forEach(elm => elm.remove());
   }
@@ -84,7 +84,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
    * @param {Object} event - The event
    * @param {Object} args - object arguments
    */
-  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs) {
+  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs): void {
     const column = args.column;
 
     if (column.header?.buttons && Array.isArray(column.header.buttons)) {
@@ -112,7 +112,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
    * @param {Object} event - The event
    * @param {Object} args.column - The column definition
    */
-  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }) {
+  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }): void {
     const column = args.column;
 
     if (column.header?.buttons && this._addonOptions?.buttonCssClass) {
@@ -126,7 +126,7 @@ export class SlickHeaderButtons extends MenuBaseClass<HeaderButton> {
     }
   }
 
-  protected handleButtonClick(event: DOMEvent<HTMLDivElement>, _type: MenuType, button: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number, columnDef?: Column) {
+  protected handleButtonClick(event: DOMEvent<HTMLDivElement>, _type: MenuType, button: ExtractMenuType<ExtendableItemTypes, MenuType>, level: number, columnDef?: Column): void {
     if ((button as HeaderButtonItem).command && !(button as HeaderButtonItem).disabled) {
       const command = (button as HeaderButtonItem).command || '';
 

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -256,7 +256,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Mouse down handler when clicking anywhere in the DOM body */
-  protected handleBodyMouseDown(e: DOMEvent<HTMLElement>) {
+  protected handleBodyMouseDown(e: DOMEvent<HTMLElement>): void {
     if (this.menuElement) {
       let isMenuClicked = false;
       const parentMenuElm = e.target.closest(`.${this.menuCssClass}`);
@@ -638,7 +638,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Sort the current column */
-  protected sortColumn(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs, isSortingAsc = true) {
+  protected sortColumn(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs, isSortingAsc = true): void {
     if (args?.column) {
       // get previously sorted columns
       const columnDef = args.column;

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -69,7 +69,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Initialize plugin. */
-  init(headerMenuOptions?: HeaderMenu) {
+  init(headerMenuOptions?: HeaderMenu): void {
     this._addonOptions = { ...this._defaults, ...headerMenuOptions };
 
     // when setColumns is called (could be via toggle filtering/sorting or anything else),
@@ -89,7 +89,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Dispose (destroy) of the plugin */
-  dispose() {
+  dispose(): void {
     super.dispose();
     this._menuElm = this._menuElm || document.body.querySelector(`.slick-header-menu${this.gridUidSelector}`);
     this._menuElm?.remove();
@@ -97,7 +97,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Hide a column from the grid */
-  hideColumn(column: Column) {
+  hideColumn(column: Column): void {
     if (this.sharedService?.slickGrid?.getColumnIndex) {
       const columnIndex = this.sharedService.slickGrid.getColumnIndex(column.id);
       const currentVisibleColumns = this.sharedService.slickGrid.getColumns();
@@ -119,20 +119,20 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Hide the Header Menu */
-  hideMenu() {
+  hideMenu(): void {
     this.disposeSubMenus();
     this._menuElm?.remove();
     this._menuElm = undefined;
   }
 
-  repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, item: MenuCommandItem, level: number, columnDef: Column) {
+  repositionSubMenu(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, item: MenuCommandItem, level: number, columnDef: Column): void {
     // creating sub-menu, we'll also pass level & the item object since we might have "subMenuTitle" to show
     const subMenuElm = this.createCommandMenu(item.commandItems || [], columnDef, level + 1, item);
     document.body.appendChild(subMenuElm);
     this.repositionMenu(e, subMenuElm);
   }
 
-  repositionMenu(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, menuElm: HTMLDivElement) {
+  repositionMenu(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, menuElm: HTMLDivElement): void {
     const buttonElm = e.target as HTMLDivElement; // get header button createElement
     const isSubMenu = menuElm.classList.contains('slick-submenu');
     const parentElm = isSubMenu
@@ -196,7 +196,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Translate the Header Menu titles, we need to loop through all column definition to re-translate them */
-  translateHeaderMenu() {
+  translateHeaderMenu(): void {
     if (this.sharedService.gridOptions?.headerMenu) {
       this.resetHeaderMenuTranslations(this.sharedService.visibleColumns);
     }
@@ -211,7 +211,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
    * @param {Object} event - The event
    * @param {Object} args - object arguments
    */
-  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs) {
+  protected handleHeaderCellRendered(_e: SlickEventData, args: OnHeaderCellRenderedEventArgs): void {
     const column = args.column;
     const menu = column.header?.menu as HeaderMenuItems;
 
@@ -244,7 +244,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
    * @param {Object} event - The event
    * @param {Object} args.column - The column definition
    */
-  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }) {
+  protected handleBeforeHeaderCellDestroy(_e: SlickEventData, args: { column: Column; node: HTMLElement; }): void {
     const column = args.column;
 
     if (column.header?.menu) {
@@ -311,7 +311,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     }
   }
 
-  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column) {
+  protected handleMenuItemMouseOver(e: DOMMouseOrTouchEvent<HTMLElement> | SlickEventData, _type: MenuType, item: ExtractMenuType<ExtendableItemTypes, MenuType>, level = 0, columnDef?: Column): void {
     if (item !== 'divider' && !item.disabled && !(item as MenuCommandItem).divider) {
       if ((item as MenuCommandItem).commandItems) {
         this.repositionSubMenu(e, item as MenuCommandItem, level, columnDef as Column);
@@ -450,21 +450,21 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Clear the Filter on the current column (if it's actually filtered) */
-  protected clearColumnFilter(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs) {
+  protected clearColumnFilter(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs): void {
     if (args?.column) {
       this.filterService.clearFilterByColumnId(event, args.column.id);
     }
   }
 
   /** Clear the Sort on the current column (if it's actually sorted) */
-  protected clearColumnSort(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs) {
+  protected clearColumnSort(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs): void {
     if (args?.column && this.sharedService) {
       this.sortService.clearSortByColumnId(event, args.column.id);
     }
   }
 
   /** Execute the Header Menu Commands that was triggered by the onCommand subscribe */
-  protected executeHeaderMenuInternalCommands(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs) {
+  protected executeHeaderMenuInternalCommands(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: MenuCommandItemCallbackArgs): void {
     if (args?.command) {
       switch (args.command) {
         case 'hide-column':
@@ -522,7 +522,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     }
   }
 
-  protected createParentMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>, columnDef: Column, menu: HeaderMenuItems) {
+  protected createParentMenu(e: DOMMouseOrTouchEvent<HTMLDivElement>, columnDef: Column, menu: HeaderMenuItems): void {
     // let the user modify the menu or cancel altogether,
     // or provide alternative menu implementation.
     const callbackArgs = {
@@ -556,7 +556,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
   }
 
   /** Create the menu or sub-menu(s) but without the column picker which is a separate single process */
-  protected createCommandMenu(commandItems: Array<MenuCommandItem | 'divider'>, columnDef: Column, level = 0, item?: MenuCommandItem | 'divider') {
+  protected createCommandMenu(commandItems: Array<MenuCommandItem | 'divider'>, columnDef: Column, level = 0, item?: MenuCommandItem | 'divider'): HTMLDivElement {
     // to avoid having multiple sub-menu trees opened
     // we need to somehow keep trace of which parent menu the tree belongs to
     // and we should keep ref of only the first sub-menu parent, we can use the command name (remove any whitespaces though)
@@ -628,7 +628,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
    * Reset all the internal Menu options which have text to translate
    * @param header menu object
    */
-  protected resetHeaderMenuTranslations(columnDefinitions: Column[]) {
+  protected resetHeaderMenuTranslations(columnDefinitions: Column[]): void {
     columnDefinitions.forEach((columnDef: Column) => {
       if (columnDef?.header?.menu?.commandItems && !columnDef.excludeFromHeaderMenu) {
         const columnHeaderMenuItems: Array<MenuCommandItem | 'divider'> = columnDef.header.menu.commandItems || [];

--- a/packages/common/src/extensions/slickRowBasedEdit.ts
+++ b/packages/common/src/extensions/slickRowBasedEdit.ts
@@ -85,7 +85,7 @@ export class SlickRowBasedEdit {
   }
 
   /** Initialize plugin. */
-  init(grid: SlickGrid, gridService: GridService) {
+  init(grid: SlickGrid, gridService: GridService): void {
     this._grid = grid;
     this._gridService = gridService;
     this._addonOptions = { ...this._defaults, ...this.addonOptions };
@@ -142,12 +142,12 @@ export class SlickRowBasedEdit {
     this.translate();
   }
 
-  destroy() {
+  destroy(): void {
     this.dispose();
   }
 
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
-  dispose() {
+  dispose(): void {
     this._eventHandler?.unsubscribeAll();
     this.pubSubService?.unsubscribeAll();
   }
@@ -197,7 +197,7 @@ export class SlickRowBasedEdit {
     } as Column;
   }
 
-  rowBasedEditCommandHandler(item: any, column: Column<any>, editCommand: EditCommand) {
+  rowBasedEditCommandHandler(item: any, column: Column<any>, editCommand: EditCommand): void {
     if (this._existingEditCommandHandler) {
       this._existingEditCommandHandler(item, column, editCommand);
     }
@@ -251,7 +251,7 @@ export class SlickRowBasedEdit {
    * User could optionally force a retranslate even if it was already translated
    * @param {Boolean} [forceRetranslate] - even if it was already translate, force a retranslate
    */
-  translate(forceRetranslate = false) {
+  translate(forceRetranslate = false): ButtonTranslation {
     this._currentLang = this.extensionUtility.translaterService?.getCurrentLanguage() ?? 'en';
 
     // translate only once or reuse what's in memory if it was translated
@@ -279,7 +279,7 @@ export class SlickRowBasedEdit {
     }
   }
 
-  protected undoRowEdit(item: any) {
+  protected undoRowEdit(item: any): void {
     const idProperty = this.gridOptions.datasetIdPropertyName ?? 'id';
     const targetRow = this._editedRows.get(item[idProperty]);
     const row = this._grid.getData().getRowByItem(item);
@@ -304,7 +304,7 @@ export class SlickRowBasedEdit {
     }
   }
 
-  protected renderUnsavedCellStyling(id: any, column: Column) {
+  protected renderUnsavedCellStyling(id: any, column: Column): void {
     if (column) {
       const row = this._grid.getData()?.getRowById(id);
       if (row !== undefined && row >= 0) {
@@ -316,7 +316,7 @@ export class SlickRowBasedEdit {
     }
   }
 
-  protected handleAllRowRerender(_e: SlickEventData, _args: OnRowsOrCountChangedEventArgs) {
+  protected handleAllRowRerender(_e: SlickEventData, _args: OnRowsOrCountChangedEventArgs): void {
     this._editedRows.forEach((editedRow, key) => {
       editedRow.cssStyleKeys.forEach((cssStyleKey) => {
         this._grid.removeCellCssStyles(cssStyleKey);
@@ -328,7 +328,7 @@ export class SlickRowBasedEdit {
     });
   }
 
-  protected removeUnsavedStylingFromCell(column: Column, row: number) {
+  protected removeUnsavedStylingFromCell(column: Column, row: number): void {
     const cssStyleKey = `${ROW_BASED_EDIT_UNSAVED_HIGHLIGHT_PREFIX}_${[column.id]}${row}`;
     this._grid.removeCellCssStyles(cssStyleKey);
   }
@@ -339,14 +339,14 @@ export class SlickRowBasedEdit {
     });
   }
 
-  protected optionsUpdatedHandler(_e: SlickEventData, args: OnSetOptionsEventArgs) {
+  protected optionsUpdatedHandler(_e: SlickEventData, args: OnSetOptionsEventArgs): void {
     this._addonOptions = {
       ...this._defaults,
       ...args.optionsAfter.rowBasedEditOptions,
     } as RowBasedEditOptions;
   }
 
-  protected async onCellClickHandler(event: Event, args: any) {
+  protected async onCellClickHandler(event: Event, args: any): Promise<void> {
     const dataContext = args.dataContext;
     const target = event.target as HTMLElement;
     const idProperty = this.gridOptions.datasetIdPropertyName ?? 'id';
@@ -420,7 +420,7 @@ export class SlickRowBasedEdit {
     }
   }
 
-  protected actionColumnFormatter(_row: number, _cell: number, _value: any, _columnDef: Column, dataContext: any) {
+  protected actionColumnFormatter(_row: number, _cell: number, _value: any, _columnDef: Column, dataContext: any): DocumentFragment {
     const options = this.gridOptions;
     const isInEditMode = this._editedRows.has(dataContext?.[options.datasetIdPropertyName ?? 'id']);
     const buttonTitles = this._translations[this._currentLang] ?? this.translate();
@@ -498,7 +498,7 @@ export class SlickRowBasedEdit {
     return this._editedRows.has(args.item?.[this.gridOptions.datasetIdPropertyName ?? 'id']);
   };
 
-  protected toggleEditmode(dataContext: any, editMode: boolean) {
+  protected toggleEditmode(dataContext: any, editMode: boolean): void {
     const idProperty = this.gridOptions.datasetIdPropertyName ?? 'id';
     if (editMode) {
       this._editedRows.set(dataContext[idProperty], {
@@ -513,7 +513,7 @@ export class SlickRowBasedEdit {
     this._grid.invalidate();
   }
 
-  protected updateItemMetadata(previousItemMetadata: any) {
+  protected updateItemMetadata(previousItemMetadata: any): (rowNumber: number) => { cssClasses: string; } {
     return (rowNumber: number) => {
       const item = this._grid.getData().getItem(rowNumber);
       let meta = {
@@ -551,7 +551,7 @@ export class SlickRowBasedEdit {
    * @param defaultTitle - fallback title
    * @returns - final tooltip title text
    */
-  protected getTitleOrDefault(key: ActionButtonTitles, defaultTitle: string) {
+  protected getTitleOrDefault(key: ActionButtonTitles, defaultTitle: string): string {
     const actionBtnOptions = this.gridOptions.rowBasedEditOptions?.actionButtons;
     return (
       (actionBtnOptions?.[(key + 'Key') as ActionButtonTitleKeys] &&

--- a/packages/common/src/extensions/slickRowBasedEdit.ts
+++ b/packages/common/src/extensions/slickRowBasedEdit.ts
@@ -267,7 +267,7 @@ export class SlickRowBasedEdit {
     return this._translations[this._currentLang];
   }
 
-  protected checkOptionsRequirements(options: GridOption) {
+  protected checkOptionsRequirements(options: GridOption): void {
     if (!options?.enableCellNavigation) {
       throw new Error(
         `[Slickgrid-Universal] Row Based Edit Plugin requires the gridOption cell navigation (enableCellNavigation = true)`
@@ -333,7 +333,7 @@ export class SlickRowBasedEdit {
     this._grid.removeCellCssStyles(cssStyleKey);
   }
 
-  protected removeUnsavedStylingFromRow(row: number) {
+  protected removeUnsavedStylingFromRow(row: number): void {
     this._grid.getColumns().forEach((column) => {
       this.removeUnsavedStylingFromCell(column, row);
     });
@@ -495,7 +495,7 @@ export class SlickRowBasedEdit {
   }
 
   protected onBeforeEditCellHandler = (_e: SlickEventData, args: OnBeforeEditCellEventArgs) => {
-    return this._editedRows.has(args.item?.[this.gridOptions.datasetIdPropertyName ?? 'id']);
+    return this._editedRows.has(args.item?.[this.gridOptions.datasetIdPropertyName ?? 'id']) as boolean;
   };
 
   protected toggleEditmode(dataContext: any, editMode: boolean): void {

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -69,7 +69,7 @@ export class SlickRowMoveManager {
   }
 
   /** Initialize plugin. */
-  init(grid: SlickGrid, options?: RowMoveManager) {
+  init(grid: SlickGrid, options?: RowMoveManager): void {
     this._addonOptions = { ...this._defaults, ...options };
     this._grid = grid;
     this._canvas = this._grid.getCanvasNode();
@@ -89,7 +89,7 @@ export class SlickRowMoveManager {
   }
 
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
-  dispose() {
+  dispose(): void {
     this._eventHandler?.unsubscribeAll();
   }
 
@@ -149,11 +149,11 @@ export class SlickRowMoveManager {
    * In order word, user can choose which rows to be an available as moveable (or not) by providing his own logic show/hide icon and usability.
    * @param overrideFn: override function callback
    */
-  usabilityOverride(overrideFn: UsabilityOverrideFn) {
+  usabilityOverride(overrideFn: UsabilityOverrideFn): void {
     this._usabilityOverride = overrideFn;
   }
 
-  setOptions(newOptions: RowMoveManagerOption) {
+  setOptions(newOptions: RowMoveManagerOption): void {
     this._addonOptions = { ...this._addonOptions, ...newOptions };
   }
 
@@ -161,12 +161,12 @@ export class SlickRowMoveManager {
   // protected functions
   // ------------------
 
-  protected handleDragInit(e: SlickEventData) {
+  protected handleDragInit(e: SlickEventData): void {
     // prevent the grid from cancelling drag'n'drop by default
     e.stopImmediatePropagation();
   }
 
-  protected handleDragEnd(e: SlickEventData, dd: DragRowMove) {
+  protected handleDragEnd(e: SlickEventData, dd: DragRowMove): void {
     if (!this._dragging) {
       return;
     }
@@ -308,7 +308,7 @@ export class SlickRowMoveManager {
     }
   }
 
-  protected checkUsabilityOverride(row: number, dataContext: any, grid: SlickGrid) {
+  protected checkUsabilityOverride(row: number, dataContext: any, grid: SlickGrid): boolean {
     if (typeof this._usabilityOverride === 'function') {
       return this._usabilityOverride(row, dataContext, grid);
     }

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -24,8 +24,10 @@ import { SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, Utils as
  *
  */
 export class SlickRowMoveManager {
-  onBeforeMoveRows = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onBeforeMoveRows');
-  onMoveRows = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onMoveRows');
+  onBeforeMoveRows: SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>
+    = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onBeforeMoveRows');
+  onMoveRows: SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>
+    = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onMoveRows');
   pluginName: 'RowMoveManager' = 'RowMoveManager' as const;
 
   protected _addonOptions!: RowMoveManager;

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -24,10 +24,8 @@ import { SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, Utils as
  *
  */
 export class SlickRowMoveManager {
-  onBeforeMoveRows: SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>
-    = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onBeforeMoveRows');
-  onMoveRows: SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>
-    = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onMoveRows');
+  onBeforeMoveRows: SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>;
+  onMoveRows: SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>;
   pluginName: 'RowMoveManager' = 'RowMoveManager' as const;
 
   protected _addonOptions!: RowMoveManager;
@@ -54,6 +52,8 @@ export class SlickRowMoveManager {
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
   constructor(protected readonly pubSubService: BasePubSubService) {
+    this.onBeforeMoveRows = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onBeforeMoveRows');
+    this.onMoveRows = new SlickEvent<{ grid: SlickGrid; rows: number[]; insertBefore: number; }>('onMoveRows');
     this._eventHandler = new SlickEventHandler();
   }
 

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -39,7 +39,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     return this._grid?.getOptions();
   }
 
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
     this._options = { ...this._defaults, ...this._options };
     this._selector = this.addonOptions.cellRangeSelector;
@@ -71,16 +71,16 @@ export class SlickRowSelectionModel implements SelectionModel {
     }
   }
 
-  destroy() {
+  destroy(): void {
     this.dispose();
   }
 
-  dispose() {
+  dispose(): void {
     this._eventHandler.unsubscribeAll();
     this.disposeSelector();
   }
 
-  disposeSelector() {
+  disposeSelector(): void {
     if (this._selector) {
       this._selector.onCellRangeSelecting.unsubscribe(this.handleCellRangeSelected.bind(this));
       this._selector.onCellRangeSelected.unsubscribe(this.handleCellRangeSelected.bind(this));
@@ -91,7 +91,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     }
   }
 
-  getCellRangeSelector() {
+  getCellRangeSelector(): SlickCellRangeSelector | undefined {
     return this._selector;
   }
 
@@ -103,15 +103,15 @@ export class SlickRowSelectionModel implements SelectionModel {
     return this.rangesToRows(this._ranges);
   }
 
-  refreshSelections() {
+  refreshSelections(): void {
     this.setSelectedRows(this.getSelectedRows());
   }
 
-  setSelectedRows(rows: number[]) {
+  setSelectedRows(rows: number[]): void {
     this.setSelectedRanges(this.rowsToRanges(rows), 'SlickRowSelectionModel.setSelectedRows');
   }
 
-  setSelectedRanges(ranges: SlickRange[], caller = 'SlickRowSelectionModel.setSelectedRanges') {
+  setSelectedRanges(ranges: SlickRange[], caller = 'SlickRowSelectionModel.setSelectedRanges'): void {
     // simple check for: empty selection didn't change, prevent firing onSelectedRangesChanged
     if ((!this._ranges || this._ranges.length === 0) && (!ranges || ranges.length === 0)) {
       return;
@@ -128,7 +128,7 @@ export class SlickRowSelectionModel implements SelectionModel {
   // protected functions
   // ---------------------
 
-  protected getRowsRange(from: number, to: number) {
+  protected getRowsRange(from: number, to: number): number[] {
     let i;
     const rows = [];
     for (i = from; i <= to; i++) {
@@ -159,7 +159,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     this.setSelectedRanges([new SlickRange(args.range.fromRow, 0, args.range.toRow, this._grid.getColumns().length - 1)]);
   }
 
-  protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs) {
+  protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs): void {
     if (this._options.selectActiveRow && args.row !== null) {
       this.setSelectedRanges([new SlickRange(args.row, 0, args.row, this._grid.getColumns().length - 1)]);
     }
@@ -206,7 +206,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     return true;
   }
 
-  protected handleKeyDown(e: SlickEventData) {
+  protected handleKeyDown(e: SlickEventData): void {
     const activeRow = this._grid.getActiveCell();
 
     if (this.gridOptions.multiSelect && activeRow &&
@@ -257,7 +257,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     return rows;
   }
 
-  protected rowsToRanges(rows: number[]) {
+  protected rowsToRanges(rows: number[]): SlickRange[] {
     const ranges: SlickRange[] = [];
     const lastCell = this._grid.getColumns().length - 1;
     rows.forEach(row => ranges.push(new SlickRange(row, 0, row, lastCell)));

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -7,7 +7,7 @@ export class SlickRowSelectionModel implements SelectionModel {
   pluginName: 'RowSelectionModel' = 'RowSelectionModel' as const;
 
   /** triggered when selected ranges changes */
-  onSelectedRangesChanged = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
+  onSelectedRangesChanged: SlickEvent<SlickRange[]> = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
 
   protected _options: RowSelectionModelOption;
   protected _eventHandler: SlickEventHandler;
@@ -27,7 +27,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     this._options = { ...this._defaults, ...options };
   }
 
-  get addonOptions() {
+  get addonOptions(): RowSelectionModelOption {
     return this._options;
   }
 
@@ -95,7 +95,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     return this._selector;
   }
 
-  getSelectedRanges() {
+  getSelectedRanges(): SlickRange[] {
     return this._ranges;
   }
 

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -7,7 +7,7 @@ export class SlickRowSelectionModel implements SelectionModel {
   pluginName: 'RowSelectionModel' = 'RowSelectionModel' as const;
 
   /** triggered when selected ranges changes */
-  onSelectedRangesChanged: SlickEvent<SlickRange[]> = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
+  onSelectedRangesChanged: SlickEvent<SlickRange[]>;
 
   protected _options: RowSelectionModelOption;
   protected _eventHandler: SlickEventHandler;
@@ -23,6 +23,7 @@ export class SlickRowSelectionModel implements SelectionModel {
   } as RowSelectionModelOption;
 
   constructor(options?: RowSelectionModelOption) {
+    this.onSelectedRangesChanged = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
     this._eventHandler = new SlickEventHandler();
     this._options = { ...this._defaults, ...options };
   }

--- a/packages/common/src/filter-conditions/filterConditions.index.ts
+++ b/packages/common/src/filter-conditions/filterConditions.index.ts
@@ -3,13 +3,12 @@ import { executeFilterConditionTest } from './filterConditionProcesses';
 import { executeCollectionSearchFilterCondition } from './collectionSearchFilterCondition';
 import { executeNumberFilterCondition } from './numberFilterCondition';
 import { executeStringFilterCondition } from './stringFilterCondition';
-import { testFilterCondition } from './filterUtilities';
+import type { FilterCondition } from '../interfaces/index';
 
-export const FilterConditions = {
-  executeFilterConditionTest,
+export const FilterConditions: Record<string, FilterCondition> = {
+  executeFilterConditionTest: executeFilterConditionTest as FilterCondition,
   booleanFilter: executeBooleanFilterCondition,
   collectionSearchFilter: executeCollectionSearchFilterCondition,
   numberFilter: executeNumberFilterCondition,
   stringFilter: executeStringFilterCondition,
-  testFilter: testFilterCondition
 };

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -77,9 +77,9 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
    * Initialize the Filter
    */
   constructor(
-    protected readonly translaterService?: TranslaterService,
-    protected readonly collectionService?: CollectionService,
-    protected readonly rxjs?: RxJsFacade
+    protected readonly translaterService?: TranslaterService | undefined,
+    protected readonly collectionService?: CollectionService | undefined,
+    protected readonly rxjs?: RxJsFacade | undefined
   ) {
     this._bindEventService = new BindingEventService();
   }

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -156,7 +156,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
   /**
    * Initialize the filter template
    */
-  init(args: FilterArguments) {
+  init(args: FilterArguments): Promise<any[] | undefined> {
     if (!args) {
       throw new Error('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
     }
@@ -218,7 +218,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
   /**
    * Clear the filter value
    */
-  clear(shouldTriggerQuery = true) {
+  clear(shouldTriggerQuery = true): void {
     if (this._filterElm) {
       this._clearFilterTriggered = true;
       this._shouldTriggerQuery = shouldTriggerQuery;
@@ -232,7 +232,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
   /**
    * destroy the filter
    */
-  destroy() {
+  destroy(): void {
     if (typeof this._instance?.destroy === 'function') {
       this._instance.destroy();
     }
@@ -248,12 +248,12 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
     unsubscribeAll(this.subscriptions);
   }
 
-  getValues() {
+  getValues(): string {
     return this._filterElm?.value;
   }
 
   /** Set value(s) on the DOM element  */
-  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString): void {
     if (values && this._filterElm) {
       this._filterElm.value = values as string;
     }
@@ -310,7 +310,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
    * They each have their own purpose, the "propertyObserver" will trigger once the collection is replaced entirely
    * while the "collectionObverser" will trigger on collection changes (`push`, `unshift`, `splice`, ...)
    */
-  protected watchCollectionChanges() {
+  protected watchCollectionChanges(): void {
     if (this.columnFilter?.collection) {
       // subscribe to the "collection" changes (array `push`, `unshift`, `splice`, ...)
       collectionObserver(this.columnFilter.collection, (updatedArray) => {
@@ -332,7 +332,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
     }
   }
 
-  renderDomElement(collection?: any[]) {
+  renderDomElement(collection?: any[]): void {
     if (!Array.isArray(collection) && this.collectionOptions?.collectionInsideObjectProperty) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty;
       collection = getDescendantProperty(collection, collectionInsideObjectProperty || '');
@@ -374,7 +374,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
    * @param searchTerm
    * @returns
    */
-  protected createFilterElement(collection?: any[], searchTerm?: SearchTerm) {
+  protected createFilterElement(collection?: any[], searchTerm?: SearchTerm): HTMLInputElement {
     this._collection = collection;
     const columnId = this.columnDef?.id ?? '';
     emptyElement(this.filterContainerElm);
@@ -501,7 +501,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
 
   // this function should be PRIVATE but for unit tests purposes we'll make it public until a better solution is found
   // a better solution would be to get the autocomplete DOM element to work with selection but I couldn't find how to do that in Jest
-  handleSelect(item: AutocompleteSearchItem) {
+  handleSelect(item: AutocompleteSearchItem): void | boolean {
     if (item !== undefined) {
       const event = undefined; // TODO do we need the event?
 
@@ -529,7 +529,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
     return false;
   }
 
-  protected handleOnInputChange(e: DOMEvent<HTMLInputElement>) {
+  protected handleOnInputChange(e: DOMEvent<HTMLInputElement>): void {
     let value = e?.target?.value ?? '';
     const shouldTriggerOnEveryKeyStroke = this.filterOptions.triggerOnEveryKeyStroke ?? false;
 
@@ -560,14 +560,14 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
     this._shouldTriggerQuery = true;
   }
 
-  protected renderRegularItem(item: T) {
+  protected renderRegularItem(item: T): HTMLDivElement {
     const itemLabel = (typeof item === 'string' ? item : item?.label ?? '') as string;
     return createDomElement('div', {
       textContent: itemLabel || ''
     });
   }
 
-  protected renderCustomItem(item: T) {
+  protected renderCustomItem(item: T): HTMLDivElement {
     const templateString = this._autocompleterOptions?.renderItem?.templateCallback(item) ?? '';
 
     // sanitize any unauthorized html tags like script and others
@@ -576,7 +576,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
     return tmpElm;
   }
 
-  protected renderCollectionItem(item: any) {
+  protected renderCollectionItem(item: any): HTMLDivElement {
     const isRenderHtmlEnabled = this.columnFilter?.enableRenderHtml ?? false;
     const prefixText = item.labelPrefix || '';
     const labelText = item.label || '';
@@ -597,7 +597,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
    * @param value - value found which could be a string or an object
    * @returns - trimmed value when it is a string and the feature is enabled
    */
-  protected trimWhitespaceWhenEnabled(value: any) {
+  protected trimWhitespaceWhenEnabled(value: any): any {
     let outputValue = value;
     const enableWhiteSpaceTrim = this.gridOptions.enableFilterTrimWhiteSpace || this.columnFilter.enableTrimWhiteSpace;
     if (typeof value === 'string' && enableWhiteSpaceTrim) {

--- a/packages/common/src/filters/compoundDateFilter.ts
+++ b/packages/common/src/filters/compoundDateFilter.ts
@@ -3,7 +3,7 @@ import { DateFilter } from './dateFilter';
 
 export class CompoundDateFilter extends DateFilter {
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputFilterType = 'compound';
   }

--- a/packages/common/src/filters/compoundInputFilter.ts
+++ b/packages/common/src/filters/compoundInputFilter.ts
@@ -5,7 +5,7 @@ export class CompoundInputFilter extends InputFilter {
   /**
    * Initialize the Filter
    */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputType = 'text';
     this.inputFilterType = 'compound';

--- a/packages/common/src/filters/compoundInputNumberFilter.ts
+++ b/packages/common/src/filters/compoundInputNumberFilter.ts
@@ -3,7 +3,7 @@ import type { TranslaterService } from '../services/translater.service';
 
 export class CompoundInputNumberFilter extends InputFilter {
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputType = 'number';
     this.inputFilterType = 'compound';

--- a/packages/common/src/filters/compoundInputPasswordFilter.ts
+++ b/packages/common/src/filters/compoundInputPasswordFilter.ts
@@ -3,7 +3,7 @@ import type { TranslaterService } from '../services/translater.service';
 
 export class CompoundInputPasswordFilter extends InputFilter {
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputType = 'password';
     this.inputFilterType = 'compound';

--- a/packages/common/src/filters/compoundSliderFilter.ts
+++ b/packages/common/src/filters/compoundSliderFilter.ts
@@ -5,7 +5,7 @@ export class CompoundSliderFilter extends SliderFilter {
   /**
    * Initialize the Filter
    */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.sliderType = 'compound';
   }

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -47,7 +47,7 @@ export class DateFilter implements Filter {
   callback!: FilterCallback;
   filterContainerElm!: HTMLDivElement;
 
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     this._bindEventService = new BindingEventService();
   }
 

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -100,7 +100,7 @@ export class DateFilter implements Filter {
   }
 
   /** Initialize the Filter */
-  init(args: FilterArguments) {
+  init(args: FilterArguments): void {
     if (!args) {
       throw new Error('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
     }
@@ -149,7 +149,7 @@ export class DateFilter implements Filter {
   }
 
   /** Clear the filter value */
-  clear(shouldTriggerQuery = true, shouldTriggerClearEvent = true) {
+  clear(shouldTriggerQuery = true, shouldTriggerClearEvent = true): void {
     if (this.calendarInstance) {
       // in some cases we don't want to trigger a Clear event, like a Backspace, we want to clear the value but trigger a value change instead
       this._clearFilterTriggered = shouldTriggerClearEvent;
@@ -176,7 +176,7 @@ export class DateFilter implements Filter {
   }
 
   /** Destroy the filter */
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this.calendarInstance?.destroy();
 
@@ -186,19 +186,19 @@ export class DateFilter implements Filter {
     this._filterElm?.remove();
   }
 
-  hide() {
+  hide(): void {
     if (typeof this.calendarInstance?.hide === 'function') {
       this.calendarInstance.hide();
     }
   }
 
-  show() {
+  show(): void {
     if (typeof this.calendarInstance?.show === 'function') {
       this.calendarInstance.show();
     }
   }
 
-  getValues() {
+  getValues(): string | Date | string[] | Date[] | undefined {
     return this._currentDateOrDates;
   }
 
@@ -206,7 +206,7 @@ export class DateFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(values?: SearchTerm[] | SearchTerm, operator?: OperatorType | OperatorString) {
+  setValues(values?: SearchTerm[] | SearchTerm, operator?: OperatorType | OperatorString): void {
     let pickerValues: any | any[];
 
     if (this.inputFilterType === 'compound') {
@@ -243,7 +243,7 @@ export class DateFilter implements Filter {
   //
   // protected functions
   // ------------------
-  protected buildDatePickerInput(searchTerms?: SearchTerm | SearchTerm[]) {
+  protected buildDatePickerInput(searchTerms?: SearchTerm | SearchTerm[]): void {
     const columnId = this.columnDef?.id ?? '';
     const columnFieldType = this.columnFilter.type || this.columnDef.type || FieldType.dateIso;
     const outputFieldType = this.columnDef.outputType || this.columnFilter.type || this.columnDef.type || FieldType.dateUtc;
@@ -482,7 +482,7 @@ export class DateFilter implements Filter {
     }
   }
 
-  protected onTriggerEvent(e: Event | undefined) {
+  protected onTriggerEvent(e: Event | undefined): void {
     if (this._clearFilterTriggered) {
       this.callback(e, { columnDef: this.columnDef, clearFilterTriggered: this._clearFilterTriggered, shouldTriggerQuery: this._shouldTriggerQuery });
       this._filterElm.classList.remove('filled');

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -62,7 +62,7 @@ export class DateFilter implements Filter {
   }
 
   /** Getter for the Current Date(s) selected */
-  get currentDateOrDates() {
+  get currentDateOrDates(): string | Date | string[] | Date[] | undefined {
     return this._currentDateOrDates;
   }
 

--- a/packages/common/src/filters/dateRangeFilter.ts
+++ b/packages/common/src/filters/dateRangeFilter.ts
@@ -3,7 +3,7 @@ import type { TranslaterService } from '../services';
 
 export class DateRangeFilter extends DateFilter {
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputFilterType = 'range';
   }

--- a/packages/common/src/filters/filterFactory.ts
+++ b/packages/common/src/filters/filterFactory.ts
@@ -12,7 +12,7 @@ export class FilterFactory {
     this._options = this.config?.options ?? {};
   }
 
-  addRxJsResource(rxjs: RxJsFacade) {
+  addRxJsResource(rxjs: RxJsFacade): void {
     this.rxjs = rxjs;
   }
 

--- a/packages/common/src/filters/filterFactory.ts
+++ b/packages/common/src/filters/filterFactory.ts
@@ -8,7 +8,7 @@ export class FilterFactory {
   /** The options from the SlickgridConfig */
   protected _options: any;
 
-  constructor(protected config: SlickgridConfig, protected readonly translaterService?: TranslaterService, protected readonly collectionService?: CollectionService, protected rxjs?: RxJsFacade) {
+  constructor(protected config: SlickgridConfig, protected readonly translaterService?: TranslaterService | undefined, protected readonly collectionService?: CollectionService | undefined, protected rxjs?: RxJsFacade | undefined) {
     this._options = this.config?.options ?? {};
   }
 

--- a/packages/common/src/filters/filterUtilities.ts
+++ b/packages/common/src/filters/filterUtilities.ts
@@ -29,7 +29,7 @@ export function buildSelectOperator(optionValues: OperatorDetail[], grid: SlickG
  * When user use a CollectionAsync we will use the returned collection to render the filter DOM element
  * and reinitialize filter collection with this new collection
  */
-export function renderDomElementFromCollectionAsync(collection: any[], columnDef: Column, renderDomElementCallback: (collection: any) => void) {
+export function renderDomElementFromCollectionAsync(collection: any[], columnDef: Column, renderDomElementCallback: (collection: any) => void): void {
   const columnFilter = columnDef?.filter ?? {};
   const collectionOptions = columnFilter?.collectionOptions ?? {};
 
@@ -101,7 +101,7 @@ export async function renderCollectionOptionsAsync(collectionAsync: Promise<any 
 }
 
 /** Create or recreate an Observable Subject and reassign it to the "collectionAsync" object so user can call a "collectionAsync.next()" on it */
-export function createCollectionAsyncSubject(columnDef: Column, renderDomElementCallback: (collection: any) => void, rxjs?: RxJsFacade, subscriptions?: Subscription[]) {
+export function createCollectionAsyncSubject(columnDef: Column, renderDomElementCallback: (collection: any) => void, rxjs?: RxJsFacade, subscriptions?: Subscription[]): void {
   const columnFilter = columnDef?.filter ?? {};
   const newCollectionAsync = rxjs?.createSubject<any>();
   columnFilter.collectionAsync = newCollectionAsync;
@@ -152,7 +152,7 @@ export function compoundOperatorNumeric(gridOptions: GridOption, translaterServi
 }
 
 // internal function to apply Operator detail alternate texts when they exists
-export function applyOperatorAltTextWhenExists(gridOptions: GridOption, operatorDetailList: OperatorDetail[], filterType: 'text' | 'numeric') {
+export function applyOperatorAltTextWhenExists(gridOptions: GridOption, operatorDetailList: OperatorDetail[], filterType: 'text' | 'numeric'): void {
   if (gridOptions.compoundOperatorAltTexts) {
     for (const opDetail of operatorDetailList) {
       if (gridOptions.compoundOperatorAltTexts.hasOwnProperty(filterType)) {

--- a/packages/common/src/filters/filters.index.ts
+++ b/packages/common/src/filters/filters.index.ts
@@ -13,8 +13,9 @@ import { DateRangeFilter } from './dateRangeFilter';
 import { SingleSelectFilter } from './singleSelectFilter';
 import { SingleSliderFilter } from './singleSliderFilter';
 import { SliderRangeFilter } from './sliderRangeFilter';
+import type { FilterConstructor } from '../interfaces/filter.interface';
 
-export const Filters = {
+export const Filters: Record<string, FilterConstructor> = {
   /** AutoComplete Filter (using https://github.com/kraaden/autocomplete) */
   autocompleter: AutocompleterFilter,
 

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -33,7 +33,7 @@ export class InputFilter implements Filter {
   columnDef!: Column;
   callback!: FilterCallback;
 
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     this._bindEventService = new BindingEventService();
   }
 

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -48,7 +48,7 @@ export class InputFilter implements Filter {
   }
 
   /** Getter of input type (text, number, password) */
-  get inputType() {
+  get inputType(): string {
     return this._inputType;
   }
 
@@ -77,7 +77,7 @@ export class InputFilter implements Filter {
   /**
    * Initialize the Filter
    */
-  init(args: FilterArguments) {
+  init(args: FilterArguments): void {
     if (!args) {
       throw new Error('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
     }
@@ -114,7 +114,7 @@ export class InputFilter implements Filter {
   /**
    * Clear the filter value
    */
-  clear(shouldTriggerQuery = true) {
+  clear(shouldTriggerQuery = true): void {
     if (this._filterInputElm) {
       this._shouldTriggerQuery = shouldTriggerQuery;
       this.searchTerms = [];
@@ -132,7 +132,7 @@ export class InputFilter implements Filter {
   /**
    * destroy the filter
    */
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this._selectOperatorElm?.remove?.();
     this._filterInputElm?.remove?.();
@@ -143,7 +143,7 @@ export class InputFilter implements Filter {
   }
 
   /** Set value(s) on the DOM element */
-  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString): void {
     const searchValues = Array.isArray(values) ? values : [values];
     let newInputValue: SearchTerm = '';
     for (const value of searchValues) {
@@ -252,7 +252,7 @@ export class InputFilter implements Filter {
    * @param {Object} searchTerm - filter search term
    * @returns {Object} DOM element filter
    */
-  protected createDomFilterElement(searchTerm?: SearchTerm) {
+  protected createDomFilterElement(searchTerm?: SearchTerm): void {
     const columnId = this.columnDef?.id ?? '';
     emptyElement(this._cellContainerElm);
 
@@ -315,7 +315,7 @@ export class InputFilter implements Filter {
    * Event handler to cover the following (keyup, change, mousewheel & spinner)
    * We will trigger the Filter Service callback from this handler
    */
-  protected onTriggerEvent(event?: MouseEvent | KeyboardEvent, isClearFilterEvent = false) {
+  protected onTriggerEvent(event?: MouseEvent | KeyboardEvent, isClearFilterEvent = false): void {
     if (isClearFilterEvent) {
       this.callback(event, { columnDef: this.columnDef, clearFilterTriggered: isClearFilterEvent, shouldTriggerQuery: this._shouldTriggerQuery });
       this._filterContainerElm.classList.remove('filled');

--- a/packages/common/src/filters/inputMaskFilter.ts
+++ b/packages/common/src/filters/inputMaskFilter.ts
@@ -19,7 +19,7 @@ export class InputMaskFilter extends InputFilter {
   /**
    * Override the Filter init used by SlickGrid
    */
-  init(args: FilterArguments) {
+  init(args: FilterArguments): void {
     if (!args) {
       throw new Error('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
     }
@@ -56,7 +56,7 @@ export class InputMaskFilter extends InputFilter {
    * Event handler to cover the following (keyup, blur, change)
    * We will trigger the Filter Service callback from this handler
    */
-  protected onTriggerEvent(event?: MouseEvent | KeyboardEvent, isClearFilterEvent = false) {
+  protected onTriggerEvent(event?: MouseEvent | KeyboardEvent, isClearFilterEvent = false): void {
     let value = '';
     if ((event?.target as HTMLInputElement)?.value) {
       let targetValue = (event?.target as HTMLInputElement)?.value ?? '';

--- a/packages/common/src/filters/inputMaskFilter.ts
+++ b/packages/common/src/filters/inputMaskFilter.ts
@@ -6,7 +6,7 @@ export class InputMaskFilter extends InputFilter {
   protected _inputMask = '';
 
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputType = 'text';
   }

--- a/packages/common/src/filters/inputNumberFilter.ts
+++ b/packages/common/src/filters/inputNumberFilter.ts
@@ -3,7 +3,7 @@ import type { TranslaterService } from '../services/translater.service';
 
 export class InputNumberFilter extends InputFilter {
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputType = 'number';
   }

--- a/packages/common/src/filters/inputPasswordFilter.ts
+++ b/packages/common/src/filters/inputPasswordFilter.ts
@@ -3,7 +3,7 @@ import type { TranslaterService } from '../services/translater.service';
 
 export class InputPasswordFilter extends InputFilter {
   /** Initialize the Filter */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.inputType = 'password';
   }

--- a/packages/common/src/filters/multipleSelectFilter.ts
+++ b/packages/common/src/filters/multipleSelectFilter.ts
@@ -7,7 +7,7 @@ export class MultipleSelectFilter extends SelectFilter {
   /**
    * Initialize the Filter
    */
-  constructor(protected readonly translaterService?: TranslaterService, protected readonly collectionService?: CollectionService, protected readonly rxjs?: RxJsFacade) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined, protected readonly collectionService?: CollectionService | undefined, protected readonly rxjs?: RxJsFacade | undefined) {
     super(translaterService, collectionService, rxjs, true);
   }
 }

--- a/packages/common/src/filters/selectFilter.ts
+++ b/packages/common/src/filters/selectFilter.ts
@@ -97,11 +97,11 @@ export class SelectFilter implements Filter {
     return this._isMultipleSelect;
   }
 
-  get msInstance() {
+  get msInstance(): MultipleSelectInstance | undefined {
     return this._msInstance;
   }
 
-  get selectOptions() {
+  get selectOptions(): Partial<MultipleSelectOption> {
     return this.defaultOptions;
   }
 
@@ -196,7 +196,7 @@ export class SelectFilter implements Filter {
   }
 
   /** Clear the filter values */
-  clear(shouldTriggerQuery = true) {
+  clear(shouldTriggerQuery = true): void {
     if (this._msInstance && this._collectionLength > 0) {
       // reload the filter element by it's id, to make sure it's still a valid element (because of some issue in the GraphQL example)
       this._msInstance.setSelects([]);
@@ -210,7 +210,7 @@ export class SelectFilter implements Filter {
   }
 
   /** destroy the filter */
-  destroy() {
+  destroy(): void {
     if (typeof this._msInstance?.destroy === 'function') {
       this._msInstance.destroy();
     }
@@ -229,7 +229,7 @@ export class SelectFilter implements Filter {
   }
 
   /** Set value(s) on the DOM element */
-  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString): void {
     if (values !== undefined && this._msInstance) {
       values = Array.isArray(values)
         ? values.every(x => isPrimitiveValue(x)) ? values.map(String) : values
@@ -286,7 +286,7 @@ export class SelectFilter implements Filter {
    * They each have their own purpose, the "propertyObserver" will trigger once the collection is replaced entirely
    * while the "collectionObverser" will trigger on collection changes (`push`, `unshift`, `splice`, ...)
    */
-  protected watchCollectionChanges() {
+  protected watchCollectionChanges(): void {
     if (this.columnFilter?.collection) {
       // subscribe to the "collection" changes (array `push`, `unshift`, `splice`, ...)
       collectionObserver(this.columnFilter.collection, this.watchCallback.bind(this));
@@ -297,7 +297,7 @@ export class SelectFilter implements Filter {
     }
   }
 
-  protected propertyObserverCallback(newValue: any) {
+  protected propertyObserverCallback(newValue: any): void {
     this.renderDomElement(newValue || []);
 
     // when new assignment arrives, we need to also reassign observer to the new reference
@@ -306,11 +306,11 @@ export class SelectFilter implements Filter {
     }
   }
 
-  protected watchCallback(updatedArray: any[]) {
+  protected watchCallback(updatedArray: any[]): void {
     this.renderDomElement(this.columnFilter.collection || updatedArray || []);
   }
 
-  renderDomElement(inputCollection: any[]) {
+  renderDomElement(inputCollection: any[]): void {
     if (!Array.isArray(inputCollection) && this.collectionOptions?.collectionInsideObjectProperty) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty;
       inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty || '');
@@ -388,7 +388,7 @@ export class SelectFilter implements Filter {
    * From the Select DOM Element created earlier, create a Multiple/Single Select Filter using the multiple-select-vanilla.js lib
    * @param {Object} selectElement
    */
-  protected createFilterElement(selectElement: HTMLSelectElement, dataCollection: OptionRowData[]) {
+  protected createFilterElement(selectElement: HTMLSelectElement, dataCollection: OptionRowData[]): void {
     const columnId = this.columnDef?.id ?? '';
 
     // provide the name attribute to the DOM element which will be needed to auto-adjust drop position (dropup / dropdown)
@@ -412,7 +412,7 @@ export class SelectFilter implements Filter {
     this._msInstance = multipleSelect(selectElement, this.filterElmOptions) as MultipleSelectInstance;
   }
 
-  protected initMultipleSelectTemplate() {
+  protected initMultipleSelectTemplate(): void {
     const isTranslateEnabled = this.gridOptions?.enableTranslate ?? false;
     const columnId = this.columnDef?.id ?? '';
 
@@ -452,7 +452,7 @@ export class SelectFilter implements Filter {
     this.defaultOptions = options;
   }
 
-  protected onTriggerEvent() {
+  protected onTriggerEvent(): void {
     if (this._msInstance) {
       const selectedItems = this.getValues();
       this.updateFilterStyle(Array.isArray(selectedItems) && selectedItems.length > 1 || (selectedItems.length === 1 && selectedItems[0] !== ''));
@@ -464,7 +464,7 @@ export class SelectFilter implements Filter {
   }
 
   /** Set value(s) on the DOM element */
-  protected updateFilterStyle(isFilled: boolean) {
+  protected updateFilterStyle(isFilled: boolean): void {
     if (isFilled) {
       this.isFilled = true;
       this.filterElm?.classList.add('filled');

--- a/packages/common/src/filters/selectFilter.ts
+++ b/packages/common/src/filters/selectFilter.ts
@@ -56,9 +56,9 @@ export class SelectFilter implements Filter {
    * Initialize the Filter
    */
   constructor(
-    protected readonly translaterService?: TranslaterService,
-    protected readonly collectionService?: CollectionService,
-    protected readonly rxjs?: RxJsFacade,
+    protected readonly translaterService?: TranslaterService | undefined,
+    protected readonly collectionService?: CollectionService | undefined,
+    protected readonly rxjs?: RxJsFacade | undefined,
     isMultipleSelect = true) {
     this._isMultipleSelect = isMultipleSelect;
   }

--- a/packages/common/src/filters/singleSelectFilter.ts
+++ b/packages/common/src/filters/singleSelectFilter.ts
@@ -7,7 +7,7 @@ export class SingleSelectFilter extends SelectFilter {
   /**
    * Initialize the Filter
    */
-  constructor(protected readonly translaterService?: TranslaterService, protected readonly collectionService?: CollectionService, protected readonly rxjs?: RxJsFacade) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined, protected readonly collectionService?: CollectionService | undefined, protected readonly rxjs?: RxJsFacade | undefined) {
     super(translaterService, collectionService, rxjs, false);
   }
 }

--- a/packages/common/src/filters/singleSliderFilter.ts
+++ b/packages/common/src/filters/singleSliderFilter.ts
@@ -5,7 +5,7 @@ export class SingleSliderFilter extends SliderFilter {
   /**
    * Initialize the Filter
    */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.sliderType = 'single';
   }

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -1,5 +1,5 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { createDomElement, emptyElement, hasData, toSentenceCase } from '@slickgrid-universal/utils';
+import { createDomElement, emptyElement, isDefined, toSentenceCase } from '@slickgrid-universal/utils';
 
 import { SlickEventData, type SlickGrid } from '../core/index';
 import { Constants } from '../constants';
@@ -106,7 +106,7 @@ export class SliderFilter implements Filter {
   }
 
   /** Initialize the Filter */
-  init(args: FilterArguments) {
+  init(args: FilterArguments): void {
     if (!args) {
       throw new Error('[Slickgrid-Universal] A filter must always have an "init()" with valid arguments.');
     }
@@ -125,7 +125,7 @@ export class SliderFilter implements Filter {
   }
 
   /** Clear the filter value */
-  clear(shouldTriggerQuery = true) {
+  clear(shouldTriggerQuery = true): void {
     if (this._filterElm) {
       this._clearFilterTriggered = true;
       this._shouldTriggerQuery = shouldTriggerQuery;
@@ -170,7 +170,7 @@ export class SliderFilter implements Filter {
   }
 
   /** destroy the filter */
-  destroy() {
+  destroy(): void {
     this._bindEventService.unbindAll();
     this._sliderTrackElm?.remove();
     this._sliderLeftInputElm?.remove();
@@ -182,7 +182,7 @@ export class SliderFilter implements Filter {
    * @param leftValue number
    * @param rightValue number
    */
-  renderSliderValues(leftValue?: number | string, rightValue?: number | string) {
+  renderSliderValues(leftValue?: number | string, rightValue?: number | string): void {
     if (this._leftSliderNumberElm?.textContent && leftValue) {
       this._leftSliderNumberElm.textContent = leftValue.toString();
     }
@@ -192,7 +192,7 @@ export class SliderFilter implements Filter {
   }
 
   /** get current slider value(s), it could be a single value or an array of 2 values depending on the slider filter type */
-  getValues() {
+  getValues(): number | number[] | undefined {
     return this.sliderType === 'double' ? this._currentValues : this._currentValue;
   }
 
@@ -200,7 +200,7 @@ export class SliderFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString): void {
     if (values) {
       let sliderVals: Array<number | string | undefined> = [];
       const term1: SearchTerm | undefined = Array.isArray(values) ? values?.[0] : values;
@@ -211,7 +211,7 @@ export class SliderFilter implements Filter {
         if (typeof term1 === 'string' && (term1 as string).indexOf('..') > 0) {
           sliderVals = (term1 as string).split('..');
           this._currentValue = +(sliderVals?.[0] ?? 0);
-        } else if (hasData(term1) || term1 === '') {
+        } else if (isDefined(term1) || term1 === '') {
           this._currentValue = term1 === null ? undefined : +term1;
           sliderVals = [term1 as string | number];
         }
@@ -259,7 +259,7 @@ export class SliderFilter implements Filter {
    * https://codingartistweb.com/2021/06/double-range-slider-html-css-javascript/
    * @param searchTerm optional preset search terms
    */
-  protected createDomFilterElement(searchTerms?: SearchTerm | SearchTerm[]) {
+  protected createDomFilterElement(searchTerms?: SearchTerm | SearchTerm[]): HTMLDivElement {
     const columnId = this.columnDef?.id ?? '';
     const minValue = +(this.columnFilter.minValue ?? Constants.SLIDER_DEFAULT_MIN_VALUE);
     const maxValue = +(this.columnFilter.maxValue ?? Constants.SLIDER_DEFAULT_MAX_VALUE);
@@ -388,7 +388,7 @@ export class SliderFilter implements Filter {
   }
 
   /** handle value change event triggered, trigger filter callback & update "filled" class name */
-  protected onValueChanged(e: MouseEvent) {
+  protected onValueChanged(e: MouseEvent): void {
     const sliderRightVal = parseInt(this._sliderRightInputElm?.value ?? '', 10);
     let value;
     let searchTerms: SearchTerm[];
@@ -436,7 +436,7 @@ export class SliderFilter implements Filter {
     this._sliderRightInputElm?.classList[addRemoveCmd]('focus');
   }
 
-  protected slideLeftInputChanged(e: Event) {
+  protected slideLeftInputChanged(e: Event): void {
     const sliderLeftVal = parseInt(this._sliderLeftInputElm?.value ?? '', 10);
     const sliderRightVal = parseInt(this._sliderRightInputElm?.value ?? '', 10);
 
@@ -460,7 +460,7 @@ export class SliderFilter implements Filter {
     this.sliderLeftOrRightChanged(e, sliderLeftVal, sliderRightVal);
   }
 
-  protected slideRightInputChanged(e: Event) {
+  protected slideRightInputChanged(e: Event): void {
     const sliderLeftVal = parseInt(this._sliderLeftInputElm?.value ?? '', 10);
     const sliderRightVal = parseInt(this._sliderRightInputElm?.value ?? '', 10);
 
@@ -471,7 +471,7 @@ export class SliderFilter implements Filter {
     this.sliderLeftOrRightChanged(e, sliderLeftVal, sliderRightVal);
   }
 
-  protected sliderLeftOrRightChanged(e: Event, sliderLeftVal: number, sliderRightVal: number) {
+  protected sliderLeftOrRightChanged(e: Event, sliderLeftVal: number, sliderRightVal: number): void {
     this.updateTrackFilledColorWhenEnabled();
     this.changeBothSliderFocuses(true);
     this._sliderRangeContainElm.title = this.sliderType === 'double' ? `${sliderLeftVal} - ${sliderRightVal}` : `${sliderRightVal}`;
@@ -490,7 +490,7 @@ export class SliderFilter implements Filter {
     this.grid.onHeaderRowMouseEnter.notify({ column: this.columnDef, grid: this.grid }, new SlickEventData(e));
   }
 
-  protected sliderTrackClicked(e: MouseEvent) {
+  protected sliderTrackClicked(e: MouseEvent): void {
     e.preventDefault();
     const sliderTrackX = e.offsetX;
     const sliderTrackWidth = this._sliderTrackElm.offsetWidth;
@@ -515,7 +515,7 @@ export class SliderFilter implements Filter {
     }
   }
 
-  protected updateTrackFilledColorWhenEnabled() {
+  protected updateTrackFilledColorWhenEnabled(): void {
     if ((this.filterOptions as SliderRangeOption)?.enableSliderTrackColoring && this._sliderRightInputElm) {
       let percent1 = 0;
       if (this._sliderLeftInputElm) {

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -45,7 +45,7 @@ export class SliderFilter implements Filter {
   protected _sliderTrackElm!: HTMLDivElement;
   protected _sliderLeftInputElm?: HTMLInputElement;
   protected _sliderRightInputElm?: HTMLInputElement;
-  protected _sliderTrackFilledColor = DEFAULT_SLIDER_TRACK_FILLED_COLOR;
+  protected _sliderTrackFilledColor: string = DEFAULT_SLIDER_TRACK_FILLED_COLOR;
   sliderType: SliderType = 'double';
   grid!: SlickGrid;
   searchTerms: SearchTerm[] = [];
@@ -430,7 +430,7 @@ export class SliderFilter implements Filter {
     this.grid.onHeaderRowMouseEnter.notify({ column: this.columnDef, grid: this.grid }, new SlickEventData(e));
   }
 
-  protected changeBothSliderFocuses(isAddingFocus: boolean) {
+  protected changeBothSliderFocuses(isAddingFocus: boolean): void {
     const addRemoveCmd = isAddingFocus ? 'add' : 'remove';
     this._sliderLeftInputElm?.classList[addRemoveCmd]('focus');
     this._sliderRightInputElm?.classList[addRemoveCmd]('focus');

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -52,7 +52,7 @@ export class SliderFilter implements Filter {
   columnDef!: Column;
   callback!: FilterCallback;
 
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     this._bindEventService = new BindingEventService();
   }
 
@@ -182,7 +182,7 @@ export class SliderFilter implements Filter {
    * @param leftValue number
    * @param rightValue number
    */
-  renderSliderValues(leftValue?: number | string, rightValue?: number | string): void {
+  renderSliderValues(leftValue?: number | string | undefined, rightValue?: number | string | undefined): void {
     if (this._leftSliderNumberElm?.textContent && leftValue) {
       this._leftSliderNumberElm.textContent = leftValue.toString();
     }

--- a/packages/common/src/filters/sliderRangeFilter.ts
+++ b/packages/common/src/filters/sliderRangeFilter.ts
@@ -5,7 +5,7 @@ export class SliderRangeFilter extends SliderFilter {
   /**
    * Initialize the Filter
    */
-  constructor(protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly translaterService?: TranslaterService | undefined) {
     super(translaterService);
     this.sliderType = 'double';
   }

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -17,7 +17,7 @@ export type NumberType = 'decimal' | 'currency' | 'percent' | 'regular';
  * It will loop through all column definitions and add an Custom Editor Formatter when necessary,
  * also note that if there's already a Formatter on the column definition it will automatically use the Formatters.multiple and add the custom formatter into the `params: formatters: {}}`
  */
-export function autoAddEditorFormatterToColumnsWithEditor(columnDefinitions: Column[], customEditableFormatter: Formatter) {
+export function autoAddEditorFormatterToColumnsWithEditor(columnDefinitions: Column[], customEditableFormatter: Formatter): void {
   if (Array.isArray(columnDefinitions)) {
     for (const columnDef of columnDefinitions) {
       if (columnDef.editor) {
@@ -39,8 +39,8 @@ export function autoAddEditorFormatterToColumnsWithEditor(columnDefinitions: Col
 }
 
 export function retrieveFormatterOptions(columnDef: Column, grid: SlickGrid, numberType: NumberType, formatterType: FormatterType) {
-  let defaultMinDecimal;
-  let defaultMaxDecimal;
+  let defaultMinDecimal: number | undefined;
+  let defaultMaxDecimal: number | undefined;
   let numberPrefix = '';
   let numberSuffix = '';
 
@@ -83,7 +83,7 @@ export function retrieveFormatterOptions(columnDef: Column, grid: SlickGrid, num
  * 2- Grid Options "formatterOptions"
  * 3- nothing found, return default value provided
  */
-export function getValueFromParamsOrFormatterOptions(optionName: string, columnDef: Column, gridOptions: GridOption, defaultValue?: any) {
+export function getValueFromParamsOrFormatterOptions(optionName: string, columnDef: Column, gridOptions: GridOption, defaultValue?: any): any {
   const params = columnDef && columnDef.params;
 
   if (params && params.hasOwnProperty(optionName)) {
@@ -139,7 +139,7 @@ export function getAssociatedDateFormatter(fieldType: typeof FieldType[keyof typ
  * @param {Object} exportOptions - Excel or Text Export Options
  * @returns formatted string output or empty string
  */
-export function exportWithFormatterWhenDefined<T = any>(row: number, col: number, columnDef: Column<T>, dataContext: T, grid: SlickGrid, exportOptions?: TextExportOption | ExcelExportOption) {
+export function exportWithFormatterWhenDefined<T = any>(row: number, col: number, columnDef: Column<T>, dataContext: T, grid: SlickGrid, exportOptions?: TextExportOption | ExcelExportOption): string {
   let isEvaluatingFormatter = false;
 
   // check if "exportWithFormatter" is provided in the column definition, if so it will have precendence over the Grid Options exportOptions

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -38,7 +38,17 @@ export function autoAddEditorFormatterToColumnsWithEditor(columnDefinitions: Col
   }
 }
 
-export function retrieveFormatterOptions(columnDef: Column, grid: SlickGrid, numberType: NumberType, formatterType: FormatterType) {
+export function retrieveFormatterOptions(columnDef: Column, grid: SlickGrid, numberType: NumberType, formatterType: FormatterType): {
+  minDecimal: number;
+  maxDecimal: number;
+  decimalSeparator: ',' | '.';
+  thousandSeparator: ',' | '_' | '.' | ' ' | '';
+  wrapNegativeNumber: boolean;
+  currencyPrefix: string;
+  currencySuffix: string;
+  numberPrefix: string;
+  numberSuffix: string;
+} {
   let defaultMinDecimal: number | undefined;
   let defaultMaxDecimal: number | undefined;
   let numberPrefix = '';

--- a/packages/common/src/formatters/formatters.index.ts
+++ b/packages/common/src/formatters/formatters.index.ts
@@ -27,9 +27,10 @@ import { treeExportFormatter } from './treeExportFormatter';
 import { treeFormatter } from './treeFormatter';
 import { treeParseTotalsFormatter } from './treeParseTotalsFormatter';
 import { translateBooleanFormatter } from './translateBooleanFormatter';
+import type { Formatter } from '../interfaces/formatter.interface';
 
 /** Provides a list of different Formatters that will change the cell value displayed in the UI */
-export const Formatters = {
+export const Formatters: Record<string, Formatter> = {
   /**
    * Takes an array of complex objects converts it to a comma delimited string.
    * Requires to pass an array of "propertyNames" in the column definition the generic "params" property

--- a/packages/common/src/formatters/percentCompleteBarFormatter.ts
+++ b/packages/common/src/formatters/percentCompleteBarFormatter.ts
@@ -9,7 +9,7 @@ export const percentCompleteBarFormatter: Formatter = (_row, _cell, value) => {
   }
 
   let color = '';
-  let inputNumber = parseFloat(value);
+  let inputNumber = parseFloat(value as any);
   if (inputNumber > 100) {
     inputNumber = 100;
   }

--- a/packages/common/src/formatters/percentCompleteBarWithTextFormatter.ts
+++ b/packages/common/src/formatters/percentCompleteBarWithTextFormatter.ts
@@ -9,7 +9,7 @@ export const percentCompleteBarWithTextFormatter: Formatter = (_row, _cell, valu
   }
 
   let color = '';
-  let inputNumber = parseFloat(value);
+  let inputNumber = parseFloat(value as any);
   if (inputNumber > 100) {
     inputNumber = 100;
   }

--- a/packages/common/src/formatters/progressBarFormatter.ts
+++ b/packages/common/src/formatters/progressBarFormatter.ts
@@ -9,7 +9,7 @@ export const progressBarFormatter: Formatter = (_row, _cell, value) => {
   }
 
   let color = '';
-  let inputNumber = parseFloat(value);
+  let inputNumber = parseFloat(value as any);
   if (inputNumber > 100) {
     inputNumber = 100;
   }

--- a/packages/common/src/grouping-formatters/avgTotalsFormatter.ts
+++ b/packages/common/src/grouping-formatters/avgTotalsFormatter.ts
@@ -25,7 +25,7 @@ export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
       if (!wrapNegativeNumber) {
         prefix += '-';
       } else {
-        if (isNaN(minDecimal) && isNaN(maxDecimal)) {
+        if (isNaN(minDecimal as any) && isNaN(maxDecimal as any)) {
           const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
           return `${prefix}(${outputVal})${suffix}`;
         }
@@ -33,7 +33,7 @@ export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
       }
     }
 
-    if (isNaN(minDecimal) && isNaN(maxDecimal)) {
+    if (isNaN(minDecimal as any) && isNaN(maxDecimal as any)) {
       const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
       return `${prefix}${outputVal}${suffix}`;
     }

--- a/packages/common/src/grouping-formatters/avgTotalsPercentageFormatter.ts
+++ b/packages/common/src/grouping-formatters/avgTotalsPercentageFormatter.ts
@@ -25,7 +25,7 @@ export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, 
       if (!wrapNegativeNumber) {
         prefix += '-';
       } else {
-        if (isNaN(minDecimal) && isNaN(maxDecimal)) {
+        if (isNaN(minDecimal as any) && isNaN(maxDecimal as any)) {
           const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
           return `${prefix}(${outputVal}%)${suffix}`;
         }
@@ -33,7 +33,7 @@ export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, 
       }
     }
 
-    if (isNaN(minDecimal) && isNaN(maxDecimal)) {
+    if (isNaN(minDecimal as any) && isNaN(maxDecimal as any)) {
       const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
       return `${prefix}${outputVal}%${suffix}`;
     }

--- a/packages/common/src/grouping-formatters/groupingFormatters.index.ts
+++ b/packages/common/src/grouping-formatters/groupingFormatters.index.ts
@@ -13,9 +13,10 @@ import { sumTotalsDollarBoldFormatter } from './sumTotalsDollarBoldFormatter';
 import { sumTotalsDollarFormatter } from './sumTotalsDollarFormatter';
 import { sumTotalsFormatter } from './sumTotalsFormatter';
 import { sumTotalsBoldFormatter } from './sumTotalsBoldFormatter';
+import type { GroupTotalsFormatter } from '../interfaces/groupTotalsFormatter.interface';
 
 /** Provides a list of different Formatters that will change the cell value displayed in the UI */
-export const GroupTotalFormatters = {
+export const GroupTotalFormatters: Record<string, GroupTotalsFormatter> = {
   /**
    * Average all the column totals
    * Extra options available in "params":: "groupFormatterPrefix" and "groupFormatterSuffix", e.g.: params: { groupFormatterPrefix: '<i>Total</i>: ', groupFormatterSuffix: '$' }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -40,7 +40,7 @@ export * from './sortComparers/sortComparers.index';
 export * from './services/index';
 export { Enums } from './enums/enums.index';
 
-const Utilities = { ...BackendUtilities, ...Observers, ...ServiceUtilities, ...SortUtilities, ...Utils, deepAssign: Utils.deepMerge };
+const Utilities: any = { ...BackendUtilities, ...Observers, ...ServiceUtilities, ...SortUtilities, ...Utils, deepAssign: Utils.deepMerge };
 export { Utilities };
 export { SlickgridConfig } from './slickgrid-config';
 

--- a/packages/common/src/interfaces/aggregator.interface.ts
+++ b/packages/common/src/interfaces/aggregator.interface.ts
@@ -17,3 +17,7 @@ export interface Aggregator {
   /** Method to store the result into the given group total object provided as argument */
   storeResult: (groupTotals: any | undefined) => void;
 }
+
+export type AggregatorConstructor = {
+  new(field: number | string): Aggregator;
+};

--- a/packages/common/src/services/backendUtility.service.ts
+++ b/packages/common/src/services/backendUtility.service.ts
@@ -59,7 +59,7 @@ export class BackendUtilityService {
    * Execute the backend callback, which are mainly the "process" & "postProcess" methods.
    * Also note that "preProcess" was executed prior to this callback
    */
-  executeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, extraCallbacks?: BackendCallbacks) {
+  executeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, extraCallbacks?: BackendCallbacks): void {
     if (backendServiceApi) {
       // emit an onFilterChanged event when it's not called by a clear filter
       if (args && !args.clearFilterTriggered && !args.clearSortTriggered && extraCallbacks?.emitActionChangedCallback) {

--- a/packages/common/src/services/backendUtility.service.ts
+++ b/packages/common/src/services/backendUtility.service.ts
@@ -10,7 +10,7 @@ export interface BackendCallbacks {
 }
 
 export class BackendUtilityService {
-  constructor(protected rxjs?: RxJsFacade) { }
+  constructor(protected rxjs?: RxJsFacade | undefined) { }
 
   addRxJsResource(rxjs: RxJsFacade): void {
     this.rxjs = rxjs;

--- a/packages/common/src/services/backendUtility.service.ts
+++ b/packages/common/src/services/backendUtility.service.ts
@@ -12,7 +12,7 @@ export interface BackendCallbacks {
 export class BackendUtilityService {
   constructor(protected rxjs?: RxJsFacade) { }
 
-  addRxJsResource(rxjs: RxJsFacade) {
+  addRxJsResource(rxjs: RxJsFacade): void {
     this.rxjs = rxjs;
   }
 
@@ -47,7 +47,7 @@ export class BackendUtilityService {
   }
 
   /** On a backend service api error, we will run the "onError" if there is 1 provided or just throw back the error when nothing is provided */
-  onBackendError(e: any, backendApi: BackendServiceApi) {
+  onBackendError(e: any, backendApi: BackendServiceApi): void {
     if (typeof backendApi?.onError === 'function') {
       backendApi.onError(e);
     } else {
@@ -105,7 +105,7 @@ export class BackendUtilityService {
   }
 
   /** Refresh the dataset through the Backend Service */
-  refreshBackendDataset(gridOptions: GridOption) {
+  refreshBackendDataset(gridOptions: GridOption): void {
     let query = '';
     const backendApi = gridOptions?.backendServiceApi;
 

--- a/packages/common/src/services/collection.service.ts
+++ b/packages/common/src/services/collection.service.ts
@@ -12,7 +12,7 @@ import { sortByFieldType } from '../sortComparers/sortUtilities';
 import type { TranslaterService } from './translater.service';
 
 export class CollectionService<T = any> {
-  constructor(protected readonly translaterService?: TranslaterService) { }
+  constructor(protected readonly translaterService?: TranslaterService | undefined) { }
 
   /**
    * Filter 1 or more items from a collection

--- a/packages/common/src/services/container.service.ts
+++ b/packages/common/src/services/container.service.ts
@@ -8,7 +8,7 @@ export class ContainerService {
     throw new Error('ContainerService "get" method must be implemented');
   }
 
-  registerInstance(_key: any, _instance: any) {
+  registerInstance(_key: any, _instance: any): void {
     throw new Error('ContainerService "registerInstance" method must be implemented');
   }
 }

--- a/packages/common/src/services/dateUtils.ts
+++ b/packages/common/src/services/dateUtils.ts
@@ -163,7 +163,7 @@ export function tryParseDate(inputDate?: string | Date, inputFormat?: string, st
  * @param inputDate
  * @returns
  */
-export function toUtcDate(inputDate: string | Date) {
+export function toUtcDate(inputDate: string | Date): Date {
   // to parse as UTC in Tempo, we need to remove the offset (which is a simple inversed offset to cancel itself)
   return removeOffset(inputDate, offset(inputDate, 'utc'));
 };

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -64,7 +64,7 @@ export class ExtensionService {
     protected readonly sharedService: SharedService,
     protected readonly sortService: SortService,
     protected readonly treeDataService: TreeDataService,
-    protected readonly translaterService?: TranslaterService,
+    protected readonly translaterService?: TranslaterService | undefined,
     protected readonly lazyGridService?: () => GridService
   ) { }
 

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -49,7 +49,7 @@ export class ExtensionService {
   protected _rowSelectionModel?: SlickRowSelectionModel;
   protected _rowBasedEdit?: SlickRowBasedEdit;
 
-  get extensionList() {
+  get extensionList(): ExtensionList<any> {
     return this._extensionList;
   }
 
@@ -69,7 +69,7 @@ export class ExtensionService {
   ) { }
 
   /** Dispose of all the controls & plugins */
-  dispose() {
+  dispose(): void {
     this.sharedService.visibleColumns = [];
 
     // dispose of each control/plugin & reset the list
@@ -110,7 +110,7 @@ export class ExtensionService {
    * @param {String} name
    * @param {Object} extension
    */
-  addExtensionToList<T = any>(name: ExtensionName, extension: { name: ExtensionName; instance: T; }) {
+  addExtensionToList<T = any>(name: ExtensionName, extension: { name: ExtensionName; instance: T; }): void {
     this._extensionList[name] = extension;
   }
 
@@ -153,12 +153,12 @@ export class ExtensionService {
   }
 
   /** Auto-resize all the column in the grid to fit the grid width */
-  autoResizeColumns() {
+  autoResizeColumns(): void {
     this.sharedService.slickGrid.autosizeColumns();
   }
 
   /** Bind/Create different Controls or Plugins after the Grid is created */
-  bindDifferentExtensions() {
+  bindDifferentExtensions(): void {
     if (this.gridOptions) {
       // make sure all columns are translated before creating ColumnPicker/GridMenu Controls
       // this is to avoid having hidden columns not being translated on first load
@@ -311,7 +311,7 @@ export class ExtensionService {
    * @param columnDefinitions
    * @param gridOptions
    */
-  createExtensionsBeforeGridCreation(columnDefinitions: Column[], gridOptions: GridOption) {
+  createExtensionsBeforeGridCreation(columnDefinitions: Column[], gridOptions: GridOption): void {
     const featureWithColumnIndexPositions: ExtensionWithColumnIndexPosition[] = [];
 
     // the following 3 features might have `columnIndexPosition` that we need to respect their column order, we will execute them by their sort order further down
@@ -350,7 +350,7 @@ export class ExtensionService {
   }
 
   /** Hide a column from the grid */
-  hideColumn(column: Column) {
+  hideColumn(column: Column): void {
     if (typeof this.sharedService?.slickGrid?.getColumns === 'function') {
       const columnIndex = this.sharedService.slickGrid.getColumnIndex(column.id);
       this.sharedService.visibleColumns = this.removeColumnByIndex(this.sharedService.slickGrid.getColumns(), columnIndex);
@@ -359,7 +359,7 @@ export class ExtensionService {
   }
 
   /** Refresh the dataset through the Backend Service */
-  refreshBackendDataset(gridOptions?: GridOption) {
+  refreshBackendDataset(gridOptions?: GridOption): void {
     this.extensionUtility.refreshBackendDataset(gridOptions);
   }
 
@@ -376,7 +376,7 @@ export class ExtensionService {
   }
 
   /** Translate all possible Extensions at once */
-  translateAllExtensions(lang?: string) {
+  translateAllExtensions(lang?: string): void {
     this.translateCellMenu();
     this.translateContextMenu();
     this.translateHeaderMenu();
@@ -388,38 +388,38 @@ export class ExtensionService {
   }
 
   /** Translate the Cell Menu titles, we need to loop through all column definition to re-translate them */
-  translateCellMenu() {
+  translateCellMenu(): void {
     this._cellMenuPlugin?.translateCellMenu();
   }
 
   /** Translate the Column Picker and it's last 2 checkboxes */
-  translateColumnPicker() {
+  translateColumnPicker(): void {
     this._columnPickerControl?.translateColumnPicker();
   }
 
   /** Translate the Context Menu titles, we need to loop through all column definition to re-translate them */
-  translateContextMenu() {
+  translateContextMenu(): void {
     this._contextMenuPlugin?.translateContextMenu();
   }
 
   /**
    * Translate the Header Menu titles, we need to loop through all column definition to re-translate them
    */
-  translateGridMenu() {
+  translateGridMenu(): void {
     this._gridMenuControl?.translateGridMenu();
   }
 
   /**
    * Translate the Header Menu titles, we need to loop through all column definition to re-translate them
    */
-  translateHeaderMenu() {
+  translateHeaderMenu(): void {
     this._headerMenuPlugin?.translateHeaderMenu();
   }
 
   /**
    * Translate the action column buttons of the Row Based Edit Plugin
    */
-  translateRowEditPlugin() {
+  translateRowEditPlugin(): void {
     this._rowBasedEdit?.translate();
   }
 
@@ -429,7 +429,7 @@ export class ExtensionService {
    * @param locale to use
    * @param new column definitions (optional)
    */
-  translateColumnHeaders(locale?: string, newColumnDefinitions?: Column[]) {
+  translateColumnHeaders(locale?: string, newColumnDefinitions?: Column[]): void {
     if (this.sharedService && this.gridOptions && this.gridOptions.enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
@@ -456,7 +456,7 @@ export class ExtensionService {
    * Render (or re-render) the column headers from column definitions.
    * calling setColumns() will trigger a grid re-render
    */
-  renderColumnHeaders(newColumnDefinitions?: Column[], forceColumnDefinitionsOverwrite = false) {
+  renderColumnHeaders(newColumnDefinitions?: Column[], forceColumnDefinitionsOverwrite = false): void {
     let collection = newColumnDefinitions;
     if (!collection) {
       collection = this.sharedService.columnDefinitions;
@@ -494,7 +494,7 @@ export class ExtensionService {
    * @param columnDefinitions
    * @param gridOptions
    */
-  protected createExtensionByTheirColumnIndex(featureWithIndexPositions: ExtensionWithColumnIndexPosition[], columnDefinitions: Column[], gridOptions: GridOption) {
+  protected createExtensionByTheirColumnIndex(featureWithIndexPositions: ExtensionWithColumnIndexPosition[], columnDefinitions: Column[], gridOptions: GridOption): void {
     // 1- first step is to sort them by their index position
     featureWithIndexPositions.sort((feat1, feat2) => feat1.columnIndexPosition - feat2.columnIndexPosition);
 
@@ -508,7 +508,7 @@ export class ExtensionService {
   }
 
   /** Translate an array of items from an input key and assign translated value to the output key */
-  protected translateItems(items: any[], inputKey: string, outputKey: string) {
+  protected translateItems(items: any[], inputKey: string, outputKey: string): void {
     if (this.gridOptions?.enableTranslate && !(this.translaterService?.translate)) {
       throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
     }

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -95,7 +95,7 @@ export class FilterService {
     return this._grid?.getData<SlickDataView>() ?? {};
   }
 
-  addRxJsResource(rxjs: RxJsFacade) {
+  addRxJsResource(rxjs: RxJsFacade): void {
     this.rxjs = rxjs;
   }
 
@@ -111,7 +111,7 @@ export class FilterService {
     }
   }
 
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
 
@@ -126,7 +126,7 @@ export class FilterService {
   /**
    * Dispose of the filters, since it's a singleton, we don't want to affect other grids with same columns
    */
-  disposeColumnFilters() {
+  disposeColumnFilters(): void {
     this.removeAllColumnFiltersProperties();
 
     // also destroy each Filter instances
@@ -145,7 +145,7 @@ export class FilterService {
    * Bind a backend filter hook to the grid
    * @param grid SlickGrid Grid object
    */
-  bindBackendOnFilter(grid: SlickGrid) {
+  bindBackendOnFilter(grid: SlickGrid): void {
     this._filtersMetadata = [];
 
     // subscribe to SlickGrid onHeaderRowCellRendered event to create filter template
@@ -176,7 +176,7 @@ export class FilterService {
    * @param gridOptions Grid Options object
    * @param dataView
    */
-  bindLocalOnFilter(grid: SlickGrid) {
+  bindLocalOnFilter(grid: SlickGrid): void {
     this._filtersMetadata = [];
     this._dataView.setFilterArgs({ columnFilters: this._columnFilters, grid: this._grid, dataView: this._dataView });
     this._dataView.setFilter(this.customLocalFilter.bind(this));
@@ -253,7 +253,7 @@ export class FilterService {
   }
 
   /** Clear the search filters (below the column titles) */
-  async clearFilters(triggerChange = true) {
+  async clearFilters(triggerChange = true): Promise<void> {
     // emit an event before the process start
     if (triggerChange) {
       await this.pubSubService.publish('onBeforeFilterClear', true, 0);
@@ -561,7 +561,7 @@ export class FilterService {
    * This will then be passed to the DataView setFilter(customLocalFilter), which will itself loop through the list of IDs and display/hide the row when found.
    * We do this in 2 steps so that we can still use the DataSet setFilter()
    */
-  preFilterTreeData(inputItems: any[], columnFilters: ColumnFilters) {
+  preFilterTreeData(inputItems: any[], columnFilters: ColumnFilters): Set<string | number> {
     const treeDataOptions = this._gridOptions.treeDataOptions;
     const collapsedPropName = treeDataOptions?.collapsedPropName ?? Constants.treeDataProperties.COLLAPSED_PROP;
     const parentPropName = treeDataOptions?.parentPropName ?? Constants.treeDataProperties.PARENT_PROP;
@@ -739,7 +739,7 @@ export class FilterService {
     }
   }
 
-  async onBackendFilterChange(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: OnSearchChangeEventArgs) {
+  async onBackendFilterChange(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData, args: OnSearchChangeEventArgs): Promise<void> {
     const isTriggeringQueryEvent = args?.shouldTriggerQuery;
 
     if (isTriggeringQueryEvent) {
@@ -784,7 +784,7 @@ export class FilterService {
    * At the end of the day, when creating the Filter (DOM Element), it will use these searchTerm(s) so we can take advantage of that without recoding each Filter type (DOM element)
    * @param grid
    */
-  populateColumnFilterSearchTermPresets(filters: CurrentFilter[]) {
+  populateColumnFilterSearchTermPresets(filters: CurrentFilter[]): Column[] {
     if (Array.isArray(filters)) {
       this._columnDefinitions.forEach((columnDef: Column) => {
         // clear any columnDef searchTerms before applying Presets
@@ -817,7 +817,7 @@ export class FilterService {
    * we need to do this because Tree Data is the only type of grid that requires a pre-filter (preFilterTreeData) to be executed before the final filtering
    * @param {Array<Object>} [items] - optional flat array of parent/child items to use while redoing the full sort & refresh
    */
-  refreshTreeDataFilters(items?: any[]) {
+  refreshTreeDataFilters(items?: any[]): void {
     const inputItems = items ?? this._dataView?.getItems() ?? [];
 
     if (this._dataView && this._gridOptions.enableTreeData && inputItems.length > 0) {
@@ -837,7 +837,7 @@ export class FilterService {
    * @param {boolean} isFilterDisabled - optionally force a disable/enable of the Sort Functionality? Defaults to True
    * @param {boolean} clearFiltersWhenDisabled - when disabling the Filter, do we also want to clear all the filters as well? Defaults to True
    */
-  disableFilterFunctionality(isFilterDisabled = true, clearFiltersWhenDisabled = true) {
+  disableFilterFunctionality(isFilterDisabled = true, clearFiltersWhenDisabled = true): void {
     const prevShowFilterFlag = this._gridOptions.enableFiltering;
     const newShowFilterFlag = !prevShowFilterFlag;
 
@@ -860,7 +860,7 @@ export class FilterService {
    * Reset (revert) to previous filters, it could be because you prevented `onBeforeSearchChange` OR a Backend Error was thrown.
    * It will reapply the previous filter state in the UI.
    */
-  resetToPreviousSearchFilters() {
+  resetToPreviousSearchFilters(): void {
     this.updateFilters(this._previousFilters, false, false, false);
   }
 
@@ -868,7 +868,7 @@ export class FilterService {
    * Toggle the Filter Functionality (show/hide the header row filter bar as well)
    * @param {boolean} clearFiltersWhenDisabled - when disabling the filters, do we want to clear the filters before hiding the filters? Defaults to True
    */
-  toggleFilterFunctionality(clearFiltersWhenDisabled = true) {
+  toggleFilterFunctionality(clearFiltersWhenDisabled = true): void {
     const prevShowFilterFlag = this._gridOptions.enableFiltering;
     this.disableFilterFunctionality(prevShowFilterFlag, clearFiltersWhenDisabled);
   }
@@ -876,7 +876,7 @@ export class FilterService {
   /**
    * Toggle the Header Row filter bar (this does not disable the Filtering itself, you can use "toggleFilterFunctionality()" instead, however this will reset any column positions)
    */
-  toggleHeaderFilterRow() {
+  toggleHeaderFilterRow(): void {
     let showHeaderRow = this._gridOptions.showHeaderRow ?? false;
     showHeaderRow = !showHeaderRow; // inverse show header flag
     this._grid.setHeaderRowVisibility(showHeaderRow);
@@ -893,7 +893,7 @@ export class FilterService {
    * you can change the sorting icons separately by passing an array of columnId/sortAsc and that will change ONLY the icons
    * @param sortColumns
    */
-  setSortColumnIcons(sortColumns: { columnId: string, sortAsc: boolean; }[]) {
+  setSortColumnIcons(sortColumns: { columnId: string, sortAsc: boolean; }[]): void {
     if (this._grid && Array.isArray(sortColumns)) {
       this._grid.setSortColumns(sortColumns);
     }
@@ -1034,7 +1034,7 @@ export class FilterService {
    * @param column - column id or column object
    * @param filterContainer - id element HTML or DOM element filter
    */
-  drawFilterTemplate(column: Column | string, filterContainer: HTMLDivElement | string) {
+  drawFilterTemplate(column: Column | string, filterContainer: HTMLDivElement | string): Filter | null | undefined {
     let filterContainerElm: HTMLDivElement | null;
     if (typeof filterContainer === 'string') {
       filterContainerElm = document.querySelector(filterContainer);
@@ -1091,7 +1091,7 @@ export class FilterService {
   // -------------------
 
   /** Add all created filters (from their template) to the header row section area */
-  protected addFilterTemplateToHeaderRow(args: { column: Column; grid: SlickGrid; node: HTMLElement; }, isFilterFirstRender = true) {
+  protected addFilterTemplateToHeaderRow(args: { column: Column; grid: SlickGrid; node: HTMLElement; }, isFilterFirstRender = true): void {
     const columnDef = args.column;
     const columnId = columnDef?.id ?? '';
 
@@ -1144,7 +1144,7 @@ export class FilterService {
    * Callback method that is called and executed by the individual Filter (DOM element),
    * for example when user starts typing chars on a search input (which uses InputFilter), this Filter will execute the callback from an input change event.
    */
-  protected callbackSearchEvent(event: Event | undefined, args: FilterCallbackArg) {
+  protected callbackSearchEvent(event: Event | undefined, args: FilterCallbackArg): void {
     if (args) {
       const searchTerm = ((event?.target) ? (event.target as HTMLInputElement).value : undefined);
       const searchTerms = (args.searchTerms && Array.isArray(args.searchTerms)) ? args.searchTerms : (searchTerm ? [searchTerm] : undefined);
@@ -1276,7 +1276,7 @@ export class FilterService {
     return filters;
   }
 
-  protected getSelectorStringFromElement(elm?: HTMLElement | null) {
+  protected getSelectorStringFromElement(elm?: HTMLElement | null): string {
     if (elm?.localName) {
       return elm?.className ? `${elm.localName}.${Array.from(elm.classList).join('.')}` : elm.localName;
     }
@@ -1287,7 +1287,7 @@ export class FilterService {
    * When clearing or disposing of all filters, we need to loop through all columnFilters and delete them 1 by 1
    * only trying to make columnFilter an empty (without looping) would not trigger a dataset change
    */
-  protected removeAllColumnFiltersProperties() {
+  protected removeAllColumnFiltersProperties(): void {
     if (typeof this._columnFilters === 'object') {
       Object.keys(this._columnFilters).forEach(columnId => {
         if (columnId && this._columnFilters[columnId]) {
@@ -1301,14 +1301,14 @@ export class FilterService {
    * Subscribe to `onBeforeHeaderRowCellDestroy` to destroy Filter(s) to avoid leak and not keep orphan filters
    * @param {Object} grid - Slick Grid object
    */
-  protected subscribeToOnHeaderRowCellRendered(grid: SlickGrid) {
+  protected subscribeToOnHeaderRowCellRendered(grid: SlickGrid): void {
     this._eventHandler.subscribe(grid.onBeforeHeaderRowCellDestroy, (_e, args) => {
       const colFilter: Filter | undefined = this._filtersMetadata.find((filter: Filter) => filter.columnDef.id === args.column.id);
       colFilter?.destroy?.();
     });
   }
 
-  protected updateColumnFilters(searchTerms: SearchTerm[] | undefined, columnDef: any, operator?: OperatorType | OperatorString) {
+  protected updateColumnFilters(searchTerms: SearchTerm[] | undefined, columnDef: any, operator?: OperatorType | OperatorString): void {
     const fieldType = columnDef.filter?.type ?? columnDef.type ?? FieldType.string;
     const parsedSearchTerms = getParsedSearchTermsByFieldType(searchTerms, fieldType); // parsed term could be a single value or an array of values
 

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -57,7 +57,7 @@ export class FilterService {
   protected _tmpPreFilteredData?: Set<number | string>;
   protected httpCancelRequests$?: Subject<void>; // this will be used to cancel any pending http request
 
-  constructor(protected filterFactory: FilterFactory, protected pubSubService: BasePubSubService, protected sharedService: SharedService, protected backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) {
+  constructor(protected filterFactory: FilterFactory, protected pubSubService: BasePubSubService, protected sharedService: SharedService, protected backendUtilities?: BackendUtilityService | undefined, protected rxjs?: RxJsFacade | undefined) {
     this._onSearchChange = new SlickEvent<OnSearchChangeEventArgs>();
     this._eventHandler = new SlickEventHandler();
     if (this.rxjs) {

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -50,7 +50,7 @@ export class GridService {
     return this._grid?.getOptions() ?? {};
   }
 
-  dispose() {
+  dispose(): void {
     this._rowSelectionPlugin?.dispose();
   }
 
@@ -59,7 +59,7 @@ export class GridService {
   }
 
   /** Clear all Filters & Sorts */
-  clearAllFiltersAndSorts() {
+  clearAllFiltersAndSorts(): void {
     // call both clear Filters & Sort but only trigger the last one to avoid sending multiple backend queries
     if (this.sortService && this.sortService.clearSorting) {
       this.sortService.clearSorting(false); // skip event trigger on this one
@@ -70,7 +70,7 @@ export class GridService {
   }
 
   /** Clear all the pinning (frozen) options */
-  clearPinning(resetColumns = true) {
+  clearPinning(resetColumns = true): void {
     const visibleColumns = [...this.sharedService.visibleColumns];
     this.sharedService.slickGrid.setOptions({ frozenColumn: -1, frozenRow: -1, frozenBottom: false, enableMouseWheelScrollHandler: false });
 
@@ -88,7 +88,7 @@ export class GridService {
    * @param {Boolean} suppressRender - do we want to supress the grid re-rendering? (defaults to false)
    * @param {Boolean} suppressColumnSet - do we want to supress the columns set, via "setColumns()" method? (defaults to false)
    */
-  setPinning(pinningOptions: CurrentPinning, shouldAutosizeColumns = true, suppressRender = false, suppressColumnSet = true) {
+  setPinning(pinningOptions: CurrentPinning, shouldAutosizeColumns = true, suppressRender = false, suppressColumnSet = true): void {
     if (isObjectEmpty(pinningOptions)) {
       this.clearPinning();
     } else {
@@ -105,7 +105,7 @@ export class GridService {
    * Get all column set in the grid, that is all visible/hidden columns
    * and also include any extra columns used by some plugins (like Row Selection, Row Detail, ...)
    */
-  getAllColumnDefinitions() {
+  getAllColumnDefinitions(): Column[] {
     return this.sharedService.allColumns;
   }
 
@@ -138,7 +138,7 @@ export class GridService {
   }
 
   /** Get data item by it's row index number */
-  getDataItemByRowNumber(rowNumber: number) {
+  getDataItemByRowNumber<T = any>(rowNumber: number): T {
     if (!this._grid || typeof this._grid.getDataItem !== 'function') {
       throw new Error(`[Slickgrid-Universal] We could not find SlickGrid Grid object or it's "getDataItem" method`);
     }
@@ -236,7 +236,7 @@ export class GridService {
    * @param {Array<string | number>} columnIds - column definition ids, can be a single string and an array of strings
    * @param {boolean} triggerEvent - do we want to trigger an event (onHeaderMenuHideColumns) when column becomes hidden? Defaults to true.
    */
-  hideColumnByIds(columnIds: Array<string | number>, options?: HideColumnOption) {
+  hideColumnByIds(columnIds: Array<string | number>, options?: HideColumnOption): void {
     options = { ...HideColumnOptionDefaults, ...options };
     if (Array.isArray(columnIds)) {
       for (const columnId of columnIds) {
@@ -259,7 +259,7 @@ export class GridService {
    * @param {Number} rowNumber - grid row number
    * @param {Number} [duration] - duration in ms
    */
-  highlightRow(rowNumber: number | number[], duration?: number) {
+  highlightRow(rowNumber: number | number[], duration?: number): void {
     // create a SelectionModel if there's not one yet
     if (!this._grid.getSelectionModel()) {
       this._rowSelectionPlugin = new SlickRowSelectionModel(this._gridOptions.rowSelectionOptions);
@@ -275,21 +275,21 @@ export class GridService {
   }
 
   /** Select the selected row by a row index */
-  setSelectedRow(rowIndex: number) {
+  setSelectedRow(rowIndex: number): void {
     if (this._grid?.setSelectedRows) {
       this._grid.setSelectedRows([rowIndex]);
     }
   }
 
   /** Set selected rows with provided array of row indexes */
-  setSelectedRows(rowIndexes: number[]) {
+  setSelectedRows(rowIndexes: number[]): void {
     if (this._grid?.setSelectedRows) {
       this._grid.setSelectedRows(rowIndexes);
     }
   }
 
   /** Re-Render the Grid */
-  renderGrid() {
+  renderGrid(): void {
     if (typeof this._grid?.invalidate === 'function') {
       this._grid.invalidate();
     }
@@ -300,7 +300,7 @@ export class GridService {
    * The column definitions could be passed as argument to reset (this can be used after a Grid State reset)
    * The reset will clear the Filters & Sort, then will reset the Columns to their original state
    */
-  resetGrid(columnDefinitions?: Column[]) {
+  resetGrid(columnDefinitions?: Column[]): void {
     // clear any Pinning/Frozen columns/rows
     // do it prior to setting the Columns back on the next few lines
     this.clearPinning(false);
@@ -838,7 +838,7 @@ export class GridService {
    * However please note that it won't be called when `updateItem`, if the data that gets updated does change the tree data column then you should call this method.
    * @param {Array<Object>} [items] - optional flat array of parent/child items to use while redoing the full sort & refresh
    */
-  invalidateHierarchicalDataset(items?: any[]) {
+  invalidateHierarchicalDataset(items?: any[]): void {
     // if we add/remove item(s) from the dataset, we need to also refresh our tree data filters
     if (this._gridOptions?.enableTreeData && this.treeDataService) {
       const inputItems = items ?? this._dataView.getItems();
@@ -856,9 +856,9 @@ export class GridService {
   // -------------------
 
   /** Check wether the grid has the Row Selection enabled */
-  protected hasRowSelectionEnabled() {
+  protected hasRowSelectionEnabled(): boolean {
     const selectionModel = this._grid.getSelectionModel();
-    const isRowSelectionEnabled = this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector;
-    return (isRowSelectionEnabled && selectionModel);
+    const isRowSelectionEnabled = !!(this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector);
+    return (isRowSelectionEnabled && !!selectionModel);
   }
 }

--- a/packages/common/src/services/gridEvent.service.ts
+++ b/packages/common/src/services/gridEvent.service.ts
@@ -4,7 +4,7 @@ import type { Column, OnEventArgs } from './../interfaces/index';
 export class GridEventService {
   protected _eventHandler: SlickEventHandler;
 
-  get eventHandler() {
+  get eventHandler(): SlickEventHandler {
     return this._eventHandler;
   }
 
@@ -12,12 +12,12 @@ export class GridEventService {
     this._eventHandler = new SlickEventHandler();
   }
 
-  dispose() {
+  dispose(): void {
     this._eventHandler.unsubscribeAll();
   }
 
   /* OnBeforeEditCell Event */
-  bindOnBeforeEditCell(grid: SlickGrid) {
+  bindOnBeforeEditCell(grid: SlickGrid): void {
     const dataView = grid?.getData<SlickDataView>();
 
     // subscribe to this Slickgrid event of onBeforeEditCell
@@ -46,7 +46,7 @@ export class GridEventService {
   }
 
   /* OnCellChange Event */
-  bindOnCellChange(grid: SlickGrid) {
+  bindOnCellChange(grid: SlickGrid): void {
     const dataView = grid?.getData<SlickDataView>();
 
     // subscribe to this Slickgrid event of onCellChange
@@ -75,7 +75,7 @@ export class GridEventService {
   }
 
   /* OnClick Event */
-  bindOnClick(grid: SlickGrid) {
+  bindOnClick(grid: SlickGrid): void {
     const dataView = grid?.getData<SlickDataView>();
 
     this._eventHandler.subscribe(grid.onClick, (e, args) => {

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -21,7 +21,7 @@ import type { TreeDataService } from './treeData.service';
 import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
 
 export class GridStateService {
-  protected _eventHandler = new SlickEventHandler();
+  protected _eventHandler: SlickEventHandler = new SlickEventHandler();
   protected _columns: Column[] = [];
   protected _grid!: SlickGrid;
   protected _subscriptions: EventSubscription[] = [];
@@ -68,7 +68,7 @@ export class GridStateService {
   }
 
   /** Dispose of all the SlickGrid & PubSub subscriptions */
-  dispose() {
+  dispose(): void {
     this._columns = [];
 
     // unsubscribe all SlickGrid events
@@ -88,7 +88,7 @@ export class GridStateService {
    * @param {Boolean} triggerAutoSizeColumns - True by default, do we also want to call the "autosizeColumns()" method to make the columns fit in the grid?
    * @param {Boolean} triggerColumnsFullResizeByContent - False by default, do we also want to call full columns resize by their content?
    */
-  changeColumnsArrangement(definedColumns: CurrentColumn[], triggerAutoSizeColumns = true, triggerColumnsFullResizeByContent = false) {
+  changeColumnsArrangement(definedColumns: CurrentColumn[], triggerAutoSizeColumns = true, triggerColumnsFullResizeByContent = false): void {
     if (Array.isArray(definedColumns) && definedColumns.length > 0) {
       const newArrangedColumns: Column[] = this.getAssociatedGridColumns(this._grid, definedColumns);
 
@@ -335,7 +335,7 @@ export class GridStateService {
     return preservedRowSelection;
   }
 
-  resetColumns(columnDefinitions?: Column[]) {
+  resetColumns(columnDefinitions?: Column[]): void {
     const columns: Column[] = columnDefinitions || this._columns;
     const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
     this.pubSubService.publish('onGridStateChanged', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
@@ -345,7 +345,7 @@ export class GridStateService {
    * Reset the grid to its original (all) columns, that is to display the entire set of columns with their original positions & visibilities
    * @param {Boolean} triggerAutoSizeColumns - True by default, do we also want to call the "autosizeColumns()" method to make the columns fit in the grid?
    */
-  resetToOriginalColumns(triggerAutoSizeColumns = true) {
+  resetToOriginalColumns(triggerAutoSizeColumns = true): void {
     this._grid.setColumns(this.sharedService.allColumns);
     this.sharedService.visibleColumns = this.sharedService.allColumns;
 
@@ -356,7 +356,7 @@ export class GridStateService {
   }
 
   /** if we use Row Selection or the Checkbox Selector, we need to reset any selection */
-  resetRowSelectionWhenRequired() {
+  resetRowSelectionWhenRequired(): void {
     if (!this.needToPreserveRowSelection() && (this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector)) {
       // this also requires the Row Selection Model to be registered as well
       const rowSelectionExtension = this.extensionService?.getExtensionByName?.(ExtensionName.rowSelection);
@@ -370,7 +370,7 @@ export class GridStateService {
    * Subscribe to all necessary SlickGrid or Service Events that deals with a Grid change,
    * when triggered, we will publish a Grid State Event with current Grid State
    */
-  subscribeToAllGridChanges(grid: SlickGrid) {
+  subscribeToAllGridChanges(grid: SlickGrid): void {
     // Subscribe to Event Emitter of Filter changed
     this._subscriptions.push(
       this.pubSubService.subscribe<CurrentFilter[]>('onFilterChanged', currentFilters => {
@@ -462,7 +462,7 @@ export class GridStateService {
    * @param {Array<Column>} fullColumnDefinitions - full column definitions array that includes every columns (including Row Selection, Row Detail, Row Move when enabled)
    * @param {Array<Column>} newArrangedColumns - output array that will be use to show in the UI (it could have less columns than fullColumnDefinitions array since user might hide some columns)
    */
-  protected addColumnDynamicWhenFeatureEnabled(dynamicAddonColumnByIndexPositionList: Array<{ columnId: string; columnIndexPosition: number; }>, fullColumnDefinitions: Column[], newArrangedColumns: Column[]) {
+  protected addColumnDynamicWhenFeatureEnabled(dynamicAddonColumnByIndexPositionList: Array<{ columnId: string; columnIndexPosition: number; }>, fullColumnDefinitions: Column[], newArrangedColumns: Column[]): void {
     // 1- first step is to sort them by their index position
     dynamicAddonColumnByIndexPositionList.sort((feat1, feat2) => feat1.columnIndexPosition - feat2.columnIndexPosition);
 
@@ -483,7 +483,7 @@ export class GridStateService {
    * @param extension name
    * @param event name
    */
-  protected bindExtensionAddonEventToGridStateChange(extensionName: ExtensionName, eventName: string) {
+  protected bindExtensionAddonEventToGridStateChange(extensionName: ExtensionName, eventName: string): void {
     const extension = this.extensionService?.getExtensionByName?.(extensionName);
     const slickEvent = extension?.instance?.[eventName];
 
@@ -501,7 +501,7 @@ export class GridStateService {
    * @param event - event name
    * @param grid - SlickGrid object
    */
-  protected bindSlickGridColumnChangeEventToGridStateChange(eventName: string, grid: SlickGrid) {
+  protected bindSlickGridColumnChangeEventToGridStateChange(eventName: string, grid: SlickGrid): void {
     const slickGridEvent = (grid as any)?.[eventName];
 
     if (slickGridEvent && typeof slickGridEvent.subscribe === 'function') {
@@ -517,7 +517,7 @@ export class GridStateService {
    * Bind a Grid Event (of grid option changes) to a Grid State change event, if we detect that any of the pinning (frozen) options changes then we'll trigger a Grid State change
    * @param grid - SlickGrid object
    */
-  protected bindSlickGridOnSetOptionsEventToGridStateChange(grid: SlickGrid) {
+  protected bindSlickGridOnSetOptionsEventToGridStateChange(grid: SlickGrid): void {
     const onSetOptionsHandler = grid.onSetOptions;
     this._eventHandler.subscribe(onSetOptionsHandler, (_e, args) => {
       const { frozenBottom: frozenBottomBefore, frozenColumn: frozenColumnBefore, frozenRow: frozenRowBefore } = args.optionsBefore;
@@ -532,9 +532,9 @@ export class GridStateService {
   }
 
   /** Check wether the grid has the Row Selection enabled */
-  protected hasRowSelectionEnabled() {
+  protected hasRowSelectionEnabled(): boolean {
     const selectionModel = this._grid.getSelectionModel();
-    const isRowSelectionEnabled = this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector;
-    return (isRowSelectionEnabled && selectionModel);
+    const isRowSelectionEnabled = !!(this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector);
+    return (isRowSelectionEnabled && !!selectionModel);
   }
 }

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -21,7 +21,7 @@ import type { TreeDataService } from './treeData.service';
 import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
 
 export class GridStateService {
-  protected _eventHandler: SlickEventHandler = new SlickEventHandler();
+  protected _eventHandler: SlickEventHandler;
   protected _columns: Column[] = [];
   protected _grid!: SlickGrid;
   protected _subscriptions: EventSubscription[] = [];
@@ -36,7 +36,9 @@ export class GridStateService {
     protected readonly sharedService: SharedService,
     protected readonly sortService: SortService,
     protected readonly treeDataService: TreeDataService,
-  ) { }
+  ) {
+    this._eventHandler = new SlickEventHandler();
+  }
 
   /** Getter of SlickGrid DataView object */
   get _dataView(): SlickDataView {

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -39,7 +39,7 @@ export class GroupingAndColspanService {
    * @param {object} grid
    * @param {object} resizerPlugin
    */
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
 
     if (grid && this._gridOptions) {
@@ -87,19 +87,19 @@ export class GroupingAndColspanService {
     }
   }
 
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
   }
 
   /** call "renderPreHeaderRowGroupingTitles()" with a setTimeout delay */
-  delayRenderPreHeaderRowGroupingTitles(delay = 0) {
+  delayRenderPreHeaderRowGroupingTitles(delay = 0): void {
     setTimeout(() => this.renderPreHeaderRowGroupingTitles(), delay);
   }
 
   /** Create or Render the Pre-Header Row Grouping Titles */
-  renderPreHeaderRowGroupingTitles() {
+  renderPreHeaderRowGroupingTitles(): void {
     const colsCount = this._columnDefinitions.length;
 
     if (this._gridOptions?.frozenColumn !== undefined && this._gridOptions.frozenColumn >= 0) {
@@ -116,7 +116,7 @@ export class GroupingAndColspanService {
     }
   }
 
-  renderHeaderGroups(preHeaderPanel: HTMLElement, start: number, end: number) {
+  renderHeaderGroups(preHeaderPanel: HTMLElement, start: number, end: number): void {
     emptyElement(preHeaderPanel);
     preHeaderPanel.className = 'slick-header-columns';
     preHeaderPanel.style.left = '-1000px';
@@ -160,7 +160,7 @@ export class GroupingAndColspanService {
   }
 
   /** Translate Column Group texts and re-render them afterward. */
-  translateGroupingAndColSpan() {
+  translateGroupingAndColSpan(): void {
     const currentColumnDefinitions = this._grid.getColumns();
     this.extensionUtility.translateItems(currentColumnDefinitions, 'columnGroupKey', 'columnGroup');
     this._grid.setColumns(currentColumnDefinitions);

--- a/packages/common/src/services/observers.ts
+++ b/packages/common/src/services/observers.ts
@@ -4,7 +4,7 @@
  * @param {any[]} inputArray - array you want to listen to
  * @param {Function} callback function that will be called on any change inside array
  */
-export function collectionObserver(inputArray: any[], callback: (outputArray: any[], newValues: any[]) => void) {
+export function collectionObserver(inputArray: any[], callback: (outputArray: any[], newValues: any[]) => void): void {
   // Add more methods here if you want to listen to them
   const mutationMethods = ['pop', 'push', 'reverse', 'shift', 'unshift', 'splice', 'sort'];
 
@@ -23,7 +23,7 @@ export function collectionObserver(inputArray: any[], callback: (outputArray: an
  * @param {String} prop - object property name
  * @param {Function} callback - function that will be called on any change inside array
  */
-export function propertyObserver(obj: any, prop: string, callback: (newValue: any, o?: any) => void) {
+export function propertyObserver(obj: any, prop: string, callback: (newValue: any, o?: any) => void): void {
   let innerValue = obj[prop];
 
   Object.defineProperty(obj, prop, {

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -16,7 +16,7 @@ import type { Observable, RxJsFacade } from './rxjsFacade';
 import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
 
 export class PaginationService {
-  protected _eventHandler = new SlickEventHandler();
+  protected _eventHandler: SlickEventHandler = new SlickEventHandler();
   protected _initialized = false;
   protected _isLocalGrid = true;
   protected _backendServiceApi: BackendServiceApi | undefined;
@@ -107,11 +107,11 @@ export class PaginationService {
     return this._isCursorBased;
   }
 
-  addRxJsResource(rxjs: RxJsFacade) {
+  addRxJsResource(rxjs: RxJsFacade): void {
     this.rxjs = rxjs;
   }
 
-  init(grid: SlickGrid, paginationOptions: Pagination, backendServiceApi?: BackendServiceApi) {
+  init(grid: SlickGrid, paginationOptions: Pagination, backendServiceApi?: BackendServiceApi): void {
     this._availablePageSizes = paginationOptions.pageSizes;
     this.grid = grid;
     this._backendServiceApi = backendServiceApi;
@@ -162,7 +162,7 @@ export class PaginationService {
     propertyObserver(paginationOptions, 'totalItems', (newTotal) => this._totalItems = newTotal);
   }
 
-  dispose() {
+  dispose(): void {
     this._initialized = false;
 
     // unsubscribe all SlickGrid events
@@ -277,7 +277,7 @@ export class PaginationService {
     return Promise.resolve(false);
   }
 
-  refreshPagination(isPageNumberReset = false, triggerChangedEvent = true, triggerInitializedEvent = false) {
+  refreshPagination(isPageNumberReset = false, triggerChangedEvent = true, triggerInitializedEvent = false): void {
     const previousPagination = { ...this.getFullPagination() };
 
     if (this._paginationOptions) {
@@ -335,7 +335,7 @@ export class PaginationService {
   }
 
   /** Reset the Pagination to first page and recalculate necessary numbers */
-  resetPagination(triggerChangedEvent = true) {
+  resetPagination(triggerChangedEvent = true): void {
     if (this._isLocalGrid && this.dataView && this.sharedService?.gridOptions?.enablePagination) {
       // on a local grid we also need to reset the DataView paging to 1st page
       this.dataView.setPagingOptions({ pageSize: this._itemsPerPage, pageNum: 0 });
@@ -351,7 +351,7 @@ export class PaginationService {
    * The Pagination must be created on initial page load, then only after can you toggle it.
    * Basically this method WILL NOT WORK to show the Pagination if it was never created from the start.
    */
-  togglePaginationVisibility(visible?: boolean) {
+  togglePaginationVisibility(visible?: boolean): void {
     if (this.grid && this.sharedService?.gridOptions) {
       const isVisible = visible !== undefined ? visible : !this.sharedService.gridOptions.enablePagination;
 
@@ -449,7 +449,7 @@ export class PaginationService {
     });
   }
 
-  recalculateFromToIndexes() {
+  recalculateFromToIndexes(): void {
     // when page is out of boundaries, reset it to page 1
     if (((this._pageNumber - 1) * this._itemsPerPage > this._totalItems) || (this._totalItems > 0 && this._pageNumber === 0)) {
       this._pageNumber = 1;
@@ -479,7 +479,7 @@ export class PaginationService {
    * Reset (revert) to previous pagination, it could be because you prevented `onBeforePaginationChange`, `onBeforePagingInfoChanged` from DataView OR a Backend Error was thrown.
    * It will reapply the previous filter state in the UI.
    */
-  resetToPreviousPagination() {
+  resetToPreviousPagination(): void {
     const hasPageNumberChange = this._previousPagination?.pageNumber !== this.getFullPagination().pageNumber;
     const hasPageSizeChange = this._previousPagination?.pageSize !== this.getFullPagination().pageSize;
 
@@ -498,7 +498,7 @@ export class PaginationService {
     }
   }
 
-  setCursorBased(isCursorBased: boolean) {
+  setCursorBased(isCursorBased: boolean): void {
     this._isCursorBased = isCursorBased;
     if (isCursorBased) {
       this.setCursorPageInfo({ startCursor: '', endCursor: '', hasNextPage: false, hasPreviousPage: false }); // reset cursor
@@ -507,11 +507,11 @@ export class PaginationService {
     this.pubSubService.publish(`onPaginationSetCursorBased`, { isCursorBased });
   }
 
-  setCursorPageInfo(pageInfo: CursorPageInfo) {
+  setCursorPageInfo(pageInfo: CursorPageInfo): void {
     this._cursorPageInfo = pageInfo;
   }
 
-  updateTotalItems(totalItems: number, triggerChangedEvent = false) {
+  updateTotalItems(totalItems: number, triggerChangedEvent = false): void {
     this._totalItems = totalItems;
     if (this._paginationOptions) {
       this._paginationOptions.totalItems = totalItems;
@@ -530,7 +530,7 @@ export class PaginationService {
    * basically we assume that this offset is fine for the time being,
    * until user does an action which will refresh the data hence the pagination which will then become normal again
    */
-  protected processOnItemAddedOrRemoved(items: any | any[], isItemAdded = true) {
+  protected processOnItemAddedOrRemoved(items: any | any[], isItemAdded = true): void {
     if (items !== null) {
       const previousDataTo = this._dataTo;
       const itemCount = Array.isArray(items) ? items.length : 1;

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -16,7 +16,7 @@ import type { Observable, RxJsFacade } from './rxjsFacade';
 import { type SlickDataView, SlickEventHandler, type SlickGrid } from '../core/index';
 
 export class PaginationService {
-  protected _eventHandler: SlickEventHandler = new SlickEventHandler();
+  protected _eventHandler: SlickEventHandler;
   protected _initialized = false;
   protected _isLocalGrid = true;
   protected _backendServiceApi: BackendServiceApi | undefined;
@@ -37,7 +37,9 @@ export class PaginationService {
   grid!: SlickGrid;
 
   /** Constructor */
-  constructor(protected readonly pubSubService: BasePubSubService, protected readonly sharedService: SharedService, protected readonly backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) { }
+  constructor(protected readonly pubSubService: BasePubSubService, protected readonly sharedService: SharedService, protected readonly backendUtilities?: BackendUtilityService | undefined, protected rxjs?: RxJsFacade | undefined) {
+    this._eventHandler = new SlickEventHandler();
+  }
 
   /** Getter of SlickGrid DataView object */
   get dataView(): SlickDataView | undefined {

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -32,7 +32,7 @@ export class ResizerService {
   protected _gridContainerElm!: HTMLElement;
   protected _pageContainerElm!: HTMLElement;
   protected _intervalId!: NodeJS.Timeout;
-  protected _intervalRetryDelay = DEFAULT_INTERVAL_RETRY_DELAY;
+  protected _intervalRetryDelay: number = DEFAULT_INTERVAL_RETRY_DELAY;
   protected _isStopResizeIntervalRequested = false;
   protected _hasResizedByContentAtLeastOnce = false;
   protected _lastDimensions?: GridSize;
@@ -81,7 +81,7 @@ export class ResizerService {
   }
 
   /** Dispose function when service is destroyed */
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler?.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
@@ -96,7 +96,7 @@ export class ResizerService {
     this._bindingEventService.unbindAll();
   }
 
-  init(grid: SlickGrid, gridParentContainerElm: HTMLElement) {
+  init(grid: SlickGrid, gridParentContainerElm: HTMLElement): void {
     if (!grid || !this.gridOptions || !gridParentContainerElm) {
       throw new Error(`
       [Slickgrid-Universal] Resizer Service requires a valid Grid object and DOM Element Container to be provided.
@@ -186,7 +186,7 @@ export class ResizerService {
     }
   }
 
-  handleResizeGrid(newSizes?: GridSize) {
+  handleResizeGrid(newSizes?: GridSize): void {
     this.pubSubService.publish('onGridBeforeResize');
     if (!this._resizePaused) {
       // for some yet unknown reason, calling the resize twice removes any stuttering/flickering
@@ -283,7 +283,7 @@ export class ResizerService {
    * Provide the possibility to pause the resizer for some time, until user decides to re-enabled it later if he wish to.
    * @param {boolean} isResizePaused are we pausing the resizer?
    */
-  pauseResizer(isResizePaused: boolean) {
+  pauseResizer(isResizePaused: boolean): void {
     this._resizePaused = isResizePaused;
   }
 
@@ -372,7 +372,7 @@ export class ResizerService {
     return this._lastDimensions;
   }
 
-  requestStopOfAutoFixResizeGrid(isStopRequired = true) {
+  requestStopOfAutoFixResizeGrid(isStopRequired = true): void {
     this._isStopResizeIntervalRequested = isStopRequired;
   }
 
@@ -384,7 +384,7 @@ export class ResizerService {
    * however user could override it by using the grid option `resizeMaxItemToInspectCellContentWidth` to increase/decrease how many items to inspect.
    * @param {Boolean} recalculateColumnsTotalWidth - defaults to false, do we want to recalculate the necessary total columns width even if it was already calculated?
    */
-  resizeColumnsByCellContent(recalculateColumnsTotalWidth = false) {
+  resizeColumnsByCellContent(recalculateColumnsTotalWidth = false): void {
     const columnDefinitions = this._grid.getColumns();
     const dataset = this.dataView.getItems() as any[];
     const columnWidths: { [columnId in string | number]: number; } = {};
@@ -464,7 +464,7 @@ export class ResizerService {
    * @param columnIndexOverride - an optional column index, if provided it will override the column index position
    * @returns - count of items that was read
    */
-  protected calculateCellWidthByReadingDataset(columnOrColumns: Column | Column[], columnWidths: { [columnId in string | number]: number; }, maxItemToInspect = 1000, columnIndexOverride?: number) {
+  protected calculateCellWidthByReadingDataset(columnOrColumns: Column | Column[], columnWidths: { [columnId in string | number]: number; }, maxItemToInspect = 1000, columnIndexOverride?: number): number {
     const columnDefinitions = Array.isArray(columnOrColumns) ? columnOrColumns : [columnOrColumns];
     const dataset = this.dataView.getItems() as any[];
 
@@ -523,7 +523,7 @@ export class ResizerService {
    * @param {Object} column - column definition to apply the width
    * @param {Number} calculatedColumnWidth - new calculated column width to possibly apply
    */
-  protected applyNewCalculatedColumnWidthByReference(column: Column<any>, calculatedColumnWidth: number) {
+  protected applyNewCalculatedColumnWidthByReference(column: Column<any>, calculatedColumnWidth: number): void {
     // read a few optional resize by content grid options
     const resizeCellPaddingWidthInPx = this.resizeByContentOptions.cellPaddingWidthInPx ?? 6;
     const resizeFormatterPaddingWidthInPx = this.resizeByContentOptions.formatterPaddingWidthInPx ?? 6;
@@ -563,7 +563,7 @@ export class ResizerService {
     }
   }
 
-  protected handleSingleColumnResizeByContent(columnId: string) {
+  protected handleSingleColumnResizeByContent(columnId: string): void {
     const columnDefinitions = this._grid.getColumns();
     const columnDefIdx = columnDefinitions.findIndex(col => col.id === columnId);
 
@@ -630,7 +630,7 @@ export class ResizerService {
    *   2- header titles are lower than the viewport of dataset (this can happen when user change Tab and DOM is not shown),
    * for these cases we'll resize until it's no longer true or until we reach a max time limit (70min)
    */
-  protected resizeGridWhenStylingIsBrokenUntilCorrected() {
+  protected resizeGridWhenStylingIsBrokenUntilCorrected(): void {
     // how many time we want to check before really stopping the resize check?
     // We do this because user might be switching to another tab too quickly for the resize be really finished, so better recheck few times to make sure
     const autoFixResizeTimeout = this.gridOptions?.autoFixResizeTimeout ?? (5 * 60 * 60); // interval is 200ms, so 4x is 1sec, so (4 * 60 * 60 = 60min)

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -25,7 +25,7 @@ export class SortService {
   protected _isBackendGrid = false;
   protected httpCancelRequests$?: Subject<void>; // this will be used to cancel any pending http request
 
-  constructor(protected readonly sharedService: SharedService, protected readonly pubSubService: BasePubSubService, protected readonly backendUtilities?: BackendUtilityService, protected rxjs?: RxJsFacade) {
+  constructor(protected readonly sharedService: SharedService, protected readonly pubSubService: BasePubSubService, protected readonly backendUtilities?: BackendUtilityService | undefined, protected rxjs?: RxJsFacade | undefined) {
     this._eventHandler = new SlickEventHandler();
     if (this.rxjs) {
       this.httpCancelRequests$ = this.rxjs.createSubject<void>();

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -47,7 +47,7 @@ export class SortService {
     return this._grid?.getColumns() ?? [];
   }
 
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     if (this._eventHandler?.unsubscribeAll) {
       this._eventHandler.unsubscribeAll();
@@ -58,7 +58,7 @@ export class SortService {
     }
   }
 
-  addRxJsResource(rxjs: RxJsFacade) {
+  addRxJsResource(rxjs: RxJsFacade): void {
     this.rxjs = rxjs;
   }
 
@@ -67,7 +67,7 @@ export class SortService {
    * @param grid SlickGrid Grid object
    * @param dataView SlickGrid DataView object
    */
-  bindBackendOnSort(grid: SlickGrid) {
+  bindBackendOnSort(grid: SlickGrid): void {
     this._isBackendGrid = true;
     this._grid = grid;
     this._dataView = grid?.getData<SlickDataView>();
@@ -82,7 +82,7 @@ export class SortService {
    * @param gridOptions Grid Options object
    * @param dataView
    */
-  bindLocalOnSort(grid: SlickGrid) {
+  bindLocalOnSort(grid: SlickGrid): void {
     this._isBackendGrid = false;
     this._grid = grid;
     this._dataView = grid?.getData<SlickDataView>();
@@ -91,7 +91,7 @@ export class SortService {
     this._eventHandler.subscribe(grid.onSort, this.handleLocalOnSort.bind(this));
   }
 
-  handleLocalOnSort(_e: SlickEventData, args: SingleColumnSort | MultiColumnSort) {
+  handleLocalOnSort(_e: SlickEventData, args: SingleColumnSort | MultiColumnSort): void {
     // multiSort and singleSort are not exactly the same, but we want to structure it the same for the (for loop) after
     // also to avoid having to rewrite the for loop in the sort, we will make the singleSort an array of 1 object
     const sortColumns: Array<SingleColumnSort> = (args.multiColumnSort)
@@ -119,7 +119,7 @@ export class SortService {
     this.emitSortChanged(EmitterType.local);
   }
 
-  clearSortByColumnId(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData | undefined, columnId: string | number) {
+  clearSortByColumnId(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData | undefined, columnId: string | number): void {
     // get previously sorted columns
     const allSortedCols = this.getCurrentColumnSorts() as ColumnSort[];
     const sortedColsWithoutCurrent = this.getCurrentColumnSorts(`${columnId}`) as ColumnSort[];
@@ -161,7 +161,7 @@ export class SortService {
    *   - however for a local grid, we need to pass a sort column and so we will sort by the 1st column
    * @param trigger query event after executing clear filter?
    */
-  clearSorting(triggerQueryEvent = true) {
+  clearSorting(triggerQueryEvent = true): void {
     if (this._grid && this._gridOptions && this._dataView) {
       // remove any sort icons (this setSortColumns function call really does only that)
       this._grid.setSortColumns([]);
@@ -197,7 +197,7 @@ export class SortService {
    * @param {boolean} isSortingDisabled - optionally force a disable/enable of the Sort Functionality? Defaults to True
    * @param {boolean} clearSortingWhenDisabled - when disabling the sorting, do we also want to clear the sorting as well? Defaults to True
    */
-  disableSortFunctionality(isSortingDisabled = true, clearSortingWhenDisabled = true) {
+  disableSortFunctionality(isSortingDisabled = true, clearSortingWhenDisabled = true): void {
     const prevSorting = this._gridOptions.enableSorting;
     const newSorting = !prevSorting;
 
@@ -225,7 +225,7 @@ export class SortService {
    * Toggle the Sorting functionality
    * @param {boolean} clearSortingWhenDisabled - when disabling the sorting, do we also want to clear the sorting as well? Defaults to True
    */
-  toggleSortFunctionality(clearSortingOnDisable = true) {
+  toggleSortFunctionality(clearSortingOnDisable = true): void {
     const previousSorting = this._gridOptions.enableSorting;
     this.disableSortFunctionality(previousSorting, clearSortingOnDisable);
   }
@@ -235,7 +235,7 @@ export class SortService {
    * Other services, like Pagination, can then subscribe to it.
    * @param sender
    */
-  emitSortChanged(sender: EmitterType, currentLocalSorters?: CurrentSorter[]) {
+  emitSortChanged(sender: EmitterType, currentLocalSorters?: CurrentSorter[]): void {
     if (sender === EmitterType.remote && this._gridOptions?.backendServiceApi) {
       let currentSorters: CurrentSorter[] = [];
       const backendService = this._gridOptions.backendServiceApi.service;
@@ -319,7 +319,7 @@ export class SortService {
   }
 
   /** Process the initial sort, typically it will sort ascending by the column that has the Tree Data unless user specifies a different initialSort */
-  processTreeDataInitialSort() {
+  processTreeDataInitialSort(): void {
     // when a Tree Data view is defined, we must sort the data so that the UI works correctly
     if (this._gridOptions?.enableTreeData && this._gridOptions.treeDataOptions) {
       // first presort it once by tree level
@@ -351,7 +351,7 @@ export class SortService {
    * @param args - sort event arguments
    * @returns - False since we'll apply the sort icon(s) manually only after server responded
    */
-  onBackendSortChanged(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData | undefined, args: (SingleColumnSort | MultiColumnSort) & { clearSortTriggered?: boolean; }) {
+  onBackendSortChanged(event: DOMMouseOrTouchEvent<HTMLDivElement> | SlickEventData | undefined, args: (SingleColumnSort | MultiColumnSort) & { clearSortTriggered?: boolean; }): void {
     if (!args || !args.grid) {
       throw new Error('Something went wrong when trying to bind the "onBackendSortChanged(event, args)" function, it seems that "args" is not populated correctly');
     }
@@ -391,7 +391,7 @@ export class SortService {
   }
 
   /** When a Sort Changes on a Local grid (JSON dataset) */
-  async onLocalSortChanged(grid: SlickGrid, sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>, forceReSort = false, emitSortChanged = false) {
+  async onLocalSortChanged(grid: SlickGrid, sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>, forceReSort = false, emitSortChanged = false): Promise<void> {
     const datasetIdPropertyName = this._gridOptions?.datasetIdPropertyName ?? 'id';
     const isTreeDataEnabled = this._gridOptions?.enableTreeData ?? false;
     const dataView = grid.getData<SlickDataView>();
@@ -434,7 +434,7 @@ export class SortService {
    * Takes a hierarchical dataset and sort it recursively by reference and returns both flat & hierarchical sorted datasets.
    * Note: for perf reasons, it mutates the array by adding extra props like `treeLevel`
    */
-  sortHierarchicalDataset<T>(hierarchicalDataset: T[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>, emitSortChanged = false) {
+  sortHierarchicalDataset<T>(hierarchicalDataset: T[], sortColumns: Array<ColumnSort & { clearSortTriggered?: boolean; }>, emitSortChanged = false): { hierarchical: T[]; flat: any[]; } {
     this.sortTreeData(hierarchicalDataset, sortColumns);
     const dataViewIdIdentifier = this._gridOptions?.datasetIdPropertyName ?? 'id';
     const treeDataOpt: TreeDataOption = this._gridOptions?.treeDataOptions ?? { columnId: '' };
@@ -455,7 +455,7 @@ export class SortService {
   }
 
   /** Call a local grid sort by its default sort field id (user can customize default field by configuring "defaultColumnSortFieldId" in the grid options, defaults to "id") */
-  sortLocalGridByDefaultSortFieldId() {
+  sortLocalGridByDefaultSortFieldId(): void {
     const sortColFieldId = this._gridOptions && this._gridOptions.defaultColumnSortFieldId || this._gridOptions.datasetIdPropertyName || 'id';
     const sortCol = { id: sortColFieldId, field: sortColFieldId } as Column;
     this.onLocalSortChanged(this._grid, new Array({ columnId: sortCol.id, sortAsc: true, sortCol, clearSortTriggered: true }), false, true);
@@ -514,7 +514,7 @@ export class SortService {
     return undefined;
   }
 
-  sortTreeData(treeArray: any[], sortColumns: Array<ColumnSort>) {
+  sortTreeData(treeArray: any[], sortColumns: Array<ColumnSort>): void {
     if (Array.isArray(sortColumns)) {
       sortColumns.forEach(sortColumn => {
         this.sortTreeChildren(treeArray, sortColumn, 0);
@@ -523,7 +523,7 @@ export class SortService {
   }
 
   /** Sort the Tree Children of a hierarchical dataset by recursion */
-  sortTreeChildren(treeArray: any[], sortColumn: ColumnSort, treeLevel: number) {
+  sortTreeChildren(treeArray: any[], sortColumn: ColumnSort, treeLevel: number): void {
     const treeDataOptions = this._gridOptions?.treeDataOptions;
     const childrenPropName = treeDataOptions?.childrenPropName ?? 'children';
     treeArray.sort((a: any, b: any) => this.sortComparer(sortColumn, a, b) ?? SortDirectionNumber.neutral);
@@ -552,7 +552,7 @@ export class SortService {
    * @param triggerEvent defaults to True, do we want to emit a sort changed event?
    * @param triggerBackendQuery defaults to True, which will query the backend.
    */
-  updateSorting(sorters: CurrentSorter[], emitChangedEvent = true, triggerBackendQuery = true) {
+  updateSorting(sorters: CurrentSorter[], emitChangedEvent = true, triggerBackendQuery = true): void {
     if (!this._gridOptions || !this._gridOptions.enableSorting) {
       throw new Error('[Slickgrid-Universal] in order to use "updateSorting" method, you need to have Sortable Columns defined in your grid and "enableSorting" set in your Grid Options');
     }

--- a/packages/common/src/services/translater.service.ts
+++ b/packages/common/src/services/translater.service.ts
@@ -10,7 +10,7 @@ export abstract class TranslaterService {
    * when defined the Translate Service will call the publish method with "onLanguageChanged" event name whenever the "use()" method is called
    * @param {BasePubSubService} pubSub
    */
-  addPubSubMessaging?(_pubSubService: BasePubSubService) {
+  addPubSubMessaging?(_pubSubService: BasePubSubService): void {
     throw new Error('TranslaterService "addPubSubMessaging" method must be implemented');
   }
 

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -62,17 +62,17 @@ export class TreeDataService {
     return this._grid?.getOptions() ?? {};
   }
 
-  get treeDataOptions() {
+  get treeDataOptions(): TreeDataOption | undefined {
     return this.gridOptions.treeDataOptions;
   }
 
-  dispose() {
+  dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
   }
 
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
     this._isTreeDataEnabled = this.gridOptions?.enableTreeData ?? false;
     this._isLastFullToggleCollapsed = this.treeDataOptions?.initiallyCollapsed ?? false;
@@ -131,7 +131,7 @@ export class TreeDataService {
    * @param {Boolean} shouldPreProcessFullToggle - should we pre-process a full toggle on all items? defaults to True
    * @param {Boolean} shouldTriggerEvent - should we trigger a toggled item event? defaults to False
    */
-  applyToggledItemStateChanges(treeToggledItems: TreeToggledItem[], previousFullToggleType?: Extract<ToggleStateChangeType, 'full-collapse' | 'full-expand'> | Extract<ToggleStateChangeTypeString, 'full-collapse' | 'full-expand'>, shouldPreProcessFullToggle = true, shouldTriggerEvent = false) {
+  applyToggledItemStateChanges(treeToggledItems: TreeToggledItem[], previousFullToggleType?: Extract<ToggleStateChangeType, 'full-collapse' | 'full-expand'> | Extract<ToggleStateChangeTypeString, 'full-collapse' | 'full-expand'>, shouldPreProcessFullToggle = true, shouldTriggerEvent = false): void {
     if (Array.isArray(treeToggledItems)) {
       const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');
       const hasChildrenPropName = this.getTreeDataOptionPropName('hasChildrenPropName');
@@ -173,7 +173,7 @@ export class TreeDataService {
    * @param {Array<TreeToggledItem>} treeToggledItems - array of parentId which are tagged as changed
    * @param {Boolean} shouldTriggerEvent - should we trigger a toggled item event? defaults to True
    */
-  dynamicallyToggleItemState(treeToggledItems: TreeToggledItem[], shouldTriggerEvent = true) {
+  dynamicallyToggleItemState(treeToggledItems: TreeToggledItem[], shouldTriggerEvent = true): void {
     if (Array.isArray(treeToggledItems)) {
       // for the rows we identified as collapsed, we'll send them to the DataView with the new updated collapsed flag
       // and we'll refresh the DataView to see the collapsing applied in the grid
@@ -233,7 +233,7 @@ export class TreeDataService {
    * @param {Number} [treeLevel] - optional tree level to get item count from
    * @returns
    */
-  getItemCount(treeLevel?: number) {
+  getItemCount(treeLevel?: number): number {
     if (treeLevel !== undefined) {
       const levelPropName = this.getTreeDataOptionPropName('levelPropName');
       return this.dataView.getItems().filter(dataContext => dataContext[levelPropName] === treeLevel).length;
@@ -276,7 +276,7 @@ export class TreeDataService {
   }
 
   /** Clear the sorting and set it back to initial sort */
-  clearSorting() {
+  clearSorting(): void {
     const initialSort = this.getInitialSort(this.sharedService.columnDefinitions, this.sharedService.gridOptions);
     this.sortService.loadGridSorters([{ columnId: initialSort.columnId, direction: initialSort.sortAsc ? 'ASC' : 'DESC' }]);
   }
@@ -290,7 +290,7 @@ export class TreeDataService {
    * @param {Array<ColumnSort>} [columnSorts] - optional sort columns
    * @returns {Array<Object>} - tree dataset
    */
-  convertFlatParentChildToTreeDatasetAndSort<P, T extends P & { [childrenPropName: string]: T[]; }>(flatDataset: P[], columnDefinitions: Column[], gridOptions: GridOption, columnSorts?: ColumnSort[]) {
+  convertFlatParentChildToTreeDatasetAndSort<P, T extends P & { [childrenPropName: string]: T[]; }>(flatDataset: P[], columnDefinitions: Column[], gridOptions: GridOption, columnSorts?: ColumnSort[]): { hierarchical: Array<P & { [childrenPropName: string]: P[]; }>; flat: P[]; } {
     // 1- convert the flat array into a hierarchical array
     const datasetHierarchical = this.convertFlatParentChildToTreeDataset(flatDataset, gridOptions);
 
@@ -327,7 +327,7 @@ export class TreeDataService {
    * Dynamically enable (or disable) Tree Totals auto-recalc feature when Aggregators exists
    * @param {Boolean} [enableFeature=true]
    */
-  enableAutoRecalcTotalsFeature(enableFeature = true) {
+  enableAutoRecalcTotalsFeature(enableFeature = true): void {
     if (enableFeature && this._isTreeDataEnabled) {
       this._treeDataRecalcHandler = this.recalculateTreeTotals.bind(this, this.gridOptions);
     } else {
@@ -340,7 +340,7 @@ export class TreeDataService {
    * NOTE: this does **not** take the current filters in consideration
    * @param gridOptions
    */
-  recalculateTreeTotals(gridOptions: GridOption) {
+  recalculateTreeTotals(gridOptions: GridOption): void {
     const treeDataOptions = gridOptions.treeDataOptions;
     const childrenPropName = (treeDataOptions?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP);
     const levelPropName = treeDataOptions?.levelPropName ?? Constants.treeDataProperties.TREE_LEVEL_PROP;
@@ -360,7 +360,7 @@ export class TreeDataService {
    * @param {ColumnSort | ColumnSort[]} [inputColumnSorts] - column sort(s)
    * @returns {Object} sort result object that includes both the flat & tree data arrays
    */
-  sortHierarchicalDataset<T>(hierarchicalDataset: T[], inputColumnSorts?: ColumnSort | ColumnSort[]) {
+  sortHierarchicalDataset<T>(hierarchicalDataset: T[], inputColumnSorts?: ColumnSort | ColumnSort[]): { hierarchical: T[]; flat: any[]; } {
     const columnSorts = inputColumnSorts ?? this.getInitialSort(this.sharedService.allColumns, this.gridOptions);
     const finalColumnSorts = Array.isArray(columnSorts) ? columnSorts : [columnSorts];
     return this.sortService.sortHierarchicalDataset(hierarchicalDataset, finalColumnSorts);
@@ -414,7 +414,7 @@ export class TreeDataService {
   // protected functions
   // ------------------
 
-  protected handleOnCellClick(event: SlickEventData, args: OnClickEventArgs) {
+  protected handleOnCellClick(event: SlickEventData, args: OnClickEventArgs): void {
     if (event && args) {
       const targetElm: any = event.target || {};
       const idPropName = this.gridOptions.datasetIdPropertyName ?? 'id';
@@ -462,7 +462,7 @@ export class TreeDataService {
     }
   }
 
-  protected updateToggledItem(item: any, isCollapsed: boolean) {
+  protected updateToggledItem(item: any, isCollapsed: boolean): void {
     const dataViewIdIdentifier = this.gridOptions?.datasetIdPropertyName ?? 'id';
     const childrenPropName = this.getTreeDataOptionPropName('childrenPropName');
     const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');
@@ -485,7 +485,7 @@ export class TreeDataService {
    * When using Tree Data with Aggregator and auto-recalc flag is enabled, we will define a callback handler
    * @return {Function | undefined} Tree Data totals recalculate callback when enabled
    */
-  protected setAutoRecalcTotalsCallbackWhenFeatEnabled(gridOptions: GridOption) {
+  protected setAutoRecalcTotalsCallbackWhenFeatEnabled(gridOptions: GridOption): (() => void) | null {
     // when using Tree Data with Aggregators, we might need to auto-recalc when necessary flag is enabled
     if (gridOptions?.enableTreeData && gridOptions?.treeDataOptions?.autoRecalcTotalsOnFilterChange && gridOptions?.treeDataOptions?.aggregators) {
       return this.recalculateTreeTotals.bind(this, gridOptions);

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -64,7 +64,7 @@ export function castObservableToPromise<T>(rxjs: RxJsFacade, input: Promise<T> |
  * @param {Object} options - options containing info like children & treeLevel property names
  * @param {Number} [treeLevel] - current tree level
  */
-export function addTreeLevelByMutation<T>(treeArray: T[], options: { childrenPropName: string; levelPropName: string; }, treeLevel = 0) {
+export function addTreeLevelByMutation<T>(treeArray: T[], options: { childrenPropName: string; levelPropName: string; }, treeLevel = 0): void {
   const childrenPropName = (options?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP) as keyof T;
 
   if (Array.isArray(treeArray)) {
@@ -81,7 +81,7 @@ export function addTreeLevelByMutation<T>(treeArray: T[], options: { childrenPro
   }
 }
 
-export function addTreeLevelAndAggregatorsByMutation<T = any>(treeArray: T[], options: { aggregator: Aggregator; childrenPropName: string; levelPropName: string; }, treeLevel = 0, parent: T = null as any) {
+export function addTreeLevelAndAggregatorsByMutation<T = any>(treeArray: T[], options: { aggregator: Aggregator; childrenPropName: string; levelPropName: string; }, treeLevel = 0, parent: T = null as any): void {
   const childrenPropName = (options?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP) as keyof T;
   const { aggregator } = options;
 
@@ -114,7 +114,7 @@ export function addTreeLevelAndAggregatorsByMutation<T = any>(treeArray: T[], op
  * @param {Object} options - you can provide "childrenPropName" and other options (defaults to "children")
  * @return {Array<Object>} output - Parent/Child array
  */
-export function flattenToParentChildArray<T>(treeArray: T[], options?: { aggregators?: Aggregator[]; parentPropName?: string; childrenPropName?: string; hasChildrenPropName?: string; identifierPropName?: string; shouldAddTreeLevelNumber?: boolean; levelPropName?: string; }) {
+export function flattenToParentChildArray<T>(treeArray: T[], options?: { aggregators?: Aggregator[]; parentPropName?: string; childrenPropName?: string; hasChildrenPropName?: string; identifierPropName?: string; shouldAddTreeLevelNumber?: boolean; levelPropName?: string; }): any[] {
   const identifierPropName = (options?.identifierPropName ?? 'id') as keyof T & string;
   const childrenPropName = (options?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP) as keyof T & string;
   const hasChildrenPropName = (options?.hasChildrenPropName ?? Constants.treeDataProperties.HAS_CHILDREN_PROP) as keyof T & string;
@@ -366,7 +366,7 @@ export function getColumnFieldType(columnDef: Column): typeof FieldType[keyof ty
 }
 
 /** Verify if the identified column is of type Date */
-export function isColumnDateType(fieldType: typeof FieldType[keyof typeof FieldType]) {
+export function isColumnDateType(fieldType: typeof FieldType[keyof typeof FieldType]): boolean {
   switch (fieldType) {
     case FieldType.date:
     case FieldType.dateTime:

--- a/packages/common/src/sortComparers/dateUtilities.ts
+++ b/packages/common/src/sortComparers/dateUtilities.ts
@@ -2,7 +2,7 @@ import { FieldType } from '../enums/fieldType.enum';
 import type { SortComparer } from '../interfaces/index';
 import { mapTempoDateFormatWithFieldType, tryParseDate } from '../services/dateUtils';
 
-export function compareDates(value1: any, value2: any, sortDirection: number, format?: string, strict?: boolean) {
+export function compareDates(value1: any, value2: any, sortDirection: number, format?: string, strict?: boolean): number {
   let diff = 0;
 
   if (value1 === value2) {

--- a/packages/common/src/sortComparers/sortComparers.index.ts
+++ b/packages/common/src/sortComparers/sortComparers.index.ts
@@ -4,13 +4,14 @@ import { objectStringSortComparer } from './objectStringSortComparer';
 import { stringSortComparer } from './stringSortComparer';
 import { getAssociatedDateSortComparer } from './dateUtilities';
 import { FieldType } from '../enums/fieldType.enum';
+import type { SortComparer } from '../interfaces/sorter.interface';
 
 // export the Sort Utilities so they could be used by others
 export * from './sortUtilities';
 
-export const SortComparers = {
+export const SortComparers: Record<string, SortComparer> = {
   /** SortComparer method to sort values as regular strings */
-  boolean: booleanSortComparer,
+  boolean: booleanSortComparer satisfies SortComparer as SortComparer,
 
   /** SortComparer method to sort values by Date object type (uses Tempo ISO_8601 standard format, optionally include time) */
   date: getAssociatedDateSortComparer(FieldType.date),
@@ -94,7 +95,7 @@ export const SortComparers = {
   dateTimeUsShortAM_PM: getAssociatedDateSortComparer(FieldType.dateTimeUsShortAM_PM),
 
   /** SortComparer method to sort values as numeric fields */
-  numeric: numericSortComparer,
+  numeric: numericSortComparer satisfies SortComparer as SortComparer,
 
   /**
    * SortComparer method to sort object values with a "dataKey" provided in your column definition, it's data content must be of type string
@@ -102,8 +103,8 @@ export const SortComparers = {
    * columnDef = { id='user', field: 'user', ..., dataKey: 'firstName', SortComparer: SortComparers.objectString }
    * collection = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Bob', lastName: 'Cash' }]
    */
-  objectString: objectStringSortComparer,
+  objectString: objectStringSortComparer satisfies SortComparer as SortComparer,
 
   /** SortComparer method to sort values as regular strings */
-  string: stringSortComparer
+  string: stringSortComparer satisfies SortComparer as SortComparer,
 };

--- a/packages/common/src/sortComparers/sortUtilities.ts
+++ b/packages/common/src/sortComparers/sortUtilities.ts
@@ -3,7 +3,7 @@ import type { Column, GridOption } from '../interfaces/index';
 import { SortComparers } from './index';
 import { getAssociatedDateSortComparer } from './dateUtilities';
 
-export function sortByFieldType(fieldType: typeof FieldType[keyof typeof FieldType], value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption): number {
+export function sortByFieldType(fieldType: typeof FieldType[keyof typeof FieldType], value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column | undefined, gridOptions?: GridOption | undefined): number {
   let sortResult = 0;
 
   switch (fieldType) {

--- a/packages/common/src/sortComparers/sortUtilities.ts
+++ b/packages/common/src/sortComparers/sortUtilities.ts
@@ -3,7 +3,7 @@ import type { Column, GridOption } from '../interfaces/index';
 import { SortComparers } from './index';
 import { getAssociatedDateSortComparer } from './dateUtilities';
 
-export function sortByFieldType(fieldType: typeof FieldType[keyof typeof FieldType], value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption) {
+export function sortByFieldType(fieldType: typeof FieldType[keyof typeof FieldType], value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column, gridOptions?: GridOption): number {
   let sortResult = 0;
 
   switch (fieldType) {

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -32,7 +32,10 @@ export interface CompositeEditorArguments extends EditorArguments {
  *  position                -   A function to be called when the grid asks the editor to reposition itself.
  *  destroy                 -   A function to be called when the editor is destroyed.
  */
-export function SlickCompositeEditor(this: any, columns: Column[], containers: Array<HTMLDivElement>, options: CompositeEditorOption) {
+export function SlickCompositeEditor(this: any, columns: Column[], containers: Array<HTMLDivElement>, options: CompositeEditorOption): {
+  (this: any, args: EditorArguments): void;
+  prototype: any;
+} {
   let firstInvalidEditor: Editor | null;
   const defaultOptions = {
     modalType: 'edit', // available type (create, clone, edit, mass)

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -104,7 +104,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * Note: we aren't using DI in the constructor simply to be as framework agnostic as possible,
    * we are simply using this init() function with a very basic container service to do the job
    */
-  init(grid: SlickGrid, containerService: ContainerService) {
+  init(grid: SlickGrid, containerService: ContainerService): void {
     this.grid = grid;
     this.gridService = containerService.get<GridService>('GridService');
     this.translaterService = containerService.get<TranslaterService>('TranslaterService');
@@ -122,7 +122,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Dispose of the Component & unsubscribe all events */
-  dispose() {
+  dispose(): void {
     this._eventHandler.unsubscribeAll();
     this._bindEventService.unbindAll();
     this._formValues = null;
@@ -130,7 +130,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Dispose of the Component without unsubscribing any events */
-  disposeComponent() {
+  disposeComponent(): void {
     // protected _editorContainers!: Array<HTMLElement | null>;
     this._modalBodyTopValidationElm?.remove();
     this._modalSaveButtonElm?.remove();
@@ -155,7 +155,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * @param {Boolean} skipMissingEditorError - defaults to False, skipping the error when the Composite Editor was not found will allow to still apply the value into the formValues object
    * @param {Boolean} triggerOnCompositeEditorChange - defaults to True, will this change trigger a onCompositeEditorChange event?
    */
-  changeFormInputValue(columnIdOrDef: string | Column, newValue: any, skipMissingEditorError = false, triggerOnCompositeEditorChange = true) {
+  changeFormInputValue(columnIdOrDef: string | Column, newValue: any, skipMissingEditorError = false, triggerOnCompositeEditorChange = true): void {
     const columnDef = this.getColumnByObjectOrId(columnIdOrDef);
     const columnId = typeof columnIdOrDef === 'string' ? columnIdOrDef : columnDef?.id ?? '';
     const editor = this._editors?.[columnId];
@@ -202,7 +202,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * @param {String | Column} columnIdOrDef - column id or column definition
    * @param {*} newValue - the new value
    */
-  changeFormValue(columnIdOrDef: string | Column, newValue: any) {
+  changeFormValue(columnIdOrDef: string | Column, newValue: any): void {
     const columnDef = this.getColumnByObjectOrId(columnIdOrDef);
     const columnId = typeof columnIdOrDef === 'string' ? columnIdOrDef : columnDef?.id ?? '';
 
@@ -227,7 +227,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * @param {String} columnId - column id
    * @param {*} newValue - the new value
    */
-  changeFormEditorOption(columnId: string, optionName: string, newOptionValue: any) {
+  changeFormEditorOption(columnId: string, optionName: string, newOptionValue: any): void {
     const editor = this._editors?.[columnId];
 
     // change an Editor option (not all Editors have that method, so make sure it exists before trying to call it)
@@ -243,7 +243,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * @param {String} columnId - column definition id
    * @param isDisabled - defaults to True, are we disabling the associated form input
    */
-  disableFormInput(columnId: string, isDisabled = true) {
+  disableFormInput(columnId: string, isDisabled = true): void {
     const editor = this._editors?.[columnId];
     if (editor?.disable && Array.isArray(this._editorContainers)) {
       editor.disable(isDisabled);
@@ -526,7 +526,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Cancel the Editing which will also close the modal window */
-  async cancelEditing() {
+  async cancelEditing(): Promise<void> {
     let confirmed = true;
     if (this.formValues && Object.keys(this.formValues).length > 0 && typeof this._options.onClose === 'function') {
       confirmed = await this._options.onClose();
@@ -547,7 +547,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Show a Validation Summary text (as a <div>) when a validation fails or simply hide it when there's no error */
-  showValidationSummaryText(isShowing: boolean, errorMsg = '') {
+  showValidationSummaryText(isShowing: boolean, errorMsg = ''): void {
     if (isShowing && errorMsg !== '') {
       this._modalBodyTopValidationElm.textContent = errorMsg;
       this._modalBodyTopValidationElm.style.display = 'block';
@@ -672,7 +672,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * Execute the onError callback when defined
    * or use the default onError callback which is to simply display the error in the console
    */
-  protected executeOnError(error: OnErrorOption) {
+  protected executeOnError(error: OnErrorOption): void {
     const onError = this._options?.onError ?? DEFAULT_ON_ERROR;
     onError(error);
   }
@@ -685,7 +685,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
    * @param {Function} beforeClosingCallback - third and last callback to execute after Saving but just before closing the modal window
    * @param {Object} itemDataContext - item data context when modal type is (create/clone/edit)
    */
-  protected async executeOnSave(applyChangesCallback: ApplyChangesCallbackFn, executePostCallback: PlainFunc, beforeClosingCallback?: PlainFunc, itemDataContext?: any) {
+  protected async executeOnSave(applyChangesCallback: ApplyChangesCallbackFn, executePostCallback: PlainFunc, beforeClosingCallback?: PlainFunc, itemDataContext?: any): Promise<void> {
     try {
       this.showValidationSummaryText(false, '');
       const validationResults = this.validateCompositeEditors();
@@ -847,7 +847,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
 
 
 
-  protected handleBodyClicked(event: Event) {
+  protected handleBodyClicked(event: Event): void {
     if ((event.target as HTMLElement)?.classList?.contains('slick-editor-modal')) {
       if (this._options?.backdrop !== 'static') {
         this.dispose();
@@ -855,7 +855,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     }
   }
 
-  protected handleKeyDown(event: KeyboardEvent) {
+  protected handleKeyDown(event: KeyboardEvent): void {
     if (event.code === 'Escape') {
       this.cancelEditing();
       event.stopPropagation();
@@ -865,7 +865,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     }
   }
 
-  protected handleResetInputValue(event: DOMEvent<HTMLButtonElement>) {
+  protected handleResetInputValue(event: DOMEvent<HTMLButtonElement>): void {
     const columnId = event.target.name;
     const editor = this._editors?.[columnId];
     if (typeof editor?.reset === 'function') {
@@ -875,7 +875,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Callback which processes a Mass Update or Mass Selection Changes */
-  protected async handleMassSaving(modalType: 'mass-update' | 'mass-selection', executePostCallback: PlainFunc) {
+  protected async handleMassSaving(modalType: 'mass-update' | 'mass-selection', executePostCallback: PlainFunc): Promise<void> {
     if (!this.formValues || Object.keys(this.formValues).length === 0) {
       this.executeOnError({ type: 'warning', code: 'NO_CHANGES_DETECTED', message: 'Sorry we could not detect any changes.' });
     } else {
@@ -885,7 +885,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Anytime an input of the Composite Editor form changes, we'll add/remove a "modified" CSS className for styling purposes */
-  protected handleOnCompositeEditorChange(_e: SlickEventData, args: OnCompositeEditorChangeEventArgs) {
+  protected handleOnCompositeEditorChange(_e: SlickEventData, args: OnCompositeEditorChangeEventArgs): void {
     const columnId = args.column?.id ?? '';
     this._formValues = { ...this._formValues, ...args.formValues };
     const editor = this._editors?.[columnId] as Editor;
@@ -914,7 +914,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Reset Form button handler */
-  protected handleResetFormClicked() {
+  protected handleResetFormClicked(): void {
     for (const columnId of Object.keys(this._editors)) {
       const editor = this._editors[columnId];
       if (editor?.reset) {
@@ -926,7 +926,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** switch case handler to determine which code to execute depending on the modal type */
-  protected async handleSaveClicked() {
+  protected async handleSaveClicked(): Promise<void> {
     const modalType = this._options?.modalType;
     switch (modalType) {
       case 'mass-update':
@@ -988,7 +988,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Insert an item into the DataView or throw an error when finding duplicate id in the dataset */
-  protected insertNewItemInDataView(item: any) {
+  protected insertNewItemInDataView(item: any): void {
     const fullDatasetLength = this.dataView?.getItemCount() || 0;
     const newId = this._options.insertNewId ?? fullDatasetLength + 1;
     item[this.gridOptions.datasetIdPropertyName || 'id'] = newId;
@@ -1008,7 +1008,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Put back the current row to its original item data context using the DataView without triggering a change */
-  protected resetCurrentRowDataContext() {
+  protected resetCurrentRowDataContext(): void {
     const idPropName = this.gridOptions.datasetIdPropertyName || 'id';
     const dataView = this.grid.getData<SlickDataView>();
     dataView.updateItem(this._originalDataContext[idPropName], this._originalDataContext);
@@ -1026,7 +1026,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   }
 
   /** Validate the current cell editor */
-  protected validateCurrentEditor() {
+  protected validateCurrentEditor(): void {
     const currentEditor = this.grid.getCellEditor();
     if (currentEditor?.validate) {
       currentEditor.validate();

--- a/packages/custom-footer-component/src/slick-footer.component.ts
+++ b/packages/custom-footer-component/src/slick-footer.component.ts
@@ -64,7 +64,7 @@ export class SlickFooterComponent {
     this.renderRightFooterText(text);
   }
 
-  constructor(protected readonly grid: SlickGrid, protected readonly customFooterOptions: CustomFooterOption, protected readonly pubSubService: BasePubSubService, protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly grid: SlickGrid, protected readonly customFooterOptions: CustomFooterOption, protected readonly pubSubService: BasePubSubService, protected readonly translaterService?: TranslaterService | undefined) {
     this._bindingHelper = new BindingHelper();
     this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
     this._eventHandler = new SlickEventHandler();
@@ -86,7 +86,7 @@ export class SlickFooterComponent {
     }
   }
 
-  dispose() {
+  dispose(): void {
     // also dispose of all Subscriptions
     this._eventHandler.unsubscribeAll();
     this.pubSubService.unsubscribeAll(this._subscriptions);
@@ -99,7 +99,7 @@ export class SlickFooterComponent {
    * We could optionally display a custom footer below the grid to show some metrics (last update, item count with/without filters)
    * It's an opt-in, user has to enable "showCustomFooter" and it cannot be used when there's already a Pagination since they display the same kind of info
    */
-  renderFooter(gridParentContainerElm: HTMLElement) {
+  renderFooter(gridParentContainerElm: HTMLElement): void {
     // execute translation when enabled or use defined text or locale
     this.translateCustomFooterTexts();
 
@@ -108,7 +108,7 @@ export class SlickFooterComponent {
   }
 
   /** Render element attribute values */
-  renderMetrics(metrics: Metrics) {
+  renderMetrics(metrics: Metrics): void {
     // get translated text & last timestamp
     const lastUpdateTimestamp = metrics?.endTime ? format(metrics.endTime, this.customFooterOptions.dateFormat, 'en-US') : '';
     this._bindingHelper.setElementAttributeValue('span.last-update-timestamp', 'textContent', lastUpdateTimestamp);
@@ -124,17 +124,17 @@ export class SlickFooterComponent {
   }
 
   /** Render the left side footer text */
-  renderLeftFooterText(text: string) {
+  renderLeftFooterText(text: string): void {
     this._bindingHelper.setElementAttributeValue('div.left-footer', 'textContent', text);
   }
 
   /** Render the right side footer text */
-  renderRightFooterText(text: string) {
+  renderRightFooterText(text: string): void {
     this._bindingHelper.setElementAttributeValue('div.right-footer', 'textContent', text);
   }
 
   /** Translate all Custom Footer Texts (footer with metrics) */
-  translateCustomFooterTexts() {
+  translateCustomFooterTexts(): void {
     if (this.gridOptions.enableTranslate && this.translaterService?.translate) {
       this.customFooterOptions.metricTexts = this.customFooterOptions.metricTexts || {};
       for (const propName of Object.keys(this.customFooterOptions.metricTexts)) {
@@ -162,7 +162,7 @@ export class SlickFooterComponent {
   // --------------------
 
   /** Create the Footer Container */
-  protected createFooterContainer(gridParentContainerElm: HTMLElement) {
+  protected createFooterContainer(gridParentContainerElm: HTMLElement): void {
     const footerElm = createDomElement('div', {
       className: `slick-custom-footer ${this.gridUid}`,
       style: {
@@ -249,7 +249,7 @@ export class SlickFooterComponent {
    * we will show the row selection count on the bottom left side of the footer (by subscribing to the SlickGrid `onSelectedRowsChanged` event).
    * @param customFooterOptions
    */
-  protected registerOnSelectedRowsChangedWhenEnabled(customFooterOptions: CustomFooterOption) {
+  protected registerOnSelectedRowsChangedWhenEnabled(customFooterOptions: CustomFooterOption): void {
     const isRowSelectionEnabled = this.gridOptions.enableCheckboxSelector || this.gridOptions.enableRowSelection;
     if (isRowSelectionEnabled && customFooterOptions && (!customFooterOptions.hideRowSelectionCount && this._isLeftFooterOriginallyEmpty)) {
       this._isLeftFooterDisplayingSelectionRowCount = true;

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -97,7 +97,7 @@ export class SlickCustomTooltip {
     return this._addonOptions;
   }
 
-  get cancellablePromise() {
+  get cancellablePromise(): CancellablePromiseWrapper<any> | undefined {
     return this._cancellablePromise;
   }
 
@@ -138,11 +138,11 @@ export class SlickCustomTooltip {
     return this._tooltipElm;
   }
 
-  addRxJsResource(rxjs: RxJsFacade) {
+  addRxJsResource(rxjs: RxJsFacade): void {
     this._rxjs = rxjs;
   }
 
-  init(grid: SlickGrid, containerService: ContainerService) {
+  init(grid: SlickGrid, containerService: ContainerService): void {
     this._grid = grid;
     this._rxjs = containerService.get<RxJsFacade>('RxJsFacade');
     this._sharedService = containerService.get<SharedService>('SharedService');
@@ -156,7 +156,7 @@ export class SlickCustomTooltip {
       .subscribe(grid.onHeaderRowMouseOut, this.hideTooltip.bind(this));
   }
 
-  dispose() {
+  dispose(): void {
     // hide (remove) any tooltip and unsubscribe from all events
     this.hideTooltip();
     this._cancellablePromise = undefined;
@@ -167,7 +167,7 @@ export class SlickCustomTooltip {
    * hide (remove) tooltip from the DOM, it will also remove it from the DOM and also cancel any pending requests (as mentioned below).
    * When using async process, it will also cancel any opened Promise/Observable that might still be pending.
    */
-  hideTooltip() {
+  hideTooltip(): void {
     this._cancellablePromise?.cancel();
     this._observable$?.unsubscribe();
     const cssClasses = classNameToList(this.className).join('.');
@@ -179,7 +179,7 @@ export class SlickCustomTooltip {
     return this._addonOptions;
   }
 
-  setOptions(newOptions: CustomTooltipOption) {
+  setOptions(newOptions: CustomTooltipOption): void {
     this._addonOptions = { ...this._addonOptions, ...newOptions } as CustomTooltipOption;
   }
 
@@ -191,7 +191,7 @@ export class SlickCustomTooltip {
    * Async process callback will hide any prior tooltip & then merge the new result with the item `dataContext` under a `__params` property
    * (unless a new prop name is provided) to provice as dataContext object to the asyncPostFormatter.
    */
-  protected asyncProcessCallback(asyncResult: any, cell: { row: number, cell: number; }, value: any, columnDef: Column, dataContext: any) {
+  protected asyncProcessCallback(asyncResult: any, cell: { row: number, cell: number; }, value: any, columnDef: Column, dataContext: any): void {
     this.hideTooltip();
     const itemWithAsyncData = { ...dataContext, [this.addonOptions?.asyncParamsPropName ?? '__params']: asyncResult };
     if (this._cellAddonOptions?.useRegularTooltip) {
@@ -202,7 +202,7 @@ export class SlickCustomTooltip {
   }
 
   /** depending on the selector type, execute the necessary handler code */
-  protected handleOnHeaderMouseOverByType(event: SlickEventData, args: any, selector: CellType) {
+  protected handleOnHeaderMouseOverByType(event: SlickEventData, args: any, selector: CellType): void {
     this._cellType = selector;
     this._mousePosition = { x: event.clientX || 0, y: event.clientY || 0 };
     this._mouseTarget = document.elementFromPoint(event.clientX || 0, event.clientY || 0)?.closest(SELECTOR_CLOSEST_TOOLTIP_ATTR);
@@ -245,7 +245,7 @@ export class SlickCustomTooltip {
     }
   }
 
-  protected async handleOnMouseOver(event: SlickEventData) {
+  protected async handleOnMouseOver(event: SlickEventData): Promise<void> {
     this._cellType = 'slick-cell';
     this._mousePosition = { x: event.clientX || 0, y: event.clientY || 0 };
     this._mouseTarget = document.elementFromPoint(event.clientX || 0, event.clientY || 0)?.closest(SELECTOR_CLOSEST_TOOLTIP_ATTR);
@@ -341,7 +341,7 @@ export class SlickCustomTooltip {
    * then create a temporary html element to easily retrieve the first [title=""] attribute text content
    * also clear the "title" attribute from the grid div text content so that it won't show also as a 2nd browser tooltip
    */
-  protected renderRegularTooltip(formatterOrText: Formatter | string | undefined, cell: { row: number; cell: number; }, value: any, columnDef: Column, item: any) {
+  protected renderRegularTooltip(formatterOrText: Formatter | string | undefined, cell: { row: number; cell: number; }, value: any, columnDef: Column, item: any): void {
     const tmpDiv = document.createElement('div');
     this._grid.applyHtmlCode(tmpDiv, this.parseFormatterAndSanitize(formatterOrText, cell, value, columnDef, item));
     this._hasMultipleTooltips = (this._cellNodeElm?.querySelectorAll(SELECTOR_CLOSEST_TOOLTIP_ATTR).length || 0) > 1;
@@ -388,7 +388,7 @@ export class SlickCustomTooltip {
     this.swapAndClearTitleAttribute(tmpTitleElm, tooltipText);
   }
 
-  protected renderTooltipFormatter(formatter: Formatter | string | undefined, cell: { row: number; cell: number; }, value: any, columnDef: Column, item: unknown, tooltipText?: string, inputTitleElm?: Element | null) {
+  protected renderTooltipFormatter(formatter: Formatter | string | undefined, cell: { row: number; cell: number; }, value: any, columnDef: Column, item: unknown, tooltipText?: string, inputTitleElm?: Element | null): void {
     // create the tooltip DOM element with the text returned by the Formatter
     this._tooltipElm = createDomElement('div', { className: this.className });
     this._tooltipBodyElm = createDomElement('div', { className: this.bodyClassName });
@@ -451,7 +451,7 @@ export class SlickCustomTooltip {
    * Most of the time positioning of the tooltip will be to the "top-right" of the cell is ok but if our column is completely on the right side then we'll want to change the position to "left" align.
    * Same goes for the top/bottom position, Most of the time positioning the tooltip to the "top" but if we are hovering a cell at the top of the grid and there's no room to display it then we might need to reposition to "bottom" instead.
    */
-  protected reposition(cell: { row: number; cell: number; }) {
+  protected reposition(cell: { row: number; cell: number; }): void {
     if (this._tooltipElm) {
       this._cellNodeElm = this._cellNodeElm || this._grid.getCellNode(cell.row, cell.cell) as HTMLDivElement;
       const cellPosition = getOffset(this._cellNodeElm) || { top: 0, left: 0 };
@@ -518,7 +518,7 @@ export class SlickCustomTooltip {
    * swap and copy the "title" attribute into a new custom attribute then clear the "title" attribute
    * from the grid div text content so that it won't show also as a 2nd browser tooltip
    */
-  protected swapAndClearTitleAttribute(inputTitleElm?: Element | null, tooltipText?: string) {
+  protected swapAndClearTitleAttribute(inputTitleElm?: Element | null, tooltipText?: string): void {
     // the title attribute might be directly on the slick-cell container element (when formatter returns a result object)
     // OR in a child element (most commonly as a custom formatter)
     let cellWithTitleElm: Element | null | undefined;

--- a/packages/empty-warning-component/src/slick-empty-warning.component.ts
+++ b/packages/empty-warning-component/src/slick-empty-warning.component.ts
@@ -20,12 +20,12 @@ export class SlickEmptyWarningComponent implements ExternalResource {
     return this._grid?.getOptions() ?? {};
   }
 
-  init(grid: SlickGrid, containerService: ContainerService) {
+  init(grid: SlickGrid, containerService: ContainerService): void {
     this._grid = grid;
     this._translaterService = containerService.get<TranslaterService>('TranslaterService');
   }
 
-  dispose() {
+  dispose(): void {
     this._warningLeftElement?.remove();
     this._warningRightElement?.remove();
     this._warningLeftElement = null;

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -11,9 +11,9 @@ export class EventPubSubService implements BasePubSubService {
   protected _subscribedEvents: PubSubEvent[] = [];
   protected _timer: any;
 
-  eventNamingStyle = EventNamingStyle.camelCase;
+  eventNamingStyle: EventNamingStyle = EventNamingStyle.camelCase;
 
-  get elementSource() {
+  get elementSource(): Element {
     return this._elementSource;
   }
   set elementSource(element: Element) {
@@ -34,7 +34,7 @@ export class EventPubSubService implements BasePubSubService {
     this._elementSource = elementSource || document.createElement('div');
   }
 
-  dispose() {
+  dispose(): void {
     this.unsubscribeAll();
     this._subscribedEvents = [];
     clearTimeout(this._timer);
@@ -51,7 +51,7 @@ export class EventPubSubService implements BasePubSubService {
    * @param {Function} externalizeEventCallback - user can optionally retrieve the CustomEvent used in the PubSub for its own usage via a callback (called just before the event dispatch)
    * @returns {Boolean} returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
    */
-  dispatchCustomEvent<T = any>(eventName: string, data?: T, isBubbling = true, isCancelable = true, externalizeEventCallback?: (e: Event) => void) {
+  dispatchCustomEvent<T = any>(eventName: string, data?: T, isBubbling = true, isCancelable = true, externalizeEventCallback?: (e: Event) => void): boolean {
     const eventInit: CustomEventInit<T> = { bubbles: isBubbling, cancelable: isCancelable };
     if (data) {
       eventInit.detail = data;
@@ -69,7 +69,7 @@ export class EventPubSubService implements BasePubSubService {
    * @param {String} eventNamePrefix - prefix to use in the event name
    * @returns {String} - output event name
    */
-  getEventNameByNamingConvention(inputEventName: string, eventNamePrefix: string) {
+  getEventNameByNamingConvention(inputEventName: string, eventNamePrefix: string): string {
     let outputEventName = '';
 
     switch (this.eventNamingStyle) {
@@ -159,7 +159,7 @@ export class EventPubSubService implements BasePubSubService {
    * @param {Boolean} shouldRemoveFromEventList - should we also remove the event from the subscriptions array?
    * @return possibly a Subscription
    */
-  unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList = true) {
+  unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList = true): void {
     const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
     this._elementSource.removeEventListener(eventNameByConvention, listener);
     if (shouldRemoveFromEventList) {
@@ -168,7 +168,7 @@ export class EventPubSubService implements BasePubSubService {
   }
 
   /** Unsubscribes all subscriptions/events that currently exists */
-  unsubscribeAll(subscriptions?: EventSubscription[]) {
+  unsubscribeAll(subscriptions?: EventSubscription[]): void {
     if (Array.isArray(subscriptions)) {
       let subscription;
       do {
@@ -192,7 +192,7 @@ export class EventPubSubService implements BasePubSubService {
   // protected functions
   // --------------------
 
-  protected removeSubscribedEventWhenFound<T>(eventName: string, listener: (event: T | CustomEventInit<T>) => void) {
+  protected removeSubscribedEventWhenFound<T>(eventName: string, listener: (event: T | CustomEventInit<T>) => void): void {
     const eventIdx = this._subscribedEvents.findIndex(evt => evt.name === eventName && evt.listener === listener);
     if (eventIdx >= 0) {
       this._subscribedEvents.splice(eventIdx, 1);

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -48,7 +48,7 @@ const DEFAULT_EXPORT_OPTIONS: ExcelExportOption = {
 };
 
 export class ExcelExportService implements ExternalResource, BaseExcelExportService {
-  protected _fileFormat = FileType.xlsx;
+  protected _fileFormat: FileType = FileType.xlsx;
   protected _grid!: SlickGrid;
   protected _locales!: Locale;
   protected _groupedColumnHeaders?: Array<KeyTitlePair>;
@@ -84,23 +84,23 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
     return this._grid?.getOptions() || {} as GridOption;
   }
 
-  get stylesheet() {
+  get stylesheet(): StyleSheet {
     return this._stylesheet;
   }
 
-  get stylesheetFormats() {
+  get stylesheetFormats(): any {
     return this._stylesheetFormats;
   }
 
-  get groupTotalExcelFormats() {
+  get groupTotalExcelFormats(): any {
     return this._groupTotalExcelFormats;
   }
 
-  get regularCellExcelFormats() {
+  get regularCellExcelFormats(): any {
     return this._regularCellExcelFormats;
   }
 
-  dispose() {
+  dispose(): void {
     this._pubSubService?.unsubscribeAll();
   }
 

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -32,7 +32,7 @@ export const getExcelNumberCallback: GetDataValueCallback = (data, { columnDef, 
 });
 
 /** Parse a number which the user might have provided formatter options (for example a user might have provided { decimalSeparator: ',', thousandSeparator: ' '}) */
-export function parseNumberWithFormatterOptions(value: any, column: Column, gridOptions: GridOption) {
+export function parseNumberWithFormatterOptions(value: any, column: Column, gridOptions: GridOption): any {
   let outValue = value;
   if (typeof value === 'string' && value) {
     const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', column, gridOptions, Constants.DEFAULT_NUMBER_DECIMAL_SEPARATOR);
@@ -45,7 +45,10 @@ export function parseNumberWithFormatterOptions(value: any, column: Column, grid
 }
 
 /** use different Excel Stylesheet Format as per the Field Type */
-export function useCellFormatByFieldType(stylesheet: StyleSheet, excelFormats: any, columnDef: Column, grid: SlickGrid, autoDetect = true) {
+export function useCellFormatByFieldType(stylesheet: StyleSheet, excelFormats: any, columnDef: Column, grid: SlickGrid, autoDetect = true): {
+  excelFormatId: number | undefined;
+  getDataValueParser: GetDataValueCallback;
+} {
   const fieldType = getColumnFieldType(columnDef);
   let excelFormatId: number | undefined;
   let callback: GetDataValueCallback = getExcelSameInputDataCallback;
@@ -57,12 +60,22 @@ export function useCellFormatByFieldType(stylesheet: StyleSheet, excelFormats: a
   return { excelFormatId, getDataValueParser: callback };
 }
 
-export function getGroupTotalValue(totals: any, args: { columnDef: Column, groupType: string; }) {
+export function getGroupTotalValue(totals: any, args: { columnDef: Column, groupType: string; }): any {
   return totals?.[args.groupType]?.[args.columnDef.field] ?? 0;
 }
 
 /** Get numeric formatter options when defined or use default values (minDecimal, maxDecimal, thousandSeparator, decimalSeparator, wrapNegativeNumber) */
-export function getNumericFormatterOptions(columnDef: Column, grid: SlickGrid, formatterType: FormatterType) {
+export function getNumericFormatterOptions(columnDef: Column, grid: SlickGrid, formatterType: FormatterType): {
+  minDecimal: number;
+  maxDecimal: number;
+  decimalSeparator: '.' | ',';
+  thousandSeparator: '' | '.' | ',' | '_' | ' ';
+  wrapNegativeNumber: boolean;
+  currencyPrefix: string;
+  currencySuffix: string;
+  numberPrefix: string;
+  numberSuffix: string;
+} {
   let dataType: 'currency' | 'decimal' | 'percent' | 'regular';
 
   if (formatterType === 'group') {
@@ -109,7 +122,7 @@ export function getNumericFormatterOptions(columnDef: Column, grid: SlickGrid, f
   return retrieveFormatterOptions(columnDef, grid, dataType!, formatterType);
 }
 
-export function getFormatterNumericDataType(formatter?: Formatter) {
+export function getFormatterNumericDataType(formatter?: Formatter): 'currency' | 'decimal' | 'percent' {
   let dataType: 'currency' | 'decimal' | 'percent' | 'regular';
 
   switch (formatter) {
@@ -135,7 +148,10 @@ export function getFormatterNumericDataType(formatter?: Formatter) {
   return dataType;
 }
 
-export function getExcelFormatFromGridFormatter(stylesheet: StyleSheet, excelFormats: any, columnDef: Column, grid: SlickGrid, formatterType: FormatterType) {
+export function getExcelFormatFromGridFormatter(stylesheet: StyleSheet, excelFormats: any, columnDef: Column, grid: SlickGrid, formatterType: FormatterType): {
+  excelFormat: ExcelFormatter;
+  groupType: string;
+} {
   let format = '';
   let groupType = columnDef.groupTotalsExcelExportOptions?.groupType || '';
   let excelFormat: undefined | ExcelFormatter;

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -48,7 +48,7 @@ export class GraphqlService implements BackendService {
   protected _currentFilters: ColumnFilters | CurrentFilter[] = [];
   protected _currentPagination: CurrentPagination | null = null;
   protected _currentSorters: CurrentSorter[] = [];
-  protected _columnDefinitions?: Column[];
+  protected _columnDefinitions: Column[] = [];
   protected _grid: SlickGrid | undefined;
   protected _datasetIdPropName = 'id';
   options: GraphqlServiceOption | undefined;
@@ -59,7 +59,7 @@ export class GraphqlService implements BackendService {
   };
 
   /** Getter for the Column Definitions */
-  get columnDefinitions() {
+  get columnDefinitions(): Column[] {
     return this._columnDefinitions;
   }
 
@@ -84,7 +84,7 @@ export class GraphqlService implements BackendService {
    * Build the GraphQL query, since the service include/exclude cursor, the output query will be different.
    * @param serviceOptions GraphqlServiceOption
    */
-  buildQuery() {
+  buildQuery(): string {
     if (!this.options || !this.options.datasetName || !Array.isArray(this._columnDefinitions)) {
       throw new Error('GraphQL Service requires the "datasetName" property to properly build the GraphQL query');
     }
@@ -198,7 +198,7 @@ export class GraphqlService implements BackendService {
    * firstName, lastName, billing{address{street, zip}}
    * @param inputArray
    */
-  buildFilterQuery(inputArray: string[]) {
+  buildFilterQuery(inputArray: string[]): string {
 
     const set = (o: any = {}, a: any) => {
       const k = a.shift();
@@ -214,12 +214,12 @@ export class GraphqlService implements BackendService {
       .replace(/\}$/, '');
   }
 
-  clearFilters() {
+  clearFilters(): void {
     this._currentFilters = [];
     this.updateOptions({ filteringOptions: [] });
   }
 
-  clearSorters() {
+  clearSorters(): void {
     this._currentSorters = [];
     this.updateOptions({ sortingOptions: [] });
   }
@@ -258,7 +258,7 @@ export class GraphqlService implements BackendService {
   /*
    * Reset the pagination options
    */
-  resetPaginationOptions() {
+  resetPaginationOptions(): void {
     let paginationOptions: GraphqlPaginationOption | GraphqlCursorPaginationOption;
 
     if (this.options?.useCursor) {
@@ -281,7 +281,7 @@ export class GraphqlService implements BackendService {
     }
   }
 
-  updateOptions(serviceOptions?: Partial<GraphqlServiceOption>) {
+  updateOptions(serviceOptions?: Partial<GraphqlServiceOption>): void {
     this.options = { ...this.options, ...serviceOptions } as GraphqlServiceOption;
   }
 
@@ -378,7 +378,7 @@ export class GraphqlService implements BackendService {
    * Update column filters by looping through all columns to inspect filters & update backend service filteringOptions
    * @param columnFilters
    */
-  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically: boolean) {
+  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically: boolean): void {
     const searchByArray: Array<GraphqlCustomFilteringOption | GraphqlFilteringOption> = [];
     let searchValue: string | string[];
 
@@ -548,7 +548,7 @@ export class GraphqlService implements BackendService {
    * @param {Number} pageSize
    * @param {*} [cursorArgs] these should be supplied when using cursor based pagination
    */
-  updatePagination(newPage: number, pageSize: number, cursorArgs?: PaginationCursorChangedArgs) {
+  updatePagination(newPage: number, pageSize: number, cursorArgs?: PaginationCursorChangedArgs): void {
     this._currentPagination = {
       pageNumber: newPage,
       pageSize
@@ -581,7 +581,7 @@ export class GraphqlService implements BackendService {
   /**
    * Update all Sorting by looping through all columns to inspect sorters & update backend service sortingOptions
    */
-  updateSorters(sortColumns?: ColumnSort[], presetSorters?: CurrentSorter[]) {
+  updateSorters(sortColumns?: ColumnSort[], presetSorters?: CurrentSorter[]): void {
     let currentSorters: CurrentSorter[] = [];
     const graphqlSorters: GraphqlSortingOption[] = [];
 
@@ -592,7 +592,7 @@ export class GraphqlService implements BackendService {
 
       // display the correct sorting icons on the UI, for that it requires (columnId, sortAsc) properties
       const tmpSorterArray = currentSorters.map((sorter) => {
-        const columnDef = this._columnDefinitions?.find((column: Column) => column.id === sorter.columnId);
+        const columnDef = this._columnDefinitions.find((column: Column) => column.id === sorter.columnId);
 
         graphqlSorters.push({
           field: columnDef ? ((columnDef.queryFieldSorter || columnDef.queryField || columnDef.field) + '') : (sorter.columnId + ''),
@@ -661,7 +661,7 @@ export class GraphqlService implements BackendService {
    * @param keepArgumentFieldDoubleQuotes - do we keep field double quotes? (i.e.: field: "user.name")
    * @returns outputStr output string
    */
-  trimDoubleQuotesOnEnumField(inputStr: string, enumSearchWords: string[], keepArgumentFieldDoubleQuotes: boolean) {
+  trimDoubleQuotesOnEnumField(inputStr: string, enumSearchWords: string[], keepArgumentFieldDoubleQuotes: boolean): string {
     // eslint-disable-next-line
     const patternWordInQuotes = `\s?((field:\s*)?".*?")`;
     let patternRegex = enumSearchWords.join(patternWordInQuotes + '|');

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -48,7 +48,7 @@ export class GraphqlService implements BackendService {
   protected _currentFilters: ColumnFilters | CurrentFilter[] = [];
   protected _currentPagination: CurrentPagination | null = null;
   protected _currentSorters: CurrentSorter[] = [];
-  protected _columnDefinitions: Column[] = [];
+  protected _columnDefinitions?: Column[] | undefined;
   protected _grid: SlickGrid | undefined;
   protected _datasetIdPropName = 'id';
   options: GraphqlServiceOption | undefined;
@@ -59,7 +59,7 @@ export class GraphqlService implements BackendService {
   };
 
   /** Getter for the Column Definitions */
-  get columnDefinitions(): Column[] {
+  get columnDefinitions(): Column[] | undefined {
     return this._columnDefinitions;
   }
 
@@ -592,7 +592,7 @@ export class GraphqlService implements BackendService {
 
       // display the correct sorting icons on the UI, for that it requires (columnId, sortAsc) properties
       const tmpSorterArray = currentSorters.map((sorter) => {
-        const columnDef = this._columnDefinitions.find((column: Column) => column.id === sorter.columnId);
+        const columnDef = this._columnDefinitions?.find((column: Column) => column.id === sorter.columnId);
 
         graphqlSorters.push({
           field: columnDef ? ((columnDef.queryFieldSorter || columnDef.queryField || columnDef.field) + '') : (sorter.columnId + ''),

--- a/packages/graphql/src/services/graphqlQueryBuilder.ts
+++ b/packages/graphql/src/services/graphqlQueryBuilder.ts
@@ -14,7 +14,7 @@ export default class GraphqlQueryBuilder {
   body: any;
 
   /* Constructor, query/mutator you wish to use, and an alias or filter arguments. */
-  constructor(protected queryFnName: string, aliasOrFilter?: string | object) {
+  constructor(protected queryFnName: string, aliasOrFilter?: string | object | undefined) {
     if (typeof aliasOrFilter === 'string') {
       this.alias = aliasOrFilter;
     } else if (typeof aliasOrFilter === 'object') {
@@ -30,7 +30,7 @@ export default class GraphqlQueryBuilder {
    * The parameters to run the query against.
    * @param filters An object mapping attribute to values
    */
-  filter(filters: any) {
+  filter(filters: any): this {
     for (const prop of Object.keys(filters)) {
       if (typeof filters[prop] === 'function') {
         continue;
@@ -48,7 +48,7 @@ export default class GraphqlQueryBuilder {
    * Outlines the properties you wish to be returned from the query.
    * @param properties representing each attribute you want Returned
    */
-  find(...searches: any[]) { // THIS NEED TO BE A "FUNCTION" to scope 'arguments'
+  find(...searches: any[]): this { // THIS NEED TO BE A "FUNCTION" to scope 'arguments'
     if (!searches || !Array.isArray(searches) || searches.length === 0) {
       throw new TypeError(`find value can not be >>falsy<<`);
     }
@@ -63,7 +63,7 @@ export default class GraphqlQueryBuilder {
    * set an alias for this result.
    * @param alias
    */
-  setAlias(alias: string) {
+  setAlias(alias: string): void {
     this.alias = alias;
   }
 
@@ -71,7 +71,7 @@ export default class GraphqlQueryBuilder {
    * Return to the formatted query string
    * @return
    */
-  toString() {
+  toString(): string {
     if (this.body === undefined) {
       throw new ReferenceError(`return properties are not defined. use the 'find' function to defined them`);
     }
@@ -83,7 +83,7 @@ export default class GraphqlQueryBuilder {
   // protected functions
   // --------------------
 
-  protected parceFind(_levelA: any[]) {
+  protected parceFind(_levelA: any[]): string {
     const propsA = _levelA.map((_currentValue, index) => {
       const itemX = _levelA[index];
 
@@ -111,7 +111,7 @@ export default class GraphqlQueryBuilder {
     return propsA.join(',');
   }
 
-  protected getGraphQLValue(value: any) {
+  protected getGraphQLValue(value: any): any {
     if (typeof value === 'string') {
       value = JSON.stringify(value);
     } else if (Array.isArray(value)) {

--- a/packages/odata/src/services/grid-odata.service.ts
+++ b/packages/odata/src/services/grid-odata.service.ts
@@ -51,12 +51,12 @@ export class GridOdataService implements BackendService {
   };
 
   /** Getter for the Column Definitions */
-  get columnDefinitions() {
+  get columnDefinitions(): Column[] {
     return this._columnDefinitions;
   }
 
   /** Getter for the Odata Service */
-  get odataService() {
+  get odataService(): OdataQueryBuilderService {
     return this._odataService;
   }
 
@@ -158,17 +158,17 @@ export class GridOdataService implements BackendService {
     }
   }
 
-  clearFilters() {
+  clearFilters(): void {
     this._currentFilters = [];
     this.updateFilters([]);
   }
 
-  clearSorters() {
+  clearSorters(): void {
     this._currentSorters = [];
     this.updateSorters([]);
   }
 
-  updateOptions(serviceOptions?: Partial<OdataOption>) {
+  updateOptions(serviceOptions?: Partial<OdataOption>): void {
     this.options = { ...this.options, ...serviceOptions };
     this._odataService.options = this.options;
   }
@@ -197,7 +197,7 @@ export class GridOdataService implements BackendService {
    * @param string operator
    * @returns string map
    */
-  mapOdataOperator(operator: string) {
+  mapOdataOperator(operator: string): string {
     let map = '';
     switch (operator) {
       case '<':
@@ -229,13 +229,13 @@ export class GridOdataService implements BackendService {
   /*
    * Reset the pagination options
    */
-  resetPaginationOptions() {
+  resetPaginationOptions(): void {
     this._odataService.updateOptions({
       skip: 0
     });
   }
 
-  saveColumnFilter(fieldName: string, value: string, terms?: SearchTerm[]) {
+  saveColumnFilter(fieldName: string, value: string, terms?: SearchTerm[]): void {
     this._odataService.saveColumnFilter(fieldName, value, terms);
   }
 
@@ -267,7 +267,7 @@ export class GridOdataService implements BackendService {
   /*
    * PAGINATION
    */
-  processOnPaginationChanged(_event: Event | undefined, args: PaginationChangedArgs) {
+  processOnPaginationChanged(_event: Event | undefined, args: PaginationChangedArgs): string {
     const pageSize = +(args.pageSize || ((this.pagination) ? this.pagination.pageSize : DEFAULT_PAGE_SIZE));
     this.updatePagination(args.newPage, pageSize);
 
@@ -278,7 +278,7 @@ export class GridOdataService implements BackendService {
   /*
    * SORTING
    */
-  processOnSortChanged(_event: Event | undefined, args: SingleColumnSort | MultiColumnSort) {
+  processOnSortChanged(_event: Event | undefined, args: SingleColumnSort | MultiColumnSort): string {
     const sortColumns = (args.multiColumnSort) ? (args as MultiColumnSort).sortCols : new Array({ columnId: (args as ColumnSort).sortCol?.id ?? '', sortCol: (args as ColumnSort).sortCol, sortAsc: (args as ColumnSort).sortAsc });
 
     // loop through all columns to inspect sorters & set the query
@@ -292,7 +292,7 @@ export class GridOdataService implements BackendService {
    * loop through all columns to inspect filters & update backend service filters
    * @param columnFilters
    */
-  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically?: boolean) {
+  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically?: boolean): void {
     let searchBy = '';
     const searchByArray: string[] = [];
     const odataVersion = this._odataService.options.version ?? 2;
@@ -505,7 +505,7 @@ export class GridOdataService implements BackendService {
    * @param newPage
    * @param pageSize
    */
-  updatePagination(newPage: number, pageSize: number) {
+  updatePagination(newPage: number, pageSize: number): void {
     this._currentPagination = {
       pageNumber: newPage,
       pageSize,
@@ -524,7 +524,7 @@ export class GridOdataService implements BackendService {
    * loop through all columns to inspect sorters & update backend service orderBy
    * @param columnFilters
    */
-  updateSorters(sortColumns?: ColumnSort[], presetSorters?: CurrentSorter[]) {
+  updateSorters(sortColumns?: ColumnSort[], presetSorters?: CurrentSorter[]): string {
     let currentSorters: CurrentSorter[] = [];
     const odataSorters: OdataSortingOption[] = [];
 
@@ -646,7 +646,7 @@ export class GridOdataService implements BackendService {
   /**
    * Filter by a range of searchTerms (2 searchTerms OR 1 string separated by 2 dots "value1..value2")
    */
-  protected filterBySearchTermRange(fieldName: string, operator: OperatorType | OperatorString, searchTerms: SearchTerm[]) {
+  protected filterBySearchTermRange(fieldName: string, operator: OperatorType | OperatorString, searchTerms: SearchTerm[]): string {
     let query = '';
     if (Array.isArray(searchTerms) && searchTerms.length === 2) {
       if (operator === OperatorType.rangeInclusive) {
@@ -671,7 +671,7 @@ export class GridOdataService implements BackendService {
   /**
    * Normalizes the search value according to field type and oData version.
    */
-  protected normalizeSearchValue(fieldType: typeof FieldType[keyof typeof FieldType], searchValue: any, version: number) {
+  protected normalizeSearchValue(fieldType: typeof FieldType[keyof typeof FieldType], searchValue: any, version: number): any {
     switch (fieldType) {
       case FieldType.date:
         searchValue = parseUtcDate(searchValue as string);

--- a/packages/odata/src/services/odataQueryBuilder.service.ts
+++ b/packages/odata/src/services/odataQueryBuilder.service.ts
@@ -119,13 +119,13 @@ export class OdataQueryBuilderService {
     this._odataOptions = options;
   }
 
-  removeColumnFilter(fieldName: string) {
+  removeColumnFilter(fieldName: string): void {
     if (this._columnFilters && this._columnFilters.hasOwnProperty(fieldName)) {
       delete this._columnFilters[fieldName];
     }
   }
 
-  saveColumnFilter(fieldName: string, value: any, searchTerms?: any[]) {
+  saveColumnFilter(fieldName: string, value: any, searchTerms?: any[]): void {
     this._columnFilters[fieldName] = {
       search: searchTerms,
       value
@@ -136,7 +136,7 @@ export class OdataQueryBuilderService {
    * Change any OData options that will be used to build the query
    * @param object options
    */
-  updateOptions(options: Partial<OdataOption>) {
+  updateOptions(options: Partial<OdataOption>): void {
     for (const property of Object.keys(options)) {
       if (options.hasOwnProperty(property)) {
         this._odataOptions[property as keyof OdataOption] = options[property as keyof OdataOption]; // replace of the property
@@ -167,7 +167,7 @@ export class OdataQueryBuilderService {
   // protected functions
   // -------------------
 
-  protected addToFilterQueueWhenNotExists(filterStr: string) {
+  protected addToFilterQueueWhenNotExists(filterStr: string): void {
     if (this._odataOptions.filterQueue && this._odataOptions.filterQueue.indexOf(filterStr) === -1) {
       this._odataOptions.filterQueue.push(filterStr);
     }
@@ -177,8 +177,8 @@ export class OdataQueryBuilderService {
   // private functions
   // -------------------
 
-  private buildSelectExpand(selectFields: string[]): { selectParts: string[]; expandParts: string[] } {
-    const navigations: { [navigation: string]: string[] } = {};
+  private buildSelectExpand(selectFields: string[]): { selectParts: string[]; expandParts: string[]; } {
+    const navigations: { [navigation: string]: string[]; } = {};
     const selectItems = new Set<string>();
 
     for (const field of selectFields) {
@@ -207,7 +207,7 @@ export class OdataQueryBuilderService {
     };
   }
 
-  private buildExpand(navigations: { [navigation: string]: string[] }): string[] {
+  private buildExpand(navigations: { [navigation: string]: string[]; }): string[] {
     const expandParts = [];
     for (const navigation of Object.keys(navigations)) {
       if (this._odataOptions.enableSelect && this._odataOptions.version && this._odataOptions.version >= 4) {

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -37,7 +37,7 @@ export class SlickPaginationComponent {
   textOf = 'of';
   textPage = 'Page';
 
-  constructor(protected readonly paginationService: PaginationService, protected readonly pubSubService: PubSubService, protected readonly sharedService: SharedService, protected readonly translaterService?: TranslaterService) {
+  constructor(protected readonly paginationService: PaginationService, protected readonly pubSubService: PubSubService, protected readonly sharedService: SharedService, protected readonly translaterService?: TranslaterService | undefined) {
     this._bindingHelper = new BindingHelper();
     this._bindingEventService = new BindingEventService();
     this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
@@ -119,7 +119,7 @@ export class SlickPaginationComponent {
     return this.gridOptions?.locales ?? Constants.locales;
   }
 
-  get totalItems() {
+  get totalItems(): number {
     return this.paginationService.totalItems;
   }
 
@@ -131,7 +131,7 @@ export class SlickPaginationComponent {
     return this.pageNumber === this.pageCount || this.totalItems === 0;
   }
 
-  dispose() {
+  dispose(): void {
     // also dispose of all Subscriptions
     this.pubSubService.unsubscribeAll(this._subscriptions);
     this._bindingEventService.unbindAll();
@@ -140,7 +140,7 @@ export class SlickPaginationComponent {
     this._paginationElement.remove();
   }
 
-  renderPagination(gridParentContainerElm: HTMLElement) {
+  renderPagination(gridParentContainerElm: HTMLElement): void {
     this._gridParentContainerElm = gridParentContainerElm;
     const paginationElm = this.createPaginationContainer();
     const divNavContainerElm = createDomElement('div', { className: 'slick-pagination-nav' });
@@ -186,7 +186,7 @@ export class SlickPaginationComponent {
   }
 
   /** Render and fill the Page Sizes <select> element */
-  renderPageSizes() {
+  renderPageSizes(): void {
     if (this._itemPerPageElm && Array.isArray(this.availablePageSizes)) {
       for (const option of this.availablePageSizes) {
         this._itemPerPageElm.appendChild(createDomElement('option', { value: `${option}`, text: `${option}` }));
@@ -195,7 +195,7 @@ export class SlickPaginationComponent {
   }
 
   /** Add some DOM Element bindings */
-  addBindings() {
+  addBindings(): void {
     this._bindingHelper.addElementBinding(this, 'firstButtonClasses', 'li.page-item.seek-first', 'className');
     this._bindingHelper.addElementBinding(this, 'prevButtonClasses', 'li.page-item.seek-prev', 'className');
     this._bindingHelper.addElementBinding(this, 'lastButtonClasses', 'li.page-item.seek-end', 'className');
@@ -217,7 +217,7 @@ export class SlickPaginationComponent {
   }
 
   /** Add some DOM Element event listeners */
-  addEventListeners() {
+  addEventListeners(): void {
     this._bindingEventService.bind(this._seekFirstElm, 'click', this.changeToFirstPage.bind(this) as EventListener);
     this._bindingEventService.bind(this._seekEndElm, 'click', this.changeToLastPage.bind(this) as EventListener);
     this._bindingEventService.bind(this._seekNextElm, 'click', this.changeToNextPage.bind(this) as EventListener);
@@ -225,40 +225,40 @@ export class SlickPaginationComponent {
     this._bindingEventService.bind(this._itemPerPageElm, 'change', this.updateItemsPerPage.bind(this));
   }
 
-  changeToFirstPage(event: MouseEvent) {
+  changeToFirstPage(event: MouseEvent): void {
     if (!this.isLeftPaginationDisabled) {
       this.paginationService.goToFirstPage(event);
     }
   }
 
-  changeToLastPage(event: MouseEvent) {
+  changeToLastPage(event: MouseEvent): void {
     if (!this.isRightPaginationDisabled) {
       this.paginationService.goToLastPage(event);
     }
   }
 
-  changeToNextPage(event: MouseEvent) {
+  changeToNextPage(event: MouseEvent): void {
     if (!this.isRightPaginationDisabled) {
       this.paginationService.goToNextPage(event);
     }
   }
 
-  changeToPreviousPage(event: MouseEvent) {
+  changeToPreviousPage(event: MouseEvent): void {
     if (!this.isLeftPaginationDisabled) {
       this.paginationService.goToPreviousPage(event);
     }
   }
 
-  changeToCurrentPage(pageNumber: number) {
+  changeToCurrentPage(pageNumber: number): void {
     this.paginationService.goToPageNumber(+pageNumber);
   }
 
-  updateItemsPerPage(event: & { target: any; }) {
+  updateItemsPerPage(event: & { target: any; }): void {
     this.itemsPerPage = +(event?.target?.value ?? 0);
   }
 
   /** Translate all the texts shown in the UI, use ngx-translate service when available or custom locales when service is null */
-  translatePaginationTexts() {
+  translatePaginationTexts(): void {
     if (this._enableTranslate && this.translaterService?.translate) {
       const translationPrefix = getTranslationPrefix(this.gridOptions);
       this.textItemsPerPage = this.translaterService.translate(`${translationPrefix}ITEMS_PER_PAGE`);
@@ -278,7 +278,7 @@ export class SlickPaginationComponent {
   // --------------------
 
   /** Create the Pagination Container */
-  protected createPaginationContainer() {
+  protected createPaginationContainer(): HTMLDivElement {
     const paginationContainerElm = createDomElement('div', {
       id: 'pager', className: `slick-pagination-container ${this.gridUid} pager`,
       style: { width: '100%' },
@@ -291,7 +291,7 @@ export class SlickPaginationComponent {
     return paginationElm;
   }
 
-  protected createPageNumberSection() {
+  protected createPageNumberSection(): HTMLDivElement {
     const divElm = createDomElement('div', { className: 'slick-page-number' });
     createDomElement('span', { className: 'text-page', textContent: 'Page' }, divElm);
     divElm.appendChild(document.createTextNode(' '));
@@ -322,7 +322,7 @@ export class SlickPaginationComponent {
     return divElm;
   }
 
-  protected createPaginationSettingsSection() {
+  protected createPaginationSettingsSection(): HTMLSpanElement {
     const spanContainerElm = createDomElement('span', { className: 'slick-pagination-settings' });
     this._itemPerPageElm = createDomElement('select', { id: 'items-per-page-label', ariaLabel: 'Items per Page', className: 'items-per-page' }, spanContainerElm);
     spanContainerElm.appendChild(document.createTextNode(' '));
@@ -346,7 +346,7 @@ export class SlickPaginationComponent {
     return spanContainerElm;
   }
 
-  protected updatePageButtonsUsability() {
+  protected updatePageButtonsUsability(): void {
     this.firstButtonClasses = this.isLeftPaginationDisabled ? 'page-item seek-first disabled' : 'page-item seek-first';
     this.prevButtonClasses = this.isLeftPaginationDisabled ? 'page-item seek-prev disabled' : 'page-item seek-prev';
     this.lastButtonClasses = this.isRightPaginationDisabled ? 'page-item seek-end disabled' : 'page-item seek-end';

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -33,22 +33,22 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   pluginName = 'RowDetailView' as const;
 
   /** Fired when the async response finished */
-  onAsyncEndUpdate = new SlickEvent<OnRowDetailAsyncEndUpdateArgs>('onAsyncEndUpdate');
+  onAsyncEndUpdate: SlickEvent<OnRowDetailAsyncEndUpdateArgs>;
 
   /** This event must be used with the "notify" by the end user once the Asynchronous Server call returns the item detail */
-  onAsyncResponse = new SlickEvent<OnRowDetailAsyncResponseArgs>('onAsyncResponse');
+  onAsyncResponse: SlickEvent<OnRowDetailAsyncResponseArgs>;
 
   /** Fired after the row detail gets toggled */
-  onAfterRowDetailToggle = new SlickEvent<OnAfterRowDetailToggleArgs>('onAfterRowDetailToggle');
+  onAfterRowDetailToggle: SlickEvent<OnAfterRowDetailToggleArgs>;
 
   /** Fired before the row detail gets toggled */
-  onBeforeRowDetailToggle = new SlickEvent<OnBeforeRowDetailToggleArgs>('onBeforeRowDetailToggle');
+  onBeforeRowDetailToggle: SlickEvent<OnBeforeRowDetailToggleArgs>;
 
   /** Fired after the row detail gets toggled */
-  onRowBackToViewportRange = new SlickEvent<OnRowBackToViewportRangeArgs>('onRowBackToViewportRange');
+  onRowBackToViewportRange: SlickEvent<OnRowBackToViewportRangeArgs>;
 
   /** Fired after a row becomes out of viewport range (when user can't see the row anymore) */
-  onRowOutOfViewportRange = new SlickEvent<OnRowOutOfViewportRangeArgs>('onRowOutOfViewportRange');
+  onRowOutOfViewportRange: SlickEvent<OnRowOutOfViewportRangeArgs>;
 
   // --
   // protected props
@@ -87,9 +87,15 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
   constructor(protected readonly pubSubService: PubSubService) {
     this._eventHandler = new SlickEventHandler();
+    this.onAsyncEndUpdate = new SlickEvent<OnRowDetailAsyncEndUpdateArgs>('onAsyncEndUpdate');
+    this.onAsyncResponse = new SlickEvent<OnRowDetailAsyncResponseArgs>('onAsyncResponse');
+    this.onAfterRowDetailToggle = new SlickEvent<OnAfterRowDetailToggleArgs>('onAfterRowDetailToggle');
+    this.onBeforeRowDetailToggle = new SlickEvent<OnBeforeRowDetailToggleArgs>('onBeforeRowDetailToggle');
+    this.onRowBackToViewportRange = new SlickEvent<OnRowBackToViewportRangeArgs>('onRowBackToViewportRange');
+    this.onRowOutOfViewportRange = new SlickEvent<OnRowOutOfViewportRangeArgs>('onRowOutOfViewportRange');
   }
 
-  get addonOptions() {
+  get addonOptions(): RowDetailView {
     return this._addonOptions;
   }
 
@@ -102,7 +108,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     return this._dataViewIdProperty;
   }
 
-  get eventHandler() {
+  get eventHandler(): SlickEventHandler {
     return this._eventHandler;
   }
 
@@ -111,7 +117,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     return this._grid?.getOptions() || {};
   }
 
-  get gridUid() {
+  get gridUid(): string {
     return this._gridUid || (this._grid?.getUID() || '');
   }
 
@@ -132,7 +138,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
    * @param _grid
    * @param _containerService
    */
-  init(grid: SlickGrid) {
+  init(grid: SlickGrid): void {
     this._grid = grid;
     if (!grid) {
       throw new Error('[Slickgrid-Universal] RowDetailView Plugin requires the Grid instance to be passed as argument to the "init()" method.');
@@ -195,7 +201,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Dispose of the Slick Row Detail View */
-  dispose() {
+  dispose(): void {
     this._eventHandler?.unsubscribeAll();
   }
 
@@ -242,7 +248,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** set or change some of the plugin options */
-  setOptions(options: Partial<RowDetailViewOption>) {
+  setOptions(options: Partial<RowDetailViewOption>): void {
     this._addonOptions = extend(true, {}, this._addonOptions, options) as RowDetailView;
     if (this._addonOptions?.singleRowExpand) {
       this.collapseAll();
@@ -250,7 +256,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Collapse all of the open items */
-  collapseAll() {
+  collapseAll(): void {
     this.dataView.beginUpdate();
     this._expandedRows.forEach(expandedRow => {
       this.collapseDetailView(expandedRow, true);
@@ -259,7 +265,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Colapse an Item so it is not longer seen */
-  collapseDetailView(item: any, isMultipleCollapsing = false) {
+  collapseDetailView(item: any, isMultipleCollapsing = false): void {
     if (!isMultipleCollapsing) {
       this.dataView.beginUpdate();
     }
@@ -286,7 +292,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Expand a row given the dataview item that is to be expanded */
-  expandDetailView(item: any) {
+  expandDetailView(item: any): void {
     if (this._addonOptions?.singleRowExpand) {
       this.collapseAll();
     }
@@ -322,7 +328,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Saves the current state of the detail view */
-  saveDetailView(item: any) {
+  saveDetailView(item: any): void {
     const view = document.querySelector(`.${this.gridUid} .innerDetailView_${item[this._dataViewIdProperty]}`);
     if (view) {
       const html = view.innerHTML;
@@ -336,7 +342,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
    * subscribe to the onAsyncResponse so that the plugin knows when the user server side calls finished
    * the response has to be as "args.item" (or "args.itemDetail") with it's data back
    */
-  handleOnAsyncResponse(e: SlickEventData, args: { item: any; itemDetail: any; detailView?: any; }) {
+  handleOnAsyncResponse(e: SlickEventData, args: { item: any; itemDetail: any; detailView?: any; }): void {
     if (!args || (!args.item && !args.itemDetail)) {
       console.error('SlickRowDetailView plugin requires the onAsyncResponse() to supply "args.item" property.');
       return;
@@ -365,7 +371,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
    * In order word, user can choose which rows to be an available row detail (or not) by providing his own logic.
    * @param overrideFn: override function callback
    */
-  expandableOverride(overrideFn: UsabilityOverrideFn) {
+  expandableOverride(overrideFn: UsabilityOverrideFn): void {
     this._expandableOverride = overrideFn;
   }
 
@@ -408,7 +414,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Takes in the item we are filtering and if it is an expanded row returns it's parents row to filter on */
-  getFilterItem(item: any) {
+  getFilterItem(item: any): any {
     if (item[`${this._keyPrefix}isPadding`] && item[`${this._keyPrefix}parent`]) {
       item = item[`${this._keyPrefix}parent`];
     }
@@ -416,7 +422,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Resize the Row Detail View */
-  resizeDetailView(item: any) {
+  resizeDetailView(item: any): void {
     if (!item) {
       return;
     }
@@ -482,7 +488,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   /**
    * create the detail ctr node. this belongs to the dev & can be custom-styled as per
    */
-  protected applyTemplateNewLineHeight(item: any) {
+  protected applyTemplateNewLineHeight(item: any): void {
     // the height is calculated by the template row count (how many line of items does the template view have)
     const rowCount = this._addonOptions.panelRows;
 
@@ -497,7 +503,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }
   }
 
-  protected calculateOutOfRangeViews() {
+  protected calculateOutOfRangeViews(): void {
     if (this._grid) {
       let scrollDir: 'UP' | 'DOWN';
       const renderedRange = this._grid.getRenderedRange();
@@ -563,7 +569,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }
   }
 
-  protected calculateOutOfRangeViewsSimplerVersion() {
+  protected calculateOutOfRangeViewsSimplerVersion(): void {
     if (this._grid) {
       const renderedRange = this._grid.getRenderedRange();
 
@@ -579,19 +585,19 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }
   }
 
-  protected checkExpandableOverride(row: number, dataContext: any, grid: SlickGrid) {
+  protected checkExpandableOverride(row: number, dataContext: any, grid: SlickGrid): boolean {
     if (typeof this._expandableOverride === 'function') {
       return this._expandableOverride(row, dataContext, grid);
     }
     return true;
   }
 
-  protected checkIsRowOutOfViewportRange(rowIndex: number, renderedRange: any) {
+  protected checkIsRowOutOfViewportRange(rowIndex: number, renderedRange: any): boolean {
     return (Math.abs(renderedRange.bottom - this._gridRowBuffer - rowIndex) > this._visibleRenderedCellCount * 2);
   }
 
   /** Get the Row Detail padding (which are the rows dedicated to the detail panel) */
-  protected getPaddingItem(parent: any, offset: any) {
+  protected getPaddingItem(parent: any, offset: any): any {
     const item: any = {};
 
     Object.keys(this.dataView).forEach(prop => {
@@ -675,7 +681,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** When row is getting toggled, we will handle the action of collapsing/expanding */
-  protected handleAccordionShowHide(item: any) {
+  protected handleAccordionShowHide(item: any): void {
     if (item) {
       if (!item[`${this._keyPrefix}collapsed`]) {
         this.collapseDetailView(item);
@@ -686,7 +692,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   /** Handle mouse click event */
-  protected handleClick(e: SlickEventData, args: { row: number; cell: number; }) {
+  protected handleClick(e: SlickEventData, args: { row: number; cell: number; }): void {
     const dataContext = this._grid.getDataItem(args.row);
 
     if (this.checkExpandableOverride(args.row, dataContext, this._grid)) {
@@ -722,7 +728,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }
   }
 
-  protected handleScroll() {
+  protected handleScroll(): void {
     if (this._addonOptions.useSimpleViewportCalc) {
       this.calculateOutOfRangeViewsSimplerVersion();
     } else {
@@ -730,7 +736,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }
   }
 
-  protected notifyOutOfViewport(item: any, rowId: number | string) {
+  protected notifyOutOfViewport(item: any, rowId: number | string): void {
     const rowIndex = item.rowIndex || this.dataView.getRowById(item[this._dataViewIdProperty]);
 
     this.onRowOutOfViewportRange.notify({
@@ -743,7 +749,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }, null, this);
   }
 
-  protected notifyBackToViewportWhenDomExist(item: any, rowId: number | string) {
+  protected notifyBackToViewportWhenDomExist(item: any, rowId: number | string): void {
     const rowIndex = item.rowIndex || this.dataView.getRowById(item[this._dataViewIdProperty]);
 
     setTimeout(() => {
@@ -761,7 +767,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     }, 100);
   }
 
-  protected syncOutOfViewportArray(rowId: number | string, isAdding: boolean) {
+  protected syncOutOfViewportArray(rowId: number | string, isAdding: boolean): Array<string | number> {
     const arrayRowIndex = this._rowIdsOutOfViewport.findIndex(outOfViewportRowId => outOfViewportRowId === rowId);
 
     if (isAdding && arrayRowIndex < 0) {
@@ -772,7 +778,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     return this._rowIdsOutOfViewport;
   }
 
-  protected toggleRowSelection(rowNumber: number, dataContext: any) {
+  protected toggleRowSelection(rowNumber: number, dataContext: any): void {
     if (this.checkExpandableOverride(rowNumber, dataContext, this._grid)) {
       this.dataView.beginUpdate();
       this.handleAccordionShowHide(dataContext);

--- a/packages/text-export/src/textExport.service.ts
+++ b/packages/text-export/src/textExport.service.ts
@@ -43,7 +43,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
   protected _delimiter = ',';
   protected _exportQuoteWrapper = '';
   protected _exportOptions!: TextExportOption;
-  protected _fileFormat = FileType.csv;
+  protected _fileFormat: FileType = FileType.csv;
   protected _lineCarriageReturn = '\n';
   protected _grid!: SlickGrid;
   protected _groupedColumnHeaders?: Array<KeyTitlePair>;
@@ -72,7 +72,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
     return this._grid?.getOptions() ?? {} as GridOption;
   }
 
-  dispose() {
+  dispose(): void {
     this._pubSubService?.unsubscribeAll();
   }
 
@@ -336,7 +336,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * @param {Number} row - row index
    * @param {Object} itemObj - item datacontext object
    */
-  protected readRegularRowData(columns: Column[], row: number, itemObj: any) {
+  protected readRegularRowData(columns: Column[], row: number, itemObj: any): string {
     let idx = 0;
     const rowOutputStrings = [];
     const exportQuoteWrapper = this._exportQuoteWrapper;
@@ -407,7 +407,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * Get the grouped title(s) and its group title formatter, for example if we grouped by salesRep, the returned result would be:: 'Sales Rep: John Dow (2 items)'
    * @param itemObj
    */
-  protected readGroupedTitleRow(itemObj: any) {
+  protected readGroupedTitleRow(itemObj: any): string {
     let groupName = stripTags(itemObj.title);
     const exportQuoteWrapper = this._exportQuoteWrapper;
 
@@ -426,7 +426,7 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
    * For example if we grouped by "salesRep" and we have a Sum Aggregator on "sales", then the returned output would be:: ["Sum 123$"]
    * @param itemObj
    */
-  protected readGroupedTotalRow(columns: Column[], itemObj: any) {
+  protected readGroupedTotalRow(columns: Column[], itemObj: any): string {
     const delimiter = this._exportOptions.delimiter;
     const format = this._exportOptions.format;
     const groupingAggregatorRowText = this._exportOptions.groupingAggregatorRowText || '';

--- a/packages/utils/src/__tests__/utils.spec.ts
+++ b/packages/utils/src/__tests__/utils.spec.ts
@@ -232,20 +232,6 @@ describe('Service/Utilies', () => {
     });
   });
 
-  describe('hasData() method', () => {
-    it('should return True when input has test, or is a boolean (true or false) or if it is an object', () => {
-      expect(hasData('test')).toBe(true);
-      expect(hasData(true)).toBe(true);
-      expect(hasData(false)).toBe(true);
-      expect(hasData({})).toBe(true);
-    });
-
-    it('should return False when input is undefined, null or false', () => {
-      expect(hasData(undefined)).toBe(false);
-      expect(hasData(null)).toBe(false);
-    });
-  });
-
   describe('isDefined() method', () => {
     it('should be truthy when comparing against any defined variable', () => {
       const result1 = isDefined({ firstName: 'John', lastName: 'Doe' });

--- a/packages/utils/src/domUtils.ts
+++ b/packages/utils/src/domUtils.ts
@@ -79,7 +79,7 @@ export function classNameToList(className = ''): string[] {
  * if we detect an array then use recursion to go inside it and apply same logic
  * @param obj - object containing 1 or more properties with DOM Elements
  */
-export function destroyAllElementProps(obj: any) {
+export function destroyAllElementProps(obj: any): void {
   if (typeof obj === 'object') {
     Object.keys(obj).forEach(key => {
       if (Array.isArray(obj[key])) {
@@ -122,7 +122,12 @@ export function getHtmlStringOutput(input: DocumentFragment | HTMLElement | stri
 }
 
 /** Get offset of HTML element relative to a parent element */
-export function getOffsetRelativeToParent(parentElm: HTMLElement | null, childElm: HTMLElement | null) {
+export function getOffsetRelativeToParent(parentElm: HTMLElement | null, childElm: HTMLElement | null): {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+} | undefined {
   if (!parentElm || !childElm) {
     return undefined;
   }
@@ -158,7 +163,7 @@ export function getOffset(elm?: HTMLElement | null): HtmlElementPosition | undef
   return { top, left, bottom, right };
 }
 
-export function getInnerSize(elm: HTMLElement, type: 'height' | 'width') {
+export function getInnerSize(elm: HTMLElement, type: 'height' | 'width'): number {
   let size = 0;
 
   if (elm) {
@@ -174,7 +179,7 @@ export function getInnerSize(elm: HTMLElement, type: 'height' | 'width') {
 }
 
 /** Get a DOM element style property value by calling getComputedStyle() on the element */
-export function getStyleProp(elm: HTMLElement, property: string) {
+export function getStyleProp(elm: HTMLElement, property: string): string | null {
   if (elm) {
     return window.getComputedStyle(elm).getPropertyValue(property);
   }
@@ -251,7 +256,7 @@ export function htmlEncodeWithPadding(inputStr: string, paddingLength: number): 
 }
 
 /** insert an HTML Element after a target Element in the DOM */
-export function insertAfterElement(referenceNode: HTMLElement, newNode: HTMLElement) {
+export function insertAfterElement(referenceNode: HTMLElement, newNode: HTMLElement): void {
   referenceNode.parentNode?.insertBefore(newNode, referenceNode.nextSibling);
 }
 

--- a/packages/utils/src/stripTagsUtil.ts
+++ b/packages/utils/src/stripTagsUtil.ts
@@ -28,7 +28,7 @@ interface Context {
   in_quote_char: string;
 }
 
-export function stripTags(htmlText: string | number | boolean | HTMLElement, allowableTags?: string | string[], tagReplacement?: string) {
+export function stripTags(htmlText: string | number | boolean | HTMLElement, allowableTags?: string | string[], tagReplacement?: string): string {
 
   /** main init function that will be executed when calling the global function */
   function init(html: string | number | boolean | HTMLElement, allowable_tags?: string | string[], tag_replacement?: string) {

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -7,7 +7,7 @@ import { extend } from './nodeExtend';
  * @param inputItem
  * @param itemIdPropName
  */
-export function addToArrayWhenNotExists<T = any>(inputArray: T[], inputItem: T, itemIdPropName = 'id') {
+export function addToArrayWhenNotExists<T = any>(inputArray: T[], inputItem: T, itemIdPropName = 'id'): void {
   let arrayRowIndex = -1;
   if (inputItem && typeof inputItem === 'object' && itemIdPropName in inputItem) {
     arrayRowIndex = inputArray.findIndex((item) => item[itemIdPropName as keyof T] === inputItem[itemIdPropName as keyof T]);
@@ -81,24 +81,24 @@ export function deepMerge(target: any, ...sources: any[]): any {
       if (source.hasOwnProperty(prop)) {
         if (prop in target) {
           // handling merging of two properties with equal names
-          if (typeof target[prop] !== 'object') {
-            target[prop] = source[prop];
+          if (typeof (target as any)[prop] !== 'object') {
+            (target as any)[prop] = (source as any)[prop];
           } else {
-            if (typeof source[prop] !== 'object') {
-              target[prop] = source[prop];
+            if (typeof (source as any)[prop] !== 'object') {
+              (target as any)[prop] = (source as any)[prop];
             } else {
-              if (target[prop].concat && source[prop].concat) {
+              if ((target as any)[prop].concat && (source as any)[prop].concat) {
                 // two arrays get concatenated
-                target[prop] = target[prop].concat(source[prop]);
+                (target as any)[prop] = (target as any)[prop].concat((source as any)[prop]);
               } else {
                 // two objects get merged recursively
-                target[prop] = deepMerge(target[prop], source[prop]);
+                (target as any)[prop] = deepMerge((target as any)[prop], (source as any)[prop]);
               }
             }
           }
         } else {
           // new properties get added to target
-          target[prop] = source[prop];
+          (target as any)[prop] = (source as any)[prop];
         }
       }
     });
@@ -110,7 +110,7 @@ export function deepMerge(target: any, ...sources: any[]): any {
  * Empty an object properties by looping through them all and deleting them
  * @param obj - input object
  */
-export function emptyObject(obj: any) {
+export function emptyObject(obj: any): any {
   if (isObject(obj)) {
     Object.keys(obj).forEach(key => {
       if (obj.hasOwnProperty(key)) {
@@ -131,7 +131,11 @@ export function emptyObject(obj: any) {
  * @param {Boolean} [addReturn] - when using ES6 function as single liner, we could add the missing `return ...`
  * @returns
  */
-export function getFunctionDetails(fn: AnyFunction, addReturn = true) {
+export function getFunctionDetails(fn: AnyFunction, addReturn = true): {
+  params: string[];
+  body: string;
+  isAsync: boolean;
+} {
   let isAsyncFn = false;
 
   const getFunctionBody = (func: AnyFunction) => {
@@ -164,7 +168,7 @@ export function getFunctionDetails(fn: AnyFunction, addReturn = true) {
   return {
     params: getFunctionParams(fn),
     body: getFunctionBody(fn),
-    isAsync: isAsyncFn,
+    isAsync: isAsyncFn satisfies typeof isAsyncFn as boolean,
   };
 }
 
@@ -193,7 +197,7 @@ export function isDefinedNumber<T>(value: T | undefined | null): value is T {
  * @param item
  * @returns {boolean}
  */
-export function isObject(item: any) {
+export function isObject(item: any): item is object {
   return item !== null && typeof item === 'object' && !Array.isArray(item) && !(item instanceof Date);
 }
 
@@ -202,20 +206,12 @@ export function isObject(item: any) {
  * @param val
  * @returns {boolean}
  */
-export function isPrimitiveValue(val: any) {
+export function isPrimitiveValue(val: any): boolean {
   return typeof val === 'boolean' || typeof val === 'number' || typeof val === 'string' || val === null || val === undefined;
 }
 
-export function isPrimitiveOrHTML(val: any) {
+export function isPrimitiveOrHTML(val: any): boolean {
   return val instanceof HTMLElement || val instanceof DocumentFragment || isPrimitiveValue(val);
-}
-
-/**
- * Check if a value has any data (undefined, null or empty string will return False...)
- * NOTE: a `false` boolean is consider as having data so it will return True
- */
-export function hasData(value: any): boolean {
-  return value !== undefined && value !== null && value !== '';
 }
 
 /**
@@ -224,7 +220,7 @@ export function hasData(value: any): boolean {
  * @param value - input value of any type
  * @param strict - when using strict it also check for strict equality, e.g "3" in strict mode would return False but True when non-strict
  */
-export function isNumber(value: any, strict = false) {
+export function isNumber(value: any, strict = false): value is number {
   if (strict) {
     return (value === null || value === undefined || typeof value === 'string') ? false : !isNaN(value);
   }
@@ -232,7 +228,7 @@ export function isNumber(value: any, strict = false) {
 }
 
 /** Check if an object is empty, it will also be considered empty when the input is null, undefined or isn't an object */
-export function isObjectEmpty(obj: unknown) {
+export function isObjectEmpty(obj: unknown): boolean {
   return !obj || (obj && typeof obj === 'object' && Object.keys(obj).length === 0);
 }
 
@@ -247,13 +243,13 @@ export function parseBoolean(input: any): boolean {
  * @param {Boolean} shouldLowerCase - should we also lowercase the string output?
  * @returns
  */
-export function removeAccentFromText(text: string, shouldLowerCase = false) {
+export function removeAccentFromText(text: string, shouldLowerCase = false): string {
   const normalizedText = (typeof text.normalize === 'function') ? text.normalize('NFD').replace(/[\u0300-\u036f]/g, '') : text;
   return shouldLowerCase ? normalizedText.toLowerCase() : normalizedText;
 }
 
 /** Set the object value of deeper node from a given dot (.) notation path (e.g.: "user.firstName") */
-export function setDeepValue<T = unknown>(obj: T, path: string | string[], value: any) {
+export function setDeepValue<T = unknown>(obj: T, path: string | string[], value: any): void {
   if (typeof path === 'string') {
     path = path.split('.');
   }
@@ -262,7 +258,7 @@ export function setDeepValue<T = unknown>(obj: T, path: string | string[], value
     const e = path.shift() as keyof T;
     if (obj && e !== undefined) {
       setDeepValue(
-        (obj)[e] = (hasData(obj[e]) && (Array.isArray(obj[e]) || Object.prototype.toString.call((obj)[e]) === '[object Object]'))
+        (obj)[e] = (isDefined(obj[e]) && (Array.isArray(obj[e]) || Object.prototype.toString.call((obj)[e]) === '[object Object]'))
           ? (obj)[e]
           : {} as any,
         path,

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -276,10 +276,10 @@ export class SlickVanillaGridBundle<TData = any> {
    */
   constructor(
     gridParentContainerElm: HTMLElement,
-    columnDefs?: Column<TData>[],
-    options?: Partial<GridOption>,
-    dataset?: TData[],
-    hierarchicalDataset?: any[],
+    columnDefs?: Column<TData>[] | undefined,
+    options?: Partial<GridOption> | undefined,
+    dataset?: TData[] | undefined,
+    hierarchicalDataset?: any[] | undefined,
     services?: {
       backendUtilityService?: BackendUtilityService,
       collectionService?: CollectionService,
@@ -299,7 +299,7 @@ export class SlickVanillaGridBundle<TData = any> {
       treeDataService?: TreeDataService,
       translaterService?: TranslaterService,
       universalContainerService?: UniversalContainerService,
-    }
+    } | undefined
   ) {
     // make sure that the grid container doesn't already have the "slickgrid-container" css class
     // if it does then we won't create yet another grid, just stop there
@@ -397,14 +397,14 @@ export class SlickVanillaGridBundle<TData = any> {
     this.initialization(this._gridContainerElm, eventHandler, dataset);
   }
 
-  emptyGridContainerElm() {
+  emptyGridContainerElm(): void {
     const gridContainerId = this.gridOptions?.gridContainerId ?? 'grid1';
     const gridContainerElm = document.querySelector(`#${gridContainerId}`);
     emptyElement(gridContainerElm);
   }
 
   /** Dispose of the Component */
-  dispose(shouldEmptyDomElementContainer = false) {
+  dispose(shouldEmptyDomElementContainer = false): void {
     this._eventPubSubService?.publish('onBeforeGridDestroy', this.slickGrid);
     this._eventHandler?.unsubscribeAll();
     this._eventPubSubService?.publish('onAfterGridDestroyed', true);
@@ -467,7 +467,7 @@ export class SlickVanillaGridBundle<TData = any> {
     this._slickerGridInstances = null as any;
   }
 
-  disposeExternalResources() {
+  disposeExternalResources(): void {
     if (Array.isArray(this._registeredResources)) {
       while (this._registeredResources.length > 0) {
         const res = this._registeredResources.pop();
@@ -479,7 +479,7 @@ export class SlickVanillaGridBundle<TData = any> {
     this._registeredResources = [];
   }
 
-  initialization(gridContainerElm: HTMLElement, eventHandler: SlickEventHandler, inputDataset?: TData[]) {
+  initialization(gridContainerElm: HTMLElement, eventHandler: SlickEventHandler, inputDataset?: TData[]): void {
     // when detecting a frozen grid, we'll automatically enable the mousewheel scroll handler so that we can scroll from both left/right frozen containers
     if (this.gridOptions && ((this.gridOptions.frozenRow !== undefined && this.gridOptions.frozenRow >= 0) || this.gridOptions.frozenColumn !== undefined && this.gridOptions.frozenColumn >= 0) && this.gridOptions.enableMouseWheelScrollHandler === undefined) {
       this.gridOptions.enableMouseWheelScrollHandler = true;
@@ -693,7 +693,7 @@ export class SlickVanillaGridBundle<TData = any> {
     this._isGridInitialized = true;
   }
 
-  mergeGridOptions(gridOptions: GridOption) {
+  mergeGridOptions(gridOptions: GridOption): GridOption {
     const options = extend<GridOption>(true, {}, GlobalGridOptions, gridOptions);
 
     // also make sure to show the header row if user have enabled filtering
@@ -725,7 +725,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * For now, this is GraphQL Service ONLY feature and it will basically
    * refresh the Dataset & Pagination without having the user to create his own PostProcess every time
    */
-  createBackendApiInternalPostProcessCallback(gridOptions?: GridOption) {
+  createBackendApiInternalPostProcessCallback(gridOptions?: GridOption): void {
     const backendApi = gridOptions?.backendServiceApi;
     if (backendApi?.service) {
       const backendApiService = backendApi.service;
@@ -744,7 +744,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  bindDifferentHooks(grid: SlickGrid, gridOptions: GridOption, dataView: SlickDataView<TData>) {
+  bindDifferentHooks(grid: SlickGrid, gridOptions: GridOption, dataView: SlickDataView<TData>): void {
     // if user is providing a Translate Service, we need to add our PubSub Service (but only after creating all dependencies)
     // so that we can later subscribe to the "onLanguageChange" event and translate any texts whenever that get triggered
     if (gridOptions.enableTranslate && this.translaterService?.addPubSubMessaging) {
@@ -856,7 +856,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  bindBackendCallbackFunctions(gridOptions: GridOption) {
+  bindBackendCallbackFunctions(gridOptions: GridOption): void {
     const backendApi = gridOptions.backendServiceApi;
     const backendApiService = backendApi?.service;
     const serviceOptions: BackendServiceOption = backendApiService?.options ?? {};
@@ -923,7 +923,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  bindResizeHook(grid: SlickGrid, options: GridOption) {
+  bindResizeHook(grid: SlickGrid, options: GridOption): void {
     if ((options.autoFitColumnsOnFirstLoad && options.autosizeColumnsByCellContentOnFirstLoad) || (options.enableAutoSizeColumns && options.enableAutoResizeColumnsByCellContent)) {
       throw new Error(`[Slickgrid-Universal] You cannot enable both autosize/fit viewport & resize by content, you must choose which resize technique to use. You can enable these 2 options ("autoFitColumnsOnFirstLoad" and "enableAutoSizeColumns") OR these other 2 options ("autosizeColumnsByCellContentOnFirstLoad" and "enableAutoResizeColumnsByCellContent").`);
     }
@@ -942,7 +942,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  executeAfterDataviewCreated(gridOptions: GridOption) {
+  executeAfterDataviewCreated(gridOptions: GridOption): void {
     // if user entered some Sort "presets", we need to reflect them all in the DOM
     if (gridOptions.enableSorting) {
       if (gridOptions.presets && Array.isArray(gridOptions.presets.sorters)) {
@@ -957,7 +957,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * On a Pagination changed, we will trigger a Grid State changed with the new pagination info
    * Also if we use Row Selection or the Checkbox Selector with a Backend Service (Odata, GraphQL), we need to reset any selection
    */
-  paginationChanged(pagination: ServicePagination) {
+  paginationChanged(pagination: ServicePagination): void {
     const isSyncGridSelectionEnabled = this.gridStateService?.needToPreserveRowSelection() ?? false;
     if (this.slickGrid && !isSyncGridSelectionEnabled && this._gridOptions?.backendServiceApi && (this.gridOptions.enableRowSelection || this.gridOptions.enableCheckboxSelector)) {
       this.slickGrid.setSelectedRows([]);
@@ -978,7 +978,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * When dataset changes, we need to refresh the entire grid UI & possibly resize it as well
    * @param dataset
    */
-  refreshGridData(dataset: TData[], totalCount?: number) {
+  refreshGridData(dataset: TData[], totalCount?: number): void {
     // local grid, check if we need to show the Pagination
     // if so then also check if there's any presets and finally initialize the PaginationService
     // a local grid with Pagination presets will potentially have a different total of items, we'll need to get it from the DataView and update our total
@@ -1044,7 +1044,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * We will re-render the grid so that the new header and data shows up correctly.
    * If using translater, we also need to trigger a re-translate of the column headers
    */
-  updateColumnDefinitionsList(newColumnDefinitions: Column<TData>[]) {
+  updateColumnDefinitionsList(newColumnDefinitions: Column<TData>[]): void {
     if (this.slickGrid && this._gridOptions && Array.isArray(newColumnDefinitions)) {
       // map the Editor model to editorClass and load editor collectionAsync
       newColumnDefinitions = this.loadSlickGridEditors(newColumnDefinitions);
@@ -1072,7 +1072,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * Show the filter row displayed on first row, we can optionally pass false to hide it.
    * @param showing
    */
-  showHeaderRow(showing = true) {
+  showHeaderRow(showing = true): boolean {
     this.slickGrid?.setHeaderRowVisibility(showing);
     if (this.slickGrid && showing === true && this._isGridInitialized) {
       this.slickGrid.setColumns(this.columnDefinitions);
@@ -1080,7 +1080,7 @@ export class SlickVanillaGridBundle<TData = any> {
     return showing;
   }
 
-  setData(data: TData[], shouldAutosizeColumns = false) {
+  setData(data: TData[], shouldAutosizeColumns = false): void {
     if (shouldAutosizeColumns) {
       this._isAutosizeColsCalled = false;
       this._currentDatasetLength = 0;
@@ -1100,7 +1100,7 @@ export class SlickVanillaGridBundle<TData = any> {
     return paginationOptions;
   }
 
-  setDarkMode(dark = false) {
+  setDarkMode(dark = false): void {
     if (dark) {
       this._gridParentContainerElm.classList.add('slick-dark-mode');
     } else {
@@ -1116,18 +1116,18 @@ export class SlickVanillaGridBundle<TData = any> {
    * Loop through all column definitions and copy the original optional `width` properties optionally provided by the user.
    * We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
    */
-  protected copyColumnWidthsReference(columnDefinitions: Column<TData>[]) {
+  protected copyColumnWidthsReference(columnDefinitions: Column<TData>[]): void {
     columnDefinitions.forEach(col => col.originalWidth = col.width);
   }
 
-  protected displayEmptyDataWarning(showWarning = true) {
+  protected displayEmptyDataWarning(showWarning = true): void {
     if (this.gridOptions.enableEmptyDataWarningMessage) {
       this.slickEmptyWarning?.showEmptyDataMessage(showWarning);
     }
   }
 
   /** When data changes in the DataView, we'll refresh the metrics and/or display a warning if the dataset is empty */
-  protected handleOnItemCountChanged(currentPageRowItemCount: number, totalItemCount: number) {
+  protected handleOnItemCountChanged(currentPageRowItemCount: number, totalItemCount: number): void {
     this._currentDatasetLength = totalItemCount;
     this.metrics = {
       startTime: new Date(),
@@ -1147,7 +1147,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Initialize the Pagination Service once */
-  protected initializePaginationService(paginationOptions: Pagination) {
+  protected initializePaginationService(paginationOptions: Pagination): void {
     if (this.slickGrid && this.gridOptions) {
       this.paginationData = {
         gridOptions: this.gridOptions,
@@ -1178,7 +1178,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * @param {Boolean} showPagination - show (new render) or not (dispose) the Pagination
    * @param {Boolean} shouldDisposePaginationService - when disposing the Pagination, do we also want to dispose of the Pagination Service? (defaults to True)
    */
-  protected renderPagination(showPagination = true) {
+  protected renderPagination(showPagination = true): void {
     if (this._gridOptions?.enablePagination && !this._isPaginationInitialized && showPagination) {
       this.slickPagination = new SlickPaginationComponent(this.paginationService, this._eventPubSubService, this.sharedService, this.translaterService);
       this.slickPagination.renderPagination(this._gridParentContainerElm);
@@ -1192,7 +1192,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Load the Editor Collection asynchronously and replace the "collection" property when Promise resolves */
-  protected loadEditorCollectionAsync(column: Column<TData>) {
+  protected loadEditorCollectionAsync(column: Column<TData>): void {
     if (column?.editor) {
       const collectionAsync = column.editor.collectionAsync;
       column.editor.disabled = true; // disable the Editor DOM element, we'll re-enable it after receiving the collection with "updateEditorCollection()"
@@ -1226,7 +1226,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  protected insertDynamicPresetColumns(columnId: string, gridPresetColumns: Column<TData>[]) {
+  protected insertDynamicPresetColumns(columnId: string, gridPresetColumns: Column<TData>[]): void {
     if (this._columnDefinitions) {
       const columnPosition = this._columnDefinitions.findIndex(c => c.id === columnId);
       if (columnPosition >= 0) {
@@ -1241,7 +1241,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Load any possible Columns Grid Presets */
-  protected loadColumnPresetsWhenDatasetInitialized() {
+  protected loadColumnPresetsWhenDatasetInitialized(): void {
     // if user entered some Columns "presets", we need to reflect them all in the grid
     if (this.slickGrid && this.gridOptions.presets && Array.isArray(this.gridOptions.presets.columns) && this.gridOptions.presets.columns.length > 0) {
       const gridPresetColumns: Column<TData>[] = this.gridStateService.getAssociatedGridColumns(this.slickGrid, this.gridOptions.presets.columns);
@@ -1272,7 +1272,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Load any possible Filters Grid Presets */
-  protected loadFilterPresetsWhenDatasetInitialized() {
+  protected loadFilterPresetsWhenDatasetInitialized(): void {
     if (this.gridOptions && !this.customDataView) {
       // if user entered some Filter "presets", we need to reflect them all in the DOM
       // also note that a presets of Tree Data Toggling will also call this method because Tree Data toggling does work with data filtering
@@ -1288,7 +1288,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * if so then also check if there's any presets and finally initialize the PaginationService
    * a local grid with Pagination presets will potentially have a different total of items, we'll need to get it from the DataView and update our total
    */
-  protected loadLocalGridPagination(dataset?: TData[]) {
+  protected loadLocalGridPagination(dataset?: TData[]): void {
     if (this.gridOptions && this._paginationOptions) {
       this.totalItems = Array.isArray(dataset) ? dataset.length : 0;
       if (this._paginationOptions && this.dataView?.getPagingInfo) {
@@ -1304,7 +1304,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Load any Row Selections into the DataView that were presets by the user */
-  protected loadRowSelectionPresetWhenExists() {
+  protected loadRowSelectionPresetWhenExists(): void {
     // if user entered some Row Selections "presets"
     const presets = this.gridOptions?.presets;
     const selectionModel = this.slickGrid?.getSelectionModel();
@@ -1333,7 +1333,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Add a register a new external resource, user could also optional dispose all previous resources before pushing any new resources to the resources array list. */
-  registerExternalResources(resources: ExternalResource[], disposePreviousResources = false) {
+  registerExternalResources(resources: ExternalResource[], disposePreviousResources = false): void {
     if (disposePreviousResources) {
       this.disposeExternalResources();
     }
@@ -1341,12 +1341,12 @@ export class SlickVanillaGridBundle<TData = any> {
     this.initializeExternalResources(resources);
   }
 
-  resetExternalResources() {
+  resetExternalResources(): void {
     this._registeredResources = [];
   }
 
   /** Pre-Register any Resource that don't require SlickGrid to be instantiated (for example RxJS Resource) */
-  protected preRegisterResources() {
+  protected preRegisterResources(): void {
     // bind & initialize all Components/Services that were tagged as enabled
     // register all services by executing their init method and providing them with the Grid object
     if (Array.isArray(this._registeredResources)) {
@@ -1358,7 +1358,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  protected initializeExternalResources(resources: ExternalResource[]) {
+  protected initializeExternalResources(resources: ExternalResource[]): void {
     if (Array.isArray(resources)) {
       for (const resource of resources) {
         if (this.slickGrid && typeof resource.init === 'function') {
@@ -1368,7 +1368,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
   }
 
-  protected registerResources() {
+  protected registerResources(): void {
     // at this point, we consider all the registered services as external services, anything else registered afterward aren't external
     if (Array.isArray(this._registeredResources)) {
       this.sharedService.externalRegisteredResources = this._registeredResources;
@@ -1402,7 +1402,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   /** Register the RxJS Resource in all necessary services which uses */
-  protected registerRxJsResource(resource: RxJsFacade) {
+  protected registerRxJsResource(resource: RxJsFacade): void {
     this.rxjs = resource;
     this.backendUtilityService.addRxJsResource(this.rxjs);
     this.filterFactory.addRxJsResource(this.rxjs);
@@ -1469,7 +1469,7 @@ export class SlickVanillaGridBundle<TData = any> {
    * When the Editor(s) has a "editor.collection" property, we'll load the async collection.
    * Since this is called after the async call resolves, the pointer will not be the same as the "column" argument passed.
    */
-  protected updateEditorCollection<U extends TData = any>(column: Column<U>, newCollection: U[]) {
+  protected updateEditorCollection<U extends TData = any>(column: Column<U>, newCollection: U[]): void {
     if (this.slickGrid && column.editor) {
       column.editor.collection = newCollection;
       column.editor.disabled = false;

--- a/packages/vanilla-bundle/src/services/universalContainer.service.ts
+++ b/packages/vanilla-bundle/src/services/universalContainer.service.ts
@@ -11,11 +11,11 @@ export class UniversalContainerService implements ContainerService {
     return null;
   }
 
-  dispose() {
+  dispose(): void {
     this.dependencies = [];
   }
 
-  registerInstance(key: string, instance: any) {
+  registerInstance(key: string, instance: any): void {
     const dependency = this.dependencies.some(dep => dep.key === key);
     if (!dependency) {
       this.dependencies.push({ key, instance });

--- a/packages/vanilla-force-bundle/src/vanilla-force-bundle.ts
+++ b/packages/vanilla-force-bundle/src/vanilla-force-bundle.ts
@@ -73,7 +73,7 @@ export class VanillaForceGridBundle extends SlickVanillaGridBundle {
     super(gridParentContainerElm, columnDefs, options, dataset, hierarchicalDataset, services);
   }
 
-  mergeGridOptions(gridOptions: GridOption) {
+  mergeGridOptions(gridOptions: GridOption): GridOption {
     const extraOptions = (gridOptions.useSalesforceDefaultGridOptions || (this._gridOptions?.useSalesforceDefaultGridOptions)) ? SalesforceGlobalGridOptions : {};
     const options = extend(true, {}, GlobalGridOptions, extraOptions, gridOptions);
 
@@ -107,7 +107,7 @@ export class VanillaForceGridBundle extends SlickVanillaGridBundle {
   // protected functions
   // ------------------
 
-  protected registerResources() {
+  protected registerResources(): void {
     // when using Salesforce, we want the Export to CSV always enabled without registering it
     if (this.gridOptions.enableTextExport) {
       this._registeredResources.push(new TextExportService());

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,7 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "isolatedDeclarations": true,
     "noImplicitReturns": true,
     "rootDir": ".",
     "sourceMap": true,


### PR DESCRIPTION
- it would be good to eventually support the new TS 5.5 `--isolatedDeclarations` flag, which requires explicit return type, to speed up monorepo builds, see TypeScript 5.5 RC release [blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-rc/) for more info
- the `isolatedDeclarations` flag can be added into `tsconfig.base.json` but I have disabled it for now because it throws a thousand of errors, I've only slowly started to fix some of these errors
- remove `hasData()` util method since it's the same as `isDefined()` declared in the same util file