### PR TITLE
feat: allow overriding readOnly behavior of dateEditor

### DIFF
--- a/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
+++ b/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
@@ -39,6 +39,11 @@ prepareGrid() {
 }
 ```
 
+On top of the default ones provided by Vanilla-Calendar there are also:
+
+* hideClearButton (default: false): which toggles the visiblity of the clear button
+* allowInput (default: false): which determines whether you can directly enter a date in the input element
+
 #### Grid Option `defaultEditorOptions
 You could also define certain options as a global level (for the entire grid or even all grids) by taking advantage of the `defaultEditorOptions` Grid Option. Note that they are set via the editor type as a key name (`autocompleter`, `date`, ...) and then the content is the same as `editorOptions` (also note that each key is already typed with the correct editor option interface), for example
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -175,7 +175,7 @@ export default class Example11 {
         type: FieldType.date, outputType: FieldType.dateIso,
         filterable: true,
         filter: { model: Filters.compoundDate },
-        editor: { model: Editors.date, massUpdate: true, disabled: false, editorOptions: { allowInput: true } },
+        editor: { model: Editors.date, massUpdate: true, editorOptions: { allowInput: true } },
       },
       {
         id: 'finish', name: 'Finish', field: 'finish', sortable: true, minWidth: 80,

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -175,7 +175,7 @@ export default class Example11 {
         type: FieldType.date, outputType: FieldType.dateIso,
         filterable: true,
         filter: { model: Filters.compoundDate },
-        editor: { model: Editors.date, massUpdate: true },
+        editor: { model: Editors.date, massUpdate: true, disabled: false, readOnly: false },
       },
       {
         id: 'finish', name: 'Finish', field: 'finish', sortable: true, minWidth: 80,
@@ -293,7 +293,7 @@ export default class Example11 {
             }
           } else if ((event.target as HTMLElement).classList.contains('mdi-check-underline')) {
             this.slickerGridInstance?.gridService.updateItem({ ...dataContext, completed: true });
-            alert(`The "${dataContext.title}" is now Completed`);
+            alert(`The "${dataContext.start}" is now Completed`);
           }
         }
       },

--- a/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example11.ts
@@ -175,7 +175,7 @@ export default class Example11 {
         type: FieldType.date, outputType: FieldType.dateIso,
         filterable: true,
         filter: { model: Filters.compoundDate },
-        editor: { model: Editors.date, massUpdate: true, disabled: false, readOnly: false },
+        editor: { model: Editors.date, massUpdate: true, disabled: false, editorOptions: { allowInput: true } },
       },
       {
         id: 'finish', name: 'Finish', field: 'finish', sortable: true, minWidth: 80,
@@ -293,7 +293,7 @@ export default class Example11 {
             }
           } else if ((event.target as HTMLElement).classList.contains('mdi-check-underline')) {
             this.slickerGridInstance?.gridService.updateItem({ ...dataContext, completed: true });
-            alert(`The "${dataContext.start}" is now Completed`);
+            alert(`The "${dataContext.title}" is now Completed`);
           }
         }
       },

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -186,7 +186,7 @@ export class DateEditor implements Editor {
           title: this.columnEditor && this.columnEditor.title || '',
           className: inputCssClasses.replace(/\./g, ' '),
           dataset: { input: '', defaultdate: this.defaultDate },
-          readOnly: this.columnEditor.readOnly === false ? false : true,
+          readOnly: this.columnEditor.editorOptions?.allowEdit === true ? true : false,
         },
         this._editorInputGroupElm
       );
