### PR TITLE
feat: migrate back to Vanilla-Calendar-Pro

### DIFF
--- a/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
+++ b/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
@@ -5,9 +5,7 @@
 - See the [Editors - Wiki](../Editors.md) for more general info about Editors (validators, event handlers, ...)
 
 ### Information
-The Date Editor is provided through an external library named [Vanilla-Calendar-Picker](https://github.com/ghiscoding/vanilla-calendar-picker) (a fork of [Vanilla-Calendar-Pro](https://vanilla-calendar.pro)) and all options from that library can be added to your `editorOptions` (see below), so in order to add things like minimum date, disabling dates, ... just review all the [Vanilla-Calendar-Pro](https://vanilla-calendar.pro/docs/reference/additionally/settings) and then add them into `editorOptions`. We use [Tempo](https://tempo.formkit.com/) to parse and format Dates to the chosen format (when `type`, `outputType` and/or `saveType` are provided in your column definition)
-
-We use an external lib named [Vanilla-Calendar](https://vanilla-calendar.pro/), however please note that since there were some features missing, I forked the project as [vanilla-calendar-picker](https://github.com/ghiscoding/vanilla-calendar-picker) with the hope that all features will eventually be merged to the original repo (if and what that happens, it will be entirely transparent to the user). 
+The Date Editor is provided through an external library named [Vanilla-Calendar-Pro](https://github.com/ghiscoding/vanilla-calendar-pro) and all options from that library can be added to your `editorOptions` (see below), so in order to add things like minimum date, disabling dates, ... just review all the [Vanilla-Calendar-Pro](https://vanilla-calendar.pro/docs/reference/additionally/settings) and then add them into `editorOptions`. We use [Tempo](https://tempo.formkit.com/) to parse and format Dates to the chosen format (when `type`, `outputType` and/or `saveType` are provided in your column definition)
 
 > **Note** Also just so you know, `editorOptions` is used by all other editors as well to expose external library like Autocompleter, Multiple-Select, etc...
 
@@ -76,7 +74,7 @@ initializeGrid() {
 ```
 
 ### Date Format
-Your column definitions may include a `type` to tell Formatters how to formate your date, this `type` is also used by the Editor when saving. 
+Your column definitions may include a `type` to tell Formatters how to formate your date, this `type` is also used by the Editor when saving.
 
 ##### What if I want to use a different format when saving?
 There are 3 types you can provide to inform the Editor on how to save:
@@ -87,6 +85,6 @@ There are 3 types you can provide to inform the Editor on how to save:
 
 The `type` and `outputType` are often used when you want to save something different compare to what you show to the user (for example, show a date in the US Format but save it as ISO or UTC).
 
-The difference between `outputType` and `saveOutputType` when you wish to display a certain format in the date editor input (while editing), but wish to save in a different format. You will rarely need the `saveOutputType` and for most use cases, the use of both `type` and `outputType` should be enough. 
+The difference between `outputType` and `saveOutputType` when you wish to display a certain format in the date editor input (while editing), but wish to save in a different format. You will rarely need the `saveOutputType` and for most use cases, the use of both `type` and `outputType` should be enough.
 
 > **Note** the type detection when saving is the inverse of the list above, whichever comes first from 3 to 1.

--- a/docs/migrations/migration-to-5.x.md
+++ b/docs/migrations/migration-to-5.x.md
@@ -1,7 +1,7 @@
 ## Version 5 - Better UI and Dark Mode with Pure CSS SVG icons ✨
 This new release brings a lot of changes oriented towards better UI/UX, our SVG icons are now pure CSS and can be colorized like any other text via the native CSS `color` property (which helps a lot to improve the Dark Mode Theme).
 
-Another noticeable UI change is the migration from [Flatpickr](https://flatpickr.js.org/) to [Vanilla-Calendar-Picker](https://github.com/ghiscoding/vanilla-calendar-picker) (which is a fork of [Vanilla-Calendar-Pro](https://vanilla-calendar.pro/) and we'll hopefully drop the fork in the near future if possible), there are multiple reasons to migrate our date picker to another library as shown below. Another change that is mostly internal but is also indirectly connected to the date picker is the migration from MomentJS to [Tempo](https://tempo.formkit.com/) which is modern and is packaged as ESM which is great for Tree Shaking.
+Another noticeable UI change is the migration from [Flatpickr](https://flatpickr.js.org/) to [Vanilla-Calendar-Pro](https://vanilla-calendar.pro/), there are multiple reasons to migrate our date picker to another library as shown below. Another change that is mostly internal but is also indirectly connected to the date picker is the migration from MomentJS to [Tempo](https://tempo.formkit.com/) which is modern and is packaged as ESM which is great for Tree Shaking.
 
 ##### Flatpickr cons:
   - barely supported (lots of opened PR but nothing merged for the past 2 years)
@@ -205,8 +205,6 @@ prepareGrid() {
   }];
 }
 ```
-
-> **Note** the `'today'` shortcut currently only exist in `Vanilla-Calendar-Picker` fork (a PR has also been opened on the original lib), however the rest of the settings should be the same, visit `Vanilla-Calendar-Pro` [settings](https://vanilla-calendar.pro/docs/reference/additionally/settings) website for all other options. The hope is to hopefully drop the fork whenever the original project receives all missing features.
 
 > **Note** to keep docs available for older as well as newer versions, I renamed the old one doc as [Date-Picker (flatpickr)](https://ghiscoding.gitbook.io/slickgrid-universal/column-functionalities/editors/date-editor-flatpickr) and created a new one named [Date-Picker (vanilla-calendar)](https://ghiscoding.gitbook.io/slickgrid-universal/column-functionalities/editors/date-editor-vanilla-calendar).
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -78,7 +78,7 @@
     "multiple-select-vanilla": "^3.3.1",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
-    "vanilla-calendar-pro": "^2.9.9"
+    "vanilla-calendar-pro": "^2.9.10"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -78,7 +78,7 @@
     "multiple-select-vanilla": "^3.3.1",
     "sortablejs": "^1.15.2",
     "un-flatten-tree": "^2.0.12",
-    "vanilla-calendar-picker": "^2.11.9"
+    "vanilla-calendar-pro": "^2.9.9"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -1,7 +1,8 @@
 import { format } from '@formkit/tempo';
 import type { AutocompleteItem } from 'autocompleter';
 import { dequal } from 'dequal/lite';
-import type { IOptions, ISelected, VanillaCalendar } from 'vanilla-calendar-picker';
+import type VanillaCalendar from 'vanilla-calendar-pro';
+import type { IOptions, ISelected } from 'vanilla-calendar-pro/types';
 
 import type { AutocompleterOption, Column, ColumnEditor, ColumnFilter } from '../interfaces/index';
 import { FieldType } from '../enums';
@@ -63,12 +64,12 @@ export function setPickerDates(
       }
     }
 
-    const newSettingSelected: ISelected = selectedSettings ?? {
+    const newSettingSelected = selectedSettings ?? {
       dates: [pickerDates.map(p => format(p, isoFormat)).join(':')],
       month: pickerDates[0]?.getMonth(),
       year: pickerDates[0]?.getFullYear(),
       time: inputFormat === 'ISO8601' || (inputFormat || '').toLowerCase().includes('h') ? format(pickerDates[0], 'HH:mm') : undefined,
-    };
+    } as ISelected;
 
     if (!dequal(pickerInstance.settings!.selected, newSettingSelected)) {
       pickerInstance.settings!.selected = newSettingSelected;

--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -2,7 +2,7 @@ import { format } from '@formkit/tempo';
 import type { AutocompleteItem } from 'autocompleter';
 import { dequal } from 'dequal/lite';
 import type VanillaCalendar from 'vanilla-calendar-pro';
-import type { IOptions, ISelected } from 'vanilla-calendar-pro/types';
+import type { IOptions, ISelected, FormatDateString } from 'vanilla-calendar-pro/types';
 
 import type { AutocompleterOption, Column, ColumnEditor, ColumnFilter } from '../interfaces/index';
 import { FieldType } from '../enums';
@@ -64,12 +64,12 @@ export function setPickerDates(
       }
     }
 
-    const newSettingSelected = selectedSettings ?? {
-      dates: [pickerDates.map(p => format(p, isoFormat)).join(':')],
+    const newSettingSelected: ISelected = selectedSettings ?? {
+      dates: [pickerDates.map(p => format(p, isoFormat)).join(':') as FormatDateString],
       month: pickerDates[0]?.getMonth(),
       year: pickerDates[0]?.getFullYear(),
       time: inputFormat === 'ISO8601' || (inputFormat || '').toLowerCase().includes('h') ? format(pickerDates[0], 'HH:mm') : undefined,
-    } as ISelected;
+    };
 
     if (!dequal(pickerInstance.settings!.selected, newSettingSelected)) {
       pickerInstance.settings!.selected = newSettingSelected;

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -1,5 +1,6 @@
 import { format } from '@formkit/tempo';
-import { type VanillaCalendar } from 'vanilla-calendar-picker';
+import type VanillaCalendar from 'vanilla-calendar-pro';
+import type { ISelected } from 'vanilla-calendar-pro/types';
 
 import { Editors } from '../index';
 import { DateEditor } from '../dateEditor';
@@ -240,7 +241,7 @@ describe('DateEditor', () => {
       expect(editor.pickerOptions.settings?.selected).toEqual({ dates: ['2001-02-04'], month: 2 });
 
       editor.changeEditorOption('range', { edgesOnly: true });
-      editor.changeEditorOption('selected', { dates: ['2020-03-10', 'today'] });
+      editor.changeEditorOption('selected', { dates: ['2020-03-10', 'today'] } as ISelected);
 
       expect(editor.pickerOptions.settings?.range).toEqual({ disablePast: true, edgesOnly: true });
       expect(editor.pickerOptions.settings?.selected).toEqual({ dates: ['2020-03-10', 'today'], month: 2 });

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -1,7 +1,8 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, setDeepValue } from '@slickgrid-universal/utils';
 import { parse } from '@formkit/tempo';
-import { VanillaCalendar, type IOptions } from 'vanilla-calendar-picker';
+import VanillaCalendar from 'vanilla-calendar-pro';
+import type { FormatDateString, IOptions } from 'vanilla-calendar-pro/types';
 
 import { Constants } from './../constants';
 import { FieldType } from '../enums/index';
@@ -23,7 +24,7 @@ import { setPickerDates } from '../commonEditorFilter';
 import { formatDateByFieldType, mapTempoDateFormatWithFieldType } from '../services/dateUtils';
 
 /*
- * An example of a date picker editor using Vanilla-Calendar-Picker
+ * An example of a date picker editor using Vanilla-Calendar-Pro
  */
 export class DateEditor implements Editor {
   protected _bindEventService: BindingEventService;
@@ -382,7 +383,7 @@ export class DateEditor implements Editor {
     const inputValue = value ?? this._originalDate ?? '';
     if (this.calendarInstance) {
       this._originalDate = inputValue;
-      this.calendarInstance.settings.selected.dates = [inputValue];
+      this.calendarInstance.settings.selected.dates = [inputValue as FormatDateString];
       if (!inputValue) {
         this.calendarInstance.settings.selected.dates = [];
         this._inputElm.value = '';

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -1,6 +1,6 @@
+import { parse } from '@formkit/tempo';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, setDeepValue } from '@slickgrid-universal/utils';
-import { parse } from '@formkit/tempo';
 import VanillaCalendar from 'vanilla-calendar-pro';
 import type { FormatDateString, IOptions } from 'vanilla-calendar-pro/types';
 

--- a/packages/common/src/editors/editors.index.ts
+++ b/packages/common/src/editors/editors.index.ts
@@ -19,7 +19,7 @@ export const Editors: Record<string, EditorConstructor> = {
   /** Checkbox Editor (uses native checkbox DOM element) */
   checkbox: CheckboxEditor,
 
-  /** Date Picker Editor (which uses 3rd party lib "vanilla-calendar-picker") */
+  /** Date Picker Editor (which uses 3rd party lib "vanilla-calendar-pro") */
   date: DateEditor,
 
   /** Dual Input Editor, default input type is text but it could be (integer/float/number/password/text) */

--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -1,6 +1,6 @@
 import 'jest-extended';
 import { format } from '@formkit/tempo';
-import type { VanillaCalendar } from 'vanilla-calendar-picker';
+import type VanillaCalendar from 'vanilla-calendar-pro';
 
 import { Filters } from '../filters.index';
 import { FieldType, OperatorType } from '../../enums/index';

--- a/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
@@ -1,5 +1,5 @@
 import 'jest-extended';
-import type { VanillaCalendar } from 'vanilla-calendar-picker';
+import type VanillaCalendar from 'vanilla-calendar-pro';
 
 import { FieldType } from '../../enums/index';
 import type { Column, FilterArguments, GridOption } from '../../interfaces/index';

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -1,7 +1,8 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, isDefined, } from '@slickgrid-universal/utils';
 import { format, parse } from '@formkit/tempo';
-import { VanillaCalendar, type IOptions } from 'vanilla-calendar-picker';
+import VanillaCalendar from 'vanilla-calendar-pro';
+import type { IOptions } from 'vanilla-calendar-pro/types';
 
 import {
   FieldType,

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -1,6 +1,6 @@
+import { format, parse } from '@formkit/tempo';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, isDefined, } from '@slickgrid-universal/utils';
-import { format, parse } from '@formkit/tempo';
 import VanillaCalendar from 'vanilla-calendar-pro';
 import type { IOptions } from 'vanilla-calendar-pro/types';
 

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -108,6 +108,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
   },
   datasetIdPropertyName: 'id',
   defaultFilter: Filters.input,
+  defaultEditorOptions: { date: { range: { min: 'today'}}},
   defaultBackendServiceFilterTypingDebounce: 500,
   enableFilterTrimWhiteSpace: false, // do we want to trim white spaces on all Filters?
   defaultFilterPlaceholder: '🔎︎',

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -108,7 +108,6 @@ export const GlobalGridOptions: Partial<GridOption> = {
   },
   datasetIdPropertyName: 'id',
   defaultFilter: Filters.input,
-  defaultEditorOptions: { date: { range: { min: 'today'}}},
   defaultBackendServiceFilterTypingDebounce: 500,
   enableFilterTrimWhiteSpace: false, // do we want to trim white spaces on all Filters?
   defaultFilterPlaceholder: '🔎︎',

--- a/packages/common/src/interfaces/vanillaCalendarOption.interface.ts
+++ b/packages/common/src/interfaces/vanillaCalendarOption.interface.ts
@@ -1,6 +1,13 @@
-import type { IPartialSettings } from 'vanilla-calendar-picker';
+import type { IRange, ISelected, ISelection, ISettings, IVisibility } from 'vanilla-calendar-pro/types';
 
-export interface VanillaCalendarOption extends Partial<IPartialSettings> {
+export type IPartialSettings = Partial<Pick<ISettings, 'iso8601' | 'lang'> & {
+  range: Partial<IRange>;
+  selection: Partial<ISelection>;
+  selected: Partial<ISelected>;
+  visibility: Partial<IVisibility>;
+}>;
+
+export interface VanillaCalendarOption extends IPartialSettings {
   //-- extra options used by SlickGrid
 
   /** defaults to false, do we want to hide the clear date button? */

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -1,5 +1,5 @@
 // import external lib CSS files (without the .css extension)
-@import 'vanilla-calendar-picker/build/vanilla-calendar.min';
+@import 'vanilla-calendar-pro/build/vanilla-calendar.min';
 
 // SASS utils to generate SVGs
 @import './svg-utilities';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: ^2.0.12
         version: 2.0.12
       vanilla-calendar-pro:
-        specifier: ^2.9.9
-        version: 2.9.9
+        specifier: ^2.9.10
+        version: 2.9.10
     devDependencies:
       autoprefixer:
         specifier: ^10.4.20
@@ -9290,8 +9290,8 @@ packages:
       builtins: 5.0.1
     dev: true
 
-  /vanilla-calendar-pro@2.9.9:
-    resolution: {integrity: sha512-cUrS9iyoWXxQGZoHPi6VaR0B2lZlKZqKiLEd+85CDUQ0rGE44NJ8cwnO9Y68MY88Mznl3ad1tZAgRc988KhclQ==}
+  /vanilla-calendar-pro@2.9.10:
+    resolution: {integrity: sha512-0yqWqlvitfQSRqjyVVr613whIgp62qC1JHgXyLalcJkNkMRZXRqEr+QQQvRdQavB2PBgB4HW+GM6VU4KU0K3Ng==}
     dev: false
 
   /verror@1.10.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,9 @@ importers:
       un-flatten-tree:
         specifier: ^2.0.12
         version: 2.0.12
-      vanilla-calendar-picker:
-        specifier: ^2.11.9
-        version: 2.11.9
+      vanilla-calendar-pro:
+        specifier: ^2.9.9
+        version: 2.9.9
     devDependencies:
       autoprefixer:
         specifier: ^10.4.20
@@ -9290,8 +9290,8 @@ packages:
       builtins: 5.0.1
     dev: true
 
-  /vanilla-calendar-picker@2.11.9:
-    resolution: {integrity: sha512-XnGs83zOgD2J1CY349DjJAxUqKf8+o5QrnhU5uIfdJxGELLkB+rVpFjXAHzOImd12UVpLrI5r6huiEljt6lpnA==}
+  /vanilla-calendar-pro@2.9.9:
+    resolution: {integrity: sha512-cUrS9iyoWXxQGZoHPi6VaR0B2lZlKZqKiLEd+85CDUQ0rGE44NJ8cwnO9Y68MY88Mznl3ad1tZAgRc988KhclQ==}
     dev: false
 
   /verror@1.10.0:

--- a/test/cypress/e2e/example10.cy.ts
+++ b/test/cypress/e2e/example10.cy.ts
@@ -404,8 +404,10 @@ describe('Example 10 - GraphQL Grid', () => {
   });
 
   it('should open Date picker and expect date range between 01-Jan to 15-Feb', () => {
-    cy.get('.search-filter.filter-finish.filled')
-      .click();
+    cy.get('.search-filter.filter-finish.filled input')
+      .click({ force: true });
+
+    cy.get('.vanilla-calendar:visible');
 
     cy.get('.vanilla-calendar-column:nth(0) .vanilla-calendar-month')
       .should('have.text', 'January');

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -562,8 +562,10 @@ describe('Example 11 - Batch Editing', () => {
         .invoke('val')
         .then(text => expect(text).to.eq(`${currentYear + 1}-01-01`));
 
-      cy.get('.search-filter.filter-finish.filled')
-        .click();
+      cy.get('.search-filter.filter-finish.filled input')
+        .click({ force: true });
+
+      cy.get('.vanilla-calendar:visible');
 
       cy.get('.vanilla-calendar-day__btn_selected')
         .should('have.length', 1);


### PR DESCRIPTION
- migrate to [`vanilla-calendar-pro`](https://github.com/uvarov-frontend/vanilla-calendar-pro) and drop the custom fork `vanilla-calendar-picker` (which was always meant to be temporary) that I had created until all features I needed were going to be merged into the original project Vanilla-Calendar-Pro and we are just about to be there.
- it's very close to be ready but it's still missing a couple of small fixes
- NOTE: the Types are not imported the same way, they must be imported `from 'vanilla-calendar-pro/types'` instead of the default import