### PR TITLE
fix(filters): filters with `!= ` (not equal empty) should return non-blanks

### DIFF
--- a/docs/column-functionalities/filters/input-filter.md
+++ b/docs/column-functionalities/filters/input-filter.md
@@ -28,11 +28,14 @@ Examples:
   - `<02/28/17` => lower than date `02/28/17`
   - `2001-01-01..2002-02-22` => range between 2001-01-01 and 2002-02-22
 - String type
-  - `<>John` (anything except the sub-string `John`)
+  - `<>John` => not containing the sub-string `John`
+  - `!=John` => not equal to the text `John` (note that this is **not** equivalent to `<>`)
   - `John*` => starts with the sub-string `John`
   - `*Doe` => ends with the sub-string `Doe`
   - `ab..ef` => anything included between "af" and "ef"
-    - refer to ASCII table for each character assigned number
+    - refer to the ASCII table for each character assigned index
+  - `!= ` => get defined only data and exclude any `undefined`, `null` or empty string `''`
+     - notice the empty string in the search value `' '`
 
 Note that you could also do the same kind of functionality by using the Compound Filter.
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -406,7 +406,9 @@ export default class Example11 {
         cost: (i % 33 === 0) ? null : Math.round(Math.random() * 10000) / 100,
         completed: (randomFinish < new Date()),
         product: { id: this.mockProducts()[randomItemId]?.id, itemName: this.mockProducts()[randomItemId]?.itemName, },
-        countryOfOrigin: (i % 2) ? { code: 'CA', name: 'Canada' } : { code: 'US', name: 'United States' },
+        countryOfOrigin: i % 33
+          ? (i % 2) ? { code: 'CA', name: 'Canada' } : { code: 'US', name: 'United States' }
+          : null
       };
 
       if (!(i % 8)) {

--- a/packages/common/src/filter-conditions/__tests__/stringFilterCondition.spec.ts
+++ b/packages/common/src/filter-conditions/__tests__/stringFilterCondition.spec.ts
@@ -95,18 +95,33 @@ describe('executeStringFilterCondition method', () => {
     expect(output).toBe(true);
   });
 
-  it('should return False when search term is a substring of the cell value and the operator is "<>" (not contains)', () => {
+  it('should return False when search term is a substring of the cell value and the operator is "<>" (not contains substring)', () => {
     const searchTerms = ['bost'];
     const options = { dataKey: '', operator: '<>', cellValue: 'abbostford', fieldType: FieldType.string, searchTerms } as FilterConditionOption;
     const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
     expect(output).toBe(false);
   });
 
-  it('should return True when search term is a substring of the cell value and the operator is "!=" (not contains) because "!=" compares agains the entire string', () => {
+  it('should return True when search term is a substring of the cell value and the operator is "!=" (not equal text) because "!=" compares agains the entire string', () => {
     const searchTerms = ['bost'];
     const options = { dataKey: '', operator: '!=', cellValue: 'abbostford', fieldType: FieldType.string, searchTerms } as FilterConditionOption;
     const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
     expect(output).toBe(true);
+  });
+
+  it('should exclude anything undefined when search term is empty string value and the operator is "!=" (not equal text) because "!=" compares agains the entire string', () => {
+    const searchTerms = [''];
+    const options1 = { dataKey: '', operator: '!=', cellValue: null, fieldType: FieldType.string, searchTerms } as FilterConditionOption;
+    const options2 = { dataKey: '', operator: '!=', cellValue: '', fieldType: FieldType.string, searchTerms } as FilterConditionOption;
+    const options3 = { dataKey: '', operator: '!=', cellValue: 'hello world', fieldType: FieldType.string, searchTerms } as FilterConditionOption;
+
+    const output1 = executeStringFilterCondition(options1, getFilterParsedText(searchTerms));
+    const output2 = executeStringFilterCondition(options2, getFilterParsedText(searchTerms));
+    const output3 = executeStringFilterCondition(options3, getFilterParsedText(searchTerms));
+
+    expect(output1).toBe(false);
+    expect(output2).toBe(false);
+    expect(output3).toBe(true);
   });
 
   it('should return True when input value provided starts with same substring and the operator is empty string', () => {
@@ -171,17 +186,17 @@ describe('executeStringFilterCondition method', () => {
     const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
     expect(output).toBe(false);
   });
-  
+
   it('should return True when input value contains accent is searchTerms value does not contain accent when "ignoreAccentOnStringFilterAndSort" is set in grid options', () => {
     const searchTerms = ['jose'];
-    const options = { dataKey: '', operator: 'EQ', cellValue: 'José', fieldType: FieldType.string, ignoreAccentOnStringFilterAndSort: true} as FilterConditionOption;
+    const options = { dataKey: '', operator: 'EQ', cellValue: 'José', fieldType: FieldType.string, ignoreAccentOnStringFilterAndSort: true } as FilterConditionOption;
     const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
     expect(output).toBe(true);
   });
 
   it('should return False when input value contains accent is searchTerms value does not contain accent when "ignoreAccentOnStringFilterAndSort" is not set in grid options', () => {
     const searchTerms = ['jose'];
-    const options = { dataKey: '', operator: 'EQ', cellValue: 'José', fieldType: FieldType.string, ignoreAccentOnStringFilterAndSort: false} as FilterConditionOption;
+    const options = { dataKey: '', operator: 'EQ', cellValue: 'José', fieldType: FieldType.string, ignoreAccentOnStringFilterAndSort: false } as FilterConditionOption;
     const output = executeStringFilterCondition(options, getFilterParsedText(searchTerms));
     expect(output).toBe(false);
   });

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -1006,6 +1006,21 @@ describe('FilterService', () => {
       expect(output).toBe(true);
     });
 
+    it('should return False, since firstname is filled, when input value from datacontext contains an operator "<>" and its value is an empty string', () => {
+      const searchTerms = ['<> '];
+      const mockColumn1 = { id: 'firstName', field: 'firstName', filterable: true } as Column;
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+
+      service.init(gridStub);
+      const columnFilter = { columnDef: mockColumn1, columnId: 'firstName', type: FieldType.string };
+      const filterCondition = service.parseFormInputFilterConditions(searchTerms, columnFilter);
+      const parsedSearchTerms = getParsedSearchTermsByFieldType(filterCondition.searchTerms, 'text');
+      const columnFilters = { firstname: { ...columnFilter, operator: filterCondition.operator, searchTerms: filterCondition.searchTerms, parsedSearchTerms } } as ColumnFilters;
+      const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+      expect(output).toBe(false);
+    });
+
     it('should return False when input value from datacontext contains an operator >= and its value is greater than 10 substring but "autoParseInputFilterOperator" is set to false', () => {
       const searchTerms = ['>=10'];
       const mockColumn1 = { id: 'age', field: 'age', filterable: true, autoParseInputFilterOperator: false } as Column;

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -453,7 +453,11 @@ export class FilterService {
     // if search value has a regex match we will only keep the value without the operator
     // in this case we need to overwrite the returned search values to truncate operator from the string search
     if (Array.isArray(matches) && matches.length >= 1 && (Array.isArray(searchValues) && searchValues.length === 1)) {
-      searchValues[0] = searchTerm;
+      // string starts with a whitespace we'll trim only the first whitespace char
+      // e.g. " " becomes "" and " slick grid " becomes "slick grid " (notice last whitespace is kept)
+      searchValues[0] = (searchTerm.length > 0 && searchTerm.substring(0, 1) === ' ')
+        ? searchTerm.substring(1)
+        : searchTerm;
     }
 
     return {

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -20,831 +20,930 @@ describe('Example 11 - Batch Editing', () => {
     cy.get('h3').should('contain', 'Example 11 - Batch Editing');
   });
 
-  it('should click on "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
-    cy.get('[data-test="clear-storage-btn"]')
-      .click();
+  describe('built-in operators', () => {
+    it('should click on "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
+      cy.get('[data-test="clear-storage-btn"]')
+        .click();
 
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-  });
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
 
-  it('should have exact Column Titles in the grid', () => {
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-  });
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(1000);
+        });
+    });
 
-  it('should have "TASK 0" (uppercase) incremented by 1 after each row', () => {
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`)
-      .contains('TASK 0', { matchCase: false })
-      .should('have.css', 'text-transform', 'uppercase');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 3', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('TASK 4', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).contains('TASK 5', { matchCase: false });
-  });
+    it('should return no rows when product filter is set to "<> " (not contain empty string)', () => {
+      cy.get('.filter-countryOfOrigin.search-filter')
+        .clear()
+        .type('<> ');
 
-  it('should be able to change "Duration" values of first 4 rows', () => {
-    // change duration
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`).should('contain', 'days').click();
-    cy.get('.editor-duration').type('0').type('{enter}', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
-      .should('contain', '0 day')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(0);
+        });
+    });
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).click().type('1{enter}');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).should('contain', '1 day')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+    it('should return rows without a product defined when using "!= " (not equal empty string)', () => {
+      cy.get('.filter-countryOfOrigin.search-filter')
+        .clear()
+        .type('!= ');
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).click().type('2{enter}');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).should('contain', '2 days')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.lt(1000);
+        });
+    });
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(2)`).click().type('3{enter}');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(2)`).should('contain', '3 days')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+    it('should return 515 rows when product filter is set to "<> nada" (not containing "nada" substring)', () => {
+      cy.get('.filter-countryOfOrigin.search-filter')
+        .clear()
+        .type('<> nada');
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(2)`).click().type('{esc}');
-    cy.get('.editor-duration').should('not.exist');
-  });
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(515);
+        });
+    });
 
-  it('should be able to change "Title" values of row indexes 1-3', () => {
-    // change title
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1', { matchCase: false }).click();
-    cy.get('.editor-title').type('task 1111').type('{enter}');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1111', { matchCase: false })
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+    it('should return no rows when product filter is set to "!= nada" (not equal to "nada" text)', () => {
+      cy.get('.filter-countryOfOrigin.search-filter')
+        .clear()
+        .type('!= nada');
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).click()
-      .type('task 2222{enter}');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 2222', { matchCase: false })
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(1000);
+        });
+    });
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).click()
-      .type('task 3333').type('{enter}');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 3333', { matchCase: false })
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+    it('should return 485 rows when Country filter is set to "Ca*" (starts with)', () => {
+      cy.get('.filter-countryOfOrigin.search-filter')
+        .clear()
+        .type('Ca*');
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).click()
-      .type('{esc}');
-    cy.get('.editor-title').should('not.exist');
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(485);
+        });
+    });
 
-    cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left')
-      .scrollTo('top');
-  });
+    it('should return 485 rows when Country filter is set to "*states" (starts with)', () => {
+      cy.get('.filter-countryOfOrigin.search-filter')
+        .clear()
+        .type('*states');
 
-  it('should be able to change "% Complete" values of row indexes 2-4', () => {
-    // change % complete
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).click();
-    cy.get('.slider-editor input[type=range]').as('range').invoke('val', 5).trigger('change', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should('contain', '5')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(4)`).click();
-    cy.get('.slider-editor input[type=range]').as('range').invoke('val', 6).trigger('change', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(4)`).should('contain', '6')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(4)`).click();
-    cy.get('.slider-editor input[type=range]').as('range').invoke('val', 7).trigger('change', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(4)`).should('contain', '7')
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
-
-    cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left')
-      .scrollTo('top');
-  });
-
-  it('should be able to change "Finish" values of row indexes 0-2', () => {
-    const now = new Date();
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const today = changeTimezone(now, tz);
-
-    const currentDate = today.getDate();
-    let currentMonth: number | string = today.getMonth() + 1; // month is zero based, let's add 1 to it
-    if (currentMonth < 10) {
-      currentMonth = `0${currentMonth}`; // add zero padding
-    }
-
-    // change Finish date to today's date
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('contain', '').click(); // this date should also always be initially empty
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
-      .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
-
-    cy.get('.unsaved-editable-field')
-      .should('have.length', 13);
-
-    cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left')
-      .scrollTo('top');
-  });
-
-  it('should undo last edit and expect the date editor to be opened as well when clicking the associated last undo with editor button', () => {
-    cy.get('[data-test=undo-open-editor-btn]').click();
-
-    cy.get('.vanilla-calendar')
-      .should('exist');
-
-    cy.get('.unsaved-editable-field')
-      .should('have.length', 12);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', '')
-      .should('have.css', 'background-color').and('eq', EDITABLE_CELL_RGB_COLOR);
-  });
-
-  it('should undo last edit and expect the date editor to NOT be opened when clicking undo last edit button', () => {
-    cy.get('[data-test=undo-last-edit-btn]').click();
-
-    cy.get('.vanilla-calendar')
-      .should('not.be.visible');
-
-    cy.get('.unsaved-editable-field')
-      .should('have.length', 11);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', '')
-      .should('have.css', 'background-color').and('eq', EDITABLE_CELL_RGB_COLOR);
-  });
-
-  it('should click on the "Save" button and expect 2 console log calls with the queued items & also expect no more unsaved cells', () => {
-    cy.get('[data-test=save-all-btn]').click();
-
-    cy.get('.unsaved-editable-field')
-      .should('have.length', 0);
-
-    cy.window().then((win) => {
-      expect(win.console.log).to.have.callCount(2);
-      // expect(win.console.log).to.be.calledWith(Array[11]);
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(484);
+        });
     });
   });
 
-  it('should be able to toggle the grid to readonly', () => {
-    cy.get('[data-test=toggle-readonly-btn]').click();
+  describe('Local Storage', () => {
+    it('should click on "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
+      cy.get('[data-test="clear-storage-btn"]')
+        .click();
 
-    cy.get('.editable-field')
-      .should('have.length', 0);
-  });
-
-  it('should be able to toggle back the grid to editable', () => {
-    cy.get('[data-test=toggle-readonly-btn]').click();
-
-    cy.get('.editable-field')
-      .should('not.have.length', 0);
-  });
-
-  it('should not have filters set', () => {
-    cy.get('.selected-view').should('contain', '');
-
-    cy.get('input.slider-filter-input')
-      .invoke('val')
-      .then(text => expect(text).to.eq('0'));
-
-    cy.get('.search-filter.filter-finish .date-picker input')
-      .invoke('val')
-      .then(text => expect(text).to.eq(''));
-
-    cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
-  });
-
-  it('should change pre-defined view to "Tasks Finished in Previous Years" and expect data to be filtered/sorted accordingly with "Cost" column shown as well', () => {
-    const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Action'];
-    cy.get('.selected-view').select('previousYears');
-    cy.get('.selected-view').should('have.value', 'previousYears');
-
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
-
-    cy.get('input.slider-filter-input')
-      .invoke('val')
-      .then(text => expect(text).to.eq('50'));
-
-    cy.get('.search-filter.filter-finish .operator .form-control')
-      .should('have.value', '<=');
-
-    cy.get('.search-filter.filter-finish .date-picker input')
-      .invoke('val')
-      .then(text => expect(text).to.eq(`${currentYear}-01-01`));
-
-    cy.get('.slick-column-name')
-      .contains('Finish')
-      .find('~ .slick-sort-indicator.slick-sort-indicator-desc')
-      .should('have.length', 1);
-
-    cy.get('.search-filter.filter-completed .ms-choice').should('contain', 'True');
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
-  });
-
-  it('should have 3 filters with "filled" css class when having values', () => {
-    cy.get('.filter-percentComplete.filled').should('exist');
-    cy.get('.filter-finish.filled').should('exist');
-    cy.get('.filter-completed.filled').should('exist');
-  });
-
-  it('should show Column Picker and expect 2 columns to be hidden', () => {
-    cy.get('.grid11')
-      .find('.slick-header-column')
-      .first()
-      .trigger('mouseover')
-      .trigger('contextmenu')
-      .invoke('show');
-
-    cy.get('.slick-column-picker-list')
-      .find('input[type="checkbox"]:checked')
-      .should('have.length', 11 - 2);
-
-    cy.get('.slick-column-picker > button.close')
-      .click();
-  });
-
-  it('should create a new View based on "Tasks Finished in Previous Years" that was already selected', () => {
-    const filterName = 'Custom View Test';
-    const winPromptStub = () => filterName;
-
-    cy.window().then(win => {
-      (cy.stub(win, 'prompt').callsFake(winPromptStub) as any).as('winPromptStubReturnNonNull');
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
     });
 
-    cy.get('input.search-filter.filter-title')
-      .type('*0');
-
-    cy.get('.action.dropdown')
-      .click();
-
-    cy.get('.action.dropdown .dropdown-item')
-      .contains('Create New View')
-      .click();
-
-    cy.get('@winPromptStubReturnNonNull').should('be.calledOnce')
-      .and('be.calledWith', 'Please provide a name for the new View.');
-
-    cy.should(() => {
-      const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
-      expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
+    it('should have exact Column Titles in the grid', () => {
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
     });
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).should('contain', '0');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).should('contain', '0');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).should('contain', '0');
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).click();
-    cy.get('[data-name="editor-completed"]')
-      .find('li.selected')
-      .find('input[data-name=selectItemeditor-completed][value=true]')
-      .should('exist');
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).click();
-
-    cy.get('.selected-view').should('have.value', 'CustomViewTest');
-  });
-
-  it('should change pre-defined view to "Tasks Finishing in Future Years" and expect data to be filtered accordingly', () => {
-    const expectedTitles = ['', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Completed', 'Product', 'Country of Origin', 'Action'];
-
-    cy.get('.selected-view').select('greaterCurrentYear');
-    cy.get('.selected-view').should('have.value', 'greaterCurrentYear');
-
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
-
-    cy.get('input.slider-filter-input')
-      .invoke('val')
-      .then(text => expect(text).to.eq('0'));
-
-    cy.get('.search-filter.filter-finish .operator .form-control')
-      .should('have.value', '>=');
-
-    cy.get('.search-filter.filter-finish .date-picker input')
-      .invoke('val')
-      .then(text => expect(text).to.eq(`${currentYear + 1}-01-01`));
-
-    cy.get('.slick-column-name')
-      .contains('Finish')
-      .find('~ .slick-sort-indicator.slick-sort-indicator-asc')
-      .should('have.length', 1);
-
-    cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('not.equal', '');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('not.contain', currentYear);
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('not.equal', '');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('not.contain', currentYear);
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('not.equal', '');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('not.contain', currentYear);
-  });
-
-  it('should NOT be able to Delete/Update a System Defined View', () => {
-    cy.get('.action.dropdown')
-      .click();
-
-    cy.get('.action.dropdown .dropdown-item:nth(1)')
-      .then($elm => {
-        expect($elm.text()).to.contain('Update Current View');
-        expect($elm.hasClass('dropdown-item-disabled')).to.be.true;
-      });
-
-    cy.get('.action.dropdown .dropdown-item:nth(2)')
-      .then($elm => {
-        expect($elm.text()).to.contain('Delete Current View');
-        expect($elm.hasClass('dropdown-item-disabled')).to.be.true;
-      });
-
-    cy.get('.selected-view').should('have.value', 'greaterCurrentYear');
-  });
-
-  it('should reload the page and expect the Custom View to be reloaded from Local Storage and expect filtered data as well', () => {
-    cy.get('.selected-view').select('CustomViewTest');
-
-    cy.reload();
-    cy.wait(50);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).should('contain', '0');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).should('contain', '0');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).should('contain', '0');
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
-
-    cy.should(() => {
-      const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
-      expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
+    it('should have "TASK 0" (uppercase) incremented by 1 after each row', () => {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`)
+        .contains('TASK 0', { matchCase: false })
+        .should('have.css', 'text-transform', 'uppercase');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 3', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('TASK 4', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).contains('TASK 5', { matchCase: false });
     });
 
