### PR TITLE
feat(PubSub): allow multiple subcribe events for a single callback

### DIFF
--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -12,7 +12,7 @@ export type Handler<ArgType = any> = (e: SlickEventData<ArgType>, args: ArgType)
 
 export interface BasePubSub {
   publish<ArgType = any>(_eventName: string | any, _data?: ArgType, delay?: number, assignEventCallback?: any): any;
-  subscribe<ArgType = any>(_eventName: string | Function, _callback: (data: ArgType) => void): any;
+  subscribe<ArgType = any>(_eventName: string | string[] | Function, _callback: (data: ArgType) => void): any;
 }
 type PubSubPublishType<ArgType = any> = { args: ArgType; eventData?: SlickEventData<ArgType>; nativeEvent?: Event; };
 

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -60,10 +60,11 @@ export class GroupingAndColspanService {
 
         // for both picker (columnPicker/gridMenu) we also need to re-create after hiding/showing columns
         this._subscriptions.push(
-          this.pubSubService.subscribe(`onColumnPickerColumnsChanged`, () => this.renderPreHeaderRowGroupingTitles()),
+          this.pubSubService.subscribe(
+            ['onColumnPickerColumnsChanged', 'onGridMenuColumnsChanged', 'onGridMenuMenuClose'],
+            () => this.renderPreHeaderRowGroupingTitles()
+          ),
           this.pubSubService.subscribe('onHeaderMenuHideColumns', () => this.delayRenderPreHeaderRowGroupingTitles(0)),
-          this.pubSubService.subscribe(`onGridMenuColumnsChanged`, () => this.renderPreHeaderRowGroupingTitles()),
-          this.pubSubService.subscribe(`onGridMenuMenuClose`, () => this.renderPreHeaderRowGroupingTitles()),
         );
 
         // we also need to re-create after a grid resize

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -142,8 +142,7 @@ export class PaginationService {
     }
 
     // Subscribe to Filter Clear & Changed and go back to page 1 when that happen
-    this._subscriptions.push(this.pubSubService.subscribe('onFilterChanged', () => this.resetPagination()));
-    this._subscriptions.push(this.pubSubService.subscribe('onFilterCleared', () => this.resetPagination()));
+    this._subscriptions.push(this.pubSubService.subscribe(['onFilterChanged', 'onFilterCleared'], () => this.resetPagination()));
 
     // when using Infinite Scroll (only), we also need to reset pagination when sorting
     if (backendServiceApi?.options?.infiniteScroll) {
@@ -153,8 +152,8 @@ export class PaginationService {
     // Subscribe to any dataview row count changed so that when Adding/Deleting item(s) through the DataView
     // that would trigger a refresh of the pagination numbers
     if (this.dataView) {
-      this._subscriptions.push(this.pubSubService.subscribe<any | any[]>(`onItemAdded`, items => this.processOnItemAddedOrRemoved(items, true)));
-      this._subscriptions.push(this.pubSubService.subscribe<any | any[]>(`onItemDeleted`, items => this.processOnItemAddedOrRemoved(items, false)));
+      this._subscriptions.push(this.pubSubService.subscribe<any | any[]>('onItemAdded', items => this.processOnItemAddedOrRemoved(items, true)));
+      this._subscriptions.push(this.pubSubService.subscribe<any | any[]>('onItemDeleted', items => this.processOnItemAddedOrRemoved(items, false)));
     }
 
     this.refreshPagination(false, false, true);

--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -216,7 +216,37 @@ describe('EventPubSub Service', () => {
       expect(service.subscribedEvents.length).toBe(0);
     });
 
-    it('should unsubscribeAll events', () => {
+    it('should be able to provide an array of event to subscribe and be able to unsubscribeAll events', () => {
+      const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
+      const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
+      const unsubscribeSpy = vi.spyOn(service, 'unsubscribe');
+      const mockCallback = vi.fn();
+
+      service.subscribe(['onClick', 'onDblClick'], mockCallback);
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+
+      expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
+      expect(getEventNameSpy).toHaveBeenCalledWith('onDblClick', '');
+      expect(service.subscribedEventNames).toEqual(['onClick', 'onDblClick']);
+      expect(service.subscribedEvents.length).toBe(2);
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith({ name: 'John' });
+
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      divContainer.dispatchEvent(new CustomEvent('onDblClick', { detail: { name: 'Jane' } }));
+
+      expect(mockCallback).toHaveBeenCalledTimes(3);
+      expect(mockCallback).toHaveBeenCalledWith({ name: 'John' });
+      expect(mockCallback).toHaveBeenCalledWith({ name: 'Jane' });
+
+      service.unsubscribeAll();
+      expect(removeEventSpy).toHaveBeenCalledWith('onClick', mockCallback);
+      expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', mockCallback);
+      expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
+      expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('should be able to subscribe to multiple event and be able to unsubscribeAll events', () => {
       const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
       const unsubscribeSpy = vi.spyOn(service, 'unsubscribe');
@@ -233,6 +263,11 @@ describe('EventPubSub Service', () => {
       expect(service.subscribedEvents.length).toBe(2);
       expect(mockCallback).toHaveBeenCalledTimes(1);
       expect(mockCallback).toHaveBeenCalledWith({ name: 'John' });
+
+      divContainer.dispatchEvent(new CustomEvent('onDblClick', { detail: { name: 'Jane' } }));
+
+      expect(mockDblCallback).toHaveBeenCalledTimes(1);
+      expect(mockDblCallback).toHaveBeenCalledWith({ name: 'Jane' });
 
       service.unsubscribeAll();
       expect(removeEventSpy).toHaveBeenCalledWith('onClick', mockCallback);

--- a/packages/event-pub-sub/src/types/basePubSubService.interface.ts
+++ b/packages/event-pub-sub/src/types/basePubSubService.interface.ts
@@ -16,7 +16,7 @@ export interface BasePubSubService {
    * @param callback The callback to be invoked when the specified message is published.
    * @return possibly a Subscription
    */
-  subscribe<T = any>(_eventName: string | Function, _callback: (data: T) => void): EventSubscription | any;
+  subscribe<T = any>(_eventName: string | string[] | Function, _callback: (data: T) => void): EventSubscription | any;
 
   /**
    * Subscribes to a custom event message channel or message type.


### PR DESCRIPTION
- we sometime have the same callback for multiple events, previously we were just adding multiple subscribe, but it would be easier to just call `pubSub.subscribe(['event1', event2'], callback)` and now we can.