### PR TITLE
fix: SlickCellExternalCopyManager should use DataView

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -5,7 +5,7 @@ import type { Column, GridOption, OnEventArgs, } from '../../interfaces/index';
 import type { SlickCellSelectionModel } from '../slickCellSelectionModel';
 import { SlickCellExternalCopyManager } from '../slickCellExternalCopyManager';
 import type { InputEditor } from '../../editors/inputEditor';
-import { SlickEvent, SlickEventData, type SlickGrid, SlickRange } from '../../core/index';
+import { type SlickDataView, SlickEvent, SlickEventData, type SlickGrid, SlickRange } from '../../core/index';
 import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
 const pubSubServiceStub = {
@@ -19,16 +19,27 @@ const mockGetSelectionModel = {
   getSelectedRanges: jest.fn(),
 };
 const returnValueStub = jest.fn();
+
+const dataViewStub = {
+  destroy: jest.fn(),
+  getItem: jest.fn(),
+  getItems: jest.fn(),
+  getItemCount: jest.fn(),
+  setItems: jest.fn(),
+} as unknown as SlickDataView;
+
 const gridStub = {
+  destroy: jest.fn(),
   getActiveCell: jest.fn(),
   getActiveCellNode: jest.fn(),
   getColumns: jest.fn().mockReturnValue([
     { id: 'firstName', field: 'firstName', name: 'First Name', },
     { id: 'lastName', field: 'lastName', name: 'Last Name' },
   ]),
-  getData: jest.fn(),
+  getData: () => dataViewStub,
   getDataItem: jest.fn(),
   getDataLength: jest.fn(),
+  hasDataView: () => true,
   getPubSubService: () => pubSubServiceStub,
   getEditorLock: () => ({
     isActive: () => false,
@@ -251,6 +262,7 @@ describe('CellExternalCopyManager', () => {
         jest.spyOn(gridStub, 'getDataLength').mockReturnValue(2);
         jest.spyOn(gridStub, 'getData').mockReturnValue([{ firstName: 'John', lastName: 'Doe', age: 30 }, { firstName: 'Jane', lastName: 'Doe' }]);
         jest.spyOn(gridStub, 'getDataItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' }).mockReturnValueOnce({ firstName: 'Jane', lastName: 'Doe' });
+        jest.spyOn(gridStub, 'hasDataView').mockReturnValue(false);
       });
 
       afterEach(() => {

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -32,7 +32,6 @@ export class SlickCellExternalCopyManager {
   protected _copiedCellStyle = 'copied';
   protected _copiedCellStyleLayerKey = 'copy-manager';
   protected _copiedRanges: SlickRange[] | null = null;
-  protected _dataView?: SlickDataView;
   protected _dataWrapper: DataWrapperService;
   protected _eventHandler: SlickEventHandler;
   protected _grid!: SlickGrid;
@@ -59,9 +58,6 @@ export class SlickCellExternalCopyManager {
   init(grid: SlickGrid, options?: ExcelCopyBufferOption): void {
     this._grid = grid;
     this._dataWrapper.init(grid);
-    if (grid.hasDataView()) {
-      this._dataView = grid.getData<SlickDataView>();
-    }
     this._addonOptions = { ...this._addonOptions, ...options };
     this._copiedCellStyleLayerKey = this._addonOptions.copiedCellStyleLayerKey || 'copy-manager';
     this._copiedCellStyle = this._addonOptions.copiedCellStyle || 'copied';
@@ -92,15 +88,13 @@ export class SlickCellExternalCopyManager {
     });
 
     if (grid && typeof this._addonOptions?.onBeforePasteCell === 'function') {
-      const dataView = grid?.getData<SlickDataView>();
-
       // subscribe to this Slickgrid event of onBeforeEditCell
       this._eventHandler.subscribe(this.onBeforePasteCell, (e, args) => {
         const column: Column = grid.getColumns()[args.cell];
         const returnedArgs: OnEventArgs = {
           row: args.row!,
           cell: args.cell,
-          dataView,
+          dataView: grid.getData<SlickDataView>(),
           grid,
           columnDef: column,
           dataContext: grid.getDataItem(args.row!)

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -114,7 +114,6 @@ export class SlickCellExternalCopyManager {
 
   dispose(): void {
     this._eventHandler.unsubscribeAll();
-    this._dataWrapper.dispose();
   }
 
   clearCopySelection(): void {

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -1,7 +1,8 @@
 import { createDomElement, getHtmlStringOutput, stripTags } from '@slickgrid-universal/utils';
 
+import { DataWrapperService } from '../services/dataWrapperService';
 import type { Column, Editor, EditorConstructor, ElementPosition, ExcelCopyBufferOption, ExternalCopyClipCommand, OnEventArgs } from '../interfaces/index';
-import { SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, SlickRange, type SlickDataView, Utils as SlickUtils } from '../core/index';
+import { type SlickDataView, SlickEvent, SlickEventData, SlickEventHandler, type SlickGrid, SlickRange, Utils as SlickUtils } from '../core/index';
 
 // using external SlickGrid JS libraries
 const CLEAR_COPY_SELECTION_DELAY = 2000;
@@ -31,12 +32,15 @@ export class SlickCellExternalCopyManager {
   protected _copiedCellStyle = 'copied';
   protected _copiedCellStyleLayerKey = 'copy-manager';
   protected _copiedRanges: SlickRange[] | null = null;
+  protected _dataView?: SlickDataView;
+  protected _dataWrapper: DataWrapperService;
   protected _eventHandler: SlickEventHandler;
   protected _grid!: SlickGrid;
   protected _onCopyInit?: () => void;
   protected _onCopySuccess?: (rowCount: number) => void;
 
   constructor() {
+    this._dataWrapper = new DataWrapperService();
     this.onCopyCells = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCells');
     this.onCopyCancelled = new SlickEvent<{ ranges: SlickRange[]; }>('onCopyCancelled');
     this.onPasteCells = new SlickEvent<{ ranges: SlickRange[]; }>('onPasteCells');
@@ -54,6 +58,10 @@ export class SlickCellExternalCopyManager {
 
   init(grid: SlickGrid, options?: ExcelCopyBufferOption): void {
     this._grid = grid;
+    this._dataWrapper.init(grid);
+    if (grid.hasDataView()) {
+      this._dataView = grid.getData<SlickDataView>();
+    }
     this._addonOptions = { ...this._addonOptions, ...options };
     this._copiedCellStyleLayerKey = this._addonOptions.copiedCellStyleLayerKey || 'copy-manager';
     this._copiedCellStyle = this._addonOptions.copiedCellStyle || 'copied';
@@ -106,6 +114,7 @@ export class SlickCellExternalCopyManager {
 
   dispose(): void {
     this._eventHandler.unsubscribeAll();
+    this._dataWrapper.dispose();
   }
 
   clearCopySelection(): void {
@@ -273,22 +282,22 @@ export class SlickCellExternalCopyManager {
       destH = selectedRange.toRow - selectedRange.fromRow + 1;
       destW = selectedRange.toCell - selectedRange.fromCell + 1;
     }
-    const availableRows = this._grid.getData<any[]>().length - activeRow;
+    const availableRows = this._dataWrapper.getDataLength() - activeRow;
     let addRows = 0;
 
     // ignore new rows if we don't have a "newRowCreator"
     if ((availableRows < destH) && typeof this._addonOptions.newRowCreator === 'function') {
-      const d = this._grid.getData<any[]>();
+      const d = this._dataWrapper.getDataItems();
       for (addRows = 1; addRows <= (destH - availableRows); addRows++) {
         d.push({});
       }
-      this._grid.setData(d);
+      this._dataWrapper.setDataItems(d);
       this._grid.render();
     }
 
-    const overflowsBottomOfGrid = (activeRow + destH) > this._grid.getDataLength();
+    const overflowsBottomOfGrid = (activeRow + destH) > this._dataWrapper.getDataLength();
     if (overflowsBottomOfGrid && typeof this._addonOptions.newRowCreator === 'function') {
-      const newRowsNeeded = activeRow + destH - this._grid.getDataLength();
+      const newRowsNeeded = activeRow + destH - this._dataWrapper.getDataLength();
       this._addonOptions.newRowCreator(newRowsNeeded);
     }
 
@@ -305,7 +314,7 @@ export class SlickCellExternalCopyManager {
       activeCell,
       destH,
       destW,
-      maxDestY: this._grid.getDataLength(),
+      maxDestY: this._dataWrapper.getDataLength(),
       maxDestX: this._grid.getColumns().length,
       h: 0,
       w: 0,
@@ -323,7 +332,7 @@ export class SlickCellExternalCopyManager {
 
             if (desty < clipCommand.maxDestY && destx < clipCommand.maxDestX) {
               // const nd = this._grid.getCellNode(desty, destx);
-              const dt = this._grid.getDataItem(desty);
+              const dt = this._dataWrapper.getDataItem(desty);
 
               if (this._grid.triggerEvent(this.onBeforePasteCell, { row: desty, cell: destx, dt, column: columns[destx], target: 'grid' }).getReturnValue() === false) {
                 continue;
@@ -366,7 +375,7 @@ export class SlickCellExternalCopyManager {
 
             if (desty < clipCommand.maxDestY && destx < clipCommand.maxDestX) {
               // const nd = this._grid.getCellNode(desty, destx);
-              const dt = this._grid.getDataItem(desty);
+              const dt = this._dataWrapper.getDataItem(desty);
               if (oneCellToMultiple) {
                 this.setDataItemValueForColumn(dt, columns[destx], clipCommand.oldValues[0][0]);
               } else {
@@ -399,11 +408,11 @@ export class SlickCellExternalCopyManager {
         }
 
         if (addRows > 1) {
-          const data = this._grid.getData<any[]>();
+          const data = this._dataWrapper.getDataItems();
           for (; addRows > 1; addRows--) {
             data.splice(data.length - 1, 1);
           }
-          this._grid.setData(data);
+          this._dataWrapper.setDataItems(data);
           this._grid.render();
         }
       }
@@ -452,7 +461,7 @@ export class SlickCellExternalCopyManager {
             const clipTextRows: string[] = [];
             for (let i = range.fromRow; i < range.toRow + 1; i++) {
               const clipTextCells: string[] = [];
-              const dt = this._grid.getDataItem(i);
+              const dt = this._dataWrapper.getDataItem(i);
 
               if (clipTextRows.length === 0 && this._addonOptions.includeHeaderWhenCopying) {
                 const clipTextHeaders: string[] = [];

--- a/packages/common/src/services/__tests__/dataWrapperService.spec.ts
+++ b/packages/common/src/services/__tests__/dataWrapperService.spec.ts
@@ -1,0 +1,141 @@
+import type { SlickDataView, SlickGrid } from '../../core';
+import { DataWrapperService } from '../dataWrapperService';
+
+const gridStub = {
+  destroy: jest.fn(),
+  getData: jest.fn(),
+  getDataItem: jest.fn(),
+  getDataItems: jest.fn(),
+  getDataLength: jest.fn(),
+  hasDataView: jest.fn(),
+  setData: jest.fn(),
+  setDataItems: jest.fn(),
+} as unknown as SlickGrid;
+
+const dataViewStub = {
+  destroy: jest.fn(),
+  getItem: jest.fn(),
+  getItems: jest.fn(),
+  getItemCount: jest.fn(),
+  setItems: jest.fn(),
+} as unknown as SlickDataView;
+
+describe('DataWrapper Service', () => {
+  let service: DataWrapperService;
+
+  beforeEach(() => {
+    service = new DataWrapperService();
+  });
+
+  it('should create the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('SlickGrid', () => {
+    beforeEach(() => {
+      service.init(gridStub);
+      jest.spyOn(gridStub, 'hasDataView').mockReturnValueOnce(false);
+    });
+
+    it('should create and dispose the service', () => {
+      service.dispose();
+
+      expect(service).toBeTruthy();
+      expect(gridStub.destroy).toHaveBeenCalled();
+    });
+
+    it('should call getDataItem() method and expect item to be returned via SlickGrid.getDataItem()', () => {
+      const itemMock = { id: 1, firstName: 'John', lastName: 'Doe' };
+      const getDataItemSpy = jest.spyOn(gridStub, 'getDataItem').mockReturnValueOnce(itemMock);
+
+      const result = service.getDataItem(1);
+
+      expect(result).toEqual(itemMock);
+      expect(getDataItemSpy).toHaveBeenCalled();
+    });
+
+    it('should call getDataItems() method and expect items to be returned via SlickGrid.getData()', () => {
+      const itemsMock = [{ id: 1, firstName: 'John', lastName: 'Doe' }, { id: 2, firstName: 'Jane', lastName: 'Smith' }];
+      const getDataItemsSpy = jest.spyOn(gridStub, 'getData').mockReturnValueOnce(itemsMock);
+
+      const result = service.getDataItems();
+
+      expect(result).toEqual(itemsMock);
+      expect(getDataItemsSpy).toHaveBeenCalled();
+    });
+
+    it('should call getDataLength() method and expect items length returned via SlickGrid.getItemCount()', () => {
+      const itemsMock = [{ id: 1, firstName: 'John', lastName: 'Doe' }, { id: 2, firstName: 'Jane', lastName: 'Smith' }];
+      const getDataLengthSpy = jest.spyOn(gridStub, 'getDataLength').mockReturnValueOnce(itemsMock.length);
+
+      const result = service.getDataLength();
+
+      expect(result).toBe(itemsMock.length);
+      expect(getDataLengthSpy).toHaveBeenCalled();
+    });
+
+    it('should call setDataItems() method and expect items to be set via SlickGrid.setData()', () => {
+      const itemsMock = [{ id: 1, firstName: 'John', lastName: 'Doe' }, { id: 2, firstName: 'Jane', lastName: 'Smith' }];
+      const setDataItemsSpy = jest.spyOn(gridStub, 'setData');
+
+      service.setDataItems(itemsMock);
+
+      expect(setDataItemsSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('SlickDataView', () => {
+    beforeEach(() => {
+      jest.spyOn(gridStub, 'hasDataView').mockReturnValueOnce(true);
+      jest.spyOn(gridStub, 'getData').mockReturnValueOnce(dataViewStub as any);
+      service.init(gridStub);
+    });
+
+    it('should create and dispose the service', () => {
+      service.init(gridStub);
+      service.dispose();
+
+      expect(service).toBeTruthy();
+      expect(dataViewStub.destroy).toHaveBeenCalled();
+    });
+
+    it('should call getDataItem() method and expect item to be returned via DataView.getItem()', () => {
+      const itemMock = { id: 1, firstName: 'John', lastName: 'Doe' };
+      const getDataItemSpy = jest.spyOn(dataViewStub, 'getItem').mockReturnValueOnce(itemMock);
+
+      const result = service.getDataItem(1);
+
+      expect(result).toEqual(itemMock);
+      expect(getDataItemSpy).toHaveBeenCalled();
+    });
+
+    it('should call getDataItems() method and expect items to be returned via DataView.getItems()', () => {
+      const itemsMock = [{ id: 1, firstName: 'John', lastName: 'Doe' }, { id: 2, firstName: 'Jane', lastName: 'Smith' }];
+      const getDataItemsSpy = jest.spyOn(dataViewStub, 'getItems').mockReturnValueOnce(itemsMock);
+
+      const result = service.getDataItems();
+
+      expect(result).toEqual(itemsMock);
+      expect(getDataItemsSpy).toHaveBeenCalled();
+    });
+
+    it('should call getDataLength() method and expect items length returned via DataView.getItemCount()', () => {
+      const itemsMock = [{ id: 1, firstName: 'John', lastName: 'Doe' }, { id: 2, firstName: 'Jane', lastName: 'Smith' }];
+      const getItemCountSpy = jest.spyOn(dataViewStub, 'getItemCount').mockReturnValueOnce(itemsMock.length);
+
+      const result = service.getDataLength();
+
+      expect(result).toBe(itemsMock.length);
+      expect(getItemCountSpy).toHaveBeenCalled();
+    });
+
+    it('should call setDataItems() method and expect items to be set via DataView.setItems()', () => {
+      const itemsMock = [{ id: 1, firstName: 'John', lastName: 'Doe' }, { id: 2, firstName: 'Jane', lastName: 'Smith' }];
+      const setItemsSpy = jest.spyOn(dataViewStub, 'setItems');
+
+      service.setDataItems(itemsMock);
+
+      expect(setItemsSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/common/src/services/__tests__/dataWrapperService.spec.ts
+++ b/packages/common/src/services/__tests__/dataWrapperService.spec.ts
@@ -37,13 +37,6 @@ describe('DataWrapper Service', () => {
       jest.spyOn(gridStub, 'hasDataView').mockReturnValueOnce(false);
     });
 
-    it('should create and dispose the service', () => {
-      service.dispose();
-
-      expect(service).toBeTruthy();
-      expect(gridStub.destroy).toHaveBeenCalled();
-    });
-
     it('should call getDataItem() method and expect item to be returned via SlickGrid.getDataItem()', () => {
       const itemMock = { id: 1, firstName: 'John', lastName: 'Doe' };
       const getDataItemSpy = jest.spyOn(gridStub, 'getDataItem').mockReturnValueOnce(itemMock);
@@ -91,18 +84,11 @@ describe('DataWrapper Service', () => {
       service.init(gridStub);
     });
 
-    it('should create and dispose the service', () => {
-      service.init(gridStub);
-      service.dispose();
-
-      expect(service).toBeTruthy();
-      expect(dataViewStub.destroy).toHaveBeenCalled();
-    });
-
     it('should call getDataItem() method and expect item to be returned via DataView.getItem()', () => {
       const itemMock = { id: 1, firstName: 'John', lastName: 'Doe' };
       const getDataItemSpy = jest.spyOn(dataViewStub, 'getItem').mockReturnValueOnce(itemMock);
 
+      service.init(gridStub);
       const result = service.getDataItem(1);
 
       expect(result).toEqual(itemMock);

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -82,6 +82,7 @@ const pubSubServiceStub = {
 
 const gridStub = {
   autosizeColumns: jest.fn(),
+  destroy: jest.fn(),
   getColumnIndex: jest.fn(),
   getContainerNode: jest.fn(),
   getPubSubService: () => pubSubServiceStub,
@@ -92,6 +93,7 @@ const gridStub = {
   getUID: () => GRID_UID,
   getColumns: jest.fn(),
   setColumns: jest.fn(),
+  hasDataView: () => false,
   onColumnsResized: jest.fn(),
   registerPlugin: jest.fn(),
   setSelectionModel: jest.fn(),

--- a/packages/common/src/services/dataWrapperService.ts
+++ b/packages/common/src/services/dataWrapperService.ts
@@ -11,12 +11,6 @@ export class DataWrapperService {
     }
   }
 
-  dispose(): void {
-    this._dataView
-      ? this._dataView.destroy()
-      : this._grid.destroy();
-  }
-
   getDataItem(row: number): any {
     return this._dataView
       ? this._dataView.getItem(row)

--- a/packages/common/src/services/dataWrapperService.ts
+++ b/packages/common/src/services/dataWrapperService.ts
@@ -1,0 +1,43 @@
+import type { SlickDataView, SlickGrid } from '../core';
+
+export class DataWrapperService {
+  protected _dataView?: SlickDataView;
+  protected _grid!: SlickGrid;
+
+  init(grid: SlickGrid): void {
+    this._grid = grid;
+    if (grid.hasDataView()) {
+      this._dataView = grid.getData<SlickDataView>();
+    }
+  }
+
+  dispose(): void {
+    this._dataView
+      ? this._dataView.destroy()
+      : this._grid.destroy();
+  }
+
+  getDataItem(row: number): any {
+    return this._dataView
+      ? this._dataView.getItem(row)
+      : this._grid.getDataItem(row);
+  }
+
+  getDataItems(): any[] {
+    return this._dataView
+      ? this._dataView.getItems()
+      : this._grid.getData<any[]>();
+  }
+
+  getDataLength(): number {
+    return this._dataView
+      ? this._dataView.getItemCount()
+      : this._grid.getDataLength();
+  }
+
+  setDataItems(items: any[]): void {
+    this._dataView
+      ? this._dataView.setItems(items)
+      : this._grid.setData(items);
+  }
+}

--- a/packages/common/src/services/index.ts
+++ b/packages/common/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from './backendUtility.service';
 export * from './collection.service';
 export * from './container.service';
+export * from './dataWrapperService';
 export * from './dateUtils';
 export * from './domUtilities';
 export * from './excelExport.service';


### PR DESCRIPTION
- while investigating for issue #1634, I found the problems shown below
- so it's a bit surprising that we didn't catch this earlier but the plugin was only coded for SlickGrid usage to get read/write data and without the DataView, but Slickgrid-Universal is all built with the DataView usage only and so we should really fix this to support both
- add a new `DataWrapperService` to make it easier to call the correct functions depending on our usage SlickGrid or SlickDataView