### PR TITLE
fix: ensure DOM alterations during initialization are always cleaned up

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -966,6 +966,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   /** handles "display:none" on container or container parents, related to issue: https://github.com/6pac/SlickGrid/issues/568 */
   cacheCssForHiddenInit(): void {
     this._hiddenParents = Utils.parents(this._container, ':hidden') as HTMLElement[];
+    this.oldProps = [];
     this._hiddenParents.forEach(el => {
       const old: Partial<CSSStyleDeclaration> = {};
       Object.keys(this.cssShow).forEach(name => {
@@ -991,6 +992,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           }
         });
       });
+      this._hiddenParents = [];
     }
   }
 


### PR DESCRIPTION
- this change was implemented in this SlickGrid [PR](https://github.com/6pac/SlickGrid/pull/1085) and I'm not sure that it will make any differences in here since SlickGrid has its own (different) auto-resizer and part of the code doesn't exists in here (only a small portion of the code was copied over), so this change might or not help at all. 