### PR TITLE
perf: Reduce iterative time complexity in Tree Data, fixes #1668

### DIFF
--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -1453,7 +1453,8 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
           } else {
             if (preserveHiddenOnSelectionChange && gridOptions.multiSelect) {
               // remove rows whose id is on the list
-              rowIds = this.selectedRowIds?.filter((id) => args.ids.indexOf(id) === -1);
+              const argsIdsSet = new Set(args.ids);
+              rowIds = this.selectedRowIds?.filter((id) => !argsIdsSet.has(id));
             } else {
               rowIds = [];
             }
@@ -1549,7 +1550,8 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       return [];
     }
 
-    const intersection = this.filteredItems.filter((a) => this.selectedRowIds!.some((b) => a[this.idProperty as keyof TData] === b));
+    const selectedRowIdSet = new Set<DataIdType>(this.selectedRowIds);
+    const intersection = this.filteredItems.filter((a) => selectedRowIdSet.has(a[this.idProperty as keyof TData] as DataIdType));
     return (intersection || []) as T[];
   }
 


### PR DESCRIPTION
fixes #1668

Optimize getAllSelectedFilteredItems and preSelectedRowIdsChangeFn with Set lookup and reducing time complexity from O(n square) to O(n)