### PR TITLE
fix(core): pinning 1st column could caused the header to get misaligned

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3036,7 +3036,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     // before applying column freeze, we need our viewports to be scrolled back to left to avoid misaligned column headers
-    if (newOptions.frozenColumn) {
+    if (newOptions.frozenColumn !== undefined && newOptions.frozenColumn >= 0) {
       this.getViewports().forEach(vp => vp.scrollLeft = 0);
       this.handleScroll(); // trigger scroll to realign column headers as well
     }


### PR DESCRIPTION
- follows SlickGrid PR: https://github.com/6pac/SlickGrid/pull/1039