### PR TITLE
chore(editors): use better Cell Menu option name activateCellOnMenuClick

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -482,7 +482,7 @@ export default class Example12 {
       // when using the cellMenu, you can change some of the default options and all use some of the callback methods
       enableCellMenu: true,
       cellMenu: {
-        preventEventBubbling: false
+        activateCellOnMenuClick: true, // this is important to know which row index to use for Composite Editor
       },
       gridMenu: {
         hideToggleDarkModeCommand: false, // disabled command by default

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -113,7 +113,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
       const columnDef = this.grid.getColumns()[cell.cell];
 
       // prevent event from bubbling but only on column that has a cell menu defined
-      if (columnDef?.cellMenu && this.gridOptions.cellMenu?.preventEventBubbling !== false) {
+      if (columnDef?.cellMenu && !this.gridOptions.cellMenu?.activateCellOnMenuClick) {
         event.preventDefault();
       }
 

--- a/packages/common/src/interfaces/cellMenuOption.interface.ts
+++ b/packages/common/src/interfaces/cellMenuOption.interface.ts
@@ -61,8 +61,11 @@ export interface CellMenuOption {
   /** Same as "optionTitle", except that it's a translation key which can be used on page load and/or when switching locale */
   optionTitleKey?: string;
 
-  /** By default event bubbling will be prevented but in some cases we want the events to be bubbling (e.g. Cell Menu with Composite Editor not receiving active cell/row) */
-  preventEventBubbling?: boolean;
+  /**
+   * Defaults to False, do we want to change the active cell when clicking the Cell Menu,
+   * typically we don't but for Cell Menu with Composite Editor we need to know the row index and for that we need to change active cell
+   */
+  activateCellOnMenuClick?: boolean;
 
   /** Defaults to True, should we show bullets when icons are missing? */
   showBulletWhenIconMissing?: boolean;


### PR DESCRIPTION
- this rename the new Cell Menu option introduced in previous PR #1591 to fix Composite Editor Cell Menu not using correct row index