### PR TITLE
fix: SlickCellExternalCopyManager should work w/hidden cols fixes #1634

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4392,15 +4392,14 @@ describe('SlickGrid core file', () => {
         expect(result5).toEqual({ cell: -1, row: -1 });
       });
 
-      it('should skip a cell when column found at x/y coordinates is hidden (Gender) so cell will the last known visible column', () => {
+      it('should return hidden cells as well since skipping them would add an unwanted offset', () => {
         grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, enableCellNavigation: true });
 
         const result1 = grid.getCellFromPoint((DEFAULT_COLUMN_WIDTH * 5) + 5, (DEFAULT_COLUMN_HEIGHT * 5) + 5);
         const result2 = grid.getCellFromPoint((DEFAULT_COLUMN_WIDTH * 6) + 5, (DEFAULT_COLUMN_HEIGHT * 6) + 5);
 
-        // last 2 columns are hidden and last visible column is cell:4
-        expect(result1).toEqual({ cell: 4, row: 5 });
-        expect(result2).toEqual({ cell: 4, row: 6 });
+        expect(result1).toEqual({ cell: 5, row: 5 });
+        expect(result2).toEqual({ cell: 6, row: 6 });
       });
     });
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5232,7 +5232,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const y2 = y1 + this._options.rowHeight! - 1;
     let x1 = 0;
     for (let i = 0; i < cell; i++) {
-      if (!this.columns[i]) {
+      if (!this.columns[i] || this.columns[i].hidden) {
         continue;
       }
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4150,7 +4150,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       const d = this.getDataItem(row);
 
-      // TODO:  shorten this loop (index? heuristics? binary search?)
+      // TODO: shorten this loop (index? heuristics? binary search?)
       for (let i = 0, ii = this.columns.length; i < ii; i++) {
         if (!this.columns[i] || this.columns[i].hidden) { continue; }
 
@@ -5104,7 +5104,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     let w = 0;
     for (let i = 0; i < this.columns.length && w <= x; i++) {
-      if (!this.columns[i] || this.columns[i].hidden) {
+      if (!this.columns[i]) {
         continue;
       }
       w += this.columns[i].width as number;
@@ -5232,7 +5232,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const y2 = y1 + this._options.rowHeight! - 1;
     let x1 = 0;
     for (let i = 0; i < cell; i++) {
-      if (!this.columns[i] || this.columns[i].hidden) {
+      if (!this.columns[i]) {
         continue;
       }
 

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -467,22 +467,26 @@ export class SlickCellExternalCopyManager {
               if (clipTextRows.length === 0 && this._addonOptions.includeHeaderWhenCopying) {
                 const clipTextHeaders: string[] = [];
                 for (let j = range.fromCell; j < range.toCell + 1; j++) {
-                  const colName: string = columns[j].name instanceof HTMLElement
-                    ? stripTags((columns[j].name as HTMLElement).innerHTML)
-                    : columns[j].name as string;
-                  if (colName.length > 0 && !columns[j].hidden) {
-                    clipTextHeaders.push(this.getHeaderValueForColumn(columns[j]));
+                  if (columns[j]) {
+                    const colName: string = columns[j].name instanceof HTMLElement
+                      ? stripTags((columns[j].name as HTMLElement).innerHTML)
+                      : columns[j].name as string;
+                    if (colName.length > 0 && !columns[j].hidden) {
+                      clipTextHeaders.push(this.getHeaderValueForColumn(columns[j]));
+                    }
                   }
                 }
                 clipTextRows.push(clipTextHeaders.join('\t'));
               }
 
               for (let j = range.fromCell; j < range.toCell + 1; j++) {
-                const colName: string = columns[j].name instanceof HTMLElement
-                  ? stripTags((columns[j].name as HTMLElement).innerHTML)
-                  : columns[j].name as string;
-                if (colName.length > 0 && !columns[j].hidden) {
-                  clipTextCells.push(this.getDataItemValueForColumn(dt, columns[j], i, j, e));
+                if (columns[j]) {
+                  const colName: string = columns[j].name instanceof HTMLElement
+                    ? stripTags((columns[j].name as HTMLElement).innerHTML)
+                    : columns[j].name as string;
+                  if (colName.length > 0 && !columns[j].hidden) {
+                    clipTextCells.push(this.getDataItemValueForColumn(dt, columns[j], i, j, e));
+                  }
                 }
               }
               clipTextRows.push(clipTextCells.join('\t'));

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -33,7 +33,7 @@ export class SlickCellSelectionModel implements SelectionModel {
 
     this._selector = (options === undefined || options.cellRangeSelector === undefined)
       ? new SlickCellRangeSelector({ selectionCss: { border: '2px solid black' } as CSSStyleDeclaration })
-      : this._selector = options.cellRangeSelector;
+      : options.cellRangeSelector;
 
     this._addonOptions = options;
   }


### PR DESCRIPTION
fixes #1634 
- prior to this PR, the hidden columns were being counted as column indexes when pasting and also when starting a cell selection

![brave_gC4wQ7pe3V](https://github.com/user-attachments/assets/6a8c4cc9-ab6e-4739-a4b6-a43f6fd77a55)
