### PR TITLE
fix(TreeData): Reset the childrens prop when unflattening dataset in case it is being reused

### DIFF
--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -361,7 +361,7 @@ export class SlickRange {
     else {
       return `(${this.fromRow}:${this.fromCell} - ${this.toRow}:${this.toCell})`;
     }
-  };
+  }
 }
 
 
@@ -470,7 +470,7 @@ export class SlickGroup extends SlickNonDataItem {
       this.count === group.count &&
       this.collapsed === group.collapsed &&
       this.title === group.title;
-  };
+  }
 }
 
 /**
@@ -525,7 +525,7 @@ export class SlickEditorLock {
    */
   isActive(editController?: EditController): boolean {
     return (editController ? this.activeEditController === editController : this.activeEditController !== null);
-  };
+  }
 
   /**
    * Sets the specified edit controller as the active edit controller (acquire edit lock).
@@ -547,7 +547,7 @@ export class SlickEditorLock {
       throw new Error('SlickEditorLock.activate: editController must implement .cancelCurrentEdit()');
     }
     this.activeEditController = editController;
-  };
+  }
 
   /**
    * Unsets the specified edit controller as the active edit controller (release edit lock).
@@ -563,7 +563,7 @@ export class SlickEditorLock {
       throw new Error('SlickEditorLock.deactivate: specified editController is not the currently active one');
     }
     this.activeEditController = null;
-  };
+  }
 
   /**
    * Attempts to commit the current edit by calling "commitCurrentEdit" method on the active edit
@@ -575,7 +575,7 @@ export class SlickEditorLock {
    */
   commitCurrentEdit(): boolean {
     return (this.activeEditController ? this.activeEditController.commitCurrentEdit() : true);
-  };
+  }
 
   /**
    * Attempts to cancel the current edit by calling "cancelCurrentEdit" method on the active edit
@@ -586,7 +586,7 @@ export class SlickEditorLock {
    */
   cancelCurrentEdit(): boolean {
     return (this.activeEditController ? this.activeEditController.cancelCurrentEdit() : true);
-  };
+  }
 }
 
 export class Utils {

--- a/packages/common/src/services/dateUtils.ts
+++ b/packages/common/src/services/dateUtils.ts
@@ -166,7 +166,7 @@ export function tryParseDate(inputDate?: string | Date, inputFormat?: string, st
 export function toUtcDate(inputDate: string | Date): Date {
   // to parse as UTC in Tempo, we need to remove the offset (which is a simple inversed offset to cancel itself)
   return removeOffset(inputDate, offset(inputDate, 'utc'));
-};
+}
 
 /**
  * Parse a date passed as a string (Date only, without time) and return a TZ Date (without milliseconds)

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -193,7 +193,10 @@ export function unflattenParentChildArrayToTree<P, T extends P & { [childrenProp
   // make them accessible by guid on this map
   const all: any = {};
 
-  inputArray.forEach((item: any) => all[item[identifierPropName]] = item);
+  inputArray.forEach((item: any) => {
+    all[item[identifierPropName]] = item;
+    delete item[childrenPropName];
+  });
 
   // connect childrens to its parent, and split roots apart
   Object.keys(all).forEach((id) => {
@@ -205,13 +208,7 @@ export function unflattenParentChildArrayToTree<P, T extends P & { [childrenProp
       if (!(childrenPropName in p)) {
         p[childrenPropName] = [];
       }
-      const existIdx = p[childrenPropName]?.findIndex((x: any) => x[identifierPropName] === item[identifierPropName]);
-      if (existIdx >= 0) {
-        // replace existing one when already exists (probably equal to the same item in the end)
-        p[childrenPropName][existIdx] = item;
-      } else {
-        p[childrenPropName].push(item);
-      }
+      p[childrenPropName].push(item);
       if (p[collapsedPropName] === undefined) {
         p[collapsedPropName] = options?.initiallyCollapsed ?? false;
       }

--- a/packages/utils/src/nodeExtend.ts
+++ b/packages/utils/src/nodeExtend.ts
@@ -128,4 +128,4 @@ export function extend<T = any>(...args: any[]): T {
 
   // Return the modified object
   return target;
-};
+}


### PR DESCRIPTION
fixes #1657 again

Recreate the children array from scratch everytime instead of entity lookups.

There were some lint errors which I had to fix to be able to commit this.