### PR TITLE
fix: home and end keys stop propagation on input based editors, closes #1686

### DIFF
--- a/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
@@ -196,30 +196,19 @@ describe('AutocompleterEditor', () => {
       expect(editor.getValue()).toBe('male');
     });
 
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Left Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
+    ["ArrowLeft", "ArrowRight", "Home", "End"].forEach((key: string) => {
+      it(`should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using ${key} key`, () => {
+        const event = new (window.window as any).KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+        const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
 
-      editor = new AutocompleterEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-gender') as HTMLInputElement;
+        editor = new AutocompleterEditor(editorArguments);
+        const editorElm = divContainer.querySelector('input.editor-gender') as HTMLInputElement;
 
-      editorElm.focus();
-      editorElm.dispatchEvent(event);
+        editorElm.focus();
+        editorElm.dispatchEvent(event);
 
-      expect(spyEvent).toHaveBeenCalled();
-    });
-
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Right Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
-
-      editor = new AutocompleterEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-gender') as HTMLInputElement;
-
-      editorElm.focus();
-      editorElm.dispatchEvent(event);
-
-      expect(spyEvent).toHaveBeenCalled();
+        expect(spyEvent).toHaveBeenCalled();
+      });
     });
 
     it('should render the DOM element with different key/value pair when user provide its own customStructure', () => {

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -147,15 +147,15 @@ describe('DateEditor', () => {
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
       editor.editorDomElement.dispatchEvent(event);
 
-      expect(editor.columnEditor.editorOptions?.allowEdit).toBeFalsy();
+      expect(editor.columnEditor.editorOptions?.allowInput).toBeFalsy();
       expect(editor.isValueTouched()).toBeFalsy();
     });
 
-    it('should stop propagation on allowEdit when hitting left or right arrow keys', () => {
+    it('should stop propagation on allowInput when hitting left or right arrow and home and end keys', () => {
       editor = new DateEditor({ ...editorArguments,
         column: { ...editorArguments.column,
           editor: { ...editorArguments.column.editor,
-            editorOptions: { ...editorArguments.column?.editor?.editorOptions, allowEdit: true }
+            editorOptions: { ...editorArguments.column?.editor?.editorOptions, allowInput: true }
            }}});
 
       let event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
@@ -300,7 +300,7 @@ describe('DateEditor', () => {
 
         editor = new DateEditor({...editorArguments,
           column: { ...mockColumn, editor: { ...editorArguments.column.editor, alwaysSaveOnEnterKey: true,
-            editorOptions: { ...editorArguments.column.editor?.editorOptions, allowEdit: true}
+            editorOptions: { ...editorArguments.column.editor?.editorOptions, allowInput: true}
            } }
         });
         const event = new KeyboardEvent('keydown', { key: 'Enter' });

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -167,6 +167,16 @@ describe('DateEditor', () => {
       propagationSpy = vi.spyOn(event, 'stopImmediatePropagation');
       editor.editorDomElement.dispatchEvent(event);
       expect(propagationSpy).toHaveBeenCalled();
+
+      event = new KeyboardEvent('keydown', { key: 'Home' });
+      propagationSpy = vi.spyOn(event, 'stopImmediatePropagation');
+      editor.editorDomElement.dispatchEvent(event);
+      expect(propagationSpy).toHaveBeenCalled();
+
+      event = new KeyboardEvent('keydown', { key: 'End' });
+      propagationSpy = vi.spyOn(event, 'stopImmediatePropagation');
+      editor.editorDomElement.dispatchEvent(event);
+      expect(propagationSpy).toHaveBeenCalled();
     });
 
     it('should have a placeholder when defined in its column definition', () => {

--- a/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
@@ -205,31 +205,20 @@ describe('DualInputEditor', () => {
       expect(editor.getValues()).toEqual({ from: 1, to: 22 });
     });
 
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Left Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
+    ["ArrowLeft", "ArrowRight", "Home", "End"].forEach((key: string) => {
+      it(`should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using ${key} key`, () => {
+        const event = new (window.window as any).KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+        const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
 
-      editor = new DualInputEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-range') as HTMLInputElement;
+        editor = new DualInputEditor(editorArguments);
+        const editorElm = divContainer.querySelector('input.editor-range') as HTMLInputElement;
 
-      editor.focus();
-      editorElm.dispatchEvent(event);
+        editor.focus();
+        editorElm.dispatchEvent(event);
 
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
-    });
-
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Right Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
-
-      editor = new DualInputEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-range') as HTMLInputElement;
-
-      editor.focus();
-      editorElm.dispatchEvent(event);
-
-      expect(spyEvent).toHaveBeenCalled();
+        expect(gridStub.focus).toHaveBeenCalled();
+        expect(spyEvent).toHaveBeenCalled();
+      });
     });
 
     describe('isValueChanged method (and isValueTouched method will always true for all since we trigger events in all)', () => {

--- a/packages/common/src/editors/__tests__/floatEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/floatEditor.spec.ts
@@ -169,32 +169,20 @@ describe('FloatEditor', () => {
       expect(editor.getValue()).toBe('213');
     });
 
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Left Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
+    ["ArrowLeft", "ArrowRight", "Home", "End"].forEach((key: string) => {
+      it(`should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using ${key} key`, () => {
+        const event = new (window.window as any).KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+        const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
 
-      editor = new FloatEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
+        editor = new FloatEditor(editorArguments);
+        const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
 
-      editor.focus();
-      editorElm.dispatchEvent(event);
+        editor.focus();
+        editorElm.dispatchEvent(event);
 
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
-    });
-
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Right Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
-
-      editor = new FloatEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
-
-      editor.focus();
-      editorElm.dispatchEvent(event);
-
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
+        expect(gridStub.focus).toHaveBeenCalled();
+        expect(spyEvent).toHaveBeenCalled();
+      });
     });
 
     describe('isValueChanged method', () => {

--- a/packages/common/src/editors/__tests__/inputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputEditor.spec.ts
@@ -178,33 +178,21 @@ describe('InputEditor (TextEditor)', () => {
       expect(editor.getValue()).toBe('task 1');
     });
 
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Left Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
+    ["ArrowLeft", "ArrowRight", "Home", "End"].forEach((key: string) => {
+      it(`should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using ${key} key`, () => {
+        const event = new (window.window as any).KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+        const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
 
-      editor = new InputEditor(editorArguments, 'text');
-      const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
+        editor = new InputEditor(editorArguments, 'text');
+        const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
 
-      editor.focus();
-      editorElm.dispatchEvent(event);
+        editor.focus();
+        editorElm.dispatchEvent(event);
 
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
-      expect(editor.isValueTouched()).toBe(true);
-    });
-
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Right Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
-
-      editor = new InputEditor(editorArguments, 'text');
-      const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
-
-      editor.focus();
-      editorElm.dispatchEvent(event);
-
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
+        expect(gridStub.focus).toHaveBeenCalled();
+        expect(spyEvent).toHaveBeenCalled();
+        expect(editor.isValueTouched()).toBe(true);
+      });
     });
 
     describe('isValueChanged method', () => {

--- a/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
@@ -178,33 +178,21 @@ describe('InputPasswordEditor', () => {
       expect(editor.getValue()).toBe('task 1');
     });
 
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Left Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
+    ["ArrowLeft", "ArrowRight", "Home", "End"].forEach((key: string) => {
+      it(`should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using ${key} key`, () => {
+        const event = new (window.window as any).KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+        const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
 
-      editor = new InputPasswordEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
+        editor = new InputPasswordEditor(editorArguments);
+        const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
 
-      editor.focus();
-      editorElm.dispatchEvent(event);
+        editor.focus();
+        editorElm.dispatchEvent(event);
 
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
-      expect(editor.isValueTouched()).toBe(true);
-    });
-
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Right Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
-
-      editor = new InputPasswordEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-title') as HTMLInputElement;
-
-      editor.focus();
-      editorElm.dispatchEvent(event);
-
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
+        expect(gridStub.focus).toHaveBeenCalled();
+        expect(spyEvent).toHaveBeenCalled();
+        expect(editor.isValueTouched()).toBe(true);
+      });
     });
 
     describe('isValueChanged method', () => {

--- a/packages/common/src/editors/__tests__/integerEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/integerEditor.spec.ts
@@ -171,32 +171,20 @@ describe('IntegerEditor', () => {
       expect(editor.getValue()).toBe('213');
     });
 
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Left Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
+    ["ArrowLeft", "ArrowRight", "Home", "End"].forEach((key: string) => {
+      it(`should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using ${key} key`, () => {
+        const event = new (window.window as any).KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+        const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
 
-      editor = new IntegerEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
+        editor = new IntegerEditor(editorArguments);
+        const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
 
-      editor.focus();
-      editorElm.dispatchEvent(event);
+        editor.focus();
+        editorElm.dispatchEvent(event);
 
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
-    });
-
-    it('should dispatch a keyboard event and expect "stopImmediatePropagation()" to have been called when using Right Arrow key', () => {
-      const event = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
-      const spyEvent = vi.spyOn(event, 'stopImmediatePropagation');
-
-      editor = new IntegerEditor(editorArguments);
-      const editorElm = divContainer.querySelector('input.editor-price') as HTMLInputElement;
-
-      editor.focus();
-      editorElm.dispatchEvent(event);
-
-      expect(gridStub.focus).toHaveBeenCalled();
-      expect(spyEvent).toHaveBeenCalled();
+        expect(gridStub.focus).toHaveBeenCalled();
+        expect(spyEvent).toHaveBeenCalled();
+      });
     });
 
     describe('isValueChanged method', () => {

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -555,7 +555,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     this._bindEventService.bind(this._inputElm, 'focus', () => this._inputElm?.select());
     this._bindEventService.bind(this._inputElm, 'keydown', ((event: KeyboardEvent & { target: HTMLInputElement; }) => {
       this._lastInputKeyEvent = event;
-      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === "Home" || event.key === "End") {
         event.stopImmediatePropagation();
       }
 

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -210,7 +210,7 @@ export class DateEditor implements Editor {
 
         this._isValueTouched = true;
         this._lastInputKeyEvent = event;
-        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight'  || event.key === "Home" || event.key === "End") {
           event.stopImmediatePropagation();
         }
       }) as EventListener);

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -186,7 +186,7 @@ export class DateEditor implements Editor {
           title: this.columnEditor && this.columnEditor.title || '',
           className: inputCssClasses.replace(/\./g, ' '),
           dataset: { input: '', defaultdate: this.defaultDate },
-          readOnly: this.columnEditor.editorOptions?.allowEdit === true ? true : false,
+          readOnly: this.columnEditor.editorOptions?.allowInput === true ? false : true,
         },
         this._editorInputGroupElm
       );
@@ -204,7 +204,7 @@ export class DateEditor implements Editor {
       }
 
       this._bindEventService.bind(this._inputElm, 'keydown', ((event: KeyboardEvent) => {
-        if (this.columnEditor.editorOptions?.allowEdit !== true) {
+        if (this.columnEditor.editorOptions?.allowInput !== true) {
           return;
         }
 
@@ -363,7 +363,7 @@ export class DateEditor implements Editor {
     const elmDateStr = this.getValue();
 
     const lastEventKey = this._lastInputKeyEvent?.key;
-    if (this.columnEditor.editorOptions?.allowEdit === true &&
+    if (this.columnEditor.editorOptions?.allowInput === true &&
         this.columnEditor?.alwaysSaveOnEnterKey && lastEventKey === 'Enter') {
       return true;
     }

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -159,7 +159,7 @@ export class DualInputEditor implements Editor {
       this._isRightValueTouched = true;
     }
     this._lastInputKeyEvent = event;
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Tab') {
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === "Home" || event.key === "End" || event.key === 'Tab') {
       event.stopImmediatePropagation();
     }
   }

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -115,7 +115,7 @@ export class InputEditor implements Editor {
     this._bindEventService.bind(this._input, 'keydown', ((event: KeyboardEvent) => {
       this._isValueTouched = true;
       this._lastInputKeyEvent = event;
-      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === "Home" || event.key === "End") {
         event.stopImmediatePropagation();
       }
     }) as EventListener);


### PR DESCRIPTION
closes https://github.com/ghiscoding/slickgrid-universal/issues/1686