### PR TITLE
chore(tree): move & reuse `getTreeDataOptionPropName()`

### DIFF
--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -3,7 +3,7 @@ import type { SortDirection, SortDirectionString } from '../enums/index';
 import type { Aggregator } from './aggregator.interface';
 import type { Formatter } from './formatter.interface';
 
-export interface TreeDataOption {
+export interface TreeDataOption extends TreeDataPropNames {
   /** Tree Data Aggregators array that can be provided to aggregate the tree (avg, sum, ...) */
   aggregators?: Aggregator[];
 
@@ -47,27 +47,6 @@ export interface TreeDataOption {
   /** Defaults to False, will the Tree be collapsed on first load? */
   initiallyCollapsed?: boolean;
 
-  /** Defaults to "children", object property name used to designate the Children array */
-  childrenPropName?: string;
-
-  /** Defaults to "__collapsed", object property name used to designate the Collapsed flag */
-  collapsedPropName?: string;
-
-  /** Defaults to "__hasChildren", object property name used to designate if the item has children or not (boolean) */
-  hasChildrenPropName?: string;
-
-  /**
-   * Defaults to "id", object property name used to designate the Id field (you would rarely override this property, it is mostly used for internal usage).
-   * NOTE: by default it will read the `datasetIdPropertyName` from the grid option, so it's typically better NOT to override this property.
-   */
-  identifierPropName?: string;
-
-  /** Defaults to "__treeLevel", object property name used to designate the Tree Level depth number */
-  levelPropName?: string;
-
-  /** Defaults to "__parentId", object property name used to designate the Parent Id */
-  parentPropName?: string;
-
   /**
    * Defaults to 15px, margin to add from the left (calculated by the tree level multiplied by this number).
    * For example if tree depth level is 2, the calculation will be (2 * 15 = 30), so the column will be displayed 30px from the left
@@ -94,4 +73,27 @@ export interface TreeDataOption {
 
   /** Optional Title Formatter (allows you to format/style the title text differently) */
   titleFormatter?: Formatter;
+}
+
+export interface TreeDataPropNames {
+  /** Defaults to "children", object property name used to designate the Children array */
+  childrenPropName?: string;
+
+  /** Defaults to "__collapsed", object property name used to designate the Collapsed flag */
+  collapsedPropName?: string;
+
+  /** Defaults to "__hasChildren", object property name used to designate if the item has children or not (boolean) */
+  hasChildrenPropName?: string;
+
+  /**
+   * Defaults to "id", object property name used to designate the Id field (you would rarely override this property, it is mostly used for internal usage).
+   * NOTE: by default it will read the `datasetIdPropertyName` from the grid option, so it's typically better NOT to override this property.
+   */
+  identifierPropName?: string;
+
+  /** Defaults to "__treeLevel", object property name used to designate the Tree Level depth number */
+  levelPropName?: string;
+
+  /** Defaults to "__parentId", object property name used to designate the Parent Id */
+  parentPropName?: string;
 }

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -1,6 +1,5 @@
 import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import { Constants } from '../../constants';
 import type { Column, GridOption, BackendService } from '../../interfaces/index';
 import { SumAggregator } from '../../aggregators';
 import { SharedService } from '../shared.service';

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -182,38 +182,6 @@ describe('TreeData Service', () => {
     expect(service.datasetHierarchical).toEqual(mockHierarchical);
   });
 
-  describe('getTreeDataOptionPropName method', () => {
-    it('should return default constant children prop name', () => {
-      const output = service.getTreeDataOptionPropName('childrenPropName');
-      expect(output).toBe(Constants.treeDataProperties.CHILDREN_PROP);
-    });
-
-    it('should return default constant collapsed prop name', () => {
-      const output = service.getTreeDataOptionPropName('collapsedPropName');
-      expect(output).toBe(Constants.treeDataProperties.COLLAPSED_PROP);
-    });
-
-    it('should return default constant hasChildren prop name', () => {
-      const output = service.getTreeDataOptionPropName('hasChildrenPropName');
-      expect(output).toBe(Constants.treeDataProperties.HAS_CHILDREN_PROP);
-    });
-
-    it('should return default constant level prop name', () => {
-      const output = service.getTreeDataOptionPropName('levelPropName');
-      expect(output).toBe(Constants.treeDataProperties.TREE_LEVEL_PROP);
-    });
-
-    it('should return default constant parent prop name', () => {
-      const output = service.getTreeDataOptionPropName('parentPropName');
-      expect(output).toBe(Constants.treeDataProperties.PARENT_PROP);
-    });
-
-    it('should return "id" as default identifier prop name', () => {
-      const output = service.getTreeDataOptionPropName('identifierPropName');
-      expect(output).toBe('id');
-    });
-  });
-
   describe('handleOnCellClick method', () => {
     let div;
     let mockColumn;

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -3,7 +3,7 @@ import type { EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { of } from 'rxjs';
 
 import { FieldType, OperatorType } from '../../enums/index';
-import type { Column, GridOption } from '../../interfaces/index';
+import type { Column, GridOption, TreeDataPropNames } from '../../interfaces/index';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub';
 import {
   addTreeLevelByMutation,
@@ -26,8 +26,10 @@ import {
   mapOperatorType,
   thousandSeparatorFormatted,
   unsubscribeAll,
+  getTreeDataOptionPropName,
 } from '../utilities';
 import { SumAggregator } from '../../aggregators';
+import { Constants } from '../../constants';
 
 describe('Service/Utilies', () => {
   describe('unflattenParentChildArrayToTree method', () => {
@@ -260,6 +262,44 @@ describe('Service/Utilies', () => {
       ]);
     });
   });
+
+  describe('getTreeDataOptionPropName method', () => {
+    let treeDataOptions: TreeDataPropNames;
+    beforeEach(() => {
+      treeDataOptions = {};
+    });
+
+    it('should return default constant children prop name', () => {
+      const output = getTreeDataOptionPropName(treeDataOptions, 'childrenPropName');
+      expect(output).toBe(Constants.treeDataProperties.CHILDREN_PROP);
+    });
+
+    it('should return default constant collapsed prop name', () => {
+      const output = getTreeDataOptionPropName(treeDataOptions, 'collapsedPropName');
+      expect(output).toBe(Constants.treeDataProperties.COLLAPSED_PROP);
+    });
+
+    it('should return default constant hasChildren prop name', () => {
+      const output = getTreeDataOptionPropName(treeDataOptions, 'hasChildrenPropName');
+      expect(output).toBe(Constants.treeDataProperties.HAS_CHILDREN_PROP);
+    });
+
+    it('should return default constant level prop name', () => {
+      const output = getTreeDataOptionPropName(treeDataOptions, 'levelPropName');
+      expect(output).toBe(Constants.treeDataProperties.TREE_LEVEL_PROP);
+    });
+
+    it('should return default constant parent prop name', () => {
+      const output = getTreeDataOptionPropName(treeDataOptions, 'parentPropName');
+      expect(output).toBe(Constants.treeDataProperties.PARENT_PROP);
+    });
+
+    it('should return "id" as default identifier prop name', () => {
+      const output = getTreeDataOptionPropName(treeDataOptions, 'identifierPropName');
+      expect(output).toBe('id');
+    });
+  });
+
 
   describe('findItemInTreeStructure method', () => {
     let mockColumns;

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -14,6 +14,7 @@ import type {
 import {
   addTreeLevelAndAggregatorsByMutation,
   findItemInTreeStructure,
+  getTreeDataOptionPropName,
   unflattenParentChildArrayToTree
 } from './utilities';
 import type { SharedService } from './shared.service';
@@ -133,8 +134,8 @@ export class TreeDataService {
    */
   applyToggledItemStateChanges(treeToggledItems: TreeToggledItem[], previousFullToggleType?: Extract<ToggleStateChangeType, 'full-collapse' | 'full-expand'> | Extract<ToggleStateChangeTypeString, 'full-collapse' | 'full-expand'>, shouldPreProcessFullToggle = true, shouldTriggerEvent = false): void {
     if (Array.isArray(treeToggledItems)) {
-      const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');
-      const hasChildrenPropName = this.getTreeDataOptionPropName('hasChildrenPropName');
+      const collapsedPropName = getTreeDataOptionPropName(this.treeDataOptions, 'collapsedPropName');
+      const hasChildrenPropName = getTreeDataOptionPropName(this.treeDataOptions, 'hasChildrenPropName');
 
       // for the rows we identified as collapsed, we'll send them to the DataView with the new updated collapsed flag
       // and we'll refresh the DataView to see the collapsing applied in the grid
@@ -235,7 +236,7 @@ export class TreeDataService {
    */
   getItemCount(treeLevel?: number): number {
     if (treeLevel !== undefined) {
-      const levelPropName = this.getTreeDataOptionPropName('levelPropName');
+      const levelPropName = getTreeDataOptionPropName(this.treeDataOptions, 'levelPropName');
       return this.dataView.getItems().filter(dataContext => dataContext[levelPropName] === treeLevel).length;
     }
     return this.dataView.getItemCount();
@@ -247,32 +248,6 @@ export class TreeDataService {
    */
   getToggledItems(): TreeToggledItem[] {
     return this._currentToggledItems;
-  }
-
-  /** Find the associated property name from the Tree Data option when found or return a default property name that we defined internally */
-  getTreeDataOptionPropName(optionName: keyof TreeDataOption): string {
-    let propName = '';
-    switch (optionName) {
-      case 'childrenPropName':
-        propName = this.treeDataOptions?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP;
-        break;
-      case 'collapsedPropName':
-        propName = this.treeDataOptions?.collapsedPropName ?? Constants.treeDataProperties.COLLAPSED_PROP;
-        break;
-      case 'hasChildrenPropName':
-        propName = this.treeDataOptions?.hasChildrenPropName ?? Constants.treeDataProperties.HAS_CHILDREN_PROP;
-        break;
-      case 'identifierPropName':
-        propName = this.treeDataOptions?.identifierPropName ?? this.gridOptions?.datasetIdPropertyName ?? 'id';
-        break;
-      case 'levelPropName':
-        propName = this.treeDataOptions?.levelPropName ?? Constants.treeDataProperties.TREE_LEVEL_PROP;
-        break;
-      case 'parentPropName':
-        propName = this.treeDataOptions?.parentPropName ?? Constants.treeDataProperties.PARENT_PROP;
-        break;
-    }
-    return propName;
   }
 
   /** Clear the sorting and set it back to initial sort */
@@ -374,7 +349,7 @@ export class TreeDataService {
    */
   async toggleTreeDataCollapse(collapsing: boolean, shouldTriggerEvent = true): Promise<void> {
     if (this.gridOptions?.enableTreeData) {
-      const hasChildrenPropName = this.getTreeDataOptionPropName('hasChildrenPropName');
+      const hasChildrenPropName = getTreeDataOptionPropName(this.treeDataOptions, 'hasChildrenPropName');
 
       // emit an event when full toggle starts (useful to show a spinner)
       if (shouldTriggerEvent) {
@@ -418,8 +393,8 @@ export class TreeDataService {
     if (event && args) {
       const targetElm: any = event.target || {};
       const idPropName = this.gridOptions.datasetIdPropertyName ?? 'id';
-      const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');
-      const childrenPropName = this.getTreeDataOptionPropName('childrenPropName');
+      const collapsedPropName = getTreeDataOptionPropName(this.treeDataOptions, 'collapsedPropName');
+      const childrenPropName = getTreeDataOptionPropName(this.treeDataOptions, 'childrenPropName');
 
       if (typeof targetElm?.className === 'string') {
         const hasToggleClass = targetElm.className.indexOf('toggle') >= 0 || false;
@@ -464,8 +439,8 @@ export class TreeDataService {
 
   protected updateToggledItem(item: any, isCollapsed: boolean): void {
     const dataViewIdIdentifier = this.gridOptions?.datasetIdPropertyName ?? 'id';
-    const childrenPropName = this.getTreeDataOptionPropName('childrenPropName');
-    const collapsedPropName = this.getTreeDataOptionPropName('collapsedPropName');
+    const childrenPropName = getTreeDataOptionPropName(this.treeDataOptions, 'childrenPropName');
+    const collapsedPropName = getTreeDataOptionPropName(this.treeDataOptions, 'collapsedPropName');
 
     if (item) {
       // update the flat dataset item


### PR DESCRIPTION
- to be DRY
- we had code that was doing the same thing over and over to get Tree Data prop names, since we already had `getTreeDataOptionPropName()`, why not move it to a common place (utilies) and use it in both places
- also separate all Tree Data prop names into a separate interface so that we can call it anywhere instead of redeclaring the same props everywhere