-    cy.get('.selected-view').should('have.value', 'CustomViewTest');
-    cy.get('.filter-title.filled').should('exist');
-  });
+    it('should be able to change "Duration" values of first 4 rows', () => {
+      // change duration
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`).should('contain', 'days').click();
+      cy.get('.editor-duration').type('0').type('{enter}', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(2)`)
+        .should('contain', '0 day')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-  it('should be able to Update the Custom View that we created earlier with a new name', () => {
-    const filterName = 'Custom Updated View Test';
-    const winPromptStub = () => filterName;
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).click().type('1{enter}');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(2)`).should('contain', '1 day')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.window().then(win => {
-      (cy.stub(win, 'prompt').callsFake(winPromptStub) as any).as('winPromptStubReturnNonNull');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).click().type('2{enter}');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(2)`).should('contain', '2 days')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(2)`).click().type('3{enter}');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(2)`).should('contain', '3 days')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(2)`).click().type('{esc}');
+      cy.get('.editor-duration').should('not.exist');
     });
 
-    cy.get('.selected-view').select('CustomViewTest');
+    it('should be able to change "Title" values of row indexes 1-3', () => {
+      // change title
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1', { matchCase: false }).click();
+      cy.get('.editor-title').type('task 1111').type('{enter}');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1111', { matchCase: false })
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.action.dropdown')
-      .click();
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).click()
+        .type('task 2222{enter}');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 2222', { matchCase: false })
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.action.dropdown .dropdown-item')
-      .contains('Update Current View')
-      .click();
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).click()
+        .type('task 3333').type('{enter}');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 3333', { matchCase: false })
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.action.dropdown .dropdown-item:nth(1)')
-      .then($elm => {
-        expect($elm.text()).to.contain('Update Current View');
-        expect($elm.hasClass('dropdown-item-disabled')).to.be.false;
-      });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).click()
+        .type('{esc}');
+      cy.get('.editor-title').should('not.exist');
 
-    cy.get('.action.dropdown')
-      .click();
-
-    cy.get('@winPromptStubReturnNonNull').should('be.calledOnce')
-      .and('be.calledWith', 'Update View name or click on OK to continue.', 'Custom View Test');
-
-    cy.should(() => {
-      const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
-      expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
+      cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left')
+        .scrollTo('top');
     });
 
-    // select should have new name
-    cy.get('.selected-view').should('have.value', 'CustomUpdatedViewTest');
-  });
+    it('should be able to change "% Complete" values of row indexes 2-4', () => {
+      // change % complete
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).click();
+      cy.get('.slider-editor input[type=range]').as('range').invoke('val', 5).trigger('change', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should('contain', '5')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-  it('should be able to Delete the Custom Filter that we created earlier', () => {
-    cy.get('.selected-view').select('CustomUpdatedViewTest');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(4)`).click();
+      cy.get('.slider-editor input[type=range]').as('range').invoke('val', 6).trigger('change', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(4)`).should('contain', '6')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.action.dropdown')
-      .click();
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(4)`).click();
+      cy.get('.slider-editor input[type=range]').as('range').invoke('val', 7).trigger('change', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(4)`).should('contain', '7')
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.action.dropdown .dropdown-item:nth(2)')
-      .then($elm => {
-        expect($elm.text()).to.contain('Delete Current View');
-        expect($elm.hasClass('dropdown-item-disabled')).to.be.false;
-      });
-
-    cy.get('.action.dropdown .dropdown-item')
-      .contains('Delete Current View')
-      .click();
-  });
-
-  it('should expect all Filters & Sorting to be cleared and also expect all columns be back to original', () => {
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-
-    cy.get('.selected-view').should('not.have.value', 'CustomUpdatedViewTest');
-
-    cy.get('.slick-sort-indicator.slick-sort-indicator-desc')
-      .should('have.length', 0);
-
-    cy.get('input.slider-filter-input')
-      .invoke('val')
-      .then(text => expect(text).to.eq('0'));
-
-    cy.get('.search-filter.filter-finish .date-picker input')
-      .invoke('val')
-      .then(text => expect(text).to.eq(''));
-
-    cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
-
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-  });
-
-  it('should change pre-defined view to "Tasks Finished in Previous Years" and expect 2 columns less than original list', () => {
-    const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Action'];
-    cy.get('.selected-view').select('previousYears');
-    cy.get('.selected-view').should('have.value', 'previousYears');
-
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
-  });
-
-  it('should "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
-    cy.get('[data-test="clear-storage-btn"]')
-      .click();
-
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-  });
-
-  it('should also expect all Filters & Sorting to be cleared', () => {
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
-
-    cy.get('.selected-view').should('not.have.value', 'CustomUpdatedViewTest');
-
-    cy.get('.slick-sort-indicator.slick-sort-indicator-desc')
-      .should('have.length', 0);
-
-    cy.get('input.slider-filter-input')
-      .invoke('val')
-      .then(text => expect(text).to.eq('0'));
-
-    cy.get('.search-filter.filter-finish .date-picker input')
-      .invoke('val')
-      .then(text => expect(text).to.eq(''));
-
-    cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
-    cy.get('.filled').should('have.length', 0);
-  });
-
-  it('should have all columns shown (checkbox is checked) in the Column Picker', () => {
-    cy.get('.grid11')
-      .find('.slick-header-column')
-      .first()
-      .trigger('mouseover')
-      .trigger('contextmenu')
-      .invoke('show');
-
-    cy.get('.slick-column-picker-list')
-      .find('input[type="checkbox"]:checked')
-      .should('have.length', 11);
-
-    cy.get('.slick-column-picker > button.close')
-      .click();
-  });
-
-  it('should be able to click on the delete button from the "Action" column of the 2nd row and expect "Task 1" to be delete', () => {
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 0', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 3', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('TASK 4', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).contains('TASK 5', { matchCase: false });
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(10)`)
-      .find('.mdi-close')
-      .click();
-
-    cy.on('window:confirm', () => true);
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 0', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 3', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 4', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('TASK 5', { matchCase: false });
-  });
-
-  it('should be able to click on the checked 2nd button from the "Action" column of the 2nd row and expect "Task 2" to be completed', () => {
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 0', { matchCase: false });
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(10)`)
-      .find('.mdi-check-underline')
-      .click();
-
-    cy.on('window:alert', (str) => {
-      expect(str).to.equal('The "Task 2" is now Completed');
+      cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left')
+        .scrollTo('top');
     });
 
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
-  });
+    it('should be able to change "Finish" values of row indexes 0-2', () => {
+      const now = new Date();
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const today = changeTimezone(now, tz);
 
-  it('should be able to filter "Country of Origin" with a text range filter "b..e" and expect to see only Canada showing up', () => {
-    cy.get('.slick-header-columns .slick-header-column:nth(9)').trigger('mouseover'); // mouseover column headers to get rid of cell tooltip
-    cy.get('input.search-filter.filter-countryOfOrigin').type('b..e');
-    cy.get('input.search-filter.filter-countryOfOrigin.filled').should('exist');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-  });
+      const currentDate = today.getDate();
+      let currentMonth: number | string = today.getMonth() + 1; // month is zero based, let's add 1 to it
+      if (currentMonth < 10) {
+        currentMonth = `0${currentMonth}`; // add zero padding
+      }
 
-  it('should be able to filter "Duration" with greater than symbol ">8"', () => {
-    cy.get('input.search-filter.filter-duration').type('>8');
+      // change Finish date to today's date
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('contain', '').click(); // this date should also always be initially empty
+      cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.grid11')
-      .find('.slick-cell:nth(2)')
-      .each(($cell, index) => {
-        if (index < 10) {
-          const [number] = $cell.text().split(' ');
-          expect(+number).to.be.greaterThan(8);
-        }
-      });
-  });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).click();
+      cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-  it('should be able to filter "Title" with Task finishing by 5', () => {
-    cy.get('input.search-filter.filter-title').type('*5');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).click();
+      cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
+        .should('have.css', 'background-color').and('eq', UNSAVED_RGB_COLOR);
 
-    cy.get('.grid11')
-      .find('.slick-cell:nth(1)')
-      .each(($cell, index) => {
-        if (index < 10) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const [_taskString, taskNumber] = $cell.text().split(' ');
-          expect(taskNumber).to.be.eq('5');
-        }
-      });
-  });
+      cy.get('.unsaved-editable-field')
+        .should('have.length', 13);
 
-  it('should be able to freeze "Duration" column', () => {
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .find('.slick-header-column:nth(2)')
-      .trigger('mouseover')
-      .children('.slick-header-menu-button')
-      .invoke('show')
-      .click();
-
-    cy.get('.slick-header-menu .slick-menu-command-list')
-      .should('be.visible')
-      .children('.slick-menu-item:nth-of-type(1)')
-      .children('.slick-menu-content')
-      .should('contain', 'Freeze Column')
-      .click();
-  });
-
-  it('should have a frozen grid with 4 containers on page load with 3 columns on the left and 8 columns on the right', () => {
-    cy.get('[style="top: 0px;"]').should('have.length', 2);
-    cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 3);
-    cy.get('.grid-canvas-right > [style="top: 0px;"]').children().should('have.length', 8);
-
-    cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(0)').should('contain', '');
-    cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(1)').contains(/^TASK [0-9]*$/i);
-    cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(2)').contains(/^[0-9]*\sday[s]?$/);
-
-    cy.get('.grid-canvas-right > [style="top: 0px;"] > .slick-cell:nth(0)').contains(/\$[0-9.]*/);
-
-    cy.get('.slick-pane-left')
-      .find('.slick-grid-menu-button')
-      .should('not.exist');
-
-    cy.get('.slick-pane-right')
-      .find('.slick-grid-menu-button')
-      .should('exist');
-  });
-
-  it('should create a new View with current pinning & filters', () => {
-    const filterName = 'Custom View Test';
-    const winPromptStub = () => filterName;
-
-    cy.window().then(win => {
-      (cy.stub(win, 'prompt').callsFake(winPromptStub) as any).as('winPromptStubReturnNonNull');
+      cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left')
+        .scrollTo('top');
     });
 
-    cy.get('.action.dropdown')
-      .click();
+    it('should undo last edit and expect the date editor to be opened as well when clicking the associated last undo with editor button', () => {
+      cy.get('[data-test=undo-open-editor-btn]').click();
 
-    cy.get('.action.dropdown .dropdown-item')
-      .contains('Create New View')
-      .click();
+      cy.get('.vanilla-calendar')
+        .should('exist');
 
-    cy.get('@winPromptStubReturnNonNull').should('be.calledOnce')
-      .and('be.calledWith', 'Please provide a name for the new View.');
+      cy.get('.unsaved-editable-field')
+        .should('have.length', 12);
 
-    cy.should(() => {
-      const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
-      expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', '')
+        .should('have.css', 'background-color').and('eq', EDITABLE_CELL_RGB_COLOR);
     });
 
-    cy.get('.selected-view').should('have.value', 'CustomViewTest');
-  });
+    it('should undo last edit and expect the date editor to NOT be opened when clicking undo last edit button', () => {
+      cy.get('[data-test=undo-last-edit-btn]').click();
 
-  it('should change pre-defined view to "Tasks Finished in Previous Years" and expect different filters and no pinning', () => {
-    const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Action'];
-    cy.get('.selected-view').select('previousYears');
-    cy.get('.selected-view').should('have.value', 'previousYears');
+      cy.get('.vanilla-calendar')
+        .should('not.be.visible');
 
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+      cy.get('.unsaved-editable-field')
+        .should('have.length', 11);
 
-    cy.get('input.slider-filter-input')
-      .invoke('val')
-      .then(text => expect(text).to.eq('50'));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', '')
+        .should('have.css', 'background-color').and('eq', EDITABLE_CELL_RGB_COLOR);
+    });
 
-    cy.get('.search-filter.filter-finish .operator .form-control')
-      .should('have.value', '<=');
+    it('should click on the "Save" button and expect 2 console log calls with the queued items & also expect no more unsaved cells', () => {
+      cy.get('[data-test=save-all-btn]').click();
 
-    cy.get('.search-filter.filter-finish .date-picker input')
-      .invoke('val')
-      .then(text => expect(text).to.eq(`${currentYear}-01-01`));
+      cy.get('.unsaved-editable-field')
+        .should('have.length', 0);
 
-    cy.get('[style="top: 0px;"]').should('have.length', 1);
-    cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 9);
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(2);
+        // expect(win.console.log).to.be.calledWith(Array[11]);
+      });
+    });
 
-    cy.get('.slick-pane-left')
-      .find('.slick-grid-menu-button')
-      .should('exist');
+    it('should be able to toggle the grid to readonly', () => {
+      cy.get('[data-test=toggle-readonly-btn]').click();
 
-    cy.get('.slick-pane-right')
-      .find('.slick-grid-menu-button')
-      .should('not.exist');
-  });
+      cy.get('.editable-field')
+        .should('have.length', 0);
+    });
 
-  it('should change pre-defined view back to the Custom View Test', () => {
-    const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Product', 'Country of Origin', 'Action'];
-    cy.get('.selected-view').select('CustomViewTest');
-    cy.get('.selected-view').should('have.value', 'CustomViewTest');
+    it('should be able to toggle back the grid to editable', () => {
+      cy.get('[data-test=toggle-readonly-btn]').click();
 
-    cy.get('.grid11')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
-  });
+      cy.get('.editable-field')
+        .should('not.have.length', 0);
+    });
 
-  it('should expect 3 filters with "filled" css class when having values', () => {
-    cy.get('.filter-title.filled').should('exist');
-    cy.get('.filter-duration.filled').should('exist');
-    cy.get('.filter-countryOfOrigin.filled').should('exist');
-  });
+    it('should not have filters set', () => {
+      cy.get('.selected-view').should('contain', '');
 
-  it('should have back the frozen columns from CustomViewTest on the right side of the "Duration" column', () => {
-    cy.get('[style="top: 0px;"]').should('have.length', 2);
-    cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 3);
-    cy.get('.grid-canvas-right > [style="top: 0px;"]').children().should('have.length', 8);
+      cy.get('input.slider-filter-input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('0'));
 
-    cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(0)').should('contain', '');
-    cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(1)').contains(/^TASK [0-9]*$/i);
-    cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(2)').contains(/^[0-9]*\sday[s]?$/);
+      cy.get('.search-filter.filter-finish .date-picker input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(''));
 
-    cy.get('.grid-canvas-right > [style="top: 0px;"] > .slick-cell:nth(0)').contains(/\$?[0-9.]*/);
+      cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
+    });
 
-    cy.get('.slick-pane-left')
-      .find('.slick-grid-menu-button')
-      .should('not.exist');
+    it('should change pre-defined view to "Tasks Finished in Previous Years" and expect data to be filtered/sorted accordingly with "Cost" column shown as well', () => {
+      const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Action'];
+      cy.get('.selected-view').select('previousYears');
+      cy.get('.selected-view').should('have.value', 'previousYears');
 
-    cy.get('.slick-pane-right')
-      .find('.slick-grid-menu-button')
-      .should('exist');
-  });
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
 
-  it('should have the same 3 filters defined in the CustomViewTest', () => {
-    cy.get('input.search-filter.filter-title').invoke('val').then(text => expect(text).to.eq('*5'));
-    cy.get('input.search-filter.filter-duration').invoke('val').then(text => expect(text).to.eq('>8'));
+      cy.get('input.slider-filter-input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('50'));
 
-    cy.get('.grid11')
-      .find('.slick-cell:nth(1)')
-      .each(($cell, index) => {
-        if (index < 10) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const [_taskString, taskNumber] = $cell.text().split(' ');
-          expect(taskNumber).to.include('5');
-        }
+      cy.get('.search-filter.filter-finish .operator .form-control')
+        .should('have.value', '<=');
+
+      cy.get('.search-filter.filter-finish .date-picker input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(`${currentYear}-01-01`));
+
+      cy.get('.slick-column-name')
+        .contains('Finish')
+        .find('~ .slick-sort-indicator.slick-sort-indicator-desc')
+        .should('have.length', 1);
+
+      cy.get('.search-filter.filter-completed .ms-choice').should('contain', 'True');
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
+    });
+
+    it('should have 3 filters with "filled" css class when having values', () => {
+      cy.get('.filter-percentComplete.filled').should('exist');
+      cy.get('.filter-finish.filled').should('exist');
+      cy.get('.filter-completed.filled').should('exist');
+    });
+
+    it('should show Column Picker and expect 2 columns to be hidden', () => {
+      cy.get('.grid11')
+        .find('.slick-header-column')
+        .first()
+        .trigger('mouseover')
+        .trigger('contextmenu')
+        .invoke('show');
+
+      cy.get('.slick-column-picker-list')
+        .find('input[type="checkbox"]:checked')
+        .should('have.length', 11 - 2);
+
+      cy.get('.slick-column-picker > button.close')
+        .click();
+    });
+
+    it('should create a new View based on "Tasks Finished in Previous Years" that was already selected', () => {
+      const filterName = 'Custom View Test';
+      const winPromptStub = () => filterName;
+
+      cy.window().then(win => {
+        (cy.stub(win, 'prompt').callsFake(winPromptStub) as any).as('winPromptStubReturnNonNull');
       });
 
-    cy.get('.grid11')
-      .find('.slick-cell:nth(2)')
-      .each(($cell, index) => {
-        if (index < 10) {
-          const [number] = $cell.text().split(' ');
-          expect(+number).to.be.greaterThan(8);
-        }
+      cy.get('input.search-filter.filter-title')
+        .type('*0');
+
+      cy.get('.action.dropdown')
+        .click();
+
+      cy.get('.action.dropdown .dropdown-item')
+        .contains('Create New View')
+        .click();
+
+      cy.get('@winPromptStubReturnNonNull').should('be.calledOnce')
+        .and('be.calledWith', 'Please provide a name for the new View.');
+
+      cy.should(() => {
+        const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
+        expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
       });
 
-    cy.get('input.search-filter.filter-countryOfOrigin').invoke('val').then(text => expect(text).to.eq('b..e'));
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
-  });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).should('contain', '0');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).should('contain', '0');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).should('contain', '0');
 
-  it('should clear pinning from Grid Menu & expect to no longer have any columns freezed', () => {
-    cy.get('.grid11')
-      .find('button.slick-grid-menu-button')
-      .click({ force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
 
-    cy.contains('Unfreeze Columns/Rows')
-      .click({ force: true });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).click();
+      cy.get('[data-name="editor-completed"]')
+        .find('li.selected')
+        .find('input[data-name=selectItemeditor-completed][value=true]')
+        .should('exist');
 
-    cy.get('[style="top: 0px;"]').should('have.length', 1);
-    cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 11);
-  });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).click();
 
-  it('should filter the "Completed" column to True and expect only completed rows to be displayed', () => {
-    cy.get('div.ms-filter.filter-completed')
-      .trigger('click');
+      cy.get('.selected-view').should('have.value', 'CustomViewTest');
+    });
 
-    cy.get('.ms-drop')
-      .find('li:nth(1)')
-      .click();
+    it('should change pre-defined view to "Tasks Finishing in Future Years" and expect data to be filtered accordingly', () => {
+      const expectedTitles = ['', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Completed', 'Product', 'Country of Origin', 'Action'];
 
-    cy.get('.grid11')
-      .find('.slick-custom-footer')
-      .find('.right-footer .item-count')
-      .should($span => {
-        expect(Number($span.text())).to.lt(50);
+      cy.get('.selected-view').select('greaterCurrentYear');
+      cy.get('.selected-view').should('have.value', 'greaterCurrentYear');
+
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+
+      cy.get('input.slider-filter-input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('0'));
+
+      cy.get('.search-filter.filter-finish .operator .form-control')
+        .should('have.value', '>=');
+
+      cy.get('.search-filter.filter-finish .date-picker input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(`${currentYear + 1}-01-01`));
+
+      cy.get('.slick-column-name')
+        .contains('Finish')
+        .find('~ .slick-sort-indicator.slick-sort-indicator-asc')
+        .should('have.length', 1);
+
+      cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('not.equal', '');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('not.contain', currentYear);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('not.equal', '');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).should('not.contain', currentYear);
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('not.equal', '');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('not.contain', currentYear);
+    });
+
+    it('should NOT be able to Delete/Update a System Defined View', () => {
+      cy.get('.action.dropdown')
+        .click();
+
+      cy.get('.action.dropdown .dropdown-item:nth(1)')
+        .then($elm => {
+          expect($elm.text()).to.contain('Update Current View');
+          expect($elm.hasClass('dropdown-item-disabled')).to.be.true;
+        });
+
+      cy.get('.action.dropdown .dropdown-item:nth(2)')
+        .then($elm => {
+          expect($elm.text()).to.contain('Delete Current View');
+          expect($elm.hasClass('dropdown-item-disabled')).to.be.true;
+        });
+
+      cy.get('.selected-view').should('have.value', 'greaterCurrentYear');
+    });
+
+    it('should reload the page and expect the Custom View to be reloaded from Local Storage and expect filtered data as well', () => {
+      cy.get('.selected-view').select('CustomViewTest');
+
+      cy.reload();
+      cy.wait(50);
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).should('contain', '0');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).should('contain', '0');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).should('contain', '0');
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(4)`).should($elm => expect(+$elm.text()).to.be.greaterThan(50));
+
+      cy.should(() => {
+        const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
+        expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
       });
-  });
 
