### PR TITLE
chore: refactor SharedService, only use Getters/Setters when necessary

### DIFF
--- a/packages/common/src/extensions/__tests__/extensionUtility.spec.ts
+++ b/packages/common/src/extensions/__tests__/extensionUtility.spec.ts
@@ -136,9 +136,9 @@ describe('extensionUtility', () => {
 
       beforeEach(() => {
         gridOptionsMock = { frozenColumn: 1 } as GridOption;
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+        sharedService.slickGrid = gridStub;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
-        vi.spyOn(SharedService.prototype, 'frozenVisibleColumnId', 'get').mockReturnValue('field2');
+        sharedService.frozenVisibleColumnId = 'field2';
       });
 
       afterEach(() => {
@@ -148,7 +148,7 @@ describe('extensionUtility', () => {
       it('should increase "frozenColumn" from 0 to 1 when showing a column that was previously hidden and its index is lower or equal to provided argument of frozenColumnIndex', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
         const visibleColumns = [{ id: 'field1' }, { id: 'field2' }] as Column[];
-        const setOptionSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setOptions');
+        const setOptionSpy = vi.spyOn(sharedService.slickGrid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(0, allColumns, visibleColumns);
 
@@ -158,7 +158,7 @@ describe('extensionUtility', () => {
       it('should keep "frozenColumn" at 1 when showing a column that was previously hidden and its index is greater than provided argument of frozenColumnIndex', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }] as Column[];
         const visibleColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
-        const setOptionSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setOptions');
+        const setOptionSpy = vi.spyOn(sharedService.slickGrid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(1, allColumns, visibleColumns);
 
@@ -168,7 +168,7 @@ describe('extensionUtility', () => {
       it('should decrease "frozenColumn" from 1 to 0 when hiding a column that was previously shown and its index is lower or equal to provided argument of frozenColumnIndex', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
         const visibleColumns = [{ id: 'field2' }] as Column[];
-        const setOptionSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setOptions');
+        const setOptionSpy = vi.spyOn(sharedService.slickGrid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(1, allColumns, visibleColumns);
 
@@ -178,7 +178,7 @@ describe('extensionUtility', () => {
       it('should keep "frozenColumn" at 1 when hiding a column that was previously hidden and its index is greater than provided argument of frozenColumnIndex', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
         const visibleColumns = [{ id: 'field1' }, { id: 'field2' }] as Column[];
-        const setOptionSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setOptions');
+        const setOptionSpy = vi.spyOn(sharedService.slickGrid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(1, allColumns, visibleColumns);
 
@@ -188,7 +188,7 @@ describe('extensionUtility', () => {
       it('should not change "frozenColumn" when showing a column that was not found in the visibleColumns columns array', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
         const visibleColumns = [{ id: 'field1' }, { field: 'field2' }] as unknown as Column[];
-        const setOptionSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setOptions');
+        const setOptionSpy = vi.spyOn(sharedService.slickGrid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(0, allColumns, visibleColumns);
 

--- a/packages/common/src/extensions/__tests__/slickAutoTooltip.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickAutoTooltip.spec.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AutoTooltipOption, Column } from '../../interfaces/index';
-import { SharedService } from '../../services/shared.service';
 import { SlickAutoTooltip } from '../slickAutoTooltip';
 import { SlickEvent, SlickEventData, type SlickGrid } from '../../core/index';
 
@@ -54,10 +53,6 @@ describe('AutoTooltip Plugin', () => {
   });
 
   describe('plugins - autotooltips - header', () => {
-    beforeEach(() => {
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
-    });
-
     afterEach(() => {
       plugin.destroy();
       plugin.dispose();
@@ -95,10 +90,6 @@ describe('AutoTooltip Plugin', () => {
   });
 
   describe('plugins - autotooltips - max tooltip', () => {
-    beforeEach(() => {
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
-    });
-
     afterEach(() => {
       plugin.dispose();
     });

--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -149,7 +149,7 @@ describe('CellMenu Plugin', () => {
     sharedService = new SharedService();
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+    sharedService.slickGrid = gridStub;
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
     vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
@@ -205,7 +205,7 @@ describe('CellMenu Plugin', () => {
       eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
       eventData.target = slickCellElm;
 
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       columnsMock[3].cellMenu!.commandItems = deepCopy(commandItemsMock);
       delete (columnsMock[3].cellMenu!.commandItems![1] as MenuCommandItem).action;
       delete (columnsMock[3].cellMenu!.commandItems![1] as MenuCommandItem).itemVisibilityOverride;

--- a/packages/common/src/extensions/__tests__/slickColumnPicker.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickColumnPicker.spec.ts
@@ -67,8 +67,8 @@ describe('ColumnPickerControl', () => {
     backendUtilityService = new BackendUtilityService();
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
+    sharedService.slickGrid = gridStub;
 
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
     vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock.slice(0, 1));

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -166,8 +166,9 @@ describe('ContextMenu Plugin', () => {
     sharedService = new SharedService();
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
-    vi.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(dataViewStub);
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+    sharedService.dataView = dataViewStub;
+    sharedService.slickGrid = gridStub;
+
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
     vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
@@ -223,8 +224,8 @@ describe('ContextMenu Plugin', () => {
       slickCellElm.className = 'slick-cell';
       eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
       eventData.target = slickCellElm;
+      sharedService.slickGrid = gridStub;
 
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
       gridOptionsMock.contextMenu!.commandItems = deepCopy(commandItemsMock);
       delete (gridOptionsMock.contextMenu!.commandItems![1] as MenuCommandItem).action;
       delete (gridOptionsMock.contextMenu!.commandItems![1] as MenuCommandItem).itemVisibilityOverride;
@@ -782,8 +783,8 @@ describe('ContextMenu Plugin', () => {
         slickCellElm.className = 'slick-cell';
         eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
         eventData.target = slickCellElm;
+        sharedService.slickGrid = gridStub;
 
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
         gridOptionsMock.contextMenu!.commandItems = deepCopy(commandItemsMock);
         delete (gridOptionsMock.contextMenu!.commandItems![1] as MenuCommandItem).action;
         delete (gridOptionsMock.contextMenu!.commandItems![1] as MenuCommandItem).itemVisibilityOverride;
@@ -1176,7 +1177,6 @@ describe('ContextMenu Plugin', () => {
       });
 
       it('should call "setGrouping" from the DataView when Grouping is enabled and the command triggered is "clear-grouping"', () => {
-        const dataviewSpy = vi.spyOn(SharedService.prototype.dataView, 'setGrouping');
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
@@ -1187,12 +1187,11 @@ describe('ContextMenu Plugin', () => {
         const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'clear-grouping') as MenuCommandItem;
         menuItemCommand.action!(new CustomEvent('change'), { command: 'clear-grouping', cell: 0, row: 0 } as any);
 
-        expect(dataviewSpy).toHaveBeenCalledWith([]);
+        expect(dataViewStub.setGrouping).toHaveBeenCalledWith([]);
         expect(pubSubSpy).toHaveBeenCalledWith('onContextMenuClearGrouping');
       });
 
       it('should call "collapseAllGroups" from the DataView when Grouping is enabled and the command triggered is "collapse-all-groups"', () => {
-        const dataviewSpy = vi.spyOn(SharedService.prototype.dataView, 'collapseAllGroups');
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideCollapseAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
@@ -1204,12 +1203,12 @@ describe('ContextMenu Plugin', () => {
         const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'collapse-all-groups') as MenuCommandItem;
         menuItemCommand.action!(new CustomEvent('change'), { command: 'collapse-all-groups', cell: 0, row: 0 } as any);
 
-        expect(dataviewSpy).toHaveBeenCalledWith();
+        expect(dataViewStub.collapseAllGroups).toHaveBeenCalledWith();
         expect(pubSubSpy).toHaveBeenCalledWith('onContextMenuCollapseAllGroups');
       });
 
       it('should call "collapseAllGroups" from the DataView when Tree Data is enabled and the command triggered is "collapse-all-groups"', () => {
-        vi.spyOn(SharedService.prototype.dataView, 'getItems').mockReturnValueOnce(columnsMock);
+        vi.spyOn(sharedService.dataView, 'getItems').mockReturnValueOnce(columnsMock);
         const treeDataSpy = vi.spyOn(treeDataServiceStub, 'toggleTreeDataCollapse');
         const copyGridOptionsMock = { ...gridOptionsMock, enableTreeData: true, contextMenu: { hideCollapseAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
@@ -1224,7 +1223,6 @@ describe('ContextMenu Plugin', () => {
       });
 
       it('should call "expandAllGroups" from the DataView when Grouping is enabled and the command triggered is "expand-all-groups"', () => {
-        const dataviewSpy = vi.spyOn(SharedService.prototype.dataView, 'expandAllGroups');
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideExpandAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
@@ -1236,13 +1234,13 @@ describe('ContextMenu Plugin', () => {
         const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find((item: MenuCommandItem) => item.command === 'expand-all-groups') as MenuCommandItem;
         menuItemCommand.action!(new CustomEvent('change'), { command: 'expand-all-groups', cell: 0, row: 0 } as any);
 
-        expect(dataviewSpy).toHaveBeenCalledWith();
+        expect(dataViewStub.expandAllGroups).toHaveBeenCalledWith();
         expect(pubSubSpy).toHaveBeenCalledWith('onContextMenuExpandAllGroups');
       });
 
       it('should call "expandAllGroups" from the DataView when Tree Data is enabled and the command triggered is "expand-all-groups"', () => {
         const treeDataSpy = vi.spyOn(treeDataServiceStub, 'toggleTreeDataCollapse');
-        vi.spyOn(SharedService.prototype.dataView, 'getItems').mockReturnValueOnce(columnsMock);
+        vi.spyOn(sharedService.dataView, 'getItems').mockReturnValueOnce(columnsMock);
         const copyGridOptionsMock = { ...gridOptionsMock, enableTreeData: true, contextMenu: { hideExpandAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
@@ -1257,7 +1255,7 @@ describe('ContextMenu Plugin', () => {
       it('should expect "itemUsabilityOverride" callback on all the Grouping command to return False when there are NO Groups in the grid', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const dataviewSpy = vi.spyOn(SharedService.prototype.dataView, 'getGrouping').mockReturnValue([]);
+        const dataviewSpy = vi.spyOn(sharedService.dataView, 'getGrouping').mockReturnValue([]);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1277,7 +1275,7 @@ describe('ContextMenu Plugin', () => {
       it('should expect "itemUsabilityOverride" callback on all the Grouping command to return True when there are Groups defined in the grid', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const dataviewSpy = vi.spyOn(SharedService.prototype.dataView, 'getGrouping').mockReturnValue([{ collapsed: true }]);
+        const dataviewSpy = vi.spyOn(sharedService.dataView, 'getGrouping').mockReturnValue([{ collapsed: true }]);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -134,11 +134,11 @@ describe('Draggable Grouping Plugin', () => {
     eventPubSubService = new EventPubSubService();
     backendUtilityService = new BackendUtilityService();
     sharedService = new SharedService();
+    sharedService.slickGrid = gridStub;
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
     vi.spyOn(gridStub, 'getContainerNode').mockReturnValue(document.body as HTMLDivElement);
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
     vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
     vi.spyOn(gridStub, 'getPreHeaderPanel').mockReturnValue(dropzoneElm);
     plugin = new SlickDraggableGrouping(extensionUtility, eventPubSubService, sharedService);

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -157,12 +157,12 @@ describe('GridMenuControl', () => {
       sharedService = new SharedService();
       translateService = new TranslateServiceStub();
       extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
+      sharedService.dataView = dataViewStub;
+      sharedService.slickGrid = gridStub;
 
       vi.spyOn(gridStub, 'getContainerNode').mockReturnValue(document.body as HTMLDivElement);
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
-      vi.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(dataViewStub);
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
       vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
       vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
       vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock.slice(0, 1));
@@ -296,7 +296,7 @@ describe('GridMenuControl', () => {
 
       it('should expect the Grid Menu to change from the Left side container to the Right side when changing from a regular to a frozen grid via "setOptions"', () => {
         const recreateSpy = vi.spyOn(control, 'recreateGridMenu');
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+        sharedService.slickGrid = gridStub;
 
         control.initEventHandlers();
         gridStub.onSetOptions.notify({ grid: gridStub, optionsBefore: { frozenColumn: -1 }, optionsAfter: { frozenColumn: 2 } }, new SlickEventData(), gridStub);
@@ -1339,7 +1339,7 @@ describe('GridMenuControl', () => {
 
         it('should call "clearFilters" and dataview refresh when the command triggered is "clear-filter"', () => {
           const filterSpy = vi.spyOn(filterServiceStub, 'clearFilters');
-          const refreshSpy = vi.spyOn(SharedService.prototype.dataView, 'refresh');
+          const refreshSpy = vi.spyOn(sharedService.dataView, 'refresh');
           const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
           const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, } as unknown as GridOption;
           vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
@@ -1359,7 +1359,7 @@ describe('GridMenuControl', () => {
 
         it('should call "clearSorting" and dataview refresh when the command triggered is "clear-sorting"', () => {
           const sortSpy = vi.spyOn(sortServiceStub, 'clearSorting');
-          const refreshSpy = vi.spyOn(SharedService.prototype.dataView, 'refresh');
+          const refreshSpy = vi.spyOn(sharedService.dataView, 'refresh');
           const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
           const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true, } as unknown as GridOption;
           vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
@@ -1519,7 +1519,6 @@ describe('GridMenuControl', () => {
           let copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: true, hideTogglePreHeaderCommand: false } as unknown as GridOption;
           vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
           vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
-          const gridSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setPreHeaderPanelVisibility');
 
           control.init();
           control.columns = columnsMock;
@@ -1527,7 +1526,7 @@ describe('GridMenuControl', () => {
           document.querySelector('.slick-grid-menu-button')!.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
           control.menuElement!.querySelector('.slick-menu-item[data-command=toggle-preheader]')!.dispatchEvent(clickEvent);
 
-          expect(gridSpy).toHaveBeenCalledWith(false);
+          expect(gridStub.setPreHeaderPanelVisibility).toHaveBeenCalledWith(false);
 
           copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: false, hideTogglePreHeaderCommand: false } as unknown as GridOption;
           vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
@@ -1535,7 +1534,7 @@ describe('GridMenuControl', () => {
           document.querySelector('.slick-grid-menu-button')!.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
           control.menuElement!.querySelector('.slick-menu-item[data-command=toggle-preheader]')!.dispatchEvent(clickEvent);
 
-          expect(gridSpy).toHaveBeenCalledWith(true);
+          expect(gridStub.setPreHeaderPanelVisibility).toHaveBeenCalledWith(true);
         });
 
         it('should call "refreshBackendDataset" method when the command triggered is "refresh-dataset"', () => {

--- a/packages/common/src/extensions/__tests__/slickHeaderButtons.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderButtons.spec.ts
@@ -71,9 +71,9 @@ describe('HeaderButton Plugin', () => {
   beforeEach(() => {
     backendUtilityService = new BackendUtilityService();
     sharedService = new SharedService();
+    sharedService.slickGrid = gridStub;
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     plugin = new SlickHeaderButtons(extensionUtility, pubSubServiceStub, sharedService);
   });
@@ -108,7 +108,7 @@ describe('HeaderButton Plugin', () => {
 
   describe('plugins - Header Button', () => {
     beforeEach(() => {
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       columnsMock[0].header!.buttons![1] = undefined as any;
       columnsMock[0].header!.buttons![1] = {
         cssClass: 'mdi mdi-lightbulb-on',

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -126,9 +126,9 @@ describe('HeaderMenu Plugin', () => {
   beforeEach(() => {
     backendUtilityService = new BackendUtilityService();
     sharedService = new SharedService();
+    sharedService.slickGrid = gridStub;
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
     vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock.slice(0, 2));
@@ -177,7 +177,7 @@ describe('HeaderMenu Plugin', () => {
     let headersDiv: HTMLDivElement;
 
     beforeEach(() => {
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       columnsMock[0].header!.menu!.commandItems![1] = undefined as any;
       columnsMock[0].header!.menu!.commandItems![1] = {
         cssClass: 'mdi mdi-lightbulb-on',
@@ -545,11 +545,11 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should call hideColumn and expect "visibleColumns" to be updated accordingly', () => {
+        sharedService.slickGrid = gridStub;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           headerMenu: { hideFreezeColumnsCommand: false, hideColumnResizeByContentCommand: true, }
         });
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
         vi.spyOn(gridStub, 'getColumnIndex').mockReturnValue(1);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
         const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
@@ -573,7 +573,7 @@ describe('HeaderMenu Plugin', () => {
           headerMenu: { hideFreezeColumnsCommand: false, hideColumnResizeByContentCommand: true, }
         });
 
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+        sharedService.slickGrid = gridStub;
         vi.spyOn(gridStub, 'getColumnIndex').mockReturnValue(1);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
         const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
@@ -854,7 +854,7 @@ describe('HeaderMenu Plugin', () => {
         // const originalColumnDefinitions = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
         // vi.spyOn(gridStub, 'getColumns').mockReturnValueOnce(originalColumnDefinitions);
         // vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValueOnce(originalColumnDefinitions);
-        vi.spyOn(SharedService.prototype, 'hasColumnsReordered', 'get').mockReturnValue(true);
+        sharedService.hasColumnsReordered = true;
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
@@ -882,7 +882,7 @@ describe('HeaderMenu Plugin', () => {
         const originalColumnDefinitions = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(originalColumnDefinitions);
-        vi.spyOn(SharedService.prototype, 'hasColumnsReordered', 'get').mockReturnValue(true);
+        sharedService.hasColumnsReordered = true;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           headerMenu: {
@@ -979,8 +979,8 @@ describe('HeaderMenu Plugin', () => {
             { title: 'Non-Blank Values', searchTerms: ['A'], operator: '>', iconCssClass: 'mdi mdi-filter-plus-outline', },
           ]
         };
-        vi.spyOn(SharedService.prototype.slickGrid, 'getColumns').mockReturnValueOnce(columnsMock);
-        vi.spyOn(SharedService.prototype.slickGrid, 'getColumnIndex').mockReturnValue(0);
+        vi.spyOn(sharedService.slickGrid, 'getColumns').mockReturnValueOnce(columnsMock);
+        vi.spyOn(sharedService.slickGrid, 'getColumnIndex').mockReturnValue(0);
         const setValueMock = vi.fn();
         const filterMock = { columnDef: columnsMock[0], setValues: setValueMock } as unknown as Filter;
         vi.spyOn(filterServiceStub, 'getFiltersMetadata').mockReturnValueOnce([filterMock]);
@@ -1028,8 +1028,8 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect only the "hide-column" command in the menu when "enableSorting" and "hideSortCommands" are set and also expect the command to execute necessary callback', () => {
-        vi.spyOn(SharedService.prototype.slickGrid, 'getColumnIndex').mockReturnValue(1);
-        vi.spyOn(SharedService.prototype.slickGrid, 'getColumns').mockReturnValue(columnsMock);
+        vi.spyOn(sharedService.slickGrid, 'getColumnIndex').mockReturnValue(1);
+        vi.spyOn(sharedService.slickGrid, 'getColumns').mockReturnValue(columnsMock);
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock, enableSorting: true, enableColumnResizeOnDoubleClick: false,
           headerMenu: { hideColumnHideCommand: false, hideSortCommands: true, }
@@ -1133,7 +1133,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(originalColumnDefinitions);
-        vi.spyOn(SharedService.prototype, 'hasColumnsReordered', 'get').mockReturnValue(false);
+        sharedService.hasColumnsReordered = false;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           headerMenu: { hideFreezeColumnsCommand: false, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true, }
@@ -1160,7 +1160,6 @@ describe('HeaderMenu Plugin', () => {
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: true, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = vi.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
         const backendSortSpy = vi.spyOn(sortServiceStub, 'onBackendSortChanged');
-        const setSortSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setSortColumns');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock, enableSorting: true,
           headerMenu: { hideFreezeColumnsCommand: true, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true, }
@@ -1184,7 +1183,7 @@ describe('HeaderMenu Plugin', () => {
         expect(previousSortSpy).toHaveBeenCalled();
         mockSortedOuput[1].sortCol = { ...columnsMock[1], ...mockSortedOuput[1].sortCol }; // merge with column header menu
         expect(backendSortSpy).toHaveBeenCalledWith(expect.anything(), { multiColumnSort: true, sortCols: mockSortedOuput, grid: gridStub });
-        expect(setSortSpy).toHaveBeenCalled();
+        expect(sharedService.slickGrid.setSortColumns).toHaveBeenCalled();
       });
 
       it('should trigger the command "sort-desc" and expect Sort Service to call "onBackendSortChanged" being called without the sorted column', () => {
@@ -1192,7 +1191,6 @@ describe('HeaderMenu Plugin', () => {
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = vi.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
         const backendSortSpy = vi.spyOn(sortServiceStub, 'onBackendSortChanged');
-        const setSortSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setSortColumns');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock, enableSorting: true,
           headerMenu: { hideFreezeColumnsCommand: true, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true, }
@@ -1216,16 +1214,15 @@ describe('HeaderMenu Plugin', () => {
         expect(previousSortSpy).toHaveBeenCalled();
         mockSortedOuput[1].sortCol = { ...columnsMock[1], ...mockSortedOuput[1].sortCol }; // merge with column header menu
         expect(backendSortSpy).toHaveBeenCalledWith(expect.anything(), { multiColumnSort: true, sortCols: mockSortedOuput, grid: gridStub });
-        expect(setSortSpy).toHaveBeenCalled();
+        expect(sharedService.slickGrid.setSortColumns).toHaveBeenCalled();
       });
 
       it('should trigger the command "sort-desc" and expect Sort Service to call "onLocalSortChanged" being called without the sorted column', () => {
-        vi.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(dataViewStub);
+        sharedService.dataView = dataViewStub;
         const mockSortedCols: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: true, sortCol: { id: 'field2', field: 'field2' } }];
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = vi.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
         const localSortSpy = vi.spyOn(sortServiceStub, 'onLocalSortChanged');
-        const setSortSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setSortColumns');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock, enableSorting: true, backendServiceApi: undefined,
           headerMenu: { hideFreezeColumnsCommand: true, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true, }
@@ -1240,15 +1237,14 @@ describe('HeaderMenu Plugin', () => {
         mockSortedOuput[1].sortCol = { ...columnsMock[1], ...mockSortedOuput[1].sortCol }; // merge with column header menu
         expect(previousSortSpy).toHaveBeenCalled();
         expect(localSortSpy).toHaveBeenCalledWith(gridStub, mockSortedOuput);
-        expect(setSortSpy).toHaveBeenCalled();
+        expect(sharedService.slickGrid.setSortColumns).toHaveBeenCalled();
       });
 
       it('should trigger the command "sort-desc" and expect "onSort" event triggered when no DataView is provided', () => {
-        vi.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(undefined as any);
+        sharedService.dataView = undefined as any;
         const mockSortedCols: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: true, sortCol: { id: 'field2', field: 'field2' } }];
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = vi.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
-        const setSortSpy = vi.spyOn(SharedService.prototype.slickGrid, 'setSortColumns');
         const gridSortSpy = vi.spyOn(gridStub.onSort, 'notify');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock, enableSorting: true, backendServiceApi: undefined,
@@ -1264,7 +1260,7 @@ describe('HeaderMenu Plugin', () => {
         mockSortedOuput[1].sortCol = { ...columnsMock[1], ...mockSortedOuput[1].sortCol }; // merge with column header menu
         expect(previousSortSpy).toHaveBeenCalled();
         expect(gridSortSpy).toHaveBeenCalledWith(mockSortedOuput);
-        expect(setSortSpy).toHaveBeenCalled();
+        expect(gridStub.setSortColumns).toHaveBeenCalled();
       });
     });
   });

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -195,6 +195,7 @@ describe('ExtensionService', () => {
       translateService = new TranslateServiceStub();
       translateService.use('fr');
       extensionUtility = new ExtensionUtility(sharedService, undefined, translateService);
+      sharedService.slickGrid = gridStub;
 
       service = new ExtensionService(
         extensionUtility,
@@ -231,9 +232,9 @@ describe('ExtensionService', () => {
     });
 
     it('should return "autosizeColumns" from the SharedService Grid object when "autoResizeColumns" method is called', () => {
-      const spy = vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       service.autoResizeColumns();
-      expect(spy).toHaveBeenCalled();
+      expect(gridStub.autosizeColumns).toHaveBeenCalled();
     });
 
     it('should return empty object when "extensionlList" GETTER is called', () => {
@@ -605,6 +606,10 @@ describe('ExtensionService', () => {
     });
 
     describe('createExtensionsBeforeGridCreation method', () => {
+      beforeEach(() => {
+        sharedService.slickGrid = gridStub;
+      });
+
       it('should call checkboxSelectorExtension create when "enableCheckboxSelector" is set in the grid options provided', () => {
         const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
         const gridOptionsMock = { enableCheckboxSelector: true } as GridOption;
@@ -693,15 +698,14 @@ describe('ExtensionService', () => {
     it('should call hideColumn and expect "visibleColumns" to be updated accordingly', () => {
       const columnsMock = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
       const updatedColumnsMock = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       vi.spyOn(gridStub, 'getColumnIndex').mockReturnValue(1);
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
       const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
-      const visibleSpy = vi.spyOn(SharedService.prototype, 'visibleColumns', 'set');
 
       service.hideColumn(columnsMock[1]);
 
-      expect(visibleSpy).toHaveBeenCalledWith(updatedColumnsMock);
+      expect(sharedService.visibleColumns).toEqual(updatedColumnsMock);
       expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock);
     });
 
@@ -821,12 +825,11 @@ describe('ExtensionService', () => {
         const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' }] as Column[];
         const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Bonjour', nameKey: 'HELLO' }] as Column[];
         vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsBeforeTranslateMock);
-        const columnSpy = vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsBeforeTranslateMock);
+        sharedService.allColumns = columnsBeforeTranslateMock;
         const renderSpy = vi.spyOn(service, 'renderColumnHeaders');
 
         service.translateColumnHeaders();
 
-        expect(columnSpy).toHaveBeenCalled();
         expect(renderSpy).toHaveBeenCalledWith(columnsAfterTranslateMock, false);
         expect(columnsBeforeTranslateMock).toEqual(columnsAfterTranslateMock);
       });
@@ -835,12 +838,11 @@ describe('ExtensionService', () => {
         const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
         const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' }] as Column[];
         vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsBeforeTranslateMock);
-        const columnSpy = vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsBeforeTranslateMock);
+        sharedService.allColumns = columnsBeforeTranslateMock;
         const renderSpy = vi.spyOn(service, 'renderColumnHeaders');
 
         service.translateColumnHeaders('en');
 
-        expect(columnSpy).toHaveBeenCalled();
         expect(renderSpy).toHaveBeenCalledWith(columnsAfterTranslateMock, false);
         expect(columnsBeforeTranslateMock).toEqual(columnsAfterTranslateMock);
       });
@@ -849,12 +851,11 @@ describe('ExtensionService', () => {
         const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
         const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' }] as Column[];
         const colDefSpy = vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get');
-        const columnSpy = vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsBeforeTranslateMock);
+        sharedService.allColumns = columnsBeforeTranslateMock;
         const renderSpy = vi.spyOn(service, 'renderColumnHeaders');
 
         service.translateColumnHeaders('en', columnsBeforeTranslateMock);
 
-        expect(columnSpy).toHaveBeenCalled();
         expect(colDefSpy).not.toHaveBeenCalled();
         expect(renderSpy).toHaveBeenCalledWith(columnsAfterTranslateMock, true);
         expect(columnsBeforeTranslateMock).toEqual(columnsAfterTranslateMock);
@@ -869,7 +870,7 @@ describe('ExtensionService', () => {
 
       it('should call "setColumns" on the Shared Service with the Shared "columnDefinitions" when no arguments is provided', () => {
         const columnsMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+        sharedService.slickGrid = gridStub;
         const colSpy = vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
         const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
 
@@ -884,7 +885,7 @@ describe('ExtensionService', () => {
           { id: 'field1', field: 'field1', nameKey: 'HELLO' },
           { id: 'field2', field: 'field2', nameKey: 'WORLD' }
         ] as Column[];
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+        sharedService.slickGrid = gridStub;
         const allColsSpy = vi.spyOn(SharedService.prototype, 'allColumns', 'set');
         const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
 
@@ -899,14 +900,12 @@ describe('ExtensionService', () => {
         const columnsMock = [
           { id: 'field1', field: 'field1', nameKey: 'HELLO' }
         ] as Column[];
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
-        const spyAllCols = vi.spyOn(SharedService.prototype, 'allColumns', 'set');
+        sharedService.slickGrid = gridStub;
         const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
 
         service.renderColumnHeaders(columnsMock);
 
         expect(setColumnsSpy).toHaveBeenCalledWith(columnsMock);
-        expect(spyAllCols).not.toHaveBeenCalled();
       });
 
       it('should replace the Column Picker columns when plugin is enabled and method is called with new column definition collection provided as argument', () => {

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -104,7 +104,7 @@ const treeDataServiceStub = {
 describe('Grid Service', () => {
   let service: GridService;
   const sharedService = new SharedService();
-  const mockGridOptions = { enableAutoResize: true } as GridOption;
+  const mockGridOptions = {} as GridOption;
 
   vi.spyOn(gridStub, 'getOptions').mockReturnValue(mockGridOptions);
 
@@ -1304,7 +1304,7 @@ describe('Grid Service', () => {
     it('should call "clearPinning" and expect SlickGrid "setOptions" and "setColumns" to be called with frozen options being reset', () => {
       const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
       const setColumnsSpy = vi.spyOn(gridStub, 'setColumns');
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
       vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock.slice(0, 1));
 
@@ -1317,7 +1317,7 @@ describe('Grid Service', () => {
     it('should call "setPinning" which itself calls "clearPinning" when the pinning option input is an empty object', () => {
       const mockPinning = {};
       const clearPinningSpy = vi.spyOn(service, 'clearPinning');
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
 
       service.setPinning(mockPinning);
 
@@ -1327,7 +1327,7 @@ describe('Grid Service', () => {
     it('should call "setPinning" which itself calls "clearPinning" when the pinning option input is null', () => {
       const mockPinning = null;
       const clearPinningSpy = vi.spyOn(service, 'clearPinning');
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
 
       service.setPinning(mockPinning as any);
 
@@ -1336,7 +1336,7 @@ describe('Grid Service', () => {
 
     it('should call "setPinning" and expect SlickGrid "setOptions" be called with new frozen options and "autosizeColumns" also be called', () => {
       const mockPinning = { frozenBottom: true, frozenColumn: 1, frozenRow: 2 };
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       const gridOptionSetterSpy = vi.spyOn(SharedService.prototype, 'gridOptions', 'set');
@@ -1350,7 +1350,7 @@ describe('Grid Service', () => {
 
     it('should call "setPinning" and expect SlickGrid "setOptions" be called with new frozen options and "autosizeColumns" not being called when passing False as 2nd argument', () => {
       const mockPinning = { frozenBottom: true, frozenColumn: 1, frozenRow: 2 };
-      vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
+      sharedService.slickGrid = gridStub;
       const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       const gridOptionSetterSpy = vi.spyOn(SharedService.prototype, 'gridOptions', 'set');
@@ -1490,7 +1490,7 @@ describe('Grid Service', () => {
 
     it('should return selected row indexes', () => {
       const mockSelectedColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
-      const gridSpy = vi.spyOn(gridStub, 'getSelectedRows').mockReturnValue([0, 2]);
+      const gridSpy = vi.spyOn(sharedService.slickGrid, 'getSelectedRows').mockReturnValue([0, 2]);
       const serviceSpy = vi.spyOn(service, 'getDataItemByRowIndexes').mockReturnValue(mockSelectedColumns);
 
       const output = service.getSelectedRowsDataItem();

--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -433,12 +433,11 @@ describe('GridStateService', () => {
       const gridOptionsMock = { enablePagination: true } as GridOption;
       const paginationMock = { pageNumber: 2, pageSize: 50 } as CurrentPagination;
       const gridSpy = vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
-      const sharedSpy = vi.spyOn(SharedService.prototype, 'currentPagination', 'get').mockReturnValue(paginationMock);
+      sharedService.currentPagination = paginationMock;
 
       const output = service.getCurrentPagination();
 
       expect(gridSpy).toHaveBeenCalled();
-      expect(sharedSpy).toHaveBeenCalled();
       expect(output).toBe(paginationMock);
     });
 

--- a/packages/common/src/services/__tests__/shared.service.spec.ts
+++ b/packages/common/src/services/__tests__/shared.service.spec.ts
@@ -1,15 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SharedService } from '../shared.service';
-import type { Column, CurrentPagination, GridOption } from '../../interfaces/index';
+import type { Column, GridOption } from '../../interfaces/index';
 import { ExcelExportService } from '../excelExport.service';
-import type { SlickDataView, SlickGrid } from '../../core';
-import type { SlickGroupItemMetadataProvider } from '../../extensions';
-
-const dataviewStub = {
-  onRowCountChanged: vi.fn(),
-  onRowsChanged: vi.fn(),
-} as unknown as SlickDataView;
+import type { SlickGrid } from '../../core';
 
 const gridStub = {
   autosizeColumns: vi.fn(),
@@ -78,71 +72,6 @@ describe('Shared Service', () => {
     expect(columns).toEqual(mockColumns);
   });
 
-  it('should call "currentPagination" GETTER and return the currentPagination object', () => {
-    const expectedResult = { pageNumber: 2, pageSize: 10 } as CurrentPagination;
-    const spy = vi.spyOn(service, 'currentPagination', 'get').mockReturnValue(expectedResult);
-
-    const output = service.currentPagination;
-
-    expect(spy).toHaveBeenCalled();
-    expect(output).toEqual(expectedResult);
-  });
-
-  it('should call "currentPagination" SETTER and expect GETTER to return the same', () => {
-    const expectedResult = { pageNumber: 2, pageSize: 10 } as CurrentPagination;
-    const getSpy = vi.spyOn(service, 'currentPagination', 'get');
-    const setSpy = vi.spyOn(service, 'currentPagination', 'set');
-
-    service.currentPagination = expectedResult;
-    const output = service.currentPagination;
-
-    expect(getSpy).toHaveBeenCalled();
-    expect(setSpy).toHaveBeenCalled();
-    expect(output).toEqual(expectedResult);
-  });
-
-  it('should call "dataView" GETTER and return a dataView', () => {
-    const spy = vi.spyOn(service, 'dataView', 'get').mockReturnValue(dataviewStub);
-
-    const ouput = service.dataView;
-
-    expect(spy).toHaveBeenCalled();
-    expect(ouput).toEqual(dataviewStub);
-  });
-
-  it('should call "dataView" SETTER and expect GETTER to return the same', () => {
-    const getSpy = vi.spyOn(service, 'dataView', 'get');
-    const setSpy = vi.spyOn(service, 'dataView', 'set');
-
-    service.dataView = dataviewStub;
-    const output = service.dataView;
-
-    expect(getSpy).toHaveBeenCalled();
-    expect(setSpy).toHaveBeenCalled();
-    expect(output).toEqual(dataviewStub);
-  });
-
-  it('should call "grid" GETTER and return the grid object', () => {
-    const spy = vi.spyOn(service, 'slickGrid', 'get').mockReturnValue(gridStub);
-
-    const output = service.slickGrid;
-
-    expect(spy).toHaveBeenCalled();
-    expect(output).toEqual(gridStub);
-  });
-
-  it('should call "grid" SETTER and expect GETTER to return the same', () => {
-    const getSpy = vi.spyOn(service, 'slickGrid', 'get');
-    const setSpy = vi.spyOn(service, 'slickGrid', 'set');
-
-    service.slickGrid = gridStub;
-    const output = service.slickGrid;
-
-    expect(getSpy).toHaveBeenCalled();
-    expect(setSpy).toHaveBeenCalled();
-    expect(output).toEqual(gridStub);
-  });
-
   it('should call "gridOptions" GETTER and expect options to return empty object when Grid object does not exist', () => {
     const options = service.gridOptions;
     expect(options).toEqual({});
@@ -177,54 +106,6 @@ describe('Shared Service', () => {
     expect(getSpy).toHaveBeenCalled();
     expect(setSpy).toHaveBeenCalled();
     expect(output).toEqual(mockGridOptions);
-  });
-
-  it('should call "groupItemMetadataProvider" GETTER and return metadata', () => {
-    const spy = vi.spyOn(service, 'groupItemMetadataProvider', 'get').mockReturnValue(mockColumns as unknown as SlickGroupItemMetadataProvider);
-
-    const output = service.groupItemMetadataProvider;
-
-    expect(spy).toHaveBeenCalled();
-    expect(output).toEqual(mockColumns);
-  });
-
-  it('should call "groupItemMetadataProvider" SETTER and expect GETTER to return the same', () => {
-    const getSpy = vi.spyOn(service, 'groupItemMetadataProvider', 'get');
-    const setSpy = vi.spyOn(service, 'groupItemMetadataProvider', 'set');
-
-    service.groupItemMetadataProvider = mockColumns as unknown as SlickGroupItemMetadataProvider;
-    const output = service.groupItemMetadataProvider;
-
-    expect(getSpy).toHaveBeenCalled();
-    expect(setSpy).toHaveBeenCalled();
-    expect(output).toEqual(mockColumns);
-  });
-
-  it('should call "frozenVisibleColumnId" GETTER and expect a boolean value to be returned', () => {
-    const columnId = service.frozenVisibleColumnId;
-    expect(columnId).toEqual(undefined);
-  });
-
-  it('should call "frozenVisibleColumnId" GETTER and SETTER expect same value to be returned', () => {
-    service.frozenVisibleColumnId = 'field1';
-    expect(service.frozenVisibleColumnId).toEqual('field1');
-  });
-
-  it('should call "gridContainerElement" GETTER and SETTER expect same value to be returned', () => {
-    const divMock = document.createElement('div');
-    divMock.className = 'some-class';
-    service.gridContainerElement = divMock;
-    expect(service.gridContainerElement).toEqual(divMock);
-  });
-
-  it('should call "hasColumnsReordered" GETTER and expect a boolean value to be returned', () => {
-    const flag = service.hasColumnsReordered;
-    expect(flag).toEqual(false);
-  });
-
-  it('should call "hasColumnsReordered" GETTER and SETTER expect same value to be returned', () => {
-    service.hasColumnsReordered = true;
-    expect(service.hasColumnsReordered).toEqual(true);
   });
 
   it('should call "visibleColumns" GETTER and return all columns', () => {
@@ -267,16 +148,6 @@ describe('Shared Service', () => {
     expect(getSpy).toHaveBeenCalled();
     expect(setSpy).toHaveBeenCalled();
     expect(columns).toEqual(mockHierarchicalDataset);
-  });
-
-  it('should call "hideHeaderRowAfterPageLoad" GETTER and expect a boolean value to be returned', () => {
-    const flag = service.hideHeaderRowAfterPageLoad;
-    expect(flag).toEqual(false);
-  });
-
-  it('should call "hideHeaderRowAfterPageLoad" GETTER and SETTER expect same value to be returned', () => {
-    service.hideHeaderRowAfterPageLoad = true;
-    expect(service.hideHeaderRowAfterPageLoad).toEqual(true);
   });
 
   it('should call "externalRegisteredResources" GETTER and return all columns', () => {

--- a/packages/common/src/services/shared.service.ts
+++ b/packages/common/src/services/shared.service.ts
@@ -4,23 +4,43 @@ import type { SlickGroupItemMetadataProvider } from '../extensions/slickGroupIte
 
 export class SharedService {
   protected _allColumns!: Column[];
-  protected _dataView!: SlickDataView;
-  protected _groupItemMetadataProvider!: SlickGroupItemMetadataProvider;
-  protected _grid!: SlickGrid;
-  protected _gridContainerElm!: HTMLElement;
   protected _gridOptions!: GridOption;
-  protected _hasColumnsReordered = false;
-  protected _currentPagination!: CurrentPagination;
   protected _visibleColumns!: Column[];
-  protected _hideHeaderRowAfterPageLoad = false;
   protected _hierarchicalDataset: any[] | undefined;
   protected _externalRegisteredResources!: any[];
-  protected _frozenVisibleColumnId!: string | number;
-
-  isItemsDateParsed = false;
 
   // --
   // public
+
+  /** Current Pagination (when Pagination is enabled) */
+  currentPagination: CurrentPagination | null = null;
+
+  /** SlickGrid DataView object */
+  dataView!: SlickDataView;
+
+  /** when `preParseDateColumns` grid option is enabled, did we already parsed all dates? */
+  isItemsDateParsed = false;
+
+  /** Frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward */
+  frozenVisibleColumnId: string | number = '';
+
+  /** Grid Container HTML Element */
+  gridContainerElement!: HTMLElement;
+
+  /** GroupItemMetadataProvider */
+  groupItemMetadataProvider?: SlickGroupItemMetadataProvider;
+
+  /** Boolean to know if the columns were ever reordered or not since the grid was created. */
+  hasColumnsReordered = false;
+
+  /** Boolean to know if user want to hide header row after 1st page load */
+  hideHeaderRowAfterPageLoad = false;
+
+  /** SlickGrid Grid object */
+  slickGrid!: SlickGrid;
+
+  // --
+  // GETTERs / SETTERs
 
   /** Getter for All Columns  in the grid (hidden/visible) */
   get allColumns(): Column[] {
@@ -33,91 +53,17 @@ export class SharedService {
 
   /** Getter for the Column Definitions pulled through the Grid Object */
   get columnDefinitions(): Column[] {
-    return this._grid?.getColumns() ?? [];
-  }
-
-  /** Getter for the Current Pagination (when Pagination is enabled) */
-  get currentPagination(): CurrentPagination {
-    return this._currentPagination;
-  }
-
-  /** Setter for the Current Pagination (when Pagination is enabled) */
-  set currentPagination(currentPagination: CurrentPagination) {
-    this._currentPagination = currentPagination;
-  }
-
-  /** Getter for SlickGrid DataView object */
-  get dataView(): SlickDataView {
-    return this._dataView;
-  }
-  /** Setter for SlickGrid DataView object */
-  set dataView(dataView: SlickDataView) {
-    this._dataView = dataView;
-  }
-
-  /** Setter to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward */
-  get frozenVisibleColumnId(): string | number {
-    return this._frozenVisibleColumnId;
-  }
-  /** Getter to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward */
-  set frozenVisibleColumnId(columnId: string | number) {
-    this._frozenVisibleColumnId = columnId;
-  }
-
-  /** Setter to know if the columns were ever reordered or not since the grid was created. */
-  get hasColumnsReordered(): boolean {
-    return this._hasColumnsReordered;
-  }
-  /** Getter to know if the columns were ever reordered or not since the grid was created. */
-  set hasColumnsReordered(isColumnReordered: boolean) {
-    this._hasColumnsReordered = isColumnReordered;
-  }
-
-  /** Getter for SlickGrid Grid object */
-  get slickGrid(): SlickGrid {
-    return this._grid;
-  }
-  /** Setter for SlickGrid Grid object */
-  set slickGrid(grid: SlickGrid) {
-    this._grid = grid;
-  }
-
-  /** Getter for the Grid Options pulled through the Grid Object */
-  get gridContainerElement(): HTMLElement {
-    return this._gridContainerElm;
-  }
-
-  /** Setter for the Grid Options pulled through the Grid Object */
-  set gridContainerElement(gridContainerElm: HTMLElement) {
-    this._gridContainerElm = gridContainerElm;
+    return this.slickGrid?.getColumns() ?? [];
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
   get gridOptions(): GridOption {
-    return this._gridOptions || this._grid?.getOptions() || {};
+    return this._gridOptions || this.slickGrid?.getOptions() || {};
   }
 
   /** Setter for the Grid Options pulled through the Grid Object */
   set gridOptions(gridOptions: GridOption) {
     this._gridOptions = gridOptions;
-  }
-
-  /** Getter for the Grid Options */
-  get groupItemMetadataProvider(): SlickGroupItemMetadataProvider {
-    return this._groupItemMetadataProvider;
-  }
-  /** Setter for the Grid Options */
-  set groupItemMetadataProvider(groupItemMetadataProvider: SlickGroupItemMetadataProvider) {
-    this._groupItemMetadataProvider = groupItemMetadataProvider;
-  }
-
-  /** Getter to know if user want to hide header row after 1st page load */
-  get hideHeaderRowAfterPageLoad(): boolean {
-    return this._hideHeaderRowAfterPageLoad;
-  }
-  /** Setter for knowing if user want to hide header row after 1st page load */
-  set hideHeaderRowAfterPageLoad(hideHeaderRowAfterPageLoad: boolean) {
-    this._hideHeaderRowAfterPageLoad = hideHeaderRowAfterPageLoad;
   }
 
   /** Getter to know if user want to hide header row after 1st page load */

--- a/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
@@ -66,13 +66,13 @@ describe('Slick-Pagination Component', () => {
   let translateService: TranslateServiceStub;
 
   beforeEach(() => {
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
     vi.spyOn(paginationServiceStub, 'getFullPagination').mockReturnValue(mockFullPagination);
     div = document.createElement('div');
     document.body.appendChild(div);
     sharedService = new SharedService();
     eventPubSubService = new EventPubSubService();
     translateService = new TranslateServiceStub();
+    sharedService.slickGrid = gridStub;
   });
 
   describe('Integration Tests', () => {

--- a/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
@@ -93,7 +93,6 @@ describe('Slick-Pagination Component', () => {
       });
 
       beforeEach(() => {
-        vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
         vi.spyOn(paginationServiceStub as PaginationService, 'getFullPagination').mockReturnValue(mockFullPagination);
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(mockGridOptions);
         div = document.createElement('div');
@@ -101,6 +100,7 @@ describe('Slick-Pagination Component', () => {
         sharedService = new SharedService();
         eventPubSubService = new EventPubSubService();
         translateService = new TranslateServiceStub();
+        sharedService.slickGrid = gridStub;
 
         component = new SlickPaginationComponent(paginationServiceStub as PaginationService, eventPubSubService, sharedService, translateService);
         component.renderPagination(div);
@@ -318,13 +318,13 @@ describe('with different i18n locale', () => {
   beforeEach(() => {
     mockGridOptions.enableTranslate = true;
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(mockGridOptions);
-    vi.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
     vi.spyOn(paginationServiceStub as PaginationService, 'getFullPagination').mockReturnValue(mockFullPagination2);
     div = document.createElement('div');
     document.body.appendChild(div);
     sharedService = new SharedService();
     eventPubSubService = new EventPubSubService();
     translateService = new TranslateServiceStub();
+    sharedService.slickGrid = gridStub;
 
     component = new SlickPaginationComponent(paginationServiceStub, eventPubSubService, sharedService, translateService);
     component.renderPagination(div);

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -401,15 +401,13 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   });
 
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {
-    const sharedFrozenIndexSpy = vi.spyOn(SharedService.prototype, 'frozenVisibleColumnId', 'set');
     component.gridOptions.frozenColumn = 0;
     component.initialization(divContainer, slickEventHandler);
 
-    expect(sharedFrozenIndexSpy).toHaveBeenCalledWith('name');
+    expect(sharedService.frozenVisibleColumnId).toBe('name');
   });
 
   it('should update "visibleColumns" in the Shared Service when "onColumnsReordered" event is triggered', () => {
-    const sharedHasColumnsReorderedSpy = vi.spyOn(SharedService.prototype, 'hasColumnsReordered', 'set');
     const sharedVisibleColumnsSpy = vi.spyOn(SharedService.prototype, 'visibleColumns', 'set');
     const newVisibleColumns = [{ id: 'lastName', field: 'lastName' }, { id: 'fristName', field: 'fristName' }];
 
@@ -418,7 +416,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
     mockGrid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns, grid: mockGrid });
 
     expect(component.eventHandler).toEqual(slickEventHandler);
-    expect(sharedHasColumnsReorderedSpy).toHaveBeenCalledWith(true);
+    expect(sharedService.hasColumnsReordered).toBe(true);
     expect(sharedVisibleColumnsSpy).toHaveBeenCalledWith(newVisibleColumns);
   });
 
@@ -863,7 +861,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
     describe('use grouping', () => {
       it('should load groupItemMetaProvider to the DataView when using "draggableGrouping" feature', () => {
-        const sharedMetaSpy = vi.spyOn(SharedService.prototype, 'groupItemMetadataProvider', 'set');
         vi.spyOn(extensionServiceStub, 'extensionList', 'get').mockReturnValue({ draggableGrouping: { pluginName: 'DraggableGrouping' } } as unknown as ExtensionList<any>);
 
         component.gridOptions = { draggableGrouping: {} };
@@ -873,20 +870,16 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(Object.keys(extensions).length).toBe(1);
         expect(SlickDataView).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() }, eventPubSubService);
         expect(sharedService.groupItemMetadataProvider instanceof SlickGroupItemMetadataProvider).toBeTruthy();
-        expect(sharedMetaSpy).toHaveBeenCalledWith(expect.any(Object));
         expect(mockGrid.registerPlugin).toHaveBeenCalled();
 
         component.dispose();
       });
 
       it('should load groupItemMetaProvider to the DataView when using "enableGrouping" feature', () => {
-        const sharedMetaSpy = vi.spyOn(SharedService.prototype, 'groupItemMetadataProvider', 'set');
-
         component.gridOptions = { enableGrouping: true };
         component.initialization(divContainer, slickEventHandler);
 
         expect(SlickDataView).toHaveBeenCalledWith({ inlineFilters: false, groupItemMetadataProvider: expect.anything() }, eventPubSubService);
-        expect(sharedMetaSpy).toHaveBeenCalledWith(expect.any(Object));
         expect(sharedService.groupItemMetadataProvider instanceof SlickGroupItemMetadataProvider).toBeTruthy();
         expect(mockGrid.registerPlugin).toHaveBeenCalled();
 


### PR DESCRIPTION
I previously overcomplicated things by using all Getters/Setters in the Shared Service, when in reality regular public props would suffice