### PR TITLE
fix: hideColumnByIds wasn't hiding columns properly

### DIFF
--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -90,7 +90,7 @@ describe('GridMenuControl', () => {
   const columnsMock: Column[] = [
     { id: 'field1', field: 'field1', name: 'Field 1', width: 100, nameKey: 'TITLE' },
     { id: 'field2', field: 'field2', name: 'Field 2', width: 75 },
-    { id: 'field3', field: 'field3', name: 'Field 3', width: 75, columnGroup: 'Billing' },
+    { id: 'field3', field: 'field3', name: 'Field 3', width: 75, columnGroup: 'Billing', excludeFromGridMenu: true },
   ];
   let backendUtilityService: BackendUtilityService;
   let extensionUtility: ExtensionUtility;
@@ -681,7 +681,11 @@ describe('GridMenuControl', () => {
         const forceFitElm = control.menuElement!.querySelector('#slickgrid_124343-gridmenu-colpicker-forcefit') as HTMLInputElement;
         const inputSyncElm = control.menuElement!.querySelector('#slickgrid_124343-gridmenu-colpicker-syncresize') as HTMLInputElement;
         const pickerField1Elm = document.querySelector('input[type="checkbox"][data-columnid="field1"]') as HTMLInputElement;
+        const li2Elm = document.querySelector('.slick-column-picker-list li:nth-of-type(2)') as HTMLLIElement;
+        const li3Elm = document.querySelector('.slick-column-picker-list li:nth-of-type(3)') as HTMLLIElement;
         expect(pickerField1Elm.checked).toBe(true);
+        expect(li2Elm.className).not.toBe('hidden');
+        expect(li3Elm.className).toBe('hidden');
         pickerField1Elm.checked = false;
         pickerField1Elm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
 
@@ -1559,12 +1563,12 @@ describe('GridMenuControl', () => {
         const columnsUnorderedMock: Column[] = [
           { id: 'field2', field: 'field2', name: 'Field 2', width: 75 },
           { id: 'field1', field: 'field1', name: 'Titre', width: 100, nameKey: 'TITLE' },
-          { id: 'field3', field: 'field3', name: 'Field 3', width: 75, columnGroup: 'Billing' },
+          { id: 'field3', field: 'field3', name: 'Field 3', width: 75, columnGroup: 'Billing', excludeFromGridMenu: true },
         ];
         const columnsMock: Column[] = [
           { id: 'field1', field: 'field1', name: 'Titre', width: 100, nameKey: 'TITLE' },
           { id: 'field2', field: 'field2', name: 'Field 2', width: 75 },
-          { id: 'field3', field: 'field3', name: 'Field 3', width: 75, columnGroup: 'Billing' },
+          { id: 'field3', field: 'field3', name: 'Field 3', width: 75, columnGroup: 'Billing', excludeFromGridMenu: true },
         ];
         vi.spyOn(gridStub, 'getColumnIndex').mockReturnValue(undefined as any).mockReturnValueOnce(0).mockReturnValueOnce(1);
         const handlerSpy = vi.spyOn(control.eventHandler, 'subscribe');
@@ -1630,7 +1634,7 @@ describe('GridMenuControl', () => {
       expect(columnsMock).toEqual([
         { id: 'field1', field: 'field1', name: 'Titre', width: 100, nameKey: 'TITLE' },
         { id: 'field2', field: 'field2', name: 'Field 2', width: 75 },
-        { id: 'field3', field: 'field3', name: 'Field 3', columnGroup: 'Billing', width: 75 },
+        { id: 'field3', field: 'field3', name: 'Field 3', columnGroup: 'Billing', width: 75, excludeFromGridMenu: true },
       ]);
       expect(control.getAllColumns()).toEqual(columnsMock);
       expect(control.getVisibleColumns()).toEqual(columnsMock);

--- a/packages/common/src/extensions/extensionCommonUtils.ts
+++ b/packages/common/src/extensions/extensionCommonUtils.ts
@@ -150,12 +150,13 @@ function generatePickerCheckbox(columnLiElm: HTMLLIElement, inputId: string, inp
 
 export function populateColumnPicker(this: SlickColumnPicker | SlickGridMenu, addonOptions: ColumnPickerOption | GridMenuOption): void {
   const context: any = this;
-  const menuPrefix = context instanceof SlickGridMenu ? 'gridmenu-' : '';
+  const isGridMenu = context instanceof SlickGridMenu;
+  const menuPrefix = isGridMenu ? 'gridmenu-' : '';
 
   for (const column of context.columns) {
     const columnId = column.id;
     const columnLiElm = document.createElement('li');
-    if (column.excludeFromColumnPicker) {
+    if ((column.excludeFromColumnPicker && !isGridMenu) || (column.excludeFromGridMenu && isGridMenu)) {
       columnLiElm.className = 'hidden';
     }
 

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -223,7 +223,7 @@ export class GridService {
         }
 
         // execute common grid commands when enabled
-        this.executeResizeTrigger(options, ['onHeaderMenuHideColumns'], visibleColumns);
+        this.executeVisibilityCommands(options, ['onHeaderMenuHideColumns'], visibleColumns);
         return colIndexFound;
       }
     }
@@ -250,7 +250,7 @@ export class GridService {
 
       // execute common grid commands when enabled
       // @deprecate `onHeaderMenuHideColumns` event, we should keep only `onHideColumns`
-      this.executeResizeTrigger(options, ['onHeaderMenuHideColumns', 'onHideColumns'], finalVisibileColumns);
+      this.executeVisibilityCommands(options, ['onHeaderMenuHideColumns', 'onHideColumns'], finalVisibileColumns);
     }
   }
 
@@ -267,11 +267,11 @@ export class GridService {
       this.sharedService.visibleColumns = columns;
 
       // execute common grid commands when enabled
-      this.executeResizeTrigger(options, ['onShowColumns'], this.sharedService.visibleColumns);
+      this.executeVisibilityCommands(options, ['onShowColumns'], this.sharedService.visibleColumns);
     }
   }
 
-  protected executeResizeTrigger(options: { autoResizeColumns?: boolean; triggerEvent?: boolean; }, eventNames: string[], columns: Column[]): void {
+  protected executeVisibilityCommands(options: { autoResizeColumns?: boolean; triggerEvent?: boolean; }, eventNames: string[], columns: Column[]): void {
     // do we want to auto-resize the columns in the grid after hidding/showing columns?
     if (options?.autoResizeColumns) {
       this._grid.autosizeColumns();


### PR DESCRIPTION
tested a bit more after previous PR #1736 and found couple of small issues
- calling `hideColumnByIds()` for multiple columns wasn't working correctly
- also the options `hideFromColumnPicker` and `hideFromGridMenu` were incorrectly tied together meaning that when `hideFromColumnPicker` was enabled, it was also hiding them in the GridMenu as well which is wrong
- lastly I've done a refactor to remove duplicate code of calling some grid commands when options `autoResizeColumns` and `triggerEvent` are enabled.