### PR TITLE
fix: move DI to init() to make Pagination Comp working with all ports

### DIFF
--- a/docs/grid-functionalities/pagination.md
+++ b/docs/grid-functionalities/pagination.md
@@ -9,7 +9,28 @@ When providing a custom pagination component as a `customPaginationComponent`, t
 
 > **Note** Your Custom Pagination must `implements BasePaginationComponent` so that the internal instantiation work as intended.
 
+##### Custom Pagination Component
+
+Create a Custom Pagination Component that requires the following functions, your class will be instantiated and the `init()` will contain all the references to the Services. The `render()` will also be called with the grid container DOM element which is important to either prepend or append your Custom Pagination to the grid.
+
+```ts
+import type { BasePaginationComponent, PaginationService, PubSubService, SlickGrid } from '@slickgrid-universal/common';
+
+export class CustomPager implements BasePaginationComponent {
+  /** initialize the custom pagination class */
+  init(grid: SlickGrid, paginationService: PaginationService, pubSubService: PubSubService, translaterService?: TranslaterService) {}
+
+  /** dipose (aka destroy) to execute when disposing of the pagination (that is when destroying the grid) */
+  dispose() {}
+
+  /** render the custom pagination */
+  render(containerElm: HTMLElement) {}
+}
+```
+
 ##### Component