-  it('should filter the "Completed" column to the null option and expect 50 rows displayed', () => {
-    cy.get('div.ms-filter.filter-completed')
-      .trigger('click');
+      cy.get('.selected-view').should('have.value', 'CustomViewTest');
+      cy.get('.filter-title.filled').should('exist');
+    });
 
-    cy.get('.ms-drop')
-      .find('li:nth(0)')
-      .click();
+    it('should be able to Update the Custom View that we created earlier with a new name', () => {
+      const filterName = 'Custom Updated View Test';
+      const winPromptStub = () => filterName;
 
-    cy.get('.filter-title.filled').should('exist');
-    cy.get('.filter-countryOfOrigin.filled').should('exist');
-    cy.get('.filter-completed.filled').should('not.exist');
-    cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
-
-    cy.get('.grid11')
-      .find('.slick-custom-footer')
-      .find('.right-footer .item-count')
-      .should($span => {
-        expect(Number($span.text())).to.eq(100);
+      cy.window().then(win => {
+        (cy.stub(win, 'prompt').callsFake(winPromptStub) as any).as('winPromptStubReturnNonNull');
       });
-  });
 
-  it('should display 2 different tooltips when hovering icons from "Action" column', () => {
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(10)`).as('first-row-action-cell');
-    cy.get('@first-row-action-cell').find('.action-btns .mdi-close').as('delete-row-btn');
-    cy.get('@first-row-action-cell').find('.action-btns .mdi-check-underline').as('mark-completed-btn');
+      cy.get('.selected-view').select('CustomViewTest');
 
-    cy.get('@delete-row-btn')
-      .trigger('mouseover');
+      cy.get('.action.dropdown')
+        .click();
 
-    cy.get('.slick-custom-tooltip').should('be.visible');
-    cy.get('.slick-custom-tooltip .tooltip-body').contains('Delete Current Row');
+      cy.get('.action.dropdown .dropdown-item')
+        .contains('Update Current View')
+        .click();
 
-    cy.get('@mark-completed-btn')
-      .trigger('mouseover');
+      cy.get('.action.dropdown .dropdown-item:nth(1)')
+        .then($elm => {
+          expect($elm.text()).to.contain('Update Current View');
+          expect($elm.hasClass('dropdown-item-disabled')).to.be.false;
+        });
 
-    cy.get('.slick-custom-tooltip').should('be.visible');
-    cy.get('.slick-custom-tooltip .tooltip-body').contains('Mark as Completed');
+      cy.get('.action.dropdown')
+        .click();
+
+      cy.get('@winPromptStubReturnNonNull').should('be.calledOnce')
+        .and('be.calledWith', 'Update View name or click on OK to continue.', 'Custom View Test');
+
+      cy.should(() => {
+        const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
+        expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
+      });
+
+      // select should have new name
+      cy.get('.selected-view').should('have.value', 'CustomUpdatedViewTest');
+    });
+
+    it('should be able to Delete the Custom Filter that we created earlier', () => {
+      cy.get('.selected-view').select('CustomUpdatedViewTest');
+
+      cy.get('.action.dropdown')
+        .click();
+
+      cy.get('.action.dropdown .dropdown-item:nth(2)')
+        .then($elm => {
+          expect($elm.text()).to.contain('Delete Current View');
+          expect($elm.hasClass('dropdown-item-disabled')).to.be.false;
+        });
+
+      cy.get('.action.dropdown .dropdown-item')
+        .contains('Delete Current View')
+        .click();
+    });
+
+    it('should expect all Filters & Sorting to be cleared and also expect all columns be back to original', () => {
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+
+      cy.get('.selected-view').should('not.have.value', 'CustomUpdatedViewTest');
+
+      cy.get('.slick-sort-indicator.slick-sort-indicator-desc')
+        .should('have.length', 0);
+
+      cy.get('input.slider-filter-input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('0'));
+
+      cy.get('.search-filter.filter-finish .date-picker input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(''));
+
+      cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
+
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should change pre-defined view to "Tasks Finished in Previous Years" and expect 2 columns less than original list', () => {
+      const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Action'];
+      cy.get('.selected-view').select('previousYears');
+      cy.get('.selected-view').should('have.value', 'previousYears');
+
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+    });
+
+    it('should "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
+      cy.get('[data-test="clear-storage-btn"]')
+        .click();
+
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    });
+
+    it('should also expect all Filters & Sorting to be cleared', () => {
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+
+      cy.get('.selected-view').should('not.have.value', 'CustomUpdatedViewTest');
+
+      cy.get('.slick-sort-indicator.slick-sort-indicator-desc')
+        .should('have.length', 0);
+
+      cy.get('input.slider-filter-input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('0'));
+
+      cy.get('.search-filter.filter-finish .date-picker input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(''));
+
+      cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
+      cy.get('.filled').should('have.length', 0);
+    });
+
+    it('should have all columns shown (checkbox is checked) in the Column Picker', () => {
+      cy.get('.grid11')
+        .find('.slick-header-column')
+        .first()
+        .trigger('mouseover')
+        .trigger('contextmenu')
+        .invoke('show');
+
+      cy.get('.slick-column-picker-list')
+        .find('input[type="checkbox"]:checked')
+        .should('have.length', 11);
+
+      cy.get('.slick-column-picker > button.close')
+        .click();
+    });
+
+    it('should be able to click on the delete button from the "Action" column of the 2nd row and expect "Task 1" to be delete', () => {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 0', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 1', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 3', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('TASK 4', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell:nth(1)`).contains('TASK 5', { matchCase: false });
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(10)`)
+        .find('.mdi-close')
+        .click();
+
+      cy.on('window:confirm', () => true);
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 0', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(1)`).contains('TASK 3', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains('TASK 4', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(1)`).contains('TASK 5', { matchCase: false });
+    });
+
+    it('should be able to click on the checked 2nd button from the "Action" column of the 2nd row and expect "Task 2" to be completed', () => {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1)`).contains('TASK 0', { matchCase: false });
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(1)`).contains('TASK 2', { matchCase: false });
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(10)`)
+        .find('.mdi-check-underline')
+        .click();
+
+      cy.on('window:alert', (str) => {
+        expect(str).to.equal('The "Task 2" is now Completed');
+      });
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(7)`).find('.checkmark-icon').should('have.length', 1);
+    });
+
+    it('should be able to filter "Country of Origin" with a text range filter "b..e" and expect to see only Canada showing up', () => {
+      cy.get('.slick-header-columns .slick-header-column:nth(9)').trigger('mouseover'); // mouseover column headers to get rid of cell tooltip
+      cy.get('input.search-filter.filter-countryOfOrigin').type('b..e');
+      cy.get('input.search-filter.filter-countryOfOrigin.filled').should('exist');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+    });
+
+    it('should be able to filter "Duration" with greater than symbol ">8"', () => {
+      cy.get('input.search-filter.filter-duration').type('>8');
+
+      cy.get('.grid11')
+        .find('.slick-cell:nth(2)')
+        .each(($cell, index) => {
+          if (index < 10) {
+            const [number] = $cell.text().split(' ');
+            expect(+number).to.be.greaterThan(8);
+          }
+        });
+    });
+
+    it('should be able to filter "Title" with Task finishing by 5', () => {
+      cy.get('input.search-filter.filter-title').type('*5');
+
+      cy.get('.grid11')
+        .find('.slick-cell:nth(1)')
+        .each(($cell, index) => {
+          if (index < 10) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const [_taskString, taskNumber] = $cell.text().split(' ');
+            expect(taskNumber).to.be.eq('5');
+          }
+        });
+    });
+
+    it('should be able to freeze "Duration" column', () => {
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .find('.slick-header-column:nth(2)')
+        .trigger('mouseover')
+        .children('.slick-header-menu-button')
+        .invoke('show')
+        .click();
+
+      cy.get('.slick-header-menu .slick-menu-command-list')
+        .should('be.visible')
+        .children('.slick-menu-item:nth-of-type(1)')
+        .children('.slick-menu-content')
+        .should('contain', 'Freeze Column')
+        .click();
+    });
+
+    it('should have a frozen grid with 4 containers on page load with 3 columns on the left and 8 columns on the right', () => {
+      cy.get('[style="top: 0px;"]').should('have.length', 2);
+      cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 3);
+      cy.get('.grid-canvas-right > [style="top: 0px;"]').children().should('have.length', 8);
+
+      cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(0)').should('contain', '');
+      cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(1)').contains(/^TASK [0-9]*$/i);
+      cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(2)').contains(/^[0-9]*\sday[s]?$/);
+
+      cy.get('.grid-canvas-right > [style="top: 0px;"] > .slick-cell:nth(0)').contains(/\$[0-9.]*/);
+
+      cy.get('.slick-pane-left')
+        .find('.slick-grid-menu-button')
+        .should('not.exist');
+
+      cy.get('.slick-pane-right')
+        .find('.slick-grid-menu-button')
+        .should('exist');
+    });
+
+    it('should create a new View with current pinning & filters', () => {
+      const filterName = 'Custom View Test';
+      const winPromptStub = () => filterName;
+
+      cy.window().then(win => {
+        (cy.stub(win, 'prompt').callsFake(winPromptStub) as any).as('winPromptStubReturnNonNull');
+      });
+
+      cy.get('.action.dropdown')
+        .click();
+
+      cy.get('.action.dropdown .dropdown-item')
+        .contains('Create New View')
+        .click();
+
+      cy.get('@winPromptStubReturnNonNull').should('be.calledOnce')
+        .and('be.calledWith', 'Please provide a name for the new View.');
+
+      cy.should(() => {
+        const savedDefinedFilters = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) as string);
+        expect(Object.keys(savedDefinedFilters)).to.have.lengthOf(3);
+      });
+
+      cy.get('.selected-view').should('have.value', 'CustomViewTest');
+    });
+
+    it('should change pre-defined view to "Tasks Finished in Previous Years" and expect different filters and no pinning', () => {
+      const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Action'];
+      cy.get('.selected-view').select('previousYears');
+      cy.get('.selected-view').should('have.value', 'previousYears');
+
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+
+      cy.get('input.slider-filter-input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('50'));
+
+      cy.get('.search-filter.filter-finish .operator .form-control')
+        .should('have.value', '<=');
+
+      cy.get('.search-filter.filter-finish .date-picker input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(`${currentYear}-01-01`));
+
+      cy.get('[style="top: 0px;"]').should('have.length', 1);
+      cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 9);
+
+      cy.get('.slick-pane-left')
+        .find('.slick-grid-menu-button')
+        .should('exist');
+
+      cy.get('.slick-pane-right')
+        .find('.slick-grid-menu-button')
+        .should('not.exist');
+    });
+
+    it('should change pre-defined view back to the Custom View Test', () => {
+      const expectedTitles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Start', 'Finish', 'Completed', 'Product', 'Country of Origin', 'Action'];
+      cy.get('.selected-view').select('CustomViewTest');
+      cy.get('.selected-view').should('have.value', 'CustomViewTest');
+
+      cy.get('.grid11')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+    });
+
+    it('should expect 3 filters with "filled" css class when having values', () => {
+      cy.get('.filter-title.filled').should('exist');
+      cy.get('.filter-duration.filled').should('exist');
+      cy.get('.filter-countryOfOrigin.filled').should('exist');
+    });
+
+    it('should have back the frozen columns from CustomViewTest on the right side of the "Duration" column', () => {
+      cy.get('[style="top: 0px;"]').should('have.length', 2);
+      cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 3);
+      cy.get('.grid-canvas-right > [style="top: 0px;"]').children().should('have.length', 8);
+
+      cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(0)').should('contain', '');
+      cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(1)').contains(/^TASK [0-9]*$/i);
+      cy.get('.grid-canvas-left > [style="top: 0px;"] > .slick-cell:nth(2)').contains(/^[0-9]*\sday[s]?$/);
+
+      cy.get('.grid-canvas-right > [style="top: 0px;"] > .slick-cell:nth(0)').contains(/\$?[0-9.]*/);
+
+      cy.get('.slick-pane-left')
+        .find('.slick-grid-menu-button')
+        .should('not.exist');
+
+      cy.get('.slick-pane-right')
+        .find('.slick-grid-menu-button')
+        .should('exist');
+    });
+
+    it('should have the same 3 filters defined in the CustomViewTest', () => {
+      cy.get('input.search-filter.filter-title').invoke('val').then(text => expect(text).to.eq('*5'));
+      cy.get('input.search-filter.filter-duration').invoke('val').then(text => expect(text).to.eq('>8'));
+
+      cy.get('.grid11')
+        .find('.slick-cell:nth(1)')
+        .each(($cell, index) => {
+          if (index < 10) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const [_taskString, taskNumber] = $cell.text().split(' ');
+            expect(taskNumber).to.include('5');
+          }
+        });
+
+      cy.get('.grid11')
+        .find('.slick-cell:nth(2)')
+        .each(($cell, index) => {
+          if (index < 10) {
+            const [number] = $cell.text().split(' ');
+            expect(+number).to.be.greaterThan(8);
+          }
+        });
+
+      cy.get('input.search-filter.filter-countryOfOrigin').invoke('val').then(text => expect(text).to.eq('b..e'));
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(9)`).should('contain', 'Canada');
+    });
+
+    it('should clear pinning from Grid Menu & expect to no longer have any columns freezed', () => {
+      cy.get('.grid11')
+        .find('button.slick-grid-menu-button')
+        .click({ force: true });
+
+      cy.contains('Unfreeze Columns/Rows')
+        .click({ force: true });
+
+      cy.get('[style="top: 0px;"]').should('have.length', 1);
+      cy.get('.grid-canvas-left > [style="top: 0px;"]').children().should('have.length', 11);
+    });
+
+    it('should filter the "Completed" column to True and expect only completed rows to be displayed', () => {
+      cy.get('div.ms-filter.filter-completed')
+        .trigger('click');
+
+      cy.get('.ms-drop')
+        .find('li:nth(1)')
+        .click();
+
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.lt(50);
+        });
+    });
+
+    it('should filter the "Completed" column to the null option and expect 50 rows displayed', () => {
+      cy.get('div.ms-filter.filter-completed')
+        .trigger('click');
+
+      cy.get('.ms-drop')
+        .find('li:nth(0)')
+        .click();
+
+      cy.get('.filter-title.filled').should('exist');
+      cy.get('.filter-countryOfOrigin.filled').should('exist');
+      cy.get('.filter-completed.filled').should('not.exist');
+      cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
+
+      cy.get('.grid11')
+        .find('.slick-custom-footer')
+        .find('.right-footer .item-count')
+        .should($span => {
+          expect(Number($span.text())).to.eq(100 - 3); // 3x of them have no country defined
+        });
+    });
+
+    it('should display 2 different tooltips when hovering icons from "Action" column', () => {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(10)`).as('first-row-action-cell');
+      cy.get('@first-row-action-cell').find('.action-btns .mdi-close').as('delete-row-btn');
+      cy.get('@first-row-action-cell').find('.action-btns .mdi-check-underline').as('mark-completed-btn');
+
+      cy.get('@delete-row-btn')
+        .trigger('mouseover');
+
+      cy.get('.slick-custom-tooltip').should('be.visible');
+      cy.get('.slick-custom-tooltip .tooltip-body').contains('Delete Current Row');
+
+      cy.get('@mark-completed-btn')
+        .trigger('mouseover');
+
+      cy.get('.slick-custom-tooltip').should('be.visible');
+      cy.get('.slick-custom-tooltip .tooltip-body').contains('Mark as Completed');
+    });
   });
 });


### PR DESCRIPTION
- note that `!=` is "not equal" and is not equivalent to `<>` which is "not contains". So only the `!= ` will return non-blanks while `<> ` will often return no data at all when the data includes white spaces.
- partially fixes a problem highlighted in issue #1569 on how to return non-blanks rows for a local JSON dataset