### PR TITLE
chore: reproduce bug

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -10,6 +10,7 @@ import {
   type Formatter,
   Formatters,
   type GridOption,
+  InputEditor,
   type LongTextEditorOption,
   type OnCompositeEditorChangeEventArgs,
   SlickGlobalEditorLock,
@@ -180,7 +181,7 @@ export default class Example12 {
           }
           return value > 1 ? `${value} days` : `${value} day`;
         },
-        editor: { model: Editors.float, massUpdate: true, decimal: 2, valueStep: 1, minValue: 0, maxValue: 10000, alwaysSaveOnEnterKey: true, required: true },
+        editor: { model: CustomEditor, massUpdate: true, decimal: 2, valueStep: 1, minValue: 0, maxValue: 10000, alwaysSaveOnEnterKey: true, required: true },
       },
       {
         id: 'cost', name: 'Cost', field: 'cost', width: 90, minWidth: 70,
@@ -1036,5 +1037,16 @@ export default class Example12 {
         }
       });
     }, openDelay);
+  }
+}
+
+class CustomEditor extends InputEditor {
+  constructor(args: any) {
+    super(args, '');
+  }
+
+  override save(): void {
+    this.args.item["cost"] = 1234567;
+    super.save();
   }
 }


### PR DESCRIPTION
!!!DO NOT MERGE, JUST FOR ERROR REPRODUCTION AND SEEING IT IN STACKBLITZ!!!

Here's the repro of https://github.com/ghiscoding/slickgrid-universal/issues/1618.
if you take a look at the example12 you'll notice that the duration column now has a custom editor in use. If you change the value of a duration cell, you'll notice that the cost column should be updated to 1234657 as well after cell leave.

If you do the same via the composite editor however, that's not happening.