+
+You then need to reference your Custom Pagination class to your grid options.
 
 ```ts
 import { CustomPager } from './custom-pager';
@@ -19,7 +40,7 @@ export class GridBasicComponent {
   gridOptions: GridOption;
   dataset: any[];
 
-  attached(): void {
+  mount(): void {
     // your columns definition
     this.columnDefinitions = [];
 
@@ -33,25 +54,6 @@ export class GridBasicComponent {
         pageSize: this.pageSize
       },
     }
-  }
-}
-```
-
-###### Custom Pagination Component
-```ts
-import type { BasePaginationComponent, PaginationService, PubSubService, SlickGrid } from '@slickgrid-universal/common';
-
-export class CustomPager implements BasePaginationComponent {
-  constructor(protected readonly grid: SlickGrid, protected readonly paginationService: PaginationService, protected readonly pubSubService: PubSubService) {
-     // ...
-  }
-
-  dispose() {
-    // ...
-  }
-
-  render(containerElm: HTMLElement) {
-    // ...
   }
 }
 ```

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30-pager.scss
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30-pager.scss
@@ -15,6 +15,7 @@
   .custom-pagination-nav {
     display: flex;
     align-items: center;
+    list-style-type: none;
 
     .page-item {
       display: flex;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30-pager.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30-pager.ts
@@ -3,6 +3,7 @@ import type { BasePaginationComponent, PaginationService, PubSubService, Paginat
 
 import './example30-pager.scss';
 
+/** Custom Pagination Componnet, please note that you MUST `implements BasePaginationComponent` with required functions */
 export class CustomPager implements BasePaginationComponent {
   protected _bindingHelper: BindingHelper;
   protected _bindingEventService: BindingEventService;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30-pager.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30-pager.ts
@@ -9,15 +9,25 @@ export class CustomPager implements BasePaginationComponent {
   protected _paginationElement!: HTMLDivElement;
   protected _subscriptions: Subscription[] = [];
   protected _gridContainerElm?: HTMLElement;
+  protected grid!: SlickGrid;
+  protected paginationService!: PaginationService;
+  protected pubSubService!: PubSubService;
   currentPagination: PaginationMetadata;
   firstButtonClasses = 'li page-item seek-first';
   prevButtonClasses = 'li page-item seek-prev';
   lastButtonClasses = 'li page-item seek-end';
   nextButtonClasses = 'li page-item seek-next';
 
-  constructor(protected readonly grid: SlickGrid, protected readonly paginationService: PaginationService, protected readonly pubSubService: PubSubService) {
+  constructor() {
     this._bindingHelper = new BindingHelper();
     this._bindingEventService = new BindingEventService();
+  }
+
+  init(grid: SlickGrid, paginationService: PaginationService, pubSubService: PubSubService) {
+    this.grid = grid;
+    this.paginationService = paginationService;
+    this.pubSubService = pubSubService;
+    this._bindingHelper.querySelectorPrefix = `.${grid.getUID()} `;
 
     // Anytime the pagination is initialized or has changes,
     // we'll copy the data into a local object so that we can add binding to this local object
@@ -47,7 +57,7 @@ export class CustomPager implements BasePaginationComponent {
     this._paginationElement.remove();
   }
 
-  render(containerElm: HTMLElement, position: 'top' | 'bottom' = 'top') {
+  renderPagination(containerElm: HTMLElement, position: 'top' | 'bottom' = 'top') {
     this._gridContainerElm = containerElm;
     this.currentPagination = this.paginationService.getFullPagination();
     this._paginationElement = document.createElement('div');

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30.html
@@ -26,8 +26,8 @@
 <br>
 
 <h6 class="title is-6 italic content">
-  You can create a Custom Pagination that will be appended/prepended (bottom or top) of the grid. In fact we can put these pagination elements
-  anywhere on the page (for example the page size is totally separate in his own corner above).
+  You can create a Custom Pagination that will be appended/prepended (bottom or top) of the grid. In fact any of the pagination elements could be moved
+  anywhere on the page (for example we purposely moved the page size away from the rest of the pagination elements).
 </h6>
 
 <div class="grid30">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30.html
@@ -26,8 +26,8 @@
 <br>
 
 <h6 class="title is-6 italic content">
-  You can create a Custom Pagination that will be appended/prepended (bottom or top) of the grid. In fact any of the pagination elements could be moved
-  anywhere on the page (for example we purposely moved the page size away from the rest of the pagination elements).
+  You can create a Custom Pagination that will be appended/prepended (bottom or top) of the grid.
+  Any of the pagination controls could be moved anywhere on the page (for example we purposely moved the page size away from the rest of the pagination elements).
 </h6>
 
 <div class="grid30">

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30.ts
@@ -34,7 +34,7 @@ export default class Example30 {
     this.defineGrid();
 
     // mock some data (different in each dataset)
-    this.dataset = this.mockData(NB_ITEMS);
+    this.dataset = this.loadData(NB_ITEMS);
     this.gridContainerElm = document.querySelector<HTMLDivElement>('.grid30') as HTMLDivElement;
     this.sgb = new Slicker.GridBundle(this.gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, this.dataset);
     document.body.classList.add('material-theme');
@@ -59,7 +59,7 @@ export default class Example30 {
         type: FieldType.string,
       },
       {
-        id: 'percentComplete', name: '% Complete', field: 'percentComplete', nameKey: 'PERCENT_COMPLETE', minWidth: 120,
+        id: 'percentComplete', name: '% Complete', field: 'percentComplete', minWidth: 120,
         sortable: true,
         customTooltip: { position: 'center' },
         formatter: Formatters.progressBar,
@@ -91,7 +91,8 @@ export default class Example30 {
         id: 'duration', field: 'duration', name: 'Duration', maxWidth: 90,
         type: FieldType.number,
         sortable: true,
-        filterable: true, filter: {
+        filterable: true,
+        filter: {
           model: Filters.input,
           operator: OperatorType.rangeExclusive // defaults to exclusive
         }
@@ -116,7 +117,7 @@ export default class Example30 {
       },
       enableExcelCopyBuffer: true,
       enableFiltering: true,
-      customPaginationComponent: CustomPager,
+      customPaginationComponent: CustomPager, // load our Custom Pagination Component
       enablePagination: true,
       pagination: {
         pageSize: this.pageSize
@@ -129,10 +130,10 @@ export default class Example30 {
     this.sgb.paginationService.changeItemPerPage(pageSize);
   }
 
-  mockData(itemCount: number, startingIndex = 0): any[] {
+  loadData(itemCount: number): any[] {
     // mock a dataset
     const tempDataset: any[] = [];
-    for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
+    for (let i = 0, ln = itemCount; i < ln; i++) {
       const randomDuration = randomBetween(0, 365);
       const randomYear = randomBetween(new Date().getFullYear(), new Date().getFullYear() + 1);
       const randomMonth = randomBetween(0, 12);
@@ -146,7 +147,7 @@ export default class Example30 {
         duration: randomDuration,
         percentComplete: randomPercent,
         percentCompleteNumber: randomPercent,
-        start: (i % 4) ? null : new Date(randomYear, randomMonth, randomDay),          // provide a Date format
+        start: (i % 4) ? null : new Date(randomYear, randomMonth, randomDay), // provide a Date format
         finish: new Date(randomYear, randomMonth, randomDay),
         completed: (randomPercent === 100) ? true : false,
       });

--- a/examples/vite-demo-vanilla-bundle/src/examples/example30.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example30.ts
@@ -118,10 +118,10 @@ export default class Example30 {
       enableFiltering: true,
       customPaginationComponent: CustomPager,
       enablePagination: true,
-      rowHeight: 40,
       pagination: {
         pageSize: this.pageSize
       },
+      rowHeight: 40,
     };
   }
 
@@ -158,6 +158,6 @@ export default class Example30 {
   togglePaginationPosition() {
     this.paginationPosition = this.paginationPosition === 'top' ? 'bottom' : 'top';
     (this.sgb.paginationComponent as CustomPager)?.disposeElement();
-    (this.sgb.paginationComponent as CustomPager)?.render(this.gridContainerElm, this.paginationPosition);
+    (this.sgb.paginationComponent as CustomPager)?.renderPagination(this.gridContainerElm, this.paginationPosition);
   }
 }

--- a/packages/common/src/interfaces/pagination.interface.ts
+++ b/packages/common/src/interfaces/pagination.interface.ts
@@ -19,16 +19,18 @@ export interface Pagination {
 }
 
 export class BasePaginationComponent {
-  constructor(
+  constructor(_elmRef?: any) { }
+
+  dispose(): void { }
+
+  init(
     _grid: SlickGrid,
     _paginationService: PaginationService,
     _pubSubService: BasePubSubService,
     _translaterService?: TranslaterService | undefined
-  ) { }
+  ): void { }
 
-  dispose(): void { }
-
-  render(_containerElm: HTMLElement): void { }
+  renderPagination(_containerElm: HTMLElement): void { }
 }
 
 export interface PaginationMetadata extends Pagination {

--- a/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination-without-i18n.spec.ts
@@ -83,8 +83,9 @@ describe('Slick-Pagination Component', () => {
         translateService = undefined as any;
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ ...mockGridOptions, enableTranslate: true });
 
-        component = new SlickPaginationComponent(gridStub, paginationServiceStub, eventPubSubService, translateService);
-        component.render(div);
+        component = new SlickPaginationComponent();
+        component.init(gridStub, paginationServiceStub, eventPubSubService, translateService);
+        component.renderPagination(div);
       } catch (e) {
         expect(e.toString()).toContain('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
         done();
@@ -94,8 +95,9 @@ describe('Slick-Pagination Component', () => {
     it('should have defined locale and expect new text in the UI', () => {
       vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ ...mockGridOptions, locales: mockLocales });
 
-      component = new SlickPaginationComponent(gridStub, paginationServiceStub, eventPubSubService, translateService);
-      component.render(div);
+      component = new SlickPaginationComponent();
+      component.init(gridStub, paginationServiceStub, eventPubSubService, translateService);
+      component.renderPagination(div);
 
       const pageInfoFromTo = document.querySelector('.page-info-from-to') as HTMLSpanElement;
       const pageInfoTotalItems = document.querySelector('.page-info-total-items') as HTMLSpanElement;

--- a/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
+++ b/packages/pagination-component/src/__tests__/slick-pagination.spec.ts
@@ -99,8 +99,9 @@ describe('Slick-Pagination Component', () => {
         eventPubSubService = new EventPubSubService();
         translateService = new TranslateServiceStub();
 
-        component = new SlickPaginationComponent(gridStub, paginationServiceStub as PaginationService, eventPubSubService, translateService);
-        component.render(div);
+        component = new SlickPaginationComponent();
+        component.init(gridStub, paginationServiceStub as PaginationService, eventPubSubService, translateService);
+        component.renderPagination(div);
       });
 
       afterEach(() => {
@@ -268,8 +269,8 @@ describe('Slick-Pagination Component', () => {
       });
 
       test(`when "onPaginationSetCursorBased" event is triggered then expect pagination to be recreated`, () => {
-        const disposeSpy = vi.spyOn(component, 'dispose');
-        const renderPagSpy = vi.spyOn(component, 'render');
+        const disposeSpy = vi.spyOn(component, 'disposeDom');
+        const renderPagSpy = vi.spyOn(component, 'renderPagination');
 
         mockFullPagination.pageNumber = 1;
         mockFullPagination.pageCount = 10;
@@ -320,13 +321,16 @@ describe('with different i18n locale', () => {
     eventPubSubService = new EventPubSubService();
     translateService = new TranslateServiceStub();
 
-    component = new SlickPaginationComponent(gridStub, paginationServiceStub, eventPubSubService, translateService);
-    component.render(div);
+    component = new SlickPaginationComponent();
+    component.init(gridStub, paginationServiceStub, eventPubSubService, translateService);
+    component.renderPagination(div);
   });
 
   it('should throw an error when enabling translate without a Translate Service', () => {
     vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ ...mockGridOptions, enableTranslate: true });
-    expect(() => new SlickPaginationComponent(gridStub, paginationServiceStub, eventPubSubService, null as any))
+    component = new SlickPaginationComponent();
+
+    expect(() => component.init(gridStub, paginationServiceStub, eventPubSubService, null as any))
       .toThrow('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
   });
 

--- a/packages/pagination-component/src/slick-pagination.component.ts
+++ b/packages/pagination-component/src/slick-pagination.component.ts
@@ -17,6 +17,7 @@ export class SlickPaginationComponent implements BasePaginationComponent {
   protected _bindingEventService: BindingEventService;
   protected _paginationElement!: HTMLDivElement;
   protected _enableTranslate = false;
+  protected _grid!: SlickGrid;
   protected _gridContainerElm?: HTMLElement;
   protected _itemPerPageElm!: HTMLSelectElement;
   protected _spanInfoFromToElm!: HTMLSpanElement;
@@ -25,7 +26,10 @@ export class SlickPaginationComponent implements BasePaginationComponent {
   protected _seekNextElm!: HTMLLIElement;
   protected _seekEndElm!: HTMLLIElement;
   protected _subscriptions: Subscription[] = [];
-  currentPagination: PaginationMetadata;
+  protected _paginationService!: PaginationService;
+  protected _pubSubService!: PubSubService;
+  protected _translaterService?: TranslaterService;
+  currentPagination = {} as PaginationMetadata;
   firstButtonClasses = '';
   lastButtonClasses = '';
   prevButtonClasses = '';
@@ -37,78 +41,45 @@ export class SlickPaginationComponent implements BasePaginationComponent {
   textOf = 'of';
   textPage = 'Page';
 
-  constructor(protected readonly grid: SlickGrid, protected readonly paginationService: PaginationService, protected readonly pubSubService: PubSubService, protected readonly translaterService?: TranslaterService | undefined) {
+  constructor() {
     this._bindingHelper = new BindingHelper();
     this._bindingEventService = new BindingEventService();
-    this._bindingHelper.querySelectorPrefix = `.${this.gridUid} `;
-    this.currentPagination = this.paginationService.getFullPagination();
-    this._enableTranslate = this.gridOptions?.enableTranslate ?? false;
-
-    if (this._enableTranslate && (!this.translaterService || !this.translaterService.translate)) {
-      throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
-    }
-    this.translatePaginationTexts();
-
-    if (this._enableTranslate && this.pubSubService?.subscribe) {
-      const translateEventName = this.translaterService?.eventName ?? 'onLanguageChange';
-      this._subscriptions.push(
-        this.pubSubService.subscribe(translateEventName, () => this.translatePaginationTexts())
-      );
-    }
-
-    // Anytime the pagination is initialized or has changes,
-    // we'll copy the data into a local object so that we can add binding to this local object
-    this._subscriptions.push(
-      this.pubSubService.subscribe<PaginationMetadata>('onPaginationRefreshed', paginationChanges => {
-        for (const key of Object.keys(paginationChanges)) {
-          (this.currentPagination as any)[key] = (paginationChanges as any)[key];
-        }
-        this.updatePageButtonsUsability();
-        if (this._spanInfoFromToElm?.style) {
-          this._spanInfoFromToElm.style.display = (this.currentPagination.totalItems === 0) ? 'none' : '';
-        }
-      }),
-      this.pubSubService.subscribe('onPaginationSetCursorBased', () => {
-        this.dispose(); // recreate pagination component, probably only used for GraphQL E2E tests
-        this.render(this._gridContainerElm!);
-      })
-    );
   }
 
   get availablePageSizes(): number[] {
-    return this.paginationService.availablePageSizes || [];
+    return this._paginationService.availablePageSizes || [];
   }
 
   get dataFrom(): number {
-    return this.paginationService.dataFrom;
+    return this._paginationService.dataFrom;
   }
 
   get dataTo(): number {
-    return this.paginationService.dataTo;
+    return this._paginationService.dataTo;
   }
 
   get itemsPerPage(): number {
-    return this.paginationService.itemsPerPage;
+    return this._paginationService.itemsPerPage;
   }
   set itemsPerPage(count: number) {
-    this.paginationService.changeItemPerPage(count);
+    this._paginationService.changeItemPerPage(count);
   }
 
   get pageCount(): number {
-    return this.paginationService.pageCount;
+    return this._paginationService.pageCount;
   }
 
   get pageNumber(): number {
-    return this.paginationService.pageNumber;
+    return this._paginationService.pageNumber;
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
   get gridOptions(): GridOption {
-    return this.grid?.getOptions() ?? {};
+    return this._grid?.getOptions() ?? {};
   }
 
   get gridUid(): string {
-    return this.grid?.getUID() ?? '';
+    return this._grid?.getUID() || '';
   }
 
   get locales(): Locale {
@@ -117,7 +88,7 @@ export class SlickPaginationComponent implements BasePaginationComponent {
   }
 
   get totalItems(): number {
-    return this.paginationService.totalItems;
+    return this._paginationService.totalItems;
   }
 
   get isLeftPaginationDisabled(): boolean {
@@ -128,16 +99,59 @@ export class SlickPaginationComponent implements BasePaginationComponent {
     return this.pageNumber === this.pageCount || this.totalItems === 0;
   }
 
-  dispose(): void {
-    // also dispose of all Subscriptions
-    this.pubSubService.unsubscribeAll(this._subscriptions);
-    this._bindingEventService.unbindAll();
+  init(grid: SlickGrid, paginationService: PaginationService, pubSubService: PubSubService, translaterService?: TranslaterService | undefined): void {
+    this._grid = grid;
+    this._pubSubService = pubSubService;
+    this._translaterService = translaterService;
+    this._paginationService = paginationService;
+    this.currentPagination = paginationService.getFullPagination();
+    this._bindingHelper.querySelectorPrefix = this.gridUid ? `.${this.gridUid} ` : '';
+    this._enableTranslate = this.gridOptions?.enableTranslate ?? false;
 
+    if (this._enableTranslate && (!this._translaterService || !this._translaterService.translate)) {
+      throw new Error('[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.');
+    }
+    this.translatePaginationTexts();
+
+    if (this._enableTranslate && this._pubSubService?.subscribe) {
+      const translateEventName = this._translaterService?.eventName ?? 'onLanguageChange';
+      this._subscriptions.push(
+        this._pubSubService.subscribe(translateEventName, () => this.translatePaginationTexts())
+      );
+    }
+
+    // Anytime the pagination is initialized or has changes,
+    // we'll copy the data into a local object so that we can add binding to this local object
+    this._subscriptions.push(
+      this._pubSubService.subscribe<PaginationMetadata>('onPaginationRefreshed', paginationChanges => {
+        Object.keys(paginationChanges).forEach(key => (this.currentPagination as any)[key] = paginationChanges[key as keyof PaginationMetadata]);
+        this.updatePageButtonsUsability();
+        if (this._spanInfoFromToElm?.style) {
+          this._spanInfoFromToElm.style.display = (this.currentPagination.totalItems === 0) ? 'none' : '';
+        }
+      }),
+      this._pubSubService.subscribe('onPaginationSetCursorBased', () => {
+        this.disposeDom(); // recreate pagination component, probably only used for GraphQL E2E tests
+        this.renderPagination(this._gridContainerElm!);
+      })
+    );
+  }
+
+  /** dispose of all Subscriptions, DOM element & bindings */
+  dispose(): void {
+    this._pubSubService.unsubscribeAll(this._subscriptions);
+    this.disposeDom();
+  }
+
+  /** dispose of the DOM element & bindings only (regular PubSub subscription will be preserved) */
+  disposeDom(): void {
+    this._bindingEventService.unbindAll();
     this._bindingHelper.dispose();
     this._paginationElement.remove();
   }
 
-  render(containerElm: HTMLElement): void {
+  /** render the Pagination in the DOM with all events & bindings */
+  renderPagination(containerElm: HTMLElement): void {
     this._gridContainerElm = containerElm;
     const paginationElm = this.createPaginationContainer();
     const divNavContainerElm = createDomElement('div', { className: 'slick-pagination-nav' });
@@ -202,7 +216,7 @@ export class SlickPaginationComponent implements BasePaginationComponent {
     this._bindingHelper.addElementBinding(this.currentPagination, 'totalItems', 'span.total-items', 'textContent');
     this._bindingHelper.addElementBinding(this.currentPagination, 'pageCount', 'span.page-count', 'textContent');
     this._bindingHelper.addElementBinding(this.currentPagination, 'pageSize', 'select.items-per-page', 'value');
-    this.paginationService.isCursorBased
+    this._paginationService.isCursorBased
       ? this._bindingHelper.addElementBinding(this.currentPagination, 'pageNumber', 'span.page-number', 'textContent')
       : this._bindingHelper.addElementBinding(this.currentPagination, 'pageNumber', 'input.page-number', 'value', 'change', this.changeToCurrentPage.bind(this));
 
@@ -224,30 +238,30 @@ export class SlickPaginationComponent implements BasePaginationComponent {
 
   changeToFirstPage(event: MouseEvent): void {
     if (!this.isLeftPaginationDisabled) {
-      this.paginationService.goToFirstPage(event);
+      this._paginationService.goToFirstPage(event);
     }
   }
 
   changeToLastPage(event: MouseEvent): void {
     if (!this.isRightPaginationDisabled) {
-      this.paginationService.goToLastPage(event);
+      this._paginationService.goToLastPage(event);
     }
   }
 
   changeToNextPage(event: MouseEvent): void {
     if (!this.isRightPaginationDisabled) {
-      this.paginationService.goToNextPage(event);
+      this._paginationService.goToNextPage(event);
     }
   }
 
   changeToPreviousPage(event: MouseEvent): void {
     if (!this.isLeftPaginationDisabled) {
-      this.paginationService.goToPreviousPage(event);
+      this._paginationService.goToPreviousPage(event);
     }
   }
 
   changeToCurrentPage(pageNumber: number): void {
-    this.paginationService.goToPageNumber(+pageNumber);
+    this._paginationService.goToPageNumber(+pageNumber);
   }
 
   updateItemsPerPage(event: & { target: any; }): void {
@@ -256,12 +270,12 @@ export class SlickPaginationComponent implements BasePaginationComponent {
 
   /** Translate all the texts shown in the UI, use ngx-translate service when available or custom locales when service is null */
   translatePaginationTexts(): void {
-    if (this._enableTranslate && this.translaterService?.translate) {
+    if (this._enableTranslate && this._translaterService?.translate) {
       const translationPrefix = getTranslationPrefix(this.gridOptions);
-      this.textItemsPerPage = this.translaterService.translate(`${translationPrefix}ITEMS_PER_PAGE`);
-      this.textItems = this.translaterService.translate(`${translationPrefix}ITEMS`);
-      this.textOf = this.translaterService.translate(`${translationPrefix}OF`);
-      this.textPage = this.translaterService.translate(`${translationPrefix}PAGE`);
+      this.textItemsPerPage = this._translaterService.translate(`${translationPrefix}ITEMS_PER_PAGE`);
+      this.textItems = this._translaterService.translate(`${translationPrefix}ITEMS`);
+      this.textOf = this._translaterService.translate(`${translationPrefix}OF`);
+      this.textPage = this._translaterService.translate(`${translationPrefix}PAGE`);
     } else if (this.locales) {
       this.textItemsPerPage = this.locales.TEXT_ITEMS_PER_PAGE || 'TEXT_ITEMS_PER_PAGE';
       this.textItems = this.locales.TEXT_ITEMS || 'TEXT_ITEMS';
@@ -292,7 +306,7 @@ export class SlickPaginationComponent implements BasePaginationComponent {
     const divElm = createDomElement('div', { className: 'slick-page-number' });
     createDomElement('span', { className: 'text-page', textContent: 'Page' }, divElm);
     divElm.appendChild(document.createTextNode(' '));
-    if (this.paginationService.isCursorBased) {
+    if (this._paginationService.isCursorBased) {
       // cursor based navigation cannot jump to an arbitrary page. Simply display current page number.
       createDomElement('span', {
         className: 'page-number',

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1043,10 +1043,8 @@ export class SlickVanillaGridBundle<TData = any> {
       this.slickGrid.setSelectedRows([]);
     }
     const { pageNumber, pageSize } = pagination;
-    if (this.sharedService) {
-      if (pageSize !== undefined && pageNumber !== undefined) {
-        this.sharedService.currentPagination = { pageNumber, pageSize };
-      }
+    if (this.sharedService && pageSize !== undefined && pageNumber !== undefined) {
+      this.sharedService.currentPagination = { pageNumber, pageSize };
     }
     this._eventPubSubService.publish('onGridStateChanged', {
       change: { newValues: { pageNumber, pageSize }, type: GridStateType.pagination },
@@ -1265,8 +1263,9 @@ export class SlickVanillaGridBundle<TData = any> {
   protected renderPagination(showPagination = true): void {
     if (this.slickGrid && this._gridOptions?.enablePagination && !this._isPaginationInitialized && showPagination) {
       const PaginationClass = this.gridOptions.customPaginationComponent ?? SlickPaginationComponent;
-      this.paginationComponent = new PaginationClass(this.slickGrid, this.paginationService, this._eventPubSubService, this.translaterService);
-      this.paginationComponent!.render(this._gridParentContainerElm);
+      this.paginationComponent = new PaginationClass();
+      this.paginationComponent.init(this.slickGrid, this.paginationService, this._eventPubSubService, this.translaterService);
+      this.paginationComponent.renderPagination(this._gridParentContainerElm);
       this._isPaginationInitialized = true;
     } else if (!showPagination) {
       this.paginationComponent?.dispose();

--- a/test/cypress/e2e/example30.cy.ts
+++ b/test/cypress/e2e/example30.cy.ts
@@ -15,7 +15,8 @@ describe('Example 30 - Custom Pagination', () => {
   });
 
   it('should expect first row to be Task 0', () => {
-    cy.get('#pager.top').should('exist');
+    cy.get('.seek-first').should('have.class', 'disabled');
+    cy.get('.seek-prev').should('have.class', 'disabled');
     cy.get('.item-from').should('contain', 1);
     cy.get('.item-to').should('contain', 50);
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).should('contain', 'Task 0');
@@ -28,6 +29,8 @@ describe('Example 30 - Custom Pagination', () => {
   it('should click on next page and expect top row to be Task 50', () => {
     cy.get('.page-item.seek-next').click();
 
+    cy.get('.seek-first').should('not.have.class', 'disabled');
+    cy.get('.seek-prev').should('not.have.class', 'disabled');
     cy.get('.item-from').should('contain', 51);
     cy.get('.item-to').should('contain', 100);
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).should('contain', 'Task 50');
@@ -40,6 +43,8 @@ describe('Example 30 - Custom Pagination', () => {
   it('should click on goto last page and expect top row to be Task 50', () => {
     cy.get('.page-item.seek-end').click();
 
+    cy.get('.seek-next').should('have.class', 'disabled');
+    cy.get('.seek-end').should('have.class', 'disabled');
     cy.get('.item-from').should('contain', 4951);
     cy.get('.item-to').should('contain', 5000);
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).should('contain', 'Task 4950');
@@ -51,6 +56,8 @@ describe('Example 30 - Custom Pagination', () => {
 
   it('should change page size and expect pagination to be updated', () => {
     cy.get('[data-test="page-size-input"]').type('{backspace}{backspace}75');
+    cy.get('.seek-first').should('have.class', 'disabled');
+    cy.get('.seek-prev').should('have.class', 'disabled');
     cy.get('.item-from').should('contain', 1);
     cy.get('.item-to').should('contain', 75);
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(0)`).should('contain', 'Task 0');
@@ -63,7 +70,6 @@ describe('Example 30 - Custom Pagination', () => {
   it('should toggle pagination position to bottom', () => {
     cy.get('[data-text="toggle-pagination-btn"]').click();
     cy.get('#pager.bottom').should('exist');
-
     cy.get('.page-item.seek-next').click();
 
     cy.get('.item-from').should('contain', 76);


### PR DESCRIPTION
- after giving it a try in Angular/Aurelia-Slickgrid, I discovered that it was better to avoid using any DI, we can simply move them to an `init()` function