### PR TITLE
fix(tooltip): Slider Filter should auto update tooltip whenever sliding

### DIFF
--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -150,6 +150,7 @@ export class SlickCustomTooltip {
     this._eventHandler
       .subscribe(grid.onMouseEnter, this.handleOnMouseOver.bind(this))
       .subscribe(grid.onHeaderMouseOver, (e, args) => this.handleOnHeaderMouseOverByType(e, args, 'slick-header-column'))
+      .subscribe(grid.onHeaderRowMouseEnter, (e, args) => this.handleOnHeaderMouseOverByType(e, args, 'slick-headerrow-column'))
       .subscribe(grid.onHeaderRowMouseOver, (e, args) => this.handleOnHeaderMouseOverByType(e, args, 'slick-headerrow-column'))
       .subscribe(grid.onMouseLeave, this.hideTooltip.bind(this))
       .subscribe(grid.onHeaderMouseOut, this.hideTooltip.bind(this))


### PR DESCRIPTION
- slider tooltip is more useful when its tooltip is updated while sliding, the `onHeaderRowMouseEnter` was missing as a Custom Tooltip listener

![msedge_8oVFA7aYdk](https://github.com/ghiscoding/slickgrid-universal/assets/643976/b7feaafd-fa0a-434b-a6d6-a4c61a9443e2)
