### PR TITLE
perf: use SortableJS ESM import to save 1kb

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1,4 +1,3 @@
-import Sortable, { type SortableEvent } from 'sortablejs';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import {
   classNameToList,
@@ -13,6 +12,9 @@ import {
   isDefinedNumber,
   isPrimitiveOrHTML,
 } from '@slickgrid-universal/utils';
+// @ts-ignore: use the ESM imports for smaller build, it however doesn't play nice with @types/sortablejs
+import Sortable from 'sortablejs/modular/sortable.core.esm.js';
+import type { Options as SortableOptions, SortableEvent } from 'sortablejs'; // from @types/sortablejs
 
 import {
   type BasePubSub,
@@ -1906,7 +1908,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           this.setFocus(); // refocus on active cell
         }
       }
-    } as Sortable.Options;
+    } as SortableOptions;
 
     this.sortableSideLeftInstance = Sortable.create(this._headerL, sortableOptions);
     this.sortableSideRightInstance = Sortable.create(this._headerR, sortableOptions);

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -1,7 +1,9 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
 import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { createDomElement, emptyElement, isEmptyObject, classNameToList } from '@slickgrid-universal/utils';
-import Sortable, { type Options as SortableOptions, type SortableEvent } from 'sortablejs';
+// @ts-ignore: use the ESM imports for smaller build, it however doesn't play nice with @types/sortablejs
+import Sortable from 'sortablejs/modular/sortable.core.esm.js';
+import type { Options as SortableOptions, SortableEvent } from 'sortablejs'; // from @types/sortablejs
 
 import type { ExtensionUtility } from '../extensions/extensionUtility';
 import { SortDirectionNumber } from '../enums/index';
@@ -553,7 +555,7 @@ export class SlickDraggableGrouping {
       onAdd: (evt: SortableEvent) => {
         const el = evt.item;
         if (el.getAttribute('id')?.replace(this._gridUid, '')) {
-          this.handleGroupByDrop(dropzoneElm, (Sortable.utils as any).clone(evt.item));
+          this.handleGroupByDrop(dropzoneElm, (el as any).cloneNode(true));
         }
         el.parentNode?.removeChild(el);
       },
@@ -571,7 +573,7 @@ export class SlickDraggableGrouping {
         this.columnsGroupBy = newGroupingOrder;
         this.updateGroupBy('sort-group');
       },
-    });
+    } as SortableOptions);
 
     // Sortable doesn't have onOver, we need to implement it ourselves
     this.addDragOverDropzoneListeners();


### PR DESCRIPTION
I'm not sure if it's worth it or not but we seem to be using 1kb from the zip when using the ESM build of SortableJS. However the thing that is not as great is that `@types/sortablejs` is not recognized when using 
`import Sortable from 'sortablejs/modular/sortable.core.esm.js';`

So I had to use something like below with a `@ts-ignore` on the ESM import
```ts
// @ts-ignore: use the ESM imports for smaller build, it however doesn't play nice with @types/sortablejs
import Sortable from 'sortablejs/modular/sortable.core.esm.js';
import type { Options as SortableOptions, SortableEvent } from 'sortablejs'; // from @types/sortablejs
```

#### before
![image](https://github.com/user-attachments/assets/9e30f993-b9fe-4810-8d18-2441509cad37)

#### after
![image](https://github.com/user-attachments/assets/d4953b58-2d70-44e7-932f-3bf40bada6c2)
