### PR TITLE
chore: fix Cypress flaky tests by always setting English locale

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -29,8 +29,8 @@ export default class Example07 {
   duplicateTitleHeaderCount = 1;
   filteringEnabledClass = '';
   sortingEnabledClass = '';
-  selectedLanguage: string;
-  selectedLanguageFile: string;
+  selectedLanguage = 'en';
+  selectedLanguageFile = 'en.json';
   translateService: TranslateService;
 
   set isFilteringEnabled(enabled: boolean) {
@@ -45,7 +45,8 @@ export default class Example07 {
     // get the Translate Service from the window object,
     // it might be better with proper Dependency Injection but this project doesn't have any at this point
     this.translateService = (<any>window).TranslateService;
-    this.selectedLanguage = this.translateService.getCurrentLanguage();
+    this.translateService.use('en');
+    this.selectedLanguage = 'en';
     this.selectedLanguageFile = `${this.selectedLanguage}.json`;
     this.isFilteringEnabled = true;
     this.isSortingEnabled = true;

--- a/examples/vite-demo-vanilla-bundle/src/examples/example10.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example10.ts
@@ -37,8 +37,8 @@ export default class Example10 {
   isWithCursor = false;
   graphqlQuery = '...';
   processing = false;
-  selectedLanguage: string;
-  selectedLanguageFile: string;
+  selectedLanguage = 'en';
+  selectedLanguageFile = 'en.json';
   status = '';
   statusClass = 'is-success';
   translateService: TranslateService;
@@ -49,7 +49,8 @@ export default class Example10 {
     // get the Translate Service from the window object,
     // it might be better with proper Dependency Injection but this project doesn't have any at this point
     this.translateService = (<any>window).TranslateService;
-    this.selectedLanguage = this.translateService.getCurrentLanguage();
+    this.translateService.use('en');
+    this.selectedLanguage = 'en';
     this.selectedLanguageFile = `${this.selectedLanguage}.json`;
   }
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example22.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example22.ts
@@ -21,8 +21,8 @@ export default class Example22 {
   dataset!: any[];
   sgb!: SlickVanillaGridBundle;
   translateService: TranslateService;
-  selectedLanguage: string;
-  selectedLanguageFile: string;
+  selectedLanguage = 'en';
+  selectedLanguageFile = 'en.json';
   fetchResult = '';
   statusClass = 'is-success';
   statusStyle = 'display: none';
@@ -30,7 +30,8 @@ export default class Example22 {
 
   constructor() {
     this.translateService = (<any>window).TranslateService;
-    this.selectedLanguage = this.translateService.getCurrentLanguage();
+    this.translateService.use('en');
+    this.selectedLanguage = 'en';
     this.selectedLanguageFile = `${this.selectedLanguage}.json`;
     this._bindingEventService = new BindingEventService();
   }

--- a/examples/vite-demo-vanilla-bundle/src/examples/example25.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example25.ts
@@ -53,6 +53,9 @@ export default class Example25 {
     // get the Translate Service from the window object,
     // it might be better with proper Dependency Injection but this project doesn't have any at this point
     this.translateService = (<any>window).TranslateService;
+    this.translateService.use('en');
+    this.selectedLanguage = 'en';
+    this.selectedLanguageFile = `${this.selectedLanguage}.json`;
   }
 
   attached() {

--- a/examples/vite-demo-vanilla-bundle/src/examples/example27.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example27.ts
@@ -40,8 +40,8 @@ export default class Example27 {
 
   graphqlQuery = '...';
   processing = false;
-  selectedLanguage: string;
-  selectedLanguageFile: string;
+  selectedLanguage = 'en';
+  selectedLanguageFile = 'en.json';
   status = '';
   statusClass = 'is-success';
   translateService: TranslateService;
@@ -53,7 +53,8 @@ export default class Example27 {
     // get the Translate Service from the window object,
     // it might be better with proper Dependency Injection but this project doesn't have any at this point
     this.translateService = (<any>window).TranslateService;
-    this.selectedLanguage = this.translateService.getCurrentLanguage();
+    this.translateService.use('en');
+    this.selectedLanguage = 'en';
     this.selectedLanguageFile = `${this.selectedLanguage}.json`;
   }
 


### PR DESCRIPTION
- we weren't resetting the locale to English when routing to a new example and in some cases running all Cypress tests locally could pollute the next Example test suite (ie, leaving previous example with French and routing to new example would show up in French when test assumes English)