### PR TITLE
fix: setting filter dynamically shouldn't make body taller

### DIFF
--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.html
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.html
@@ -59,6 +59,13 @@
             onclick.delegate="groupByDurationEffortDriven()">
       Group by Duration then Effort-Driven
     </button>
+    <button class="button is-small" data-test="set-dynamic-filter"
+            onclick.delegate="setFiltersDynamically()">
+      <span class="mdi mdi-filter-outline"></span>
+      <span>
+        Set Filters Dynamically
+      </span>
+    </button>
     <span class.bind="loadingClass"></span>
   </div>
 </section>

--- a/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example03.ts
@@ -462,6 +462,14 @@ export default class Example03 {
     }
   }
 
+  setFiltersDynamically() {
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.sgb.filterService.updateFilters([
+      { columnId: 'percentComplete', operator: '>=', searchTerms: ['55'] },
+      { columnId: 'cost', operator: '<', searchTerms: ['80'] },
+    ]);
+  }
+
   showTopHeader() {
     this.sgb?.slickGrid?.setTopHeaderPanelVisibility(true);
   }

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -909,6 +909,13 @@ li.hidden {
 .vanilla-calendar {
   padding: 0.9rem;
   z-index: 9999;
+
+  // when setting filters dynamically, the calendar picker is appended to the body
+  // making the body taller and unnecessary scrollable
+  &.vanilla-calendar_hidden {
+    left: 0;
+    top: 0;
+  }
 }
 
 


### PR DESCRIPTION
- when setting filters dynamically, the calendar picker is appended to the body without being repositioning which is making the body taller and unnecessary scrollable
- to fix this issue, we can simply preset hidden calendar picker at position 0,0

![brave_E5rX3Q4jjW](https://github.com/user-attachments/assets/d21ed2be-42ec-439f-b2c8-7fa412ad3be7)
