### PR TITLE
fix(styling): SASS deprecated `lighten` and `darken` methods

### DIFF
--- a/docs/grid-functionalities/grouping-aggregators.md
+++ b/docs/grid-functionalities/grouping-aggregators.md
@@ -219,7 +219,7 @@ To "Clear all Grouping", "Collapse all Groups" and "Expand all Groups", we can s
 ### Styling (change icons)
 The current icons are chevron (right/down), however if you wish to use +/- icons. You can simply update the SASS variables to use whichever SVG icon paths. The SASS variables you can change are
 ```css
-$slick-icon-group-color:                    $primary-color;
+$slick-icon-group-color:                    $slick-primary-color;
 $slick-icon-group-expanded-svg-path:        "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M11,7H13V11H17V13H13V17H11V13H7V11H11V7Z";
 $slick-icon-group-collapsed-svg-path:       "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M17,11V13H7V11H17Z";
 $slick-icon-group-font-size:                20px;

--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -28,7 +28,7 @@
     "bulma": "^1.0.2",
     "dompurify": "^3.1.6",
     "fetch-jsonp": "^1.3.0",
-    "multiple-select-vanilla": "^3.3.3",
+    "multiple-select-vanilla": "^3.3.4",
     "rxjs": "^7.8.1",
     "whatwg-fetch": "^3.6.20"
   },
@@ -36,7 +36,7 @@
     "@types/fnando__sparkline": "^0.3.7",
     "@types/node": "^22.5.1",
     "@types/whatwg-fetch": "^0.0.33",
-    "sass": "^1.77.8",
+    "sass": "^1.79.3",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
   }

--- a/examples/vite-demo-vanilla-bundle/src/material-styles.scss
+++ b/examples/vite-demo-vanilla-bundle/src/material-styles.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 /* make sure to add the @import the SlickGrid Material Theme AFTER the variables changes */
 // @import '@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-material-with-font.scss';
 // @import '@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-material.scss';
@@ -6,6 +8,7 @@
   body.material-theme,
   body.material-theme .icon-checkbox-container {
     $dark-primary-color: #66bb6a;
+    $primary-color: #009530;
     $slick-primary-color: #009530;
     --text-color-primary: #009530;
     --slick-primary-color: #009530;
@@ -18,7 +21,7 @@
     --slick-cell-box-shadow: none;
     --slick-cell-active-box-shadow: inset 0 0 0 1px #aaaaaa;
     --slick-form-control-focus-border-color: #00c840;
-    --slick-form-control-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(53, 121, 154, 0.3);
+    --slick-form-control-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(102, 187, 106, 0.3);
     --slick-editor-focus-border-color: #00b93c;
     --slick-editor-focus-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px rgba(#00a033, .3);
     --slick-multiselect-input-focus-border-color: #00c840;
@@ -26,8 +29,10 @@
     --slick-input-focus-border-color: #00c840;
     --slick-text-editor-focus-border-color: #00c840;
     --slick-slider-editor-focus-border-color: #00c840;
-    --slick-input-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(53, 121, 154, 0.3);
-    --slick-multiselect-input-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(53, 121, 154, 0.3);
+    --slick-slider-filter-focus-border-color: #00c840;
+    --input-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(102, 187, 106, 0.3);
+    --slick-input-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(102, 187, 106, 0.3);
+    --slick-multiselect-input-focus-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(102, 187, 106, 0.3);
     --slick-header-filter-row-border-bottom: 1px solid #d0d0d0;
     --slick-container-border-right: 1px solid #ccc;
     --slick-container-border-top: 1px solid #ccc;
@@ -59,6 +64,8 @@
     --slick-icon-group-color: var(--slick-primary-color);
     --slick-draggable-group-toggle-all-icon-color: var(--slick-primary-color);
     --slick-pagination-icon-color: #009530;
+    --slick-slider-filter-filled-track-color: #9ac49c;
+    --slick-slider-filter-focus-box-shadow: var(--slick-input-focus-box-shadow);
     --slick-slider-filter-thumb-border: 2px solid rgba(0, 149, 48, .68);
     --slick-slider-filter-thumb-active-bg-color: #fff;
     --slick-slider-filter-thumb-active-color: rgba(#02bf3e, .88);
@@ -68,7 +75,6 @@
     --slick-header-resizable-hover-border-left: 2px solid #83d9a0;
     --slick-header-resizable-hover-border-top: 2px solid #83d9a0;
     --slick-header-resizable-hover-border-right: 2px solid #83d9a0;
-    --slick-slider-filter-filled-track-color: #9ac49c;
     --ms-ok-button-text-color: #009530;
     --ms-select-all-text-color: #007c28;
     --slick-multiselect-icon-radio-border: none;
@@ -100,6 +106,9 @@
         font-weight: normal;
         border: 1px solid #55B876;
         box-shadow: none;
+        &.focus, &:focus {
+          box-shadow: var(--slick-input-focus-box-shadow);
+        }
       }
       .search-filter.filled .input-group-addon select {
         border-right: 0px;
@@ -158,9 +167,9 @@
       --slick-menu-item-hover-border: 1px solid #5a5a5a;
       --slick-submenu-box-shadow: none;
       --ms-checkbox-color: #66bb6a;
-      --ms-checkbox-hover-color: #{lighten(#49a54e, 13%)};
+      --ms-checkbox-hover-color: #{color.adjust(#49a54e, $lightness: 13%)};
       --ms-ok-button-text-color: #66bb6a;
-      --ms-ok-button-text-hover-color: #{lighten(#66bb6a, 5%)};
+      --ms-ok-button-text-hover-color: #{color.adjust(#66bb6a, $lightness: 5%)};
 
       .slick-headerrow {
         .search-filter.filled .input-group-addon.slider-value,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -75,7 +75,7 @@
     "@types/trusted-types": "^2.0.7",
     "autocompleter": "^9.3.2",
     "dequal": "^2.0.3",
-    "multiple-select-vanilla": "^3.3.3",
+    "multiple-select-vanilla": "^3.3.4",
     "sortablejs": "^1.15.3",
     "un-flatten-tree": "^2.0.12",
     "vanilla-calendar-pro": "^2.9.10"
@@ -88,7 +88,7 @@
     "npm-run-all2": "^6.2.3",
     "postcss": "^8.4.47",
     "postcss-cli": "^11.0.0",
-    "sass": "^1.78.0"
+    "sass": "^1.79.3"
   },
   "engines": {
     "node": "^18.0.0 || >=20.0.0"

--- a/packages/common/src/styles/_variables-theme-material.scss
+++ b/packages/common/src/styles/_variables-theme-material.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 /**
  * This is a bare version of "slickgrid-theme-material.scss",
  * A few files were removed and aren't included in this styling theme (while they are in original theme)
@@ -24,7 +26,7 @@ $slick-header-text-color:                                   rgba(0, 0, 0, 0.87) 
 $slick-sorting-header-color:                                rgba(0, 0, 0, 0.87) !default;
 $slick-header-border-bottom:                                transparent !default;
 $slick-header-filter-row-border-bottom:                     1px solid #d0d0d0 !default;
-$slick-header-resizable-hover:                              2px solid lighten(#48c774, 15%) !default;
+$slick-header-resizable-hover:                              2px solid #{color.adjust(#48c774, $lightness: 15%)} !default;
 $slick-header-resizable-hover-border-bottom:                $slick-header-resizable-hover !default;
 $slick-header-resizable-hover-border-left:                  $slick-header-resizable-hover !default;
 $slick-header-resizable-hover-border-right:                 $slick-header-resizable-hover !default;
@@ -72,8 +74,8 @@ $slick-header-button-width:                                 18px !default;
 $slick-header-button-margin:                                -4px 0 100px 0 !default;
 $slick-header-menu-button-icon-color:                       $slick-icon-color !default;
 $slick-header-menu-display:                                 inline-block !default;
-$slick-compound-filter-operator-select-border:              1px solid #{lighten($slick-primary-color, 10%)} !default;
-$slick-compound-filter-text-color:                          darken($slick-primary-color, 20%) !default;
+$slick-compound-filter-operator-select-border:              1px solid #{color.adjust($slick-primary-color, $lightness: 10%)} !default;
+$slick-compound-filter-text-color:                          color.adjust($slick-primary-color, $lightness: -20%) !default;
 $slick-preheader-border-right:                              1px solid #e2e2e2 !default;
 $slick-row-move-plugin-cursor:                              grab !default;
 $slick-row-move-plugin-icon-color:                          $slick-icon-color !default;
@@ -124,7 +126,7 @@ $slick-dark-text-color:                                   #d4d4d4;
   --slick-icon-sort-color:                        #66bb6a;
   --slick-multiselect-icon-radio-color:           #66bb6a;
   --ms-checkbox-color:                            #66bb6a;
-  --ms-checkbox-hover-color:                      #{lighten(#49a54e, 13%)};
+  --ms-checkbox-hover-color:                      #{color.adjust(#49a54e, $lightness: 13%)};
   --ms-ok-button-text-color:                      #66bb6a;
-  --ms-ok-button-text-hover-color:                #{lighten(#66bb6a, 5%)};
+  --ms-ok-button-text-hover-color:                #{color.adjust(#66bb6a, $lightness: 5%)};
 }

--- a/packages/common/src/styles/_variables-theme-salesforce.scss
+++ b/packages/common/src/styles/_variables-theme-salesforce.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 /**
  * This is a bare version of "slickgrid-theme-salesforce.scss",
  * A few files were removed and aren't included in this styling theme (while they are in original theme)
@@ -69,7 +71,7 @@ $slick-menu-title-font-size:                                  17px !default;
 $slick-icon-group-color:                                      $slick-primary-color !default;
 $slick-filled-filter-color:                                   $slick-primary-color-dark !default;
 $slick-filled-filter-border:                                  1px solid #{$slick-primary-color} !default;
-$slick-filled-filter-box-shadow:                              inset 0 0 0 1px #{lighten($slick-primary-color, 30%)} !default;
+$slick-filled-filter-box-shadow:                              inset 0 0 0 1px #{color.adjust($slick-primary-color, $lightness: 30%)} !default;
 $slick-filled-filter-font-weight:                             bold !default;
 $slick-draggable-group-drop-border-top:                       0px !default;
 $slick-draggable-group-drop-width:                            100% !default;
@@ -115,7 +117,7 @@ $slick-editor-modal-title-text-align:                         center !default;
 $slick-large-editor-button-border-radius:                     3px !default;
 $slick-slider-filter-runnable-track-bgcolor:                  #ECEBEA !default;
 $slick-row-selected-color:                                    #ECEBEA !default;
-$slick-row-highlight-background-color:                        lighten($slick-highlight-color, 50%) !default;
+$slick-row-highlight-background-color:                        color.adjust($slick-highlight-color, $lightness: 50%) !default;
 $slick-row-mouse-hover-color:                                 #f3f2f2 !default;
 $slick-row-mouse-hover-box-shadow:                            0 0 0 2px #dddbda !default;
 $slick-pagination-icon-color:                                 $slick-primary-color !default;

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 // import external lib CSS files (without the .css extension)
 @import 'vanilla-calendar-pro/build/vanilla-calendar.min';
 
@@ -13,9 +15,10 @@
 /* this is the only variable without $slick prefix and exists so that user could use the same Bootstrap primary color without declaring $slick-primary-color variable (which also exists) */
 /** extra styling when Bootstrap isn't provided */
 $primary-color:                                             #0d6efd !default;
-$input-focus-box-shadow:                                    inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px rgba(lighten($primary-color, 3%), .3) !default;
 $slick-highlight-color:                                     #fcfcfc !default;
+$slick-primary-color:                                       $primary-color !default;
 // Bootstrap 5 box-shadow
+$input-focus-box-shadow:                                    inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px rgba(color.adjust($slick-primary-color, $lightness: 3%), .3) !default;
 // $input-focus-box-shadow: 0 0 0 0.25rem #0d6efd40 !default;
 
 $slick-border-color:                                        #dddddd !default;
@@ -23,7 +26,6 @@ $slick-font-size-base-value:                                14 !default;
 $slick-font-color:                                          #000 !default;
 $slick-font-size-base:          			                      $slick-font-size-base-value + 0px !default;
 $slick-font-family:                                         -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
-$slick-primary-color:                                       $primary-color !default;
 $slick-btn-default-bg-color:                                #fff !default;
 $slick-btn-default-border:                                  1px solid #dbdbdb !default;
 $slick-btn-default-border-color:                            #ccc !default;
@@ -33,16 +35,16 @@ $slick-button-primary-bg-color:                             $slick-primary-color
 $slick-button-primary-bg-color-disabled:                    #bebebe !default;
 $slick-button-primary-color:                                inherit !default;
 $slick-button-border-color:                                 #c7c7c7 !default;
-$slick-button-hover-border-color:                           darken($slick-button-border-color, 15%) !default;
+$slick-button-hover-border-color:                           color.adjust($slick-button-border-color, $lightness: -15%) !default;
 $slick-button-style-bg-color:                               #fff !default;
 $slick-filter-placeholder-font-family:                      'Segoe UI Symbol' !default;
 $slick-focus-color:                                         rgb(115, 179, 229) !default;
 $slick-date-picker-bg-color:                                #fff !default;
 
 $slick-form-control-bg-color:                               #fff !default;
-$slick-form-control-border:                                  1px solid #ccc !default;
-$slick-form-control-focus-border-color:                      lighten($slick-primary-color, 10%) !default;
-$slick-form-control-focus-box-shadow:                        $input-focus-box-shadow !default;
+$slick-form-control-border:                                 1px solid #ccc !default;
+$slick-form-control-focus-border-color:                     color.adjust($slick-primary-color, $lightness: 10%) !default;
+$slick-form-control-focus-box-shadow:                       $input-focus-box-shadow !default;
 
 $slick-input-group-addon-border:                            1px solid #ccc !default;
 $slick-input-group-addon-color:                             #555 !default;
@@ -51,7 +53,7 @@ $slick-input-group-btn-bg-color:                            #f9f9f9 !default;
 $slick-input-group-btn-hover-bg-color:                      #eee !default;
 $slick-input-group-btn-border:                              1px solid #ccc !default;
 $slick-input-group-append-bg-color:                         #eee !default;
-$slick-input-focus-border-color:                            lighten($slick-primary-color, 10%) !default;
+$slick-input-focus-border-color:                            color.adjust($slick-primary-color, $lightness: 10%) !default;
 $slick-input-focus-box-shadow:                              $input-focus-box-shadow !default;
 
 /* Slickgrid container, including headers but excluding pagination */
@@ -92,8 +94,8 @@ $slick-cell-border-right:                                   1px transparent !def
 $slick-cell-border-bottom:                                  1px transparent !default;
 $slick-cell-border-left:                                    1px transparent !default;
 $slick-cell-even-background-color: 			                    #ffffff !default;
-$slick-cell-odd-background-color:                           darken($slick-grid-cell-color, 3%) !default; // for striping every second row
-$slick-cell-odd-active-background-color:                    darken($slick-grid-cell-color, 5%) !default;
+$slick-cell-odd-background-color:                           color.adjust($slick-grid-cell-color, $lightness: -3%) !default; // for striping every second row
+$slick-cell-odd-active-background-color:                    color.adjust($slick-grid-cell-color, $lightness: -5%) !default;
 $slick-cell-padding-top-bottom:                             5px !default;
 $slick-cell-padding-left-right:                             6px !default;
 $slick-cell-padding:                                        $slick-cell-padding-top-bottom $slick-cell-padding-left-right !default;
@@ -107,7 +109,7 @@ $slick-row-mouse-hover-color:                               #eff5fc !default;
 $slick-row-mouse-hover-box-shadow:                          none !default;
 $slick-row-mouse-hover-z-index:                             5 !default;
 $slick-row-selected-color:                                  #dae8f1 !default;
-$slick-row-highlight-background-color:                      darken($slick-row-selected-color, 5%) !default;
+$slick-row-highlight-background-color:                      color.adjust($slick-row-selected-color, $lightness: -5%) !default;
 $slick-row-highlight-fade-animation:                        1s linear !default;
 $slick-row-checkbox-selector-background:                    inherit !default;
 $slick-row-checkbox-selector-border:                        none !default;
@@ -132,8 +134,8 @@ $slick-header-border-right:                                 0 none !default;
 $slick-header-border-bottom:                                0 none !default;
 $slick-header-border-left:                                  0 none !default;
 $slick-header-column-height:                                calc(17px * #{$slick-header-row-count}) !default;  // header is calculated by rows to show
-$slick-header-column-background-active:                     darken($slick-grid-header-background, 5%) !default;
-$slick-header-column-background-hover:                      darken($slick-grid-header-background, 2%) !default;
+$slick-header-column-background-active:                     color.adjust($slick-grid-header-background, $lightness: -5%) !default;
+$slick-header-column-background-hover:                      color.adjust($slick-grid-header-background, $lightness: -2%) !default;
 $slick-header-column-sortable-background-hover:             #e0e0e0 !default;
 $slick-header-column-name-margin-right:                     0 !default;
 $slick-header-column-border-top:                            0 none !default;                      // header, column titles, that is without the Filters
@@ -191,7 +193,7 @@ $slick-icon-group-margin-right:                             2px !default;
 $slick-autocomplete-bg-color:	                              #ffffff !default;
 $slick-autocomplete-group-bg-color:	                        #eeeeee !default;
 $slick-autocomplete-border:	                                1px solid rgba(0, 0, 0, 0.15) !default;
-$slick-autocomplete-hover-bg-color:                         darken($slick-row-mouse-hover-color, 3%) !default;
+$slick-autocomplete-hover-bg-color:                         color.adjust($slick-row-mouse-hover-color, $lightness: -3%) !default;
 $slick-autocomplete-loading-input-bg-color:                 transparent !default;
 $slick-autocomplete-loading-icon-color:                     #777777 !default;
 $slick-autocomplete-loading-icon:                           url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{encodecolor($slick-autocomplete-loading-icon-color)}" viewBox="0 0 24 24"><path d="M16,13V11H21V13H16M14.83,7.76L17.66,4.93L19.07,6.34L16.24,9.17L14.83,7.76M11,16H13V21H11V16M11,3H13V8H11V3M4.93,17.66L7.76,14.83L9.17,16.24L6.34,19.07L4.93,17.66M4.93,6.34L6.34,4.93L9.17,7.76L7.76,9.17L4.93,6.34M8,13H3V11H8V13M19.07,17.66L17.66,19.07L14.83,16.24L16.24,14.83L19.07,17.66Z"></path></svg>') !default;
@@ -249,7 +251,7 @@ $slick-autocomplete-tpl4-top-left-font-size:                $slick-autocomplete-
 $slick-autocomplete-tpl4-top-left-font-style:               normal !default;
 $slick-autocomplete-tpl4-top-left-font-weight:              bold !default;
 $slick-autocomplete-tpl4-top-left-max-width:                $slick-autocomplete-tpl4-bottom-left-max-width !default;
-$slick-autocomplete-tpl4-top-right-text-color:              lighten($slick-primary-color, 7%) !default;
+$slick-autocomplete-tpl4-top-right-text-color:              color.adjust($slick-primary-color, $lightness: 7%) !default;
 $slick-autocomplete-tpl4-top-right-font-size:               calc(#{$slick-autocomplete-tpl4-font-size} - 1px) !default;
 $slick-autocomplete-tpl4-top-right-font-style:              normal !default;
 $slick-autocomplete-tpl4-top-right-font-weight:             bold !default;
@@ -277,7 +279,7 @@ $slick-group-totals-formatter-font-size:                    14px !default;
 
 /** Row Detail View Plugin */
 $slick-detail-view-icon-color:                              $slick-primary-color !default;
-$slick-detail-view-icon-color-hover:                        darken($slick-detail-view-icon-color, 10%) !default;
+$slick-detail-view-icon-color-hover:                        color.adjust($slick-detail-view-icon-color, $lightness: -10%) !default;
 $slick-detail-view-icon-opacity-hover:                      1 !default;
 $slick-detail-view-icon-collapse-svg-path:                  "M17,13H7V11H17M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" !default;
 $slick-detail-view-icon-expand-svg-path:                    "M17,13H13V17H11V13H7V11H11V7H13V11H17M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z" !default;
@@ -289,11 +291,11 @@ $slick-detail-view-container-padding:                       10px !default;
 $slick-detail-view-container-z-index:                       10 !default;
 
 /** Row based edit plugin */
-$slick-row-based-edit-unsaved-cell-bgcolor:                #f3ed91 !default;
-$slick-row-based-edit-editmode-active-bgcolor:              darken($slick-grid-cell-color, 15%) !default;
-$slick-row-based-edit-editmode-active-hover-bgcolor:        darken($slick-grid-cell-color, 10%) !default;
-$slick-row-based-edit-editmode-bgcolor:                     darken($slick-grid-cell-color, 15%) !default;
-$slick-row-based-edit-editmode-hover-bgcolor:               darken($slick-grid-cell-color, 10%) !default;
+$slick-row-based-edit-unsaved-cell-bgcolor:                 #f3ed91 !default;
+$slick-row-based-edit-editmode-active-bgcolor:              color.adjust($slick-grid-cell-color, $lightness: -15%) !default;
+$slick-row-based-edit-editmode-active-hover-bgcolor:        color.adjust($slick-grid-cell-color, $lightness: -10%) !default;
+$slick-row-based-edit-editmode-bgcolor:                     color.adjust($slick-grid-cell-color, $lightness: -15%) !default;
+$slick-row-based-edit-editmode-hover-bgcolor:               color.adjust($slick-grid-cell-color, $lightness: -10%) !default;
 
 /* Excel copy plugin */
 $slick-copied-cell-bg-color-transition:                     rgba(0, 0, 255, 0.2) !default;
@@ -306,7 +308,7 @@ $slick-column-picker-border-radius:                         2px !default;
 $slick-column-picker-box-shadow:                            none !default;
 $slick-column-picker-close-btn-bg-color:                    #ffffff !default;
 $slick-column-picker-close-btn-color:                       #909090 !default;
-$slick-column-picker-close-btn-color-hover:                 darken($slick-column-picker-close-btn-color, 25%) !default;
+$slick-column-picker-close-btn-color-hover:                 color.adjust($slick-column-picker-close-btn-color, $lightness: -25%) !default;
 $slick-column-picker-close-btn-cursor:                      pointer !default;
 $slick-column-picker-close-btn-font-family:                 "Calibri Light", "Helvetica Neue", Arial, sans-serif !default;
 $slick-column-picker-close-btn-font-size:                   21px !default;
@@ -550,7 +552,7 @@ $slick-editor-modal-close-btn-top:                          10px !default;
 $slick-editor-modal-close-btn-border-left:                  1px solid #ced4da !default;
 $slick-editor-modal-close-btn-border-radius:                0 4px 4px 0 !default;
 $slick-editor-modal-close-btn-outside-color:                #dddddd !default;
-$slick-editor-modal-close-btn-outside-color-hover:          darken($slick-editor-modal-close-btn-outside-color, 10%) !default;
+$slick-editor-modal-close-btn-outside-color-hover:          color.adjust($slick-editor-modal-close-btn-outside-color, $lightness: -10%) !default;
 $slick-editor-modal-close-btn-outside-font-size:            30px !default;
 $slick-editor-modal-close-btn-outside-right:                -24px !default;
 $slick-editor-modal-close-btn-outside-top:                  -28px !default;
@@ -644,12 +646,12 @@ $slick-editor-modal-validation-summary-font-style:          italic !default;
 $slick-compound-filter-bgcolor:                             #ffffff !default;
 $slick-compound-filter-operator-select-font-family:         "Cascadia Mono", Consolas, "Lucida Console" !default; // use a monospace font so the operator descriptions are all aligned
 $slick-compound-filter-operator-select-font-size:           14px !important !default;
-$slick-compound-filter-operator-select-border:              1px solid #{lighten($slick-primary-color, 15%)} !default;
+$slick-compound-filter-operator-select-border:              1px solid #{color.adjust($slick-primary-color, $lightness: 15%)} !default;
 $slick-compound-filter-operator-select-width:               25px !default;
 $slick-compound-filter-operator-border-radius:              4px 0 0 4px !default;
 $slick-compound-filter-border-radius:                       0 4px 4px 0 !default;
 $slick-compound-filter-text-weight:                         bold !default;
-$slick-compound-filter-text-color:                          #{lighten($slick-primary-color, 15%)} !default;
+$slick-compound-filter-text-color:                          color.adjust($slick-primary-color, $lightness: 15%) !default;
 $slick-compound-filter-text-font-size:                      13px !default;
 $slick-compound-filter-text-padding:                        0 0 0 2px !default;
 
@@ -731,11 +733,11 @@ $slick-slider-filter-height:                                $slick-header-input-
 $slick-slider-filter-thumb-border-radius:                   50% !default;
 $slick-slider-filter-thumb-cursor:                          grab !default;
 $slick-slider-filter-thumb-border:                          2px solid rgba($slick-primary-color, .68) !default;
-$slick-slider-filter-thumb-color:                           lighten($slick-primary-color, 75%) !default; // #c9dbcb
+$slick-slider-filter-thumb-color:                           color.adjust($slick-primary-color, $lightness: 75%) !default; // #c9dbcb
 $slick-slider-filter-thumb-active-color:                    rgba($slick-primary-color, .88) !default; // #c9dbcb
 $slick-slider-filter-thumb-active-bg-color:                 #fff !default;
 $slick-slider-filter-thumb-active-border:                   2px solid #{$slick-slider-filter-thumb-active-color} !default; // #c9dbcb
-$slick-slider-filter-thumb-active-box-shadow:               0 0 0 2px rgba(lighten($slick-primary-color, 3%), .15) !default; // #c9dbcb
+$slick-slider-filter-thumb-active-box-shadow:               0 0 0 2px #{rgba(color.adjust($slick-primary-color, $lightness: 3%), .15)} !default; // #c9dbcb
 $slick-slider-filter-thumb-size:                            14px !default;
 $slick-slider-filter-thumb-height:                          calc(#{$slick-slider-filter-thumb-size} - 4px) !default;
 $slick-slider-filter-thumb-width:                           $slick-slider-filter-thumb-height !default;
@@ -775,7 +777,7 @@ $slick-multiselect-ok-button-border-radius:                 0 0 4px 4px !default
 $slick-multiselect-ok-button-border-width:                  1px 0 0 0 !default;
 $slick-multiselect-ok-button-font-weight:                   600 !default;
 $slick-multiselect-ok-button-text-color:                    $slick-primary-color !default;
-$slick-multiselect-ok-button-text-hover-color:              darken($slick-primary-color, 5%) !default;
+$slick-multiselect-ok-button-text-hover-color:              color.adjust($slick-primary-color, $lightness: -5%) !default;
 $slick-multiselect-ok-button-height:                        26px !default;
 $slick-multiselect-ok-button-width:                         100% !default;
 $slick-multiselect-ok-button-text-align:                    center !default;
@@ -788,7 +790,7 @@ $slick-multiselect-select-all-label-hover-bg-color:         $slick-multiselect-c
 $slick-multiselect-select-all-label-padding:                4px !default;
 $slick-multiselect-select-all-line-height:                  calc(#{$slick-multiselect-icon-font-size} + 2px) !default;
 $slick-multiselect-select-all-padding:                      6px 10px !default;
-$slick-multiselect-select-all-text-color:                   darken($slick-primary-color, 5%) !default;
+$slick-multiselect-select-all-text-color:                   color.adjust($slick-primary-color, $lightness: -5%) !default;
 $slick-multiselect-select-all-text-hover-color:             transparent !default;
 
 // override some multiple-select SASS variables with our variables
@@ -933,7 +935,7 @@ $slick-tooltip-text-overflow:                               ellipsis !default;
 $slick-tooltip-white-space:                                 normal !default;
 $slick-tooltip-z-index:                                     9999 !default;
 // tooltip arrow
-$slick-tooltip-arrow-color:                                 darken($slick-tooltip-border-color, 5%) !default;
+$slick-tooltip-arrow-color:                                 color.adjust($slick-tooltip-border-color, $lightness: -5%) !default;
 $slick-tooltip-arrow-size:                                  8px !default;
 $slick-tooltip-down-arrow-top-margin:                       100% !default;
 $slick-tooltip-up-arrow-top-margin:                         -($slick-tooltip-arrow-size * 2) !default;
@@ -958,7 +960,7 @@ $slick-empty-data-warning-z-index:                          10 !default;
 // -----------
 
 // add a few Dark Mode SASS variables, just the basic vars
-$slick-dark-primary-color:                                lighten($primary-color, 15%) !default;
+$slick-dark-primary-color:                                color.adjust($slick-primary-color, $lightness: 15%) !default;
 $slick-dark-base-dark-text-color:                         #d4d4d4 !default;
 $slick-dark-base-dark-menu-bg-color:                      #252525 !default;
 $slick-dark-base-dark-menu-border-color:                  #505050 !default;
@@ -1016,7 +1018,7 @@ $slick-dark-text-color:                                   #d4d4d4 !default;
   --slick-checkbox-opacity-hover:                         0.7;
   --slick-checkbox-icon-color:                            var(--slick-primary-color);
   --slick-checkbox-icon-bg-color:                         #444444;
-  --slick-checkbox-unchecked-color:                       #{lighten($primary-color, 10%)};
+  --slick-checkbox-unchecked-color:                       #{color.adjust($slick-primary-color, $lightness: 10%)};
   --slick-checkbox-unchecked-opacity:                     0.4;
   --slick-detail-view-icon-color:                         var(--slick-primary-color);
   --slick-detail-view-icon-color-hover:                   var(--slick-primary-color);
@@ -1168,7 +1170,7 @@ $slick-dark-text-color:                                   #d4d4d4 !default;
   --slick-button-primary-color:                           #bababa;
   --slick-button-style-bg-color:                          #252525;
   .text-color-primary {
-    --text-color-primary:                                 var(--slick-primary-color, #{lighten($primary-color, 15%)});
+    --text-color-primary:                                 var(--slick-primary-color, #{color.adjust($slick-primary-color, $lightness: 15%)});
   }
   .text-color-secondary {
     --text-color-secondary:                               rgba(222, 226, 230, 0.75);

--- a/packages/common/src/styles/colors.scss
+++ b/packages/common/src/styles/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 @import './svg-utilities';
 
 /* icon/text colors */
@@ -66,28 +68,28 @@ $text-color-sf-primary-dark: #004487 !default;
 .text-color-sf-primary { color: var(--text-color-sf-primary, $text-color-sf-primary); }
 .text-color-sf-primary-dark { color: var(--text-color-sf-primary-dark, $text-color-sf-primary-dark); }
 
-.text-color-primary-light { color: lighten($text-color-primary, $text-color-lighten-percentage); }
-.text-color-primary-dark { color: darken($text-color-primary, $text-color-darken-percentage); }
-.text-color-secondary-light { color: lighten($text-color-secondary, $text-color-lighten-percentage); }
-.text-color-secondary-dark { color: darken($text-color-secondary, $text-color-darken-percentage); }
-.text-color-success-light { color: lighten($text-color-success, $text-color-lighten-percentage); }
-.text-color-success-dark { color: darken($text-color-success, $text-color-darken-percentage); }
-.text-color-danger-light { color: lighten($text-color-danger, $text-color-lighten-percentage); }
-.text-color-danger-dark { color: darken($text-color-danger, $text-color-darken-percentage); }
-.text-color-warning-light { color: lighten($text-color-warning, $text-color-lighten-percentage); }
-.text-color-warning-dark { color: darken($text-color-warning, $text-color-darken-percentage); }
-.text-color-info-light { color: lighten($text-color-info, $text-color-lighten-percentage); }
-.text-color-info-dark { color: darken($text-color-info, $text-color-darken-percentage); }
-.text-color-body-light { color: lighten($text-color-body, $text-color-lighten-percentage); }
-.text-color-body-dark { color: darken($text-color-body, $text-color-darken-percentage); }
-.text-color-muted-light { color: lighten($text-color-muted, $text-color-lighten-percentage); }
-.text-color-muted-dark { color: darken($text-color-muted, $text-color-darken-percentage); }
-.text-color-alt-warning-light { color: lighten($text-color-alt-warning, $text-color-lighten-percentage); }
-.text-color-alt-warning-dark { color: darken($text-color-alt-warning, $text-color-darken-percentage); }
-.text-color-alt-default-light { color: lighten($text-color-alt-default, $text-color-lighten-percentage); }
-.text-color-alt-default-dark { color: darken($text-color-alt-default, $text-color-darken-percentage); }
-.text-color-alt-danger-light { color: lighten($text-color-alt-danger, $text-color-lighten-percentage); }
-.text-color-alt-danger-dark { color: darken($text-color-alt-danger, $text-color-darken-percentage); }
-.text-color-alt-success-light { color: lighten($text-color-alt-success, $text-color-lighten-percentage); }
-.text-color-alt-success-dark { color: darken($text-color-alt-success, $text-color-darken-percentage); }
-.text-color-se-secondary-light { color: lighten($text-color-se-secondary, $text-color-lighten-percentage); }
+.text-color-primary-light { color: color.adjust($text-color-primary, $lightness: $text-color-lighten-percentage); }
+.text-color-primary-dark { color: color.adjust($text-color-primary, $lightness: -$text-color-darken-percentage); }
+.text-color-secondary-light { color: color.adjust($text-color-secondary, $lightness: $text-color-lighten-percentage); }
+.text-color-secondary-dark { color: color.adjust($text-color-secondary, $lightness: -$text-color-darken-percentage); }
+.text-color-success-light { color: color.adjust($text-color-success, $lightness: $text-color-lighten-percentage); }
+.text-color-success-dark { color: color.adjust($text-color-success, $lightness: -$text-color-darken-percentage); }
+.text-color-danger-light { color: color.adjust($text-color-danger, $lightness: $text-color-lighten-percentage); }
+.text-color-danger-dark { color: color.adjust($text-color-danger, $lightness: -$text-color-darken-percentage); }
+.text-color-warning-light { color: color.adjust($text-color-warning, $lightness: $text-color-lighten-percentage); }
+.text-color-warning-dark { color: color.adjust($text-color-warning, $lightness: -$text-color-darken-percentage); }
+.text-color-info-light { color: color.adjust($text-color-info, $lightness: $text-color-lighten-percentage); }
+.text-color-info-dark { color: color.adjust($text-color-info, $lightness: -$text-color-darken-percentage); }
+.text-color-body-light { color: color.adjust($text-color-body, $lightness: $text-color-lighten-percentage); }
+.text-color-body-dark { color: color.adjust($text-color-body, $lightness: -$text-color-darken-percentage); }
+.text-color-muted-light { color: color.adjust($text-color-muted, $lightness: $text-color-lighten-percentage); }
+.text-color-muted-dark { color: color.adjust($text-color-muted, $lightness: -$text-color-darken-percentage); }
+.text-color-alt-warning-light { color: color.adjust($text-color-alt-warning, $lightness: $text-color-lighten-percentage); }
+.text-color-alt-warning-dark { color: color.adjust($text-color-alt-warning, $lightness: -$text-color-darken-percentage); }
+.text-color-alt-default-light { color: color.adjust($text-color-alt-default, $lightness: $text-color-lighten-percentage); }
+.text-color-alt-default-dark { color: color.adjust($text-color-alt-default, $lightness: -$text-color-darken-percentage); }
+.text-color-alt-danger-light { color: color.adjust($text-color-alt-danger, $lightness: $text-color-lighten-percentage); }
+.text-color-alt-danger-dark { color: color.adjust($text-color-alt-danger, $lightness: -$text-color-darken-percentage); }
+.text-color-alt-success-light { color: color.adjust($text-color-alt-success, $lightness: $text-color-lighten-percentage); }
+.text-color-alt-success-dark { color: color.adjust($text-color-alt-success, $lightness: -$text-color-darken-percentage); }
+.text-color-se-secondary-light { color: color.adjust($text-color-se-secondary, $lightness: $text-color-lighten-percentage); }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       multiple-select-vanilla:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.3.4
+        version: 3.3.4
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -196,14 +196,14 @@ importers:
         specifier: ^0.0.33
         version: 0.0.33
       sass:
-        specifier: ^1.77.8
-        version: 1.77.8
+        specifier: ^1.79.3
+        version: 1.79.3
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.4.2
-        version: 5.4.2(@types/node@22.5.1)(sass@1.77.8)
+        version: 5.4.2(@types/node@22.5.1)(sass@1.79.3)
 
   packages/binding:
     devDependencies:
@@ -241,8 +241,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       multiple-select-vanilla:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.3.4
+        version: 3.3.4
       sortablejs:
         specifier: ^1.15.3
         version: 1.15.3
@@ -275,8 +275,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0(postcss@8.4.47)
       sass:
-        specifier: ^1.78.0
-        version: 1.78.0
+        specifier: ^1.79.3
+        version: 1.79.3
 
   packages/composite-editor-component:
     dependencies:
@@ -2890,6 +2890,13 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /chokidar@4.0.0:
+    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.0.1
+    dev: true
+
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
@@ -3239,7 +3246,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     dev: true
 
   /css-tree@2.3.1:
@@ -3247,7 +3254,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     dev: true
 
   /css-what@6.1.0:
@@ -5605,7 +5612,7 @@ packages:
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     dev: true
 
   /make-dir@4.0.0:
@@ -5805,8 +5812,8 @@ packages:
       minimatch: 9.0.5
     dev: true
 
-  /multiple-select-vanilla@3.3.3:
-    resolution: {integrity: sha512-SOcWuYEB3ISR3M3YohaDJgRH7Fe6nupcgp1UpefVTSvbLluzlyRaQxwQqMXFI3ePMkrX9ERY1uU3NZ9pmW//7A==}
+  /multiple-select-vanilla@3.3.4:
+    resolution: {integrity: sha512-NQuuoJqj+LY9JAhg94qvGIXPELKQpVlocuegxi1vhADvUnZSFbbgflcryO3CgcHII77zkWl82U0sFs8tLpBmlg==}
     dependencies:
       '@types/trusted-types': 2.0.7
     dev: false
@@ -6755,7 +6762,7 @@ packages:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     dev: true
 
   /postcss@8.4.47:
@@ -6964,6 +6971,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /readdirp@4.0.1:
+    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
+    engines: {node: '>= 14.16.0'}
+    dev: true
+
   /regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
@@ -7145,24 +7157,14 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /sass@1.77.8:
-    resolution: {integrity: sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==}
+  /sass@1.79.3:
+    resolution: {integrity: sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.0
       immutable: 4.3.5
-      source-map-js: 1.2.0
-    dev: true
-
-  /sass@1.78.0:
-    resolution: {integrity: sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      chokidar: 3.6.0
-      immutable: 4.3.5
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     dev: true
 
   /saxes@6.0.0:
@@ -7350,11 +7352,6 @@ packages:
 
   /sortablejs@1.15.3:
     resolution: {integrity: sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==}
-
-  /source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8087,7 +8084,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.4.2(@types/node@22.5.1)(sass@1.77.8):
+  /vite@5.4.2(@types/node@22.5.1)(sass@1.79.3):
     resolution: {integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -8122,7 +8119,7 @@ packages:
       esbuild: 0.21.5
       postcss: 8.4.41
       rollup: 4.21.0
-      sass: 1.77.8
+      sass: 1.79.3
     optionalDependencies:
       fsevents: 2.3.3
     dev: true


### PR DESCRIPTION
- another deprecation from SASS which is again displaying a load of console warnings
- more info on SASS website: https://sass-lang.com/documentation/breaking-changes/color-functions/