### PR TITLE
fix: pasting multiple new rows

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -26,6 +26,7 @@ const dataViewStub = {
   getItems: jest.fn(),
   getItemCount: jest.fn(),
   setItems: jest.fn(),
+  addItem: jest.fn()
 } as unknown as SlickDataView;
 
 const gridStub = {
@@ -679,6 +680,45 @@ describe('CellExternalCopyManager', () => {
 
           const getDataItemSpy = jest.spyOn(gridStub, 'getDataItem');
           expect(getDataItemSpy).toHaveBeenCalled();
+          done();
+        }, 2);
+      });
+
+      it('should warn if no new rows have been added via newRowCreator', (done) => {
+        const mockNewRowCreator = jest.fn((_count: number) => {
+          // user forgot to add rows
+        });
+        const consoleWarnSpy = jest.spyOn(global.console, 'warn').mockReturnValue();
+        const mockOnPasteCells = jest.fn();
+        jest.spyOn(gridStub.getSelectionModel() as SelectionModel, 'getSelectedRanges').mockReturnValueOnce([new SlickRange(0, 1, 2, 2)]).mockReturnValueOnce(null as any);
+        const clipboardCommandHandler = (cmd) => {
+          cmd.execute();
+        };
+        plugin.init(gridStub, { clearCopySelectionDelay: 1, clipboardPasteDelay: 1, includeHeaderWhenCopying: true, clipboardCommandHandler, newRowCreator: mockNewRowCreator, onPasteCells: mockOnPasteCells });
+
+        const keyDownCtrlCopyEvent = new Event('keydown');
+        Object.defineProperty(keyDownCtrlCopyEvent, 'ctrlKey', { writable: true, configurable: true, value: true });
+        Object.defineProperty(keyDownCtrlCopyEvent, 'key', { writable: true, configurable: true, value: 'c' });
+        Object.defineProperty(keyDownCtrlCopyEvent, 'isPropagationStopped', { writable: true, configurable: true, value: jest.fn() });
+        Object.defineProperty(keyDownCtrlCopyEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: jest.fn() });
+        gridStub.onKeyDown.notify({ cell: 0, row: 0, grid: gridStub }, keyDownCtrlCopyEvent, gridStub);
+
+        const getActiveCellSpy = jest.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 0, row: 3 });
+        const keyDownCtrlPasteEvent = new Event('keydown');
+        jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+        Object.defineProperty(keyDownCtrlPasteEvent, 'ctrlKey', { writable: true, configurable: true, value: true });
+        Object.defineProperty(keyDownCtrlPasteEvent, 'key', { writable: true, configurable: true, value: 'v' });
+        Object.defineProperty(keyDownCtrlPasteEvent, 'isPropagationStopped', { writable: true, configurable: true, value: jest.fn() });
+        Object.defineProperty(keyDownCtrlPasteEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: jest.fn() });
+        gridStub.onKeyDown.notify({ cell: 0, row: 0, grid: gridStub }, keyDownCtrlPasteEvent, gridStub);
+        document.querySelector('textarea')!.value = `Doe\tserialized output`;
+        setTimeout(() => {
+          expect(getActiveCellSpy).toHaveBeenCalled();
+          expect(mockNewRowCreator).toHaveBeenCalled();
+
+          const getDataItemSpy = jest.spyOn(gridStub, 'getDataItem');
+          expect(getDataItemSpy).toHaveBeenCalled();
+          expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('newRowCreator'));
           done();
         }, 2);
       });

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -280,11 +280,7 @@ export class SlickCellExternalCopyManager {
 
     // ignore new rows if we don't have a "newRowCreator"
     if ((availableRows < destH) && typeof this._addonOptions.newRowCreator === 'function') {
-      const d = this._dataWrapper.getDataItems();
-      for (addRows = 1; addRows <= (destH - availableRows); addRows++) {
-        d.push({});
-      }
-      this._dataWrapper.setDataItems(d);
+      this._addonOptions.newRowCreator(destH - availableRows);
       this._grid.render();
     }
 

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -280,7 +280,15 @@ export class SlickCellExternalCopyManager {
 
     // ignore new rows if we don't have a "newRowCreator"
     if ((availableRows < destH) && typeof this._addonOptions.newRowCreator === 'function') {
-      this._addonOptions.newRowCreator(destH - availableRows);
+      const rowsToAdd = destH - availableRows;
+      const rowsBeforePaste = this._dataWrapper.getDataLength();
+      this._addonOptions.newRowCreator(rowsToAdd);
+      const rowsAfterPaste = this._dataWrapper.getDataLength();
+
+      if (rowsAfterPaste !== rowsBeforePaste + rowsToAdd) {
+        console.warn(`[Slickgrid-Universal] The "newRowCreator" did not add the correct amount of rows, it should add "${rowsToAdd}" rows but it added "${rowsAfterPaste - rowsBeforePaste}" rows`);
+      }
+
       this._grid.render();
     }
 

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -893,7 +893,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     this._itemDataContext = editor?.dataContext ?? {}; // keep reference of the item data context
 
     // add extra css styling to the composite editor input(s) that got modified
-    const editorElm = this._modalElm.querySelector(`[data-editorid=${columnId}]`);
+    const editorElm = this._modalElm.querySelector(`[data-editorid='${columnId}']`);
     if (editorElm?.classList) {
       if (isEditorValueTouched) {
         editorElm.classList.add('modified');


### PR DESCRIPTION
I guess this feature was actually never properly tested but when pasting new rows at the bottom, with the defined `newRowCreator`, the previously auto created empty rows were not having an individual unique id, causing the subsequent actions to fail.

This changes it so that the burden is on the dev to provide the actual new row addition. At least that way he/she can control the newly created ids.

If you see this ok I would actually also update the docs to desribe the `newRowCreator` behavior.