### PR TITLE
fix: Date parsing shouldn't fail & dateIso type should accept time

### DIFF
--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -106,19 +106,19 @@ export function getValueFromParamsOrFormatterOptions(optionName: string, columnD
 
 /** From a FieldType, return the associated date Formatter */
 export function getAssociatedDateFormatter(fieldType: typeof FieldType[keyof typeof FieldType], defaultSeparator: string): Formatter {
-  const defaultDateFormat = mapTempoDateFormatWithFieldType(fieldType, true);
+  const defaultDateFormat = mapTempoDateFormatWithFieldType(fieldType, { withZeroPadding: true });
 
   return (_row: number, _cell: number, value: any, columnDef: Column, _dataContext: any, grid: SlickGrid) => {
     const gridOptions = ((grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {}) as GridOption;
     const customSeparator = gridOptions?.formatterOptions?.dateSeparator ?? defaultSeparator;
     const inputType = columnDef?.type ?? FieldType.date;
-    const inputDateFormat = mapTempoDateFormatWithFieldType(inputType, true);
+    const inputDateFormat = mapTempoDateFormatWithFieldType(inputType, { withDefaultIso8601: true });
     const isParsingAsUtc = columnDef?.params?.parseDateAsUtc ?? false;
 
     const date = tryParseDate(value, inputDateFormat);
     let outputDate = value;
     if (date) {
-      let d = value;
+      let d = date;
       if (isParsingAsUtc) {
         d = toUtcDate(date);
       }

--- a/packages/common/src/services/__tests__/dateUtils.spec.ts
+++ b/packages/common/src/services/__tests__/dateUtils.spec.ts
@@ -38,7 +38,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateEuroShort format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateEuroShort, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateEuroShort, { withZeroPadding: true });
       expect(output).toEqual('DD/MM/YY');
     });
 
@@ -53,7 +53,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateTimeShortEuro format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeShortEuro, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeShortEuro, { withZeroPadding: true });
       expect(output).toEqual('DD/MM/YYYY HH:mm');
     });
 
@@ -73,7 +73,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateTimeEuroShort format', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeEuroShort, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeEuroShort, { withZeroPadding: true });
       expect(output).toEqual('DD/MM/YY HH:mm:ss');
     });
 
@@ -83,7 +83,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateTimeEuroShortAmPm format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeEuroShortAmPm, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeEuroShortAmPm, { withZeroPadding: true });
       expect(output).toEqual('DD/MM/YY hh:mm:ss a');
     });
 
@@ -98,7 +98,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateUsShort format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateUsShort, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateUsShort, { withZeroPadding: true });
       expect(output).toEqual('MM/DD/YY');
     });
 
@@ -113,7 +113,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateTimeShortUs format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeShortUs, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeShortUs, { withZeroPadding: true });
       expect(output).toEqual('MM/DD/YYYY HH:mm');
     });
 
@@ -133,7 +133,7 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateTimeUsShort format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeUsShort, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeUsShort, { withZeroPadding: true });
       expect(output).toEqual('MM/DD/YY HH:mm:ss');
     });
 
@@ -143,11 +143,11 @@ describe('Service/Utilies', () => {
     });
 
     it('should return a Date in dateTimeUsShortAmPm format with zero padding', () => {
-      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeUsShortAmPm, true);
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateTimeUsShortAmPm, { withZeroPadding: true });
       expect(output).toEqual('MM/DD/YY hh:mm:ss a');
     });
 
-    it('should return a Date in dateUtc format', () => {
+    it('should return a Date as ISO8601 when using dateUtc format', () => {
       const output = mapTempoDateFormatWithFieldType(FieldType.dateUtc);
       expect(output).toBe('ISO8601');
     });
@@ -157,6 +157,16 @@ describe('Service/Utilies', () => {
       const output2 = mapTempoDateFormatWithFieldType(FieldType.dateIso);
       expect(output1).toBe('YYYY-MM-DD');
       expect(output2).toBe('YYYY-MM-DD');
+    });
+
+    it('should return a Date as ISO8601 when enabling the option withDefaultIso8601 and providing FieldType.date as input format', () => {
+      const output = mapTempoDateFormatWithFieldType(FieldType.date, { withDefaultIso8601: true });
+      expect(output).toBe('ISO8601');
+    });
+
+    it('should return a Date as ISO8601 when enabling the option withDefaultIso8601 and providing FieldType.dateIso as input format', () => {
+      const output = mapTempoDateFormatWithFieldType(FieldType.dateIso, { withDefaultIso8601: true });
+      expect(output).toBe('ISO8601');
     });
   });
 

--- a/packages/common/src/services/dateUtils.ts
+++ b/packages/common/src/services/dateUtils.ts
@@ -5,11 +5,18 @@ import { FieldType } from '../enums/index';
 /**
  * From a Date FieldType, return it's equivalent TempoJS format,
  * refer to TempoJS docs for the format tokens being used: https://tempo.formkit.com/#format
- * @param fieldType
- * @param withZeroPadding - should we include zero padding in format (e.g.: 03:04:54)
+ * @param {FieldType} fieldType
+ * @param { withZeroPadding: [boolean]; withDefaultIso8601: [boolean]; } [options] -
+ *   - withZeroPadding: should we include zero padding in format (e.g.: 03:04:54 instead of 3:4:54)
+ *   - withDefaultIso8601: should we use ISO8601 for `FieldType.date` or `FieldType.dateIso`
  */
-export function mapTempoDateFormatWithFieldType(fieldType: typeof FieldType[keyof typeof FieldType], withZeroPadding = false): string {
+export function mapTempoDateFormatWithFieldType(
+  fieldType: typeof FieldType[keyof typeof FieldType],
+  options?: { withZeroPadding?: boolean; withDefaultIso8601?: boolean; }
+): string {
   let map: string;
+  const withZeroPadding = options?.withZeroPadding ?? false;
+
   switch (fieldType) {
     case FieldType.dateTime:
     case FieldType.dateTimeIso:
@@ -106,7 +113,9 @@ export function mapTempoDateFormatWithFieldType(fieldType: typeof FieldType[keyo
     case FieldType.date:
     case FieldType.dateIso:
     default:
-      map = 'YYYY-MM-DD';
+      map = options?.withDefaultIso8601
+        ? 'ISO8601'
+        : 'YYYY-MM-DD';
       break;
   }
   return map;


### PR DESCRIPTION
- before switching to Tempo, we were using MomentJS and with MomentJS if we were passing "YYYY-MM-DD" as input format it wasn't stripping the time if it had any, however with Tempo it was stripping the time and assuming midnight which wasn't the same as MomentJS.... to overcome this, we can simply pass ISO8601 as input format, I added `withDefaultIso8601` option for use case
- also fix a parsing format for short format (like dateUsShort), it should work with both with/without zero padding
- fixes a problem detected while implementing PR #1691 but I think it should be created as a separate PR