### PR TITLE
fix(editor): Composite Editor should work with Cell Menu

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -481,6 +481,9 @@ export default class Example12 {
       },
       // when using the cellMenu, you can change some of the default options and all use some of the callback methods
       enableCellMenu: true,
+      cellMenu: {
+        preventEventBubbling: false
+      },
       gridMenu: {
         hideToggleDarkModeCommand: false, // disabled command by default
         onCommand: (_, args) => {

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -113,7 +113,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
       const columnDef = this.grid.getColumns()[cell.cell];
 
       // prevent event from bubbling but only on column that has a cell menu defined
-      if (columnDef?.cellMenu) {
+      if (columnDef?.cellMenu && this.gridOptions.cellMenu?.preventEventBubbling !== false) {
         event.preventDefault();
       }
 

--- a/packages/common/src/interfaces/cellMenuOption.interface.ts
+++ b/packages/common/src/interfaces/cellMenuOption.interface.ts
@@ -61,6 +61,9 @@ export interface CellMenuOption {
   /** Same as "optionTitle", except that it's a translation key which can be used on page load and/or when switching locale */
   optionTitleKey?: string;
 
+  /** By default event bubbling will be prevented but in some cases we want the events to be bubbling (e.g. Cell Menu with Composite Editor not receiving active cell/row) */
+  preventEventBubbling?: boolean;
+
   /** Defaults to True, should we show bullets when icons are missing? */
   showBulletWhenIconMissing?: boolean;
 

--- a/test/cypress/e2e/example12.cy.ts
+++ b/test/cypress/e2e/example12.cy.ts
@@ -697,4 +697,33 @@ describe('Example 12 - Composite Editor Modal', () => {
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(10)`).should('contain', '');
   });
+
+  it('should open Edit Composite Editor from Cell Menu and expect Task 3 on 6th row', () => {
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(11)`).click();
+
+    cy.get('.slick-menu-item .slick-menu-content')
+      .first()
+      .should('contain', 'Edit Row')
+      .click();
+
+    cy.get('.slick-editor-modal-title')
+      .should('contain', 'Editing - Task 3');
+
+    cy.get('.slick-editor-modal-footer .btn-cancel')
+      .click();
+  });
+
+  it('should open Clone Composite Editor from Cell Menu and expect Task 3 on 6th row', () => {
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell:nth(11)`).click();
+
+    cy.get('.slick-menu-item .slick-menu-content:nth(1)')
+      .should('contain', 'Clone Row')
+      .click();
+
+    cy.get('.slick-editor-modal-title')
+      .should('contain', 'Clone - Task 3');
+
+    cy.get('.slick-editor-modal-footer .btn-cancel')
+      .click();
+  });
 });


### PR DESCRIPTION
- by default Cell Menu are preventing event bubbling and this causes the Cell Menu to not activate the active cell and this causes the Composite Editor to not receive the correct row number, let's add a `cellMenu.preventEventBubbling` to keep the default but offer the option to disable the default and fix Composite Editor