### PR TITLE
chore: remove unused PubSub refs after PR #1702

### DIFF
--- a/packages/common/src/services/__tests__/groupingAndColspan.service.spec.ts
+++ b/packages/common/src/services/__tests__/groupingAndColspan.service.spec.ts
@@ -9,20 +9,6 @@ const gridId = 'grid1';
 const gridUid = 'slickgrid_124343';
 const containerId = 'demo-container';
 
-const fnCallbacks = {};
-const mockPubSub = {
-  publish: vi.fn(),
-  subscribe: (eventName, fn) => {
-    const eventNames = Array.isArray(eventName) ? eventName : [eventName];
-    eventNames.forEach(eventName => fnCallbacks[eventName] = fn);
-  },
-  unsubscribe: vi.fn(),
-  unsubscribeAll: vi.fn(),
-};
-vi.mock('@slickgrid-universal/event-pub-sub', () => ({
-  BasePubSubService: () => mockPubSub
-}));
-
 const gridOptionMock = {
   createPreHeaderPanel: true,
   enablePagination: true,
@@ -97,7 +83,7 @@ describe('GroupingAndColspanService', () => {
     div.innerHTML = template;
     document.body.appendChild(div);
 
-    service = new GroupingAndColspanService(mockExtensionUtility, mockPubSub);
+    service = new GroupingAndColspanService(mockExtensionUtility);
     slickgridEventHandler = service.eventHandler;
   });
 

--- a/packages/common/src/services/groupingAndColspan.service.ts
+++ b/packages/common/src/services/groupingAndColspan.service.ts
@@ -1,4 +1,4 @@
-import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
+import type { EventSubscription } from '@slickgrid-universal/event-pub-sub';
 import { createDomElement, emptyElement } from '@slickgrid-universal/utils';
 
 import type { Column, GridOption, } from './../interfaces/index';
@@ -10,7 +10,7 @@ export class GroupingAndColspanService {
   protected _grid!: SlickGrid;
   protected _subscriptions: EventSubscription[] = [];
 
-  constructor(protected readonly extensionUtility: ExtensionUtility, protected readonly pubSubService: BasePubSubService) {
+  constructor(protected readonly extensionUtility: ExtensionUtility) {
     this._eventHandler = new SlickEventHandler();
   }
 
@@ -36,7 +36,7 @@ export class GroupingAndColspanService {
 
   /**
    * Initialize the Service
-   * @param {object} grid
+   * @param {SlickGrid} grid
    */
   init(grid: SlickGrid): void {
     this._grid = grid;
@@ -72,7 +72,6 @@ export class GroupingAndColspanService {
   dispose(): void {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
-    this.pubSubService.unsubscribeAll(this._subscriptions);
   }
 
   /** call "renderPreHeaderRowGroupingTitles()" with a setTimeout delay */

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -380,7 +380,7 @@ export class SlickVanillaGridBundle<TData = any> {
 
     this.gridStateService = services?.gridStateService ?? new GridStateService(this.extensionService, this.filterService, this._eventPubSubService, this.sharedService, this.sortService, this.treeDataService);
     this.gridService = services?.gridService ?? new GridService(this.gridStateService, this.filterService, this._eventPubSubService, this.paginationService, this.sharedService, this.sortService, this.treeDataService);
-    this.groupingService = services?.groupingAndColspanService ?? new GroupingAndColspanService(this.extensionUtility, this._eventPubSubService);
+    this.groupingService = services?.groupingAndColspanService ?? new GroupingAndColspanService(this.extensionUtility);
 
     if (hierarchicalDataset) {
       this.sharedService.hierarchicalDataset = (isDeepCopyDataOnPageLoadEnabled ? extend(true, [], hierarchicalDataset) : hierarchicalDataset) || [];


### PR DESCRIPTION
- it seems that after PR #1702, there's no more need for the PubSub DI, so let's remove it from the argument list (note that this will require changes in the downstream repos as well for the same DI removal)