### PR TITLE
fix: calling `preRegisterExternalExtensions` should be added to ext list

### DIFF
--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -674,6 +674,7 @@ describe('ExtensionService', () => {
 
         service.bindDifferentExtensions();
         expect(initMock).toHaveBeenCalledWith(gridStub);
+        expect(service.extensionList.rowDetailView).toBeTruthy();
       });
     });
 

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -342,6 +342,9 @@ export class ExtensionService {
       extraExtensions.forEach(extension => {
         featureWithColumnIndexPositions.push(extension);
         this._requireInitExternalExtensions.push(extension);
+        if (!this._extensionList[extension.name]) {
+          this.addExtensionToList(extension.name, extension);
+        }
       });
     }
 


### PR DESCRIPTION
- calling `preRegisterExternalExtensions` should be added to the `extensionList` array so that it will later be dispose off when looping through the array when it is time to dispose each extension