### PR TITLE
chore: change `getOffset()` to always return (never null)

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1867,13 +1867,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       },
       onStart: (e: SortableEvent) => {
         canDragScroll = !this.hasFrozenColumns() ||
-          getOffset(e.item)!.left > getOffset(this._viewportScrollContainerX)!.left;
+          getOffset(e.item).left > getOffset(this._viewportScrollContainerX).left;
 
         if (canDragScroll && (e as SortableEvent & { originalEvent: MouseEvent; }).originalEvent.pageX > this._container.clientWidth) {
           if (!(columnScrollTimer)) {
             columnScrollTimer = setInterval(scrollColumnsRight, 100);
           }
-        } else if (canDragScroll && (e as SortableEvent & { originalEvent: MouseEvent; }).originalEvent.pageX < getOffset(this._viewportScrollContainerX)!.left) {
+        } else if (canDragScroll && (e as SortableEvent & { originalEvent: MouseEvent; }).originalEvent.pageX < getOffset(this._viewportScrollContainerX).left) {
           if (!(columnScrollTimer)) {
             columnScrollTimer = setInterval(scrollColumnsLeft, 100);
           }
@@ -5192,8 +5192,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         rowOffset = (this._options.frozenBottom) ? Utils.height(this._canvasTopL) as number : this.frozenRowsHeight;
       }
 
-      const x = targetEvent.clientX - c!.left;
-      const y = targetEvent.clientY - c!.top + rowOffset + document.documentElement.scrollTop;
+      const x = targetEvent.clientX - c.left;
+      const y = targetEvent.clientY - c.top + rowOffset + document.documentElement.scrollTop;
       row = this.getCellFromPoint(x, y).row;
     }
 
@@ -5307,7 +5307,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (isDefined(this.activeCellNode)) {
       const activeCellOffset = getOffset(this.activeCellNode);
-      let rowOffset = Math.floor(getOffset(Utils.parents(this.activeCellNode, '.grid-canvas')[0] as HTMLElement)!.top);
+      let rowOffset = Math.floor(getOffset(Utils.parents(this.activeCellNode, '.grid-canvas')[0] as HTMLElement).top);
       const isBottom = Utils.parents(this.activeCellNode, '.grid-canvas-bottom').length;
 
       if (this.hasFrozenRows && isBottom) {
@@ -5316,7 +5316,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           : this.frozenRowsHeight;
       }
 
-      const cell = this.getCellFromPoint(activeCellOffset!.left, Math.ceil(activeCellOffset!.top) - rowOffset);
+      const cell = this.getCellFromPoint(activeCellOffset.left, Math.ceil(activeCellOffset.top) - rowOffset);
       this.activeRow = cell.row;
       this.activeCell = this.activePosX = this.activeCell = this.activePosX = this.getCellFromNode(this.activeCellNode);
 

--- a/packages/common/src/editors/__tests__/longTextEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/longTextEditor.spec.ts
@@ -86,6 +86,7 @@ describe('LongTextEditor', () => {
       translater: null as any,
       editorTypingDebounce: 0,
     };
+    (getOffset as jest.Mock).mockReturnValue({ top: 0, left: 0, right: 0, bottom: 0 });
   });
 
   describe('with invalid Editor instance', () => {
@@ -819,7 +820,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should assume editor to positioned on the right & bottom of the cell when there is enough room', () => {
-        (getOffset as jest.Mock).mockReturnValue({ top: 100, left: 200 }); // mock cell position
+        (getOffset as jest.Mock).mockReturnValueOnce({ top: 100, left: 200 }); // mock cell position
 
         editor = new LongTextEditor(editorArguments);
         const editorElm = document.body.querySelector('.slick-large-editor-text') as HTMLDivElement;
@@ -829,7 +830,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should assume editor to positioned on the right of the cell when there is NOT enough room on the left', () => {
-        (getOffset as jest.Mock).mockReturnValue({ top: 100, left: 900 }); // mock cell position that will be over max of 1024px
+        (getOffset as jest.Mock).mockReturnValueOnce({ top: 100, left: 900 }); // mock cell position that will be over max of 1024px
 
         editor = new LongTextEditor(editorArguments);
         const editorElm = document.body.querySelector('.slick-large-editor-text') as HTMLDivElement;
@@ -839,7 +840,7 @@ describe('LongTextEditor', () => {
       });
 
       it('should assume editor to positioned on the top of the cell when there is NOT enough room on the bottom', () => {
-        (getOffset as jest.Mock).mockReturnValue({ top: 550, left: 200 }); // mock cell position that will be over max of 600px
+        (getOffset as jest.Mock).mockReturnValueOnce({ top: 550, left: 200 }); // mock cell position that will be over max of 600px
 
         editor = new LongTextEditor(editorArguments);
         const editorElm = document.body.querySelector('.slick-large-editor-text') as HTMLDivElement;

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -315,8 +315,8 @@ export class LongTextEditor implements Editor {
     const calculatedBodyWidth = document.body.offsetWidth || window.innerWidth;
 
     // first defined position will be bottom/right (which will position the editor completely over the cell)
-    let newPositionTop = containerOffset?.top ?? parentPosition.top ?? 0;
-    let newPositionLeft = containerOffset?.left ?? parentPosition.left ?? 0;
+    let newPositionTop = this.args.container ? containerOffset.top : parentPosition.top ?? 0;
+    let newPositionLeft = this.args.container ? containerOffset.left : parentPosition.left ?? 0;
 
     // user could explicitely use a "left" position (when user knows his column is completely on the right)
     // or when using "auto" and we detect not enough available space then we'll position to the "left" of the cell

--- a/packages/common/src/extensions/menuFromCellBaseClass.ts
+++ b/packages/common/src/extensions/menuFromCellBaseClass.ts
@@ -364,11 +364,11 @@ export class MenuFromCellBaseClass<M extends CellMenu | ContextMenu> extends Men
 
       const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;
       const parentOffset = getOffset(parentElm);
-      let menuOffsetLeft = (parentElm && this._camelPluginName === 'cellMenu') ? parentOffset?.left ?? 0 : targetEvent.pageX;
-      let menuOffsetTop = (parentElm && this._camelPluginName === 'cellMenu') ? parentOffset?.top ?? 0 : targetEvent.pageY;
+      let menuOffsetLeft = (parentElm && this._camelPluginName === 'cellMenu') ? parentOffset.left : targetEvent.pageX;
+      let menuOffsetTop = (parentElm && this._camelPluginName === 'cellMenu') ? parentOffset.top : targetEvent.pageY;
       if (isSubMenu && this._camelPluginName === 'contextMenu') {
-        menuOffsetLeft = parentOffset?.left ?? 0;
-        menuOffsetTop = parentOffset?.top ?? 0;
+        menuOffsetLeft = parentOffset.left;
+        menuOffsetTop = parentOffset.top;
       }
       const parentCellWidth = parentElm.offsetWidth || 0;
       const menuHeight = menuElm?.offsetHeight || 0;

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -133,8 +133,8 @@ export class SlickCellRangeSelector {
     const viewportBottom = viewportTop + this._viewportHeight;
 
     const viewportOffset = getOffset(this._activeViewport);
-    const viewportOffsetLeft = viewportOffset?.left ?? 0;
-    const viewportOffsetTop = viewportOffset?.top ?? 0;
+    const viewportOffsetLeft = viewportOffset.left;
+    const viewportOffsetTop = viewportOffset.top;
     const viewportOffsetRight = viewportOffsetLeft + this._viewportWidth;
     const viewportOffsetBottom = viewportOffsetTop + this._viewportHeight;
 
@@ -264,8 +264,8 @@ export class SlickCellRangeSelector {
   protected handleDragTo(e: { pageX: number; pageY: number; }, dd: DragPosition): void {
     const targetEvent: MouseEvent | Touch = (e as unknown as TouchEvent)?.touches?.[0] ?? e;
     const end = this._grid.getCellFromPoint(
-      targetEvent.pageX - (getOffset(this._activeCanvas)?.left ?? 0) + this._columnOffset,
-      targetEvent.pageY - (getOffset(this._activeCanvas)?.top ?? 0) + this._rowOffset
+      targetEvent.pageX - getOffset(this._activeCanvas).left + this._columnOffset,
+      targetEvent.pageY - getOffset(this._activeCanvas).top + this._rowOffset
     );
 
     if (end !== undefined) {
@@ -376,12 +376,12 @@ export class SlickCellRangeSelector {
     this._grid.focus();
 
     const canvasOffset = getOffset(this._canvas);
-    let startX = dd.startX - (canvasOffset?.left ?? 0);
+    let startX = dd.startX - (canvasOffset.left);
     if (this._gridOptions.frozenColumn! >= 0 && this._isRightCanvas) {
       startX += this._scrollLeft;
     }
 
-    let startY = dd.startY - (canvasOffset?.top ?? 0);
+    let startY = dd.startY - (canvasOffset.top);
     if (this._gridOptions.frozenRow! >= 0 && this._isBottomCanvas) {
       startY += this._scrollTop;
     }

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -371,14 +371,14 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       const menuWidth = menuElm?.offsetWidth ?? 0;
       const contentMinWidth = gridMenuOptions?.contentMinWidth ?? this._defaults.contentMinWidth ?? 0;
       const currentMenuWidth = ((contentMinWidth > menuWidth) ? contentMinWidth : (menuWidth)) || 0;
-      const nextPositionTop = menuIconOffset?.top ?? 0;
-      const nextPositionLeft = menuIconOffset?.right ?? 0;
+      const nextPositionTop = menuIconOffset.top;
+      const nextPositionLeft = menuIconOffset.right;
 
       let menuOffsetLeft;
       let menuOffsetTop;
       if (isSubMenu) {
-        menuOffsetTop = parentOffset?.top ?? 0;
-        menuOffsetLeft = parentOffset?.left ?? 0;
+        menuOffsetTop = parentOffset.top;
+        menuOffsetLeft = parentOffset.left;
       } else {
         menuOffsetTop = nextPositionTop + iconButtonElm.offsetHeight; // top position has to include button height so the menu is placed just below it
         menuOffsetLeft = gridMenuOptions?.dropSide === 'right'

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -143,9 +143,9 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     const gridPos = this.grid.getGridPosition();
     const menuWidth = menuElm.offsetWidth;
     const parentOffset = getOffset(parentElm);
-    let menuOffsetLeft = isSubMenu ? parentOffset?.left ?? 0 : relativePos?.left ?? 0;
+    let menuOffsetLeft = isSubMenu ? parentOffset.left : relativePos?.left ?? 0;
     let menuOffsetTop = isSubMenu
-      ? parentOffset?.top ?? 0
+      ? parentOffset.top
       : (relativePos?.top ?? 0) + (this.addonOptions?.menuOffsetTop ?? 0) + buttonElm.clientHeight;
 
     // for sub-menus only, auto-adjust drop position (up/down)

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -199,7 +199,7 @@ export class SlickRowMoveManager {
       const e = evt.getNativeEvent<MouseEvent | TouchEvent>();
 
       const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
-      const top = targetEvent.pageY - (getOffset(this._canvas)?.top ?? 0);
+      const top = targetEvent.pageY - (getOffset(this._canvas).top);
       dd.selectionProxy.style.top = `${top - 5}px`;
       dd.selectionProxy.style.display = 'block';
 

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -238,7 +238,7 @@ describe('Resizer Service', () => {
       service.init(gridStub, divContainer);
       const output = service.bindAutoResizeDataGrid();
 
-      expect(output).toBe(null as any);
+      expect(output).toBeFalsy();
       expect(service.eventHandler).toBeTruthy();
     });
 
@@ -246,7 +246,7 @@ describe('Resizer Service', () => {
       jest.spyOn(gridStub, 'getContainerNode').mockReturnValueOnce(null as any);
       service.init(gridStub, divContainer);
       const output = service.calculateGridNewDimensions(mockGridOptions);
-      expect(output).toBe(null as any);
+      expect(output).toBeFalsy();
     });
 
     it('should trigger a grid resize when a window resize event occurs', () => {

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -210,7 +210,7 @@ export class ResizerService {
     const autoResizeOptions = gridOptions?.autoResize ?? {};
     const gridElmOffset = getOffset(this._gridDomElm);
 
-    if (!window || this._gridDomElm === undefined) {
+    if (!window || !this._gridDomElm) {
       return null;
     }
 

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -168,7 +168,7 @@ export class ResizerService {
       this._resizeObserver.observe(this._pageContainerElm);
     } else {
       // if we can't find the grid to resize, return without binding anything
-      if (this._gridDomElm === undefined || getOffset(this._gridDomElm) === undefined) {
+      if (this._gridDomElm === undefined) {
         return null;
       }
 
@@ -210,7 +210,7 @@ export class ResizerService {
     const autoResizeOptions = gridOptions?.autoResize ?? {};
     const gridElmOffset = getOffset(this._gridDomElm);
 
-    if (!window || gridElmOffset === undefined) {
+    if (!window || this._gridDomElm === undefined) {
       return null;
     }
 
@@ -237,7 +237,7 @@ export class ResizerService {
     } else {
       // uses the browser's window height with its top offset to calculate grid height
       gridHeight = window.innerHeight || 0;
-      gridOffsetTop = gridElmOffset?.top ?? 0;
+      gridOffsetTop = gridElmOffset.top;
     }
 
     const availableHeight = gridHeight - gridOffsetTop - bottomPadding;
@@ -648,7 +648,7 @@ export class ResizerService {
       this._intervalId = setInterval(async () => {
         const headerTitleRowHeight = 44; // this one is set by SASS/CSS so let's hard code it
         const headerPos = getOffset(headerElm);
-        let headerOffsetTop = headerPos?.top ?? 0;
+        let headerOffsetTop = headerPos.top;
         if (this.gridOptions?.enableFiltering && this.gridOptions.headerRowHeight) {
           headerOffsetTop += this.gridOptions.headerRowHeight; // filter row height
         }
@@ -658,13 +658,13 @@ export class ResizerService {
         headerOffsetTop += headerTitleRowHeight; // header title row height
 
         const viewportPos = getOffset(viewportElm);
-        const viewportOffsetTop = viewportPos?.top ?? 0;
+        const viewportOffsetTop = viewportPos.top;
 
         // if header row is Y coordinate 0 (happens when user is not in current Tab) or when header titles are lower than the viewport of dataset (this can happen when user change Tab and DOM is not shown)
         // another resize condition could be that if the grid location is at coordinate x/y 0/0, we assume that it's in a hidden tab and we'll need to resize whenever that tab becomes active
         // for these cases we'll resize until it's no longer true or until we reach a max time limit (70min)
         const containerElmOffset = getOffset(this._gridContainerElm);
-        let isResizeRequired = (headerPos?.top === 0 || ((headerOffsetTop - viewportOffsetTop) > 2) || (containerElmOffset?.left === 0 && containerElmOffset?.top === 0)) ? true : false;
+        let isResizeRequired = (headerPos?.top === 0 || ((headerOffsetTop - viewportOffsetTop) > 2) || (containerElmOffset.left === 0 && containerElmOffset.top === 0)) ? true : false;
 
         // another condition for a required resize is when the grid is hidden (not in current tab) then its "rightPx" rendered range will be 0px
         // if that's the case then we know the grid is still hidden and we need to resize it whenever it becomes visible (when its "rightPx" becomes greater than 0 then it's visible)
@@ -680,7 +680,7 @@ export class ResizerService {
         }
 
         // visible grid (shown to the user and not hidden in another Tab will have an offsetParent defined)
-        if (this.checkIsGridShown() && (isResizeRequired || containerElmOffset?.left === 0 || containerElmOffset?.top === 0)) {
+        if (this.checkIsGridShown() && (isResizeRequired || containerElmOffset.left === 0 || containerElmOffset.top === 0)) {
           await this.resizeGrid();
           if (resizeGoodCount < 5) {
             this._grid.updateColumns(); // also refresh header titles after grid becomes visible in new tab, this fixes an issue observed in Salesforce

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -60,10 +60,10 @@ export function SlickCompositeEditor(this: any, columns: Column[], containers: A
     const height = container?.clientHeight ?? 0;
 
     return {
-      top: offset?.top ?? 0,
-      left: offset?.left ?? 0,
-      bottom: (offset?.top ?? 0) + height,
-      right: (offset?.left ?? 0) + width,
+      top: offset.top,
+      left: offset.left,
+      bottom: offset.top + height,
+      right: offset.left + width,
       width,
       height,
       visible: true

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -1,6 +1,6 @@
 import { delay, of, throwError } from 'rxjs';
 
-import { Column, getOffset, GridOption, SlickGrid, SharedService, type SlickDataView, SlickEvent, SlickEventData, } from '@slickgrid-universal/common';
+import { Column, getOffset, GridOption, SlickGrid, type SlickDataView, SlickEvent, SlickEventData, } from '@slickgrid-universal/common';
 
 import { SlickCustomTooltip } from '../slickCustomTooltip';
 import { ContainerServiceStub } from '../../../../test/containerServiceStub';
@@ -50,16 +50,15 @@ describe('SlickCustomTooltip plugin', () => {
   let container: ContainerServiceStub;
   let plugin: SlickCustomTooltip;
   let rxjsResourceStub: RxJsResourceStub;
-  let sharedService: SharedService;
 
   beforeEach(() => {
     container = new ContainerServiceStub();
-    sharedService = new SharedService();
     rxjsResourceStub = new RxJsResourceStub();
     plugin = new SlickCustomTooltip();
     divContainer.className = `slickgrid-container ${GRID_UID}`;
     document.body.appendChild(divContainer);
     (document as any).elementFromPoint = jest.fn(); // document.elementFromPoint() doesn't exist in JSDOM but we can mock it
+    (getOffset as jest.Mock).mockReturnValue({ top: 0, left: 0, right: 0, bottom: 0 });
   });
 
   afterEach(() => {
@@ -651,7 +650,7 @@ describe('SlickCustomTooltip plugin', () => {
     jest.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
     jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
     jest.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
-    (getOffset as jest.Mock).mockReturnValue({ top: 100, left: 1030, height: 75, width: 400 }); // mock cell position
+    (getOffset as jest.Mock).mockReturnValueOnce({ top: 100, left: 1030, height: 75, width: 400 }); // mock cell position
 
     plugin.init(gridStub, container);
     plugin.setOptions({
@@ -766,7 +765,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('name title tooltip');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseOver" is triggered', () => {
@@ -795,7 +794,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header tooltip text');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseEnter" is triggered', () => {
@@ -824,7 +823,7 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header row tooltip text');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseOver" is triggered', () => {
@@ -853,6 +852,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header row tooltip text');
     expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
+    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 });

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -456,7 +456,7 @@ export class SlickCustomTooltip {
   protected reposition(cell: { row: number; cell: number; }): void {
     if (this._tooltipElm) {
       this._cellNodeElm = this._cellNodeElm || this._grid.getCellNode(cell.row, cell.cell) as HTMLDivElement;
-      const cellPosition = getOffset(this._cellNodeElm) || { top: 0, left: 0 };
+      const cellPosition = getOffset(this._cellNodeElm);
       const cellContainerWidth = this._cellNodeElm.offsetWidth;
       const calculatedTooltipHeight = this._tooltipElm.getBoundingClientRect().height;
       const calculatedTooltipWidth = this._tooltipElm.getBoundingClientRect().width;
@@ -502,7 +502,7 @@ export class SlickCustomTooltip {
 
       // when having multiple tooltips, we'll try to reposition tooltip to mouse position
       if (this._tooltipElm && (this._hasMultipleTooltips || this.cellAddonOptions?.repositionByMouseOverTarget)) {
-        const mouseElmOffset = getOffset(this._mouseTarget)!;
+        const mouseElmOffset = getOffset(this._mouseTarget);
         if (finalTooltipPosition.includes('left') || finalTooltipPosition === 'top-center') {
           newPositionLeft = mouseElmOffset.left - (this._addonOptions?.offsetArrow ?? 3);
         } else if (finalTooltipPosition.includes('right')) {

--- a/packages/utils/src/__tests__/domUtils.spec.ts
+++ b/packages/utils/src/__tests__/domUtils.spec.ts
@@ -232,7 +232,7 @@ describe('Service/domUtilies', () => {
 
     it('should return undefined when element if not a valid html element', () => {
       const output = getOffset(null as any);
-      expect(output).toEqual(undefined);
+      expect(output).toEqual({ top: 0, bottom: 0, left: 0, right: 0 });
     });
 
     it('should return top/left 0 when creating a new element in the document without positions', () => {

--- a/packages/utils/src/domUtils.ts
+++ b/packages/utils/src/domUtils.ts
@@ -7,16 +7,16 @@ export function calculateAvailableSpace(element: HTMLElement): { top: number; bo
   let left = 0;
   let right = 0;
 
-  const windowHeight = window.innerHeight ?? 0;
-  const windowWidth = window.innerWidth ?? 0;
+  const windowHeight = window.innerHeight || 0;
+  const windowWidth = window.innerWidth || 0;
   const scrollPosition = windowScrollPosition();
   const pageScrollTop = scrollPosition.top;
   const pageScrollLeft = scrollPosition.left;
   const elmOffset = getOffset(element);
 
   if (elmOffset) {
-    const elementOffsetTop = elmOffset.top ?? 0;
-    const elementOffsetLeft = elmOffset.left ?? 0;
+    const elementOffsetTop = elmOffset.top;
+    const elementOffsetLeft = elmOffset.left;
     top = elementOffsetTop - pageScrollTop;
     left = elementOffsetLeft - pageScrollLeft;
     bottom = windowHeight - (elementOffsetTop - pageScrollTop + element.clientHeight);
@@ -142,17 +142,17 @@ export function getOffsetRelativeToParent(parentElm: HTMLElement | null, childEl
 }
 
 /** Get HTML element offset with pure JS */
-export function getOffset(elm?: HTMLElement | null): HtmlElementPosition | undefined {
-  if (!elm || !elm.getBoundingClientRect) {
-    return undefined;
-  }
-  const box = elm.getBoundingClientRect();
-  const docElem = document.documentElement;
-
+export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
   let top = 0;
   let left = 0;
   let bottom = 0;
   let right = 0;
+
+  if (!elm || !elm.getBoundingClientRect) {
+    return { top, bottom, left, right };
+  }
+  const box = elm.getBoundingClientRect();
+  const docElem = document.documentElement;
 
   if (box?.top !== undefined && box.left !== undefined) {
     top = box.top + window.pageYOffset - docElem.clientTop;


### PR DESCRIPTION
- prior to the code change, we could provide an undefined/null element which would have returned an undefined result, but I think it's better to always return and if the element is really null then we should check it before calling the method
- this code change is also simplifies the code a lot too