### PR TITLE
perf: use Set to improve perf when read current Select Editor values

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -17,6 +17,8 @@ import type { TranslateService } from '../translate.service';
 import './example07.scss';
 import '../material-styles.scss';
 
+const NB_ITEMS = 500;
+
 export default class Example07 {
   private _bindingEventService: BindingEventService;
   private _darkMode = false;
@@ -51,7 +53,7 @@ export default class Example07 {
 
   async attached() {
     this.initializeGrid();
-    this.dataset = this.loadData(500);
+    this.dataset = this.loadData(NB_ITEMS);
     const gridContainerElm = document.querySelector(`.grid7`) as HTMLDivElement;
     this._bindingEventService.bind(gridContainerElm, 'oncellchange', this.handleOnCellChange.bind(this));
     this._bindingEventService.bind(gridContainerElm, 'onvalidationerror', this.handleValidationError.bind(this));
@@ -272,7 +274,7 @@ export default class Example07 {
           }),
 
           // OR a regular collection load
-          // collection: Array.from(Array((this.dataset || []).length).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
+          // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
           collectionSortBy: {
             property: 'value',
             sortDesc: true,

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -222,11 +222,13 @@ export class SelectEditor implements Editor {
    * The current selected values (multiple select) from the collection
    */
   get currentValues(): any[] | null {
-    const selectedValues = this._msInstance?.getSelects() ?? [];
+    const selectedValuesSet = new Set();
+    (this._msInstance?.getSelects('value') ?? [])
+      .forEach(x => selectedValuesSet.add(x.toString()));
 
     // collection of strings, just return the filtered string that are equals
     if (this.collection.every(x => typeof x === 'number' || typeof x === 'string')) {
-      return this.collection.filter((c: SelectOption) => selectedValues?.some(val => `${val}` === c?.toString()));
+      return this.collection.filter((c: SelectOption) => selectedValuesSet.has(c?.toString()));
     }
 
     // collection of label/value pair
@@ -234,7 +236,7 @@ export class SelectEditor implements Editor {
     const isIncludingPrefixSuffix = this.collectionOptions?.includePrefixSuffixToSelectedValues ?? false;
 
     return this.collection
-      .filter(c => selectedValues.some(val => `${val}` === c?.[this.valueName]?.toString()))
+      .filter(c => selectedValuesSet.has(c?.[this.valueName]?.toString()))
       .map(c => {
         const labelText = c[this.valueName];
         let prefixText = c[this.labelPrefixName] || '';


### PR DESCRIPTION
- similar to PR #1670, we can use a `Set` to improve perf by using O(n) instead of O(n square)