### PR TITLE
chore: move Infinite Scroll logic to vanilla component

### DIFF
--- a/packages/odata/src/services/__tests__/grid-odata.service.spec.ts
+++ b/packages/odata/src/services/__tests__/grid-odata.service.spec.ts
@@ -14,7 +14,6 @@ import {
   OperatorType,
   Pagination,
   SharedService,
-  SlickEvent,
   type SlickGrid,
 } from '@slickgrid-universal/common';
 import { GridOdataService } from '../grid-odata.service';
@@ -25,24 +24,12 @@ const DEFAULT_PAGE_SIZE = 20;
 
 let gridOptionMock: GridOption;
 
-const addVanillaEventPropagation = function (event) {
-  Object.defineProperty(event, 'isPropagationStopped', { writable: true, configurable: true, value: jest.fn() });
-  Object.defineProperty(event, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: jest.fn() });
-  return event;
-};
-
-const viewportElm = document.createElement('div');
-viewportElm.className = 'slick-viewport';
-Object.defineProperty(viewportElm, 'offsetHeight', { writable: true, configurable: true, value: 12 });
-
 const gridStub = {
   autosizeColumns: jest.fn(),
   getColumnIndex: jest.fn(),
   getScrollbarDimensions: jest.fn(),
   getColumns: jest.fn(),
   getOptions: () => gridOptionMock,
-  getViewportNode: () => viewportElm,
-  onScroll: new SlickEvent(),
   setColumns: jest.fn(),
   registerPlugin: jest.fn(),
   setSelectedRows: jest.fn(),
@@ -55,7 +42,6 @@ describe('GridOdataService', () => {
   let paginationOptions: Pagination;
   let serviceOptions: OdataOption;
   let sharedService: SharedService;
-  const onScrollEndMock = jest.fn();
 
   beforeEach(() => {
     sharedService = new SharedService();
@@ -77,7 +63,6 @@ describe('GridOdataService', () => {
       defaultFilterRangeOperator: OperatorType.rangeInclusive,
       backendServiceApi: {
         service: service as BackendService,
-        onScrollEnd: onScrollEndMock,
         preProcess: jest.fn(),
         process: jest.fn(),
         postProcess: jest.fn(),
@@ -86,7 +71,6 @@ describe('GridOdataService', () => {
   });
 
   afterEach(() => {
-    service.dispose();
     jest.clearAllMocks();
   });
 
@@ -109,33 +93,6 @@ describe('GridOdataService', () => {
 
       expect(spy).toHaveBeenCalled();
       expect(service.columnDefinitions).toEqual(columns);
-    });
-
-    it('should execute onScrollEnd callback when SlickGrid onScroll is triggered with a "mousewheel" event', () => {
-      service.init({ ...serviceOptions, infiniteScroll: true }, paginationOptions, gridStub);
-
-      const mouseEvent = addVanillaEventPropagation(new Event('scroll'));
-      gridStub.onScroll.notify({ scrollHeight: 10, scrollTop: 10, scrollLeft: 15, grid: gridStub, triggeredBy: 'mousewheel' }, mouseEvent, gridStub);
-
-      expect(onScrollEndMock).toHaveBeenCalled();
-    });
-
-    it('should execute onScrollEnd callback when SlickGrid onScroll is triggered with a "scroll" event', () => {
-      service.init({ ...serviceOptions, infiniteScroll: true }, paginationOptions, gridStub);
-
-      const scrollEvent = addVanillaEventPropagation(new Event('scroll'));
-      gridStub.onScroll.notify({ scrollHeight: 10, scrollTop: 10, scrollLeft: 15, grid: gridStub, triggeredBy: 'scroll' }, scrollEvent, gridStub);
-
-      expect(onScrollEndMock).toHaveBeenCalled();
-    });
-
-    it('should NOT execute onScrollEnd callback when SlickGrid onScroll is triggered with an event that is NOT "mousewheel" neither "scroll"', () => {
-      service.init({ ...serviceOptions, infiniteScroll: true }, paginationOptions, gridStub);
-
-      const clickEvent = addVanillaEventPropagation(new Event('click'));
-      gridStub.onScroll.notify({ scrollHeight: 10, scrollTop: 10, scrollLeft: 15, grid: gridStub, triggeredBy: 'click' }, clickEvent, gridStub);
-
-      expect(onScrollEndMock).not.toHaveBeenCalled();
     });
   });
 
@@ -571,21 +528,6 @@ describe('GridOdataService', () => {
         expect(query).toBe(expectation);
         expect(querySpy).toHaveBeenCalled();
       });
-    });
-
-    it('should expect the "skip" options to be undefined when the "processOnSortChanged()" is called and infinite scroll is enabled', () => {
-      const expectation = `$top=10&$orderby=Gender desc`;
-      const querySpy = jest.spyOn(service.odataService, 'buildQuery');
-      const mockColumn = { id: 'gender', field: 'gender' } as Column;
-      const mockSortChangedArgs = { columnId: 'gender', sortCol: mockColumn, sortAsc: false, multiColumnSort: false } as ColumnSort;
-
-      service.init({ ...serviceOptions, infiniteScroll: true }, paginationOptions, gridStub);
-      service.updateOptions({ skip: 10 });
-      const query = service.processOnSortChanged(null as any, mockSortChangedArgs);
-
-      expect(service.options!.skip).toBeUndefined();
-      expect(query).toBe(expectation);
-      expect(querySpy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
- as per this [comment](https://github.com/ghiscoding/slickgrid-universal/pull/1609#issuecomment-2268745793) suggestion, the Infinite Scroll logic shouldn't be in any Backend Services, it should rather be moved to the vanilla component (for other repos, that would be within Angular-Slickgrid, ...)