### PR TITLE
fix(GraphQL): filter `<>` is `Not_Contains` instead of `Not_Equal`

### DIFF
--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -747,16 +747,14 @@ describe('Service/Utilies', () => {
       expect(output2).toBe(expectation);
     });
 
-    it('should return OperatoryType associated to "<>", "!=", "neq" or "NEQ"', () => {
+    it('should return OperatoryType associated to "!=", "neq" or "NEQ"', () => {
       const expectation = OperatorType.notEqual;
 
-      const output1 = mapOperatorType('<>');
-      const output2 = mapOperatorType('!=');
-      const output3 = mapOperatorType('NE');
+      const output1 = mapOperatorType('!=');
+      const output2 = mapOperatorType('NE');
 
       expect(output1).toBe(expectation);
       expect(output2).toBe(expectation);
-      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "*", "a*", ".*", "startsWith"', () => {
@@ -814,11 +812,13 @@ describe('Service/Utilies', () => {
     it('should return OperatoryType associated to "not_contains", "Not_Contains", "notContains"', () => {
       const expectation = OperatorType.notContains;
 
-      const output1 = mapOperatorType('Not_Contains');
-      const output2 = mapOperatorType('NOT_CONTAINS');
+      const output1 = mapOperatorType('<>');
+      const output2 = mapOperatorType('Not_Contains');
+      const output3 = mapOperatorType('NOT_CONTAINS');
 
       expect(output1).toBe(expectation);
       expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return default OperatoryType associated to contains', () => {

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -425,7 +425,6 @@ export function mapOperatorType(operator: OperatorType | OperatorString): Operat
     case 'GE':
       map = OperatorType.greaterThanOrEqual;
       break;
-    case '<>':
     case '!=':
     case 'NE':
       map = OperatorType.notEqual;
@@ -451,6 +450,7 @@ export function mapOperatorType(operator: OperatorType | OperatorString): Operat
     case 'NOT_IN':
       map = OperatorType.notIn;
       break;
+    case '<>':
     case 'Not_Contains':
     case 'NOT_CONTAINS':
       map = OperatorType.notContains;

--- a/packages/graphql/src/services/__tests__/graphql.service.spec.ts
+++ b/packages/graphql/src/services/__tests__/graphql.service.spec.ts
@@ -758,7 +758,23 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should return a query with multiple filters when the filters object has multiple search and they are passed as a filter trigger by a filter event and is of type ColumnFilters', () => {
+    it('should return a query with multiple filters when the filters object has multiple search with Equal & "<>" and they are passed as a filter trigger by a filter event and is of type ColumnFilters', () => {
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"female"}, {field:company, operator:Not_Contains, value:"abc"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      const mockColumnGender = { id: 'gender', field: 'gender' } as Column;
+      const mockColumnCompany = { id: 'company', field: 'company' } as Column;
+      const mockColumnFilters = {
+        gender: { columnId: 'gender', columnDef: mockColumnGender, searchTerms: ['female'], operator: 'EQ', type: FieldType.string, },
+        company: { columnId: 'company', columnDef: mockColumnCompany, searchTerms: ['abc'], operator: '<>', type: FieldType.string, },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
+    it('should return a query with multiple filters when the filters object has multiple search with Equal & Not Contains and they are passed as a filter trigger by a filter event and is of type ColumnFilters', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"female"}, {field:company, operator:Not_Contains, value:"abc"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumnGender = { id: 'gender', field: 'gender' } as Column;
       const mockColumnCompany = { id: 'company', field: 'company' } as Column;


### PR DESCRIPTION
- while investigating for issue #1569, I found out that the GraphQL `<>` was set to be the equivalent of `!=` but this is in fact false, since the `<>` is meant to represent `Not_Contains` while `!=` is meant to represent `Not_Equals` and they both work differently since `<>` is for a substring but the `!=` is for the entire string
- it is also related to the PR #1570
- Note that OData doesn't have a "Not Contains" query filter and so I only made the modification for GraphQL (OData has its own switch case for each operator)