### PR TITLE
chore: move no pre-parse date warning to vanilla grid comp

### DIFF
--- a/packages/common/src/services/__tests__/sort.service.spec.ts
+++ b/packages/common/src/services/__tests__/sort.service.spec.ts
@@ -388,34 +388,6 @@ describe('SortService', () => {
       expect(spyOnLocalSort).toHaveBeenCalledWith(gridStub, mockSortedCols);
     });
 
-    it('should expect a console warning when dataset is larger than 5K items without pre-parsing enabled', () => {
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockReturnValue();
-      vi.spyOn(dataViewStub, 'getLength').mockReturnValueOnce(5001);
-      const mockColumns: Column[] = [
-        { id: 'firstName', field: 'firstName' },
-        { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso },
-      ];
-      vi.spyOn(gridStub, 'getColumns').mockReturnValueOnce(mockColumns);
-
-      service.bindLocalOnSort(gridStub);
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option'));
-    });
-
-    it('should expect a console warning when dataset is larger than 5K items without pre-parsing enabled', () => {
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockReturnValue();
-      vi.spyOn(dataViewStub, 'getLength').mockReturnValueOnce(5001);
-      const mockColumns: Column[] = [
-        { id: 'firstName', field: 'firstName' },
-        { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso },
-      ];
-      vi.spyOn(gridStub, 'getColumns').mockReturnValueOnce(mockColumns);
-
-      service.bindLocalOnSort(gridStub);
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option'));
-    });
-
     it('should enable pre-parse and expect "preParseSingleDateItem()" being called when "grid.onCellChange" is called', async () => {
       const mockColumns = [{ id: 'firstName', field: 'firstName' }, { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso }] as Column[];
       const mockData = [{ firstName: 'John', updatedDate: '2020-01-01' }, { firstName: 'Jane', updatedDate: '2020-02-02' }];

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -18,8 +18,6 @@ import type { SharedService } from './shared.service';
 import type { RxJsFacade, Subject } from './rxjsFacade';
 import { type SlickDataView, type SlickEventData, SlickEventHandler, type SlickGrid } from '../core/index';
 
-const WARN_NO_PREPARSE_DATE_SIZE = 5000; // data size to warn user when pre-parse isn't enabled
-
 export class SortService {
   protected _currentLocalSorters: CurrentSorter[] = [];
   protected _eventHandler: SlickEventHandler;
@@ -104,11 +102,6 @@ export class SortService {
     if (this._gridOptions.preParseDateColumns) {
       this._eventHandler.subscribe(grid.onCellChange, (_e, args) => this.preParseSingleDateItem(args.item));
       this.pubSubService.subscribe(['onItemAdded', 'onItemUpdated'], (item) => this.preParseSingleDateItem(item));
-    } else if (this._dataView?.getLength() > WARN_NO_PREPARSE_DATE_SIZE && grid.getColumns().some(c => isColumnDateType(c.type))) {
-      console.warn(
-        '[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option, ' +
-        'for more info visit:: https://ghiscoding.gitbook.io/slickgrid-universal/column-functionalities/sorting#pre-parse-date-columns-for-better-perf'
-      );
     }
   }
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -19,6 +19,7 @@ import {
   type ExtensionList,
   type ExtensionService,
   type ExtensionUtility,
+  FieldType,
   Filters,
   type FilterService,
   type Formatter,
@@ -519,6 +520,40 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       component.initialization(divContainer, slickEventHandler);
 
       expect(resizerSpy).toHaveBeenCalledWith();
+    });
+
+    it('should expect a console warning when grid is initialized with a dataset larger than 5K items without pre-parsing enabled', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockReturnValue();
+      vi.spyOn(mockDataView, 'getItemCount').mockReturnValueOnce(5001);
+      const mockColumns: Column[] = [
+        { id: 'firstName', field: 'firstName' },
+        { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso },
+      ];
+      vi.spyOn(mockGrid, 'getColumns').mockReturnValueOnce(mockColumns);
+
+      component.gridOptions = { enableAutoResize: true };
+      component.initialization(divContainer, slickEventHandler);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option'));
+    });
+
+    it('should expect a console warning when assigned dataset is larger than 5K items without pre-parsing enabled', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockReturnValue();
+      vi.spyOn(mockDataView, 'getItemCount').mockReturnValueOnce(0);
+      const mockColumns: Column[] = [
+        { id: 'firstName', field: 'firstName' },
+        { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso },
+      ];
+      vi.spyOn(mockGrid, 'getColumns').mockReturnValueOnce(mockColumns);
+
+      component.gridOptions = { enableAutoResize: true };
+      component.initialization(divContainer, slickEventHandler);
+
+      // we'll do a fake dataset assignment of 5001 items
+      vi.spyOn(mockDataView, 'getItemCount').mockReturnValueOnce(5001);
+      component.dataset = [{ firstName: 'John', updatedDate: '2020-02-01' }];
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option'));
     });
 
     describe('autoAddCustomEditorFormatter grid option', () => {

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -45,6 +45,7 @@ import {
 
   // utilities
   emptyElement,
+  isColumnDateType,
   SlickEventHandler,
   SlickDataView,
   SlickGrid,
@@ -58,6 +59,8 @@ import { SlickPaginationComponent } from '@slickgrid-universal/pagination-compon
 
 import { type SlickerGridInstance } from '../interfaces/slickerGridInstance.interface';
 import { UniversalContainerService } from '../services/universalContainer.service';
+
+const WARN_NO_PREPARSE_DATE_SIZE = 5000; // data size to warn user when pre-parse isn't enabled
 
 export class SlickVanillaGridBundle<TData = any> {
   protected _currentDatasetLength = 0;
@@ -169,6 +172,8 @@ export class SlickVanillaGridBundle<TData = any> {
       this.slickGrid.autosizeColumns();
       this._isAutosizeColsCalled = true;
     }
+
+    this.suggestDateParsingWhenHelpful();
   }
 
   get datasetHierarchical(): any[] | undefined {
@@ -704,6 +709,7 @@ export class SlickVanillaGridBundle<TData = any> {
     // all instances (SlickGrid, DataView & all Services)
     this._eventPubSubService.publish('onSlickerGridCreated', this.instances);
     this._isGridInitialized = true;
+    this.suggestDateParsingWhenHelpful();
   }
 
   hasBackendInfiniteScroll(): boolean {
@@ -1531,6 +1537,15 @@ export class SlickVanillaGridBundle<TData = any> {
       }
       return { ...column, editorClass: column.editor?.model };
     });
+  }
+
+  protected suggestDateParsingWhenHelpful(): void {
+    if (this.dataView && this.dataView.getItemCount() > WARN_NO_PREPARSE_DATE_SIZE && this.slickGrid?.getColumns().some(c => isColumnDateType(c.type))) {
+      console.warn(
+        '[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option, ' +
+        'for more info visit:: https://ghiscoding.gitbook.io/slickgrid-universal/column-functionalities/sorting#pre-parse-date-columns-for-better-perf'
+      );
+    }
   }
 
   /**

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1540,7 +1540,7 @@ export class SlickVanillaGridBundle<TData = any> {
   }
 
   protected suggestDateParsingWhenHelpful(): void {
-    if (this.dataView && this.dataView.getItemCount() > WARN_NO_PREPARSE_DATE_SIZE && this.slickGrid?.getColumns().some(c => isColumnDateType(c.type))) {
+    if (this.dataView && this.dataView.getItemCount() > WARN_NO_PREPARSE_DATE_SIZE && !this.gridOptions.preParseDateColumns && this.slickGrid?.getColumns().some(c => isColumnDateType(c.type))) {
       console.warn(
         '[Slickgrid-Universal] For getting better perf, we suggest you enable the `preParseDateColumns` grid option, ' +
         'for more info visit:: https://ghiscoding.gitbook.io/slickgrid-universal/column-functionalities/sorting#pre-parse-date-columns-for-better-perf'


### PR DESCRIPTION
- the previous warning wasn't always showing up when dataset is assigned later (i.e., it wasn't showing in Angular-Slickgrid), we should really move this warning in each framework whenever the dataset is assigned