### PR TITLE
feat: add `preRegisterExternalExtensions` to help external RowDetail

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example21.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example21.html
@@ -36,6 +36,11 @@
       <label for="server-delay">Simulated Server Delay (ms): </label>
       <input type="number" id="server-delay" class="is-narrow input is-small" data-test="server-delay" value.bind="serverApiDelay">
     </span>
+
+    <span class="ml-2">
+      <label>Selected Rows:</label>
+      <span textcontent.bind="selectedRowString" data-test="row-selections"></span>
+    </span>
   </div>
 
   <div class="column is-narrow">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example21.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example21.ts
@@ -32,6 +32,7 @@ export default class Example21 {
   columnDefinitions!: Column<Item>[];
   dataset!: Item[];
   sgb!: SlickVanillaGridBundle;
+  selectedRowString = '';
   serverApiDelay = 400;
   status = '';
   statusClass = '';
@@ -55,6 +56,12 @@ export default class Example21 {
 
     // add all row detail event listeners
     this.addRowDetailEventHandlers();
+    this._bindingEventService.bind(this.gridContainerElm, 'onselectedrowschanged', () => {
+      this.selectedRowString = this.sgb.slickGrid?.getSelectedRows().join(',') || '';
+      if (this.selectedRowString.length > 50) {
+        this.selectedRowString = this.selectedRowString.substring(0, 50) + '...';
+      }
+    });
   }
 
   dispose() {

--- a/packages/common/src/interfaces/extensionModel.interface.ts
+++ b/packages/common/src/interfaces/extensionModel.interface.ts
@@ -6,4 +6,6 @@ export interface ExtensionModel<P extends (SlickControlList | SlickPluginList)> 
 
   /** Instance of the Addon (3rd party SlickGrid Control or Plugin) */
   instance: P;
+
+  columnIndexPosition?: number;
 }

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -1,4 +1,4 @@
-import type { EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
+import type { BasePubSubService, EventNamingStyle } from '@slickgrid-universal/event-pub-sub';
 import type { MultipleSelectOption } from 'multiple-select-vanilla';
 
 import type {
@@ -20,6 +20,7 @@ import type {
   EmptyWarning,
   ExcelCopyBufferOption,
   ExcelExportOption,
+  ExtensionModel,
   ExternalResource,
   Formatter,
   FormatterOption,
@@ -525,6 +526,12 @@ export interface GridOption<C extends Column = Column> {
 
   /** Register any external Resources (Components, Services) like the ExcelExportService, TextExportService, SlickCompositeEditorComponent, ... */
   externalResources?: ExternalResource[];
+
+  /**
+   * Some external (optional) extensions might need to be pre-registered, for example SlickRowDetail.
+   * Note: this will not only call `create()` method before SlickGrid instantiation, but will also call its `init()` method
+   */
+  preRegisterExternalExtensions?: (eventPubSubService: BasePubSubService) => Array<ExtensionModel<any>>;
 
   /**
    * Default to 0, how long to wait between each characters that the user types before processing the filtering process (only applies for local/in-memory grid).

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -647,6 +647,38 @@ describe('ExtensionService', () => {
         expect(extCheckSelectSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
         expect(extRowMoveSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
       });
+
+      it('should create & init external extensions when "preRegisterExternalExtensions" is set in the grid options', () => {
+        const createMock = jest.fn();
+        const initMock = jest.fn();
+        class ExternalExtension {
+          create(columnDefinitions: Column[], gridOptions: GridOption) {
+            createMock(columnDefinitions, gridOptions);
+          }
+          init(grid: SlickGrid) {
+            initMock(grid);
+          }
+        }
+
+        const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }, { id: 'field2', field: 'field2', width: 50, }] as Column[];
+        const gridOptionsMock = {
+          enableCheckboxSelector: true, enableRowSelection: true,
+          checkboxSelector: { columnIndexPosition: 1 },
+          preRegisterExternalExtensions: (pubSub) => {
+            const ext = new ExternalExtension();
+            return [{ name: ExtensionName.rowDetailView, instance: ext }];
+          }
+        } as GridOption;
+        const extCheckSelectSpy = jest.spyOn(mockCheckboxSelectColumn, 'create');
+
+        service.createExtensionsBeforeGridCreation(columnsMock, gridOptionsMock);
+
+        expect(extCheckSelectSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
+        expect(createMock).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
+
+        service.bindDifferentExtensions();
+        expect(initMock).toHaveBeenCalledWith(gridStub);
+      });
     });
 
     it('should call hideColumn and expect "visibleColumns" to be updated accordingly', () => {

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -47,7 +47,7 @@ import {
   unsubscribeAll,
   SlickEventHandler,
   SlickDataView,
-  SlickGrid
+  SlickGrid,
 } from '@slickgrid-universal/common';
 import { extend } from '@slickgrid-universal/utils';
 import { EventNamingStyle, EventPubSubService } from '@slickgrid-universal/event-pub-sub';

--- a/test/cypress/e2e/example21.cy.ts
+++ b/test/cypress/e2e/example21.cy.ts
@@ -392,4 +392,12 @@ describe('Example 21 - Row Detail View', () => {
     cy.get('.dynamic-cell-detail')
       .should('have.length', 0);
   });
+
+  it('should be able to select any rows, i.e.: row 2 and 4', () => {
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(0)`).click();
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell:nth(0)`).click();
+
+    cy.get('[data-test="row-selections"]')
+      .contains('2,4');
+  });
 });

--- a/test/cypress/e2e/example21.cy.ts
+++ b/test/cypress/e2e/example21.cy.ts
@@ -1,5 +1,5 @@
 describe('Example 21 - Row Detail View', () => {
-  const fullTitles = ['', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
+  const fullTitles = ['', '', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Effort Driven'];
   const GRID_ROW_HEIGHT = 33;
 
   it('should display Example title', () => {
@@ -101,7 +101,7 @@ describe('Example 21 - Row Detail View', () => {
         if (index > expectedTasks.length - 1) {
           return;
         }
-        cy.wrap($row).children('.slick-cell:nth(1)')
+        cy.wrap($row).children('.slick-cell:nth(2)')
           .first()
           .should('contain', expectedTasks[index]);
       });
@@ -157,7 +157,7 @@ describe('Example 21 - Row Detail View', () => {
         if (index > expectedTasks.length - 1) {
           return;
         }
-        cy.wrap($row).children('.slick-cell:nth(1)')
+        cy.wrap($row).children('.slick-cell:nth(2)')
           .first()
           .should('contain', expectedTasks[index]);
       });
@@ -179,7 +179,7 @@ describe('Example 21 - Row Detail View', () => {
       .contains('Task 1');
 
     cy.get('.grid21')
-      .find('.slick-row:nth(9)')
+      .find('.slick-row:nth(9) .slick-cell:nth(1)')
       .click();
 
     cy.get('.grid21')
@@ -191,7 +191,7 @@ describe('Example 21 - Row Detail View', () => {
       .contains('Task 5');
 
     cy.get('.grid21')
-      .find('.slick-header-column:nth(1)')
+      .find('.slick-header-column:nth(2)')
       .trigger('mouseover')
       .children('.slick-header-menu-button')
       .should('be.hidden')
@@ -206,7 +206,7 @@ describe('Example 21 - Row Detail View', () => {
       .click();
 
     cy.get('.grid21')
-      .find('.slick-header-column:nth(1)')
+      .find('.slick-header-column:nth(2)')
       .trigger('mouseover')
       .children('.slick-header-menu-button')
       .invoke('show')
@@ -220,7 +220,7 @@ describe('Example 21 - Row Detail View', () => {
       .click();
 
     cy.get('.grid21')
-      .find('.slick-header-column:nth(1)')
+      .find('.slick-header-column:nth(2)')
       .find('.slick-sort-indicator-asc')
       .should('have.length', 1);
 
@@ -241,7 +241,7 @@ describe('Example 21 - Row Detail View', () => {
         if (index > expectedTasks.length - 1) {
           return;
         }
-        cy.wrap($row).children('.slick-cell:nth(1)')
+        cy.wrap($row).children('.slick-cell:nth(2)')
           .first()
           .should('contain', expectedTasks[index]);
       });
@@ -249,11 +249,11 @@ describe('Example 21 - Row Detail View', () => {
 
   it('should click open Row Detail of Task 1 and Task 101 then type a title filter of "Task 101" and expect Row Detail to be opened and still be rendered', () => {
     cy.get('.grid21')
-      .find('.slick-row:nth(4)')
+      .find('.slick-row:nth(4) .slick-cell:nth(1)')
       .click();
 
     cy.get('.grid21')
-      .find('.slick-row:nth(1)')
+      .find('.slick-row:nth(1) .slick-cell:nth(1)')
       .click();
 
     cy.get('.grid21')
@@ -316,7 +316,7 @@ describe('Example 21 - Row Detail View', () => {
 
   it('should click on 5th row detail open icon and expect it to open', () => {
     cy.get('.grid21')
-      .find('.slick-row:nth(4) .slick-cell:nth(0)')
+      .find('.slick-row:nth(4) .slick-cell:nth(1)')
       .click();
 
     cy.get('.grid21')
@@ -330,8 +330,8 @@ describe('Example 21 - Row Detail View', () => {
 
   it('should click on 2nd row "Title" cell to edit it and expect Task 5 row detail to get closed', () => {
     cy.get('.grid21')
-      .find('.slick-row:nth(1) .slick-cell:nth(1)')
-      .click();
+      .find('.slick-row:nth(1) .slick-cell:nth(2)')
+      .dblclick();
 
     cy.get('.editor-title')
       .invoke('val')
@@ -348,7 +348,7 @@ describe('Example 21 - Row Detail View', () => {
     cy.get('.slick-viewport-top.slick-viewport-left')
       .scrollTo('top');
 
-    cy.get(`.slick-row[style="top: ${GRID_ROW_HEIGHT * 8}px;"] .slick-cell:nth(1)`)
+    cy.get(`.slick-row[style="top: ${GRID_ROW_HEIGHT * 8}px;"] .slick-cell:nth(2)`)
       .click()
       .wait(40);
 


### PR DESCRIPTION
- provide a new `preRegisterExternalExtensions()` callback in the grid options to help multiple extensions to work together.
- add Row Selection + Row Detail to Example 21
- that will mostly help only Slickgrid-Universal (and won't help Angular/Aurelia projects but it might be useful in the future, who knows)