### PR TITLE
fix: hideColumnByIds() should call setColumn() only once, fix #1728

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.html
@@ -28,6 +28,10 @@
     <span class="mdi mdi-eye-off-outline"></span>
     <span>Dynamically Hide "Finish"</span>
   </button>
+  <button class="button is-small" data-test="show-column-subset-btn" onclick.delegate="showColumnSubset()">
+    <span class="mdi mdi-eye-outline"></span>
+    <span>Show Certain Columns</span>
+  </button>
   <button class="button is-small" data-test="add-item-btn" onclick.delegate="addItem()"
     title="Clear Filters &amp; Sorting to see it better">
     <span class="mdi mdi-plus"></span>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example07.ts
@@ -638,6 +638,11 @@ export default class Example07 {
     // this.sgb.gridService.hideColumnByIds(['duration', 'finish'], { autoResizeColumns: false, hideFromColumnPicker: true, hideFromGridMenu: false });
   }
 
+  showColumnSubset() {
+    // note that calling this function will NOT include dynamically created columns like row selection & row move, you need to include them yourself
+    this.sgb.gridService.showColumnByIds(['_move', '_checkbox_selector', 'title', 'action', 'percentComplete', 'start', 'finish']);
+  }
+
   // Disable/Enable Filtering/Sorting functionalities
   // --------------------------------------------------
 

--- a/packages/common/src/interfaces/hideColumnOption.interface.ts
+++ b/packages/common/src/interfaces/hideColumnOption.interface.ts
@@ -1,5 +1,8 @@
 export interface HideColumnOption {
-  /** Defaults to true, do we want to auto-reize the columns in the grid after hidding the column(s)? */
+  /** Defaults to true, do we want to call `grid.setColumns()` */
+  applySetColumns?: boolean;
+
+  /** Defaults to true, do we want to auto-resize (by calling `grid.autosizeColumns()`) the columns in the grid after hidding the column(s)? */
   autoResizeColumns?: boolean;
 
   /** Defaults to false, do we want to hide the column name from the column picker after hidding the column from the grid? */
@@ -8,6 +11,14 @@ export interface HideColumnOption {
   /** Defaults to false, do we want to hide the column name from the grid menu after hidding the column from the grid? */
   hideFromGridMenu?: boolean;
 
-  /** Defaults to true, do we want to trigger an event "onHeaderMenuHideColumns" after hidding the column(s)? */
+  /** Defaults to true, do we want to trigger an event "onHideColumns" after hidding the column(s)? */
+  triggerEvent?: boolean;
+}
+
+export interface ShowColumnOption {
+  /** Defaults to true, do we want to auto-resize (by calling `grid.autosizeColumns()`) the columns in the grid after hidding the column(s)? */
+  autoResizeColumns?: boolean;
+
+  /** Defaults to true, do we want to trigger an event "onShowColumns" after showing the column(s)? */
   triggerEvent?: boolean;
 }

--- a/test/cypress/e2e/example07.cy.ts
+++ b/test/cypress/e2e/example07.cy.ts
@@ -1188,4 +1188,15 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', () => {
       .click()
       .then(() => expect(stub.getCall(0)).to.be.calledWith('Command: contact-chat'));
   });
+
+  it('should be able to show certain defined columns', () => {
+    const expectedTitles = ['', '', 'Title', 'Action', '% Complete', 'Start', 'Finish'];
+
+    cy.get('[data-test="show-column-subset-btn"]').click();
+
+    cy.get('.grid7')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+  });
 });


### PR DESCRIPTION
fixes #1728 
- we should only ever call `setColumn()` once when hiding multiple columns to avoid perf issues
- also add `showColumnByIds()` to align with `hideColumnByIds()`