### PR TITLE
fix: hiding column(s) returned incorrect Grid State changes data

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example09.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example09.ts
@@ -1,5 +1,5 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { type Column, FieldType, Filters, type GridOption, type GridStateChange, type Metrics, OperatorType, type GridState, CurrentColumn, } from '@slickgrid-universal/common';
+import { type Column, FieldType, Filters, type GridOption, type GridStateChange, type Metrics, OperatorType, type GridState, type CurrentColumn, } from '@slickgrid-universal/common';
 import { GridOdataService, type OdataServiceApi, type OdataOption } from '@slickgrid-universal/odata';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 

--- a/examples/vite-demo-vanilla-bundle/src/examples/example09.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example09.ts
@@ -1,5 +1,5 @@
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { type Column, FieldType, Filters, type GridOption, type GridStateChange, type Metrics, OperatorType, type GridState, } from '@slickgrid-universal/common';
+import { type Column, FieldType, Filters, type GridOption, type GridStateChange, type Metrics, OperatorType, type GridState, CurrentColumn, } from '@slickgrid-universal/common';
 import { GridOdataService, type OdataServiceApi, type OdataOption } from '@slickgrid-universal/odata';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 
@@ -429,8 +429,11 @@ export default class Example09 {
   gridStateChanged(event) {
     if (event?.detail) {
       const gridStateChanges: GridStateChange = event.detail;
-      // console.log('Client sample, Grid State changed:: ', gridStateChanges);
-      console.log('Client sample, Grid State changed:: ', gridStateChanges.change);
+      // console.log('Grid State changed:: ', gridStateChanges);
+      console.log('Grid State changed:: ', gridStateChanges.change);
+      if (gridStateChanges.change?.type === 'columns') {
+        console.log(`Grid State changed, ${(gridStateChanges.change.newValues as CurrentColumn[]).length} columns displayed`);
+      }
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(gridStateChanges.gridState));
     }

--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -940,7 +940,7 @@ describe('GridStateService', () => {
       expect(pubSubSpy).toHaveBeenCalledWith(`onGridStateChanged`, stateChangeMock);
     });
 
-    it('should trigger a "onGridStateChanged" event when "onHeaderMenuHideColumns" is triggered', () => {
+    it('should trigger a "onGridStateChanged" event when "onHeaderMenuHideColumns", "onHideColumns" or "onShowColumns" are triggered', () => {
       const columnsMock1 = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const currentColumnsMock1 = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
       const gridStateMock = { columns: currentColumnsMock1, filters: [], sorters: [] } as GridState;
@@ -949,27 +949,13 @@ describe('GridStateService', () => {
       const getCurGridStateSpy = vi.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
       const getAssocCurColSpy = vi.spyOn(service, 'getAssociatedCurrentColumns').mockReturnValue(currentColumnsMock1);
 
-      fnCallbacks['onHeaderMenuHideColumns'](columnsMock1);
+      for (const eventName of ['onHeaderMenuHideColumns', 'onHideColumns', 'onShowColumns']) {
+        fnCallbacks[eventName](columnsMock1);
 
-      expect(getCurGridStateSpy).toHaveBeenCalled();
-      expect(getAssocCurColSpy).toHaveBeenCalled();
-      expect(pubSubSpy).toHaveBeenCalledWith(`onGridStateChanged`, stateChangeMock);
-    });
-
-    it('should trigger a "onGridStateChanged" event when "onHideColumns" is triggered', () => {
-      const columnsMock1 = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
-      const currentColumnsMock1 = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
-      const gridStateMock = { columns: currentColumnsMock1, filters: [], sorters: [] } as GridState;
-      const stateChangeMock = { change: { newValues: currentColumnsMock1, type: GridStateType.columns }, gridState: gridStateMock } as GridStateChange;
-      const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
-      const getCurGridStateSpy = vi.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
-      const getAssocCurColSpy = vi.spyOn(service, 'getAssociatedCurrentColumns').mockReturnValue(currentColumnsMock1);
-
-      fnCallbacks['onHideColumns'](columnsMock1);
-
-      expect(getCurGridStateSpy).toHaveBeenCalled();
-      expect(getAssocCurColSpy).toHaveBeenCalled();
-      expect(pubSubSpy).toHaveBeenCalledWith(`onGridStateChanged`, stateChangeMock);
+        expect(getCurGridStateSpy).toHaveBeenCalled();
+        expect(getAssocCurColSpy).toHaveBeenCalled();
+        expect(pubSubSpy).toHaveBeenCalledWith('onGridStateChanged', stateChangeMock);
+      }
     });
 
     it('should trigger a "onGridStateChanged" event when "onTreeItemToggled" is triggered', () => {

--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -34,7 +34,13 @@ vi.useFakeTimers();
 const fnCallbacks = {};
 const mockPubSub = {
   publish: vi.fn(),
-  subscribe: (eventName, fn) => fnCallbacks[eventName as string] = fn,
+  subscribe: (eventName, fn) => {
+    if (Array.isArray(eventName)) {
+      eventName.forEach(ev => fnCallbacks[ev as string] = fn);
+    } else {
+      fnCallbacks[eventName as string] = fn;
+    }
+  },
   unsubscribe: vi.fn(),
   unsubscribeAll: vi.fn(),
 } as BasePubSubService;
@@ -944,6 +950,22 @@ describe('GridStateService', () => {
       const getAssocCurColSpy = vi.spyOn(service, 'getAssociatedCurrentColumns').mockReturnValue(currentColumnsMock1);
 
       fnCallbacks['onHeaderMenuHideColumns'](columnsMock1);
+
+      expect(getCurGridStateSpy).toHaveBeenCalled();
+      expect(getAssocCurColSpy).toHaveBeenCalled();
+      expect(pubSubSpy).toHaveBeenCalledWith(`onGridStateChanged`, stateChangeMock);
+    });
+
+    it('should trigger a "onGridStateChanged" event when "onHideColumns" is triggered', () => {
+      const columnsMock1 = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
+      const currentColumnsMock1 = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+      const gridStateMock = { columns: currentColumnsMock1, filters: [], sorters: [] } as GridState;
+      const stateChangeMock = { change: { newValues: currentColumnsMock1, type: GridStateType.columns }, gridState: gridStateMock } as GridStateChange;
+      const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
+      const getCurGridStateSpy = vi.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
+      const getAssocCurColSpy = vi.spyOn(service, 'getAssociatedCurrentColumns').mockReturnValue(currentColumnsMock1);
+
+      fnCallbacks['onHideColumns'](columnsMock1);
 
       expect(getCurGridStateSpy).toHaveBeenCalled();
       expect(getAssocCurColSpy).toHaveBeenCalled();

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -428,10 +428,10 @@ export class GridStateService {
       });
     }
 
-    // subscribe to HeaderMenu (hide column)
+    // subscribe to HeaderMenu & GridService show/hide column(s)
     this._subscriptions.push(
-      this.pubSubService.subscribe<Column[]>('onHeaderMenuHideColumns', visibleColumns => {
-        const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(visibleColumns);
+      this.pubSubService.subscribe<{ columns: Column[]; hiddenColumn?: Column; }>(['onHeaderMenuHideColumns', 'onHideColumns', 'onShowColumns'], data => {
+        const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(data.columns);
         this.pubSubService.publish('onGridStateChanged', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       })
     );

--- a/test/cypress/e2e/example09.cy.ts
+++ b/test/cypress/e2e/example09.cy.ts
@@ -63,7 +63,7 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 3, pageSize: 20 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 3, pageSize: 20 }, type: 'pagination' });
       });
     });
 
@@ -97,7 +97,7 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -130,7 +130,7 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -164,7 +164,7 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -198,7 +198,7 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -240,8 +240,8 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(2);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: [], type: 'filter' });
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: [], type: 'filter' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -267,7 +267,7 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: [], type: 'sorter' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: [], type: 'sorter' });
       });
     });
 
@@ -646,8 +646,8 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().then((win) => {
         // expect(win.console.log).to.have.callCount(2);
-        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: [{ columnId: 'name', operator: 'Contains', searchTerms: ['x'], targetSelector: 'input.form-control.filter-name.compound-input.filled' }], type: 'filter' });
-        // expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: [{ columnId: 'name', operator: 'Contains', searchTerms: ['x'], targetSelector: 'input.form-control.filter-name.compound-input.filled' }], type: 'filter' });
+        // expect(win.console.log).to.be.calledWith('Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -997,6 +997,27 @@ describe('Example 09 - OData Grid', () => {
 
       cy.window().its('localStorage').invoke('getItem', STORAGE_KEY)
         .should('be.null');
+    });
+
+    it('should hide column from header menu and expect grid state change to reflect that', () => {
+      cy.get('.grid9')
+        .find('.slick-header-column:nth(2)')
+        .trigger('mouseover')
+        .children('.slick-header-menu-button')
+        .invoke('show')
+        .click();
+
+      cy.get('.slick-header-menu .slick-menu-command-list')
+        .should('be.visible')
+        .children('.slick-menu-item:nth-of-type(8)')
+        .children('.slick-menu-content')
+        .should('contain', 'Hide Column')
+        .click();
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(2);
+        expect(win.console.log).to.be.calledWith('Grid State changed, 4 columns displayed');
+      });
     });
   });
 });


### PR DESCRIPTION
hiding columns is triggering an event which was maybe an array of columns in the past but it probably changed to an object of shape `{ columns, hiddenColumn }` later on, however the Grid State subscribing to this event was never updated causing the Grid State to return incorrect data in its metadata