### PR TITLE
chore: remove `exports.node` from all packages

### DIFF
--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.0",
   "description": "Simple Vanilla Implementation of a Binding Engine & Helper to add properties/events 2 way bindings",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,18 +3,17 @@
   "version": "5.3.3",
   "description": "SlickGrid-Universal Common Code",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./dist/styles/*": "./dist/styles/*",
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "license": "MIT",
   "author": "Ghislain B.",
   "homepage": "https://github.com/ghiscoding/slickgrid-universal",

--- a/packages/composite-editor-component/package.json
+++ b/packages/composite-editor-component/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Slick Composite Editor Component - Vanilla Implementation of a Composite Editor Modal Window Component",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-footer-component/package.json
+++ b/packages/custom-footer-component/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Slick Custom Footer Component - Vanilla Implementation of a Custom Footer Component",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/custom-tooltip-plugin/package.json
+++ b/packages/custom-tooltip-plugin/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "A plugin to add Custom Tooltip when hovering a cell, it subscribes to the cell",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/empty-warning-component/package.json
+++ b/packages/empty-warning-component/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Slick Empty Warning Component - Vanilla Implementation of an Empty Dataset Warning Component",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/event-pub-sub/package.json
+++ b/packages/event-pub-sub/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.0",
   "description": "Simple Vanilla Implementation of an Event PubSub Service to do simply publish/subscribe inter-communication while optionally providing data in the event",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/excel-export/package.json
+++ b/packages/excel-export/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Excel Export (xls/xlsx) Service.",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "GraphQL Service to sync a grid with a GraphQL backend server",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/odata/package.json
+++ b/packages/odata/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Grid OData Service to sync a grid with an OData backend server",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pagination-component/package.json
+++ b/packages/pagination-component/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Slick Pagination Component - Vanilla Implementation of a Pagination Component",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/row-detail-view-plugin/package.json
+++ b/packages/row-detail-view-plugin/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "SlickRowDetail plugin - A plugin to add Row Detail Panel",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rxjs-observable/package.json
+++ b/packages/rxjs-observable/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "RxJS Observable Wrapper",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/text-export/package.json
+++ b/packages/text-export/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Export to Text File (csv/txt) Service.",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.0",
   "description": "Common set of small utilities",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Vanilla Slick Grid Bundle - Framework agnostic the output is to be used in vanilla JS/TS - Written in TypeScript and we also use Vite to bundle everything into a single JS file.",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -3,17 +3,16 @@
   "version": "5.3.3",
   "description": "Vanilla Slick Grid Bundle (mostly exist for our Salesforce implementation) - Similar to Vanilla Bundle, the only difference is that it adds extra packages within its bundle (CustomTooltip, CompositeEditor & TextExport)",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
+  "module": "./dist/esm/index.js",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- I don't think we need the `exports.node` since it's not a package meant to be used in NodeJS but rather in a browser, so let's remove it
- also move `module` to be after the `exports` since order might matter (not entirely sure but that is what `rimraf` does and it's a package made a NodeJS member, so it should be a good indication)
- related to issue #1601