### PR TITLE
fix: queryselector should support numeric ids

### DIFF
--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -184,7 +184,7 @@ export function SlickCompositeEditor(this: any, columns: Column[], containers: A
           const compositeModalElm = document.querySelector(`.slick-editor-modal`);
           let validationElm = compositeModalElm?.querySelector(`.item-details-validation.editor-${columnDef.id}`);
           let labelElm = compositeModalElm?.querySelector(`.item-details-label.editor-${columnDef.id}`);
-          let editorElm = compositeModalElm?.querySelector(`[data-editorid=${columnDef.id}]`);
+          let editorElm = compositeModalElm?.querySelector(`[data-editorid='${columnDef.id}']`);
           const validationMsgPrefix = options?.validationMsgPrefix ?? '';
 
           if (!targetElm || editorElm?.contains(targetElm)) {

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -490,7 +490,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         }
 
         this._editors = {};
-        this._editorContainers = modalColumns.map(col => modalBodyElm.querySelector<HTMLDivElement>(`[data-editorid=${col.id}]`)) || [];
+        this._editorContainers = modalColumns.map(col => modalBodyElm.querySelector<HTMLDivElement>(`[data-editorid='${col.id}']`)) || [];
         this._compositeOptions = { destroy: this.disposeComponent.bind(this), modalType, validationMsgPrefix: '* ', formValues: {}, editors: this._editors };
         const compositeEditor = new (SlickCompositeEditor as any)(modalColumns, this._editorContainers, this._compositeOptions) as typeof SlickCompositeEditor;
         this.grid.editActiveCell(compositeEditor as any);


### PR DESCRIPTION
I just tried to integrate the composite editor and it failed with the error that `[data-editor=1234]` is an invalid selector. Guess what, my column ids are numeric strings :)