### PR TITLE
fix(common): add missing dependency `@types/trusted-types`

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -71,6 +71,7 @@
     "@slickgrid-universal/event-pub-sub": "workspace:~",
     "@slickgrid-universal/utils": "workspace:~",
     "@types/sortablejs": "^1.15.8",
+    "@types/trusted-types": "^2.0.7",
     "autocompleter": "^9.3.0",
     "dequal": "^2.0.3",
     "excel-builder-vanilla": "3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       '@types/sortablejs':
         specifier: ^1.15.8
         version: 1.15.8
+      '@types/trusted-types':
+        specifier: ^2.0.7
+        version: 2.0.7
       autocompleter:
         specifier: ^9.3.0
         version: 9.3.0


### PR DESCRIPTION
`@types/trusted-types` must be installed in order to use `TrustedHTML` interface (for CSP)