### PR TITLE
fix: ExternalCopyManager shouldn't change body scroll pos when pasting

### DIFF
--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -215,13 +215,15 @@ export class SlickCellExternalCopyManager {
   // ---------------------
 
   protected createTextBox(innerText: string): HTMLTextAreaElement {
-    const textAreaElm = createDomElement(
-      'textarea',
-      {
-        value: innerText,
-        style: { position: 'absolute', left: '-1000px', top: `${document.body.scrollTop}px`, }
-      },
-      this._bodyElement);
+    const scrollPos = document.documentElement.scrollTop || document.body.scrollTop;
+    const textAreaElm = createDomElement('textarea', {
+      value: innerText,
+      style: {
+        position: 'absolute',
+        opacity: '0',
+        top: `${scrollPos}px`
+      }
+    }, this._bodyElement);
     textAreaElm.select();
 
     return textAreaElm;


### PR DESCRIPTION
- using SlickExternalCopyManager plugin shouldn't change scroll position when copy/pasting values in the grid
- issue was identified in SlickGrid with a fix published in that repo as well

![Code_ekFXu2AffX](https://github.com/user-attachments/assets/bf43056e-dc06-44b6-bd5a-f810e82442e1)