### PR TITLE
feat: matching border color for range selector in darkmode

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1159,6 +1159,15 @@ describe('SlickGrid core file', () => {
 
       expect(rowSelectSpy).toHaveBeenCalled();
     });
+
+    it('should clear previous selection model when calling setSelectionModel() with a different model', () => {
+      const cellSelectionModel = new SlickCellSelectionModel();
+
+      grid = new SlickGrid<any, Column>(container, [], columns, { ...defaultOptions, darkMode: true });
+      cellSelectionModel.init(grid);
+
+      expect(cellSelectionModel.cellRangeSelector.addonOptions.selectionCss).toBe('2px solid white');
+    });
   });
 
   describe('Node Getters', () => {

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1160,13 +1160,13 @@ describe('SlickGrid core file', () => {
       expect(rowSelectSpy).toHaveBeenCalled();
     });
 
-    it('should clear previous selection model when calling setSelectionModel() with a different model', () => {
+    it('should change border color for darkMode', () => {
       const cellSelectionModel = new SlickCellSelectionModel();
 
       grid = new SlickGrid<any, Column>(container, [], columns, { ...defaultOptions, darkMode: true });
       cellSelectionModel.init(grid);
 
-      expect(cellSelectionModel.cellRangeSelector.addonOptions.selectionCss).toBe('2px solid white');
+      expect(cellSelectionModel.cellRangeSelector.addonOptions.selectionCss.border).toBe('2px solid white');
     });
   });
 

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -32,7 +32,7 @@ export class SlickCellSelectionModel implements SelectionModel {
     this._eventHandler = new SlickEventHandler();
 
     this._selector = (options === undefined || options.cellRangeSelector === undefined)
-      ? new SlickCellRangeSelector({ selectionCss: { border: '2px solid black' } as CSSStyleDeclaration })
+      ? new SlickCellRangeSelector({ selectionCss: { border: `2px solid ${this._grid.getOptions().darkMode ? "white" : "black"}` } as CSSStyleDeclaration })
       : options.cellRangeSelector;
 
     this._addonOptions = options;

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -32,7 +32,7 @@ export class SlickCellSelectionModel implements SelectionModel {
     this._eventHandler = new SlickEventHandler();
 
     this._selector = (options === undefined || options.cellRangeSelector === undefined)
-      ? new SlickCellRangeSelector({ selectionCss: { border: `2px solid ${this._grid.getOptions().darkMode ? "white" : "black"}` } as CSSStyleDeclaration })
+      ? new SlickCellRangeSelector({ selectionCss: { border: '2px solid black' } as CSSStyleDeclaration })
       : options.cellRangeSelector;
 
     this._addonOptions = options;
@@ -52,6 +52,10 @@ export class SlickCellSelectionModel implements SelectionModel {
 
   init(grid: SlickGrid): void {
     this._grid = grid;
+    if (this._addonOptions === undefined || this._addonOptions.cellRangeSelector === undefined) {
+      this._selector = new SlickCellRangeSelector({ selectionCss: { border: `2px solid ${this._grid.getOptions().darkMode ? "white" : "black"}` } as CSSStyleDeclaration })
+    }
+
     if (grid.hasDataView()) {
       this._dataView = grid.getData<CustomDataView | SlickDataView>();
     }


### PR DESCRIPTION
I needed a new project to get to know the react wrapper of Slickgrid Universal better. So why not build a whole VSCode extension right ? ;)

![cell-selector-darkmode](https://github.com/user-attachments/assets/cb9db17b-171e-461d-9d6b-644769838360)

Also, I used that as the first time to try out the darkMode in more detail and noticed this little gotcha when selecting cells via mouse (at the end of the gif). This PR fixes it.
