### PR TITLE
Add preventDocumentFragmentUsage condition to checkboxSelectorColumn

### DIFF
--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -220,8 +220,8 @@ export class SlickCheckboxSelectColumn<T = any> {
    * @param {Boolean} checked - is the input checkbox checked?
    * @returns
    */
-  createCheckboxElement(inputId: string, checked = false): DocumentFragment {
-    const fragmentElm = new DocumentFragment();
+  createCheckboxElement(inputId: string, checked = false): DocumentFragment | HTMLSpanElement {
+    const checkboxElm = this.gridOptions?.preventDocumentFragmentUsage ? document.createElement('span') : new DocumentFragment();
     const labelElm = createDomElement('label', { className: 'checkbox-selector-label', htmlFor: inputId });
     const divElm = createDomElement('div', { className: 'icon-checkbox-container' });
     divElm.appendChild(
@@ -231,9 +231,9 @@ export class SlickCheckboxSelectColumn<T = any> {
       createDomElement('div', { className: `mdi ${checked ? CHECK_ICON : UNCHECK_ICON}` })
     );
     labelElm.appendChild(divElm);
-    fragmentElm.appendChild(labelElm);
+    checkboxElm.appendChild(labelElm);
 
-    return fragmentElm;
+    return checkboxElm;
   }
 
   getColumnDefinition(): Column {


### PR DESCRIPTION
In the Salesforce environment, DocumentFragment is not supported. So add condition to createElement for checkboxSelectorColumn.