### PR TITLE
fix: input filter loses focus after edit+filtering with `enableExcelCopyBuffer`

### DIFF
--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -81,7 +81,7 @@ export class SlickCellExternalCopyManager {
 
     // we give focus on the grid when a selection is done on it (unless it's an editor, if so the editor should have already set focus to the grid prior to editing a cell).
     // without this, if the user selects a range of cell without giving focus on a particular cell, the grid doesn't get the focus and key stroke handles (ctrl+c) don't work
-    this._eventHandler.subscribe(cellSelectionModel.onSelectedRangesChanged, (_e, ranges) => {
+    this._eventHandler.subscribe(cellSelectionModel.onSelectedRangesChanged, () => {
       if (!this._grid.getEditorLock().isActive() && !document.activeElement?.classList.contains('slick-filter')) {
         this._grid.focus();
       }

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -81,8 +81,8 @@ export class SlickCellExternalCopyManager {
 
     // we give focus on the grid when a selection is done on it (unless it's an editor, if so the editor should have already set focus to the grid prior to editing a cell).
     // without this, if the user selects a range of cell without giving focus on a particular cell, the grid doesn't get the focus and key stroke handles (ctrl+c) don't work
-    this._eventHandler.subscribe(cellSelectionModel.onSelectedRangesChanged, () => {
-      if (!this._grid.getEditorLock().isActive()) {
+    this._eventHandler.subscribe(cellSelectionModel.onSelectedRangesChanged, (_e, ranges) => {
+      if (!this._grid.getEditorLock().isActive() && ranges.length) {
         this._grid.focus();
       }
     });

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -82,7 +82,7 @@ export class SlickCellExternalCopyManager {
     // we give focus on the grid when a selection is done on it (unless it's an editor, if so the editor should have already set focus to the grid prior to editing a cell).
     // without this, if the user selects a range of cell without giving focus on a particular cell, the grid doesn't get the focus and key stroke handles (ctrl+c) don't work
     this._eventHandler.subscribe(cellSelectionModel.onSelectedRangesChanged, (_e, ranges) => {
-      if (!this._grid.getEditorLock().isActive() && ranges.length) {
+      if (!this._grid.getEditorLock().isActive() && ranges.length && !document.activeElement?.classList.contains('slick-filter')) {
         this._grid.focus();
       }
     });

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -82,7 +82,7 @@ export class SlickCellExternalCopyManager {
     // we give focus on the grid when a selection is done on it (unless it's an editor, if so the editor should have already set focus to the grid prior to editing a cell).
     // without this, if the user selects a range of cell without giving focus on a particular cell, the grid doesn't get the focus and key stroke handles (ctrl+c) don't work
     this._eventHandler.subscribe(cellSelectionModel.onSelectedRangesChanged, (_e, ranges) => {
-      if (!this._grid.getEditorLock().isActive() && ranges.length && !document.activeElement?.classList.contains('slick-filter')) {
+      if (!this._grid.getEditorLock().isActive() && !document.activeElement?.classList.contains('slick-filter')) {
         this._grid.focus();
       }
     });

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -393,7 +393,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
       ariaLabel: this.columnFilter?.ariaLabel ?? `${toSentenceCase(columnId + '')} Search Filter`,
       autocomplete: 'off', ariaAutoComplete: 'none',
       placeholder,
-      className: `form-control search-filter filter-${columnId} slick-autocomplete-container`,
+      className: `form-control search-filter slick-filter filter-${columnId} slick-autocomplete-container`,
       value: (searchTerm ?? '') as string,
       dataset: { columnid: `${columnId}` }
     });

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -448,7 +448,7 @@ export class DateFilter implements Filter {
 
     if (this.inputFilterType === 'range') {
       // if there's a search term, we will add the "filled" class for styling purposes
-      const inputContainerElm = createDomElement('div', { className: `date-picker form-group search-filter filter-${columnId}` });
+      const inputContainerElm = createDomElement('div', { className: `date-picker form-group search-filter slick-filter filter-${columnId}` });
 
       if (Array.isArray(searchTerms) && searchTerms.length > 0 && searchTerms[0] !== '') {
         this._currentDateOrDates = searchTerms as Date[];

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -316,7 +316,7 @@ export class InputFilter implements Filter {
       this.callback(event, { columnDef: this.columnDef, clearFilterTriggered: isClearFilterEvent, shouldTriggerQuery: this._shouldTriggerQuery });
       this.updateFilterStyle(false);
     } else {
-      const eventType = event?.type ?? '';
+      const eventType = event?.type || '';
       const selectedOperator = (this._selectOperatorElm?.value ?? this.operator) as OperatorString;
       let value = this._filterInputElm.value;
       const enableWhiteSpaceTrim = this.gridOptions.enableFilterTrimWhiteSpace || this.columnFilter.enableTrimWhiteSpace;

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -280,7 +280,7 @@ export class InputFilter implements Filter {
     if (this.inputFilterType === 'single') {
       this._filterContainerElm = this._filterInputElm;
       // append the new DOM element to the header row & an empty span
-      this._filterInputElm.classList.add('search-filter');
+      this._filterInputElm.classList.add('search-filter', 'slick-filter');
       this._cellContainerElm.appendChild(this._filterInputElm);
       this._cellContainerElm.appendChild(document.createElement('span'));
     } else {

--- a/packages/common/src/filters/sliderFilter.ts
+++ b/packages/common/src/filters/sliderFilter.ts
@@ -322,7 +322,7 @@ export class SliderFilter implements Filter {
     // put all DOM elements together to create the final Slider
     const hideSliderNumbers = (this.filterOptions as SliderOption)?.hideSliderNumber ?? (this.filterOptions as SliderRangeOption)?.hideSliderNumbers;
     const sliderNumberClass = hideSliderNumbers ? '' : 'input-group';
-    this._divContainerFilterElm = createDomElement('div', { className: `${sliderNumberClass} search-filter slider-container slider-values filter-${columnId}`.trim() });
+    this._divContainerFilterElm = createDomElement('div', { className: `${sliderNumberClass} search-filter slick-filter slider-container slider-values filter-${columnId}`.trim() });
 
     this._sliderRangeContainElm.appendChild(this._sliderTrackElm);
     if (this.sliderType === 'double' && this._sliderLeftInputElm) {


### PR DESCRIPTION
- some changes made in PR #917 caused a small issue but only when `enableExcelCopyBuffer` is set, which only happen after these 2 steps
  1. click on a cell to open an editor
  2. focus on a filter then start typing, the filter will lose focus because it was sent to the grid 
- the issue can be reproduced in Slickgrid-Universal Example 13 (or Angular-Slickgrid Example 3 as shown below)

![brave_26DdOI28Gf](https://github.com/user-attachments/assets/d88867d7-7ad7-4869-bc60-3afe0c759324)