@@ -204,7 +204,7 @@ export class DateEditor implements Editor {
       }
 
       this._bindEventService.bind(this._inputElm, 'keydown', ((event: KeyboardEvent) => {
-        if (this.columnEditor.readOnly !== false) {
+        if (this.columnEditor.editorOptions?.allowEdit !== true) {
           return;
         }
 
@@ -363,7 +363,8 @@ export class DateEditor implements Editor {
     const elmDateStr = this.getValue();
 
     const lastEventKey = this._lastInputKeyEvent?.key;
-    if (this.columnEditor.readOnly === false && this.columnEditor?.alwaysSaveOnEnterKey && lastEventKey === 'Enter') {
+    if (this.columnEditor.editorOptions?.allowEdit === true &&
+        this.columnEditor?.alwaysSaveOnEnterKey && lastEventKey === 'Enter') {
       return true;
     }
 

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -36,6 +36,7 @@ export class DateEditor implements Editor {
   protected _lastTriggeredByClearDate = false;
   protected _originalDate?: string;
   protected _pickerMergedOptions!: IOptions;
+  protected _lastInputKeyEvent?: KeyboardEvent;
   calendarInstance?: VanillaCalendar;
   defaultDate?: string;
   hasTimePicker = false;
@@ -185,7 +186,7 @@ export class DateEditor implements Editor {
           title: this.columnEditor && this.columnEditor.title || '',
           className: inputCssClasses.replace(/\./g, ' '),
           dataset: { input: '', defaultdate: this.defaultDate },
-          readOnly: true,
+          readOnly: this.columnEditor.readOnly === false ? false : true,
         },
         this._editorInputGroupElm
       );
@@ -201,6 +202,18 @@ export class DateEditor implements Editor {
           this.handleOnDateChange();
         });
       }
+
+      this._bindEventService.bind(this._inputElm, 'keydown', ((event: KeyboardEvent) => {
+        if (this.columnEditor.readOnly !== false) {
+          return;
+        }
+
+        this._isValueTouched = true;
+        this._lastInputKeyEvent = event;
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+          event.stopImmediatePropagation();
+        }
+      }) as EventListener);
 
       queueMicrotask(() => {
         this.calendarInstance = new VanillaCalendar(this._inputElm, this._pickerMergedOptions);
@@ -348,6 +361,11 @@ export class DateEditor implements Editor {
   isValueChanged(): boolean {
     let isChanged = false;
     const elmDateStr = this.getValue();
+
+    const lastEventKey = this._lastInputKeyEvent?.key;
+    if (this.columnEditor.readOnly === false && this.columnEditor?.alwaysSaveOnEnterKey && lastEventKey === 'Enter') {
+      return true;
+    }
 
     if (this.columnDef) {
       isChanged = this._lastTriggeredByClearDate || (!(elmDateStr === '' && this._originalDate === '')) && (elmDateStr !== this._originalDate);

--- a/packages/common/src/interfaces/columnEditor.interface.ts
+++ b/packages/common/src/interfaces/columnEditor.interface.ts
@@ -129,6 +129,11 @@ export interface ColumnEditor {
   required?: boolean;
 
   /**
+   * only applicable for dateEditors. If explicitely set to false, it will allow to enter a new date in the input field.
+   */
+  readOnly?: boolean;
+
+  /**
    * defaults to 'object', how do we want to serialize the editor value to the resulting dataContext object when using a complex object?
    * Currently only applies to Single/Multiple Select Editor.
    *

--- a/packages/common/src/interfaces/columnEditor.interface.ts
+++ b/packages/common/src/interfaces/columnEditor.interface.ts
@@ -129,11 +129,6 @@ export interface ColumnEditor {
   required?: boolean;
 
   /**
-   * only applicable for dateEditors. If explicitely set to false, it will allow to enter a new date in the input field.
-   */
-  readOnly?: boolean;
-
-  /**
    * defaults to 'object', how do we want to serialize the editor value to the resulting dataContext object when using a complex object?
    * Currently only applies to Single/Multiple Select Editor.
    *

--- a/packages/common/src/interfaces/vanillaCalendarOption.interface.ts
+++ b/packages/common/src/interfaces/vanillaCalendarOption.interface.ts
@@ -12,4 +12,7 @@ export interface VanillaCalendarOption extends IPartialSettings {
 
   /** defaults to false, do we want to hide the clear date button? */
   hideClearButton?: boolean;
+
+  /** defaults to false, should keyboard entries be allowed in input field? */
+  allowInput?: boolean;
 }

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -22,6 +22,20 @@ describe('Example 11 - Batch Editing', () => {
     cy.get('h3').should('contain', 'Example 11 - Batch Editing');
   });
 
+  it('should input values directly in input of datepicker', () => {
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`)
+      .click();
+
+    cy.get(`.input-group-editor`)
+      .focus()
+      .type('{backspace}'.repeat(10))
+      .type('1970-01-01')
+      .type('{enter}');
+
+    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`)
+      .should('contain', '1970-01-01');
+  })
+
   describe('built-in operators', () => {
     it('should click on "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
       cy.get('[data-test="clear-storage-btn"]')

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -22,20 +22,6 @@ describe('Example 11 - Batch Editing', () => {
     cy.get('h3').should('contain', 'Example 11 - Batch Editing');
   });
 
-  it('should input values directly in input of datepicker', () => {
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`)
-      .click();
-
-    cy.get(`.input-group-editor`)
-      .focus()
-      .type('{backspace}'.repeat(10))
-      .type('1970-01-01')
-      .type('{enter}');
-
-    cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`)
-      .should('contain', '1970-01-01');
-  })
-
   describe('built-in operators', () => {
     it('should click on "Clear Local Storage" and expect to be back to original grid with all the columns', () => {
       cy.get('[data-test="clear-storage-btn"]')
@@ -1099,6 +1085,22 @@ describe('Example 11 - Batch Editing', () => {
     it('should clear local storage before leaving', () => {
       cy.get('[data-test="clear-storage-btn"]')
         .click({ force: true });
+    });
+  });
+
+  describe('with Date Editor', () => {
+    it('should input values directly in input of datepicker', () => {
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`)
+        .click();
+
+      cy.get(`.input-group-editor`)
+        .focus()
+        .type('{backspace}'.repeat(10))
+        .type('1970-01-01')
+        .type('{enter}');
+
+      cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(5)`)
+        .should('contain', '1970-01-01');
     });
   });
 });


### PR DESCRIPTION
So this is a general idea of how I thought of tackling the realted issue https://github.com/ghiscoding/slickgrid-universal/issues/1684

No tests or docs yet as I first would like to validate what you think about the feature request @ghiscoding 