### PR TITLE
perf(treeData): decrease Tree Grid expandAll/collapseAll time by 40x

### DIFF
--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
 import type { Column, GridOption, BackendService } from '../../interfaces/index';


### PR DESCRIPTION
Another perf optimization that is probably O(n square) if not more. 

When collapsing/expanding items in the grid, we also need to update the hierarchical (tree) dataset and the previous code was searching for the item in the tree and then was toggling its collapse prop. When we have a single item that we collapse, searching in the tree is relatively quick, but when we toggle thousand of items and we search them one-by-one then this becomes extremely costly to execute (search+toggle for every row). What we can do to decrease the time is to keep doing the toggle of the collapse prop on the flat array BUT instead of searching each item in the tree, we can simply recreate the hierarchical (tree) only once and we're done (40x decrease as shown below).

---

### Perf logs for [Example 5](https://ghiscoding.github.io/slickgrid-universal/#/example05) with 25k items

#### Before (expand all, collapse all)
tree collapse/expand: 2572.123779296875 ms
tree collapse/expand: 2432.596923828125 ms

#### After (expand all, collapse all)
tree collapse/expand: 65.237060546875 ms
tree collapse/expand: 57.0859375 ms

![brave_bpGVGeKDmc](https://github.com/user-attachments/assets/03a0c689-46af-4488-95ec-bda62eceec1f)
