### PR TITLE
fix: add "frozen" class to all slick-pane for easier styling

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -875,6 +875,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       }
 
       this.setFrozenOptions();
+      this.setPaneFrozenClasses();
       this.setPaneVisibility();
       this.setScroller();
       this.setOverflow();
@@ -2285,6 +2286,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
+  /** add/remove frozen class to left headers/footer when defined */
+  protected setPaneFrozenClasses(): void {
+    const classAction = this.hasFrozenColumns() ? 'add' : 'remove';
+    for (const elm of [this._paneHeaderL, this._paneTopL, this._paneBottomL]) {
+      elm.classList[classAction]('frozen');
+    }
+  }
+
   protected setPaneVisibility(): void {
     if (this.hasFrozenColumns()) {
       Utils.show(this._paneHeaderR);
@@ -3017,6 +3026,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.updateColumnCaches();
 
     if (this.initialized) {
+      this.setPaneFrozenClasses();
       this.setPaneVisibility();
       this.setOverflow();
       this.invalidateAllRows();

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -174,9 +174,6 @@ $slick-header-scroll-width-to-remove:                       16px !default;      
 /* Frozen pinned rows/columns */
 $slick-frozen-border-bottom:                                1px solid #a5a5a5 !default;
 $slick-frozen-border-right:                                 1px solid #a5a5a5 !default;
-$slick-frozen-preheader-row-border-right:                   $slick-frozen-border-right !default;
-$slick-frozen-header-row-border-right:                      $slick-frozen-border-right !default;
-$slick-frozen-filter-row-border-right:                      $slick-frozen-border-right !default;
 $slick-frozen-overflow-right:                               scroll !default;                      // typically we would like to always have the scroll displayed when using hamburger menu (top right)
 
 /* icons */

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -758,22 +758,8 @@
   }
 
   /** Frozen/Pinned styling */
-
-  .slick-row .slick-cell.frozen:last-child,
-  .slick-footerrow-column.frozen:last-child {
+  .slick-pane-left.frozen {
     border-right: var(--slick-frozen-border-right, v.$slick-frozen-border-right);
-  }
-  .slick-header-column.frozen:last-child {
-    border-right: var(--slick-frozen-header-row-border-right, v.$slick-frozen-header-row-border-right);
-  }
-  .slick-pane-left {
-    .slick-preheader-panel .slick-header-column.frozen:last-child,
-    .slick-topheader-panel .slick-header-column.frozen:last-child {
-      border-right: var(--slick-frozen-preheader-row-border-right, v.$slick-frozen-preheader-row-border-right);
-    }
-  }
-  .slick-headerrow-column.frozen:last-child {
-    border-right: var(--slick-frozen-filter-row-border-right, v.$slick-frozen-filter-row-border-right);
   }
 
   .slick-pane-bottom {


### PR DESCRIPTION
- prior to this PR, we needed to add frozen broder style on last header/columns, this was not only hard to style, it also wasn't styled correctly in the UI. by adding the "frozen" class directly on every left pane (when frozen column is enabled) makes it much easier to style the UI correctly
- NOTE: since we can now style the frozen pane with 1 line, I deleted a bunch of SASS/CSS variables that are no longer necessary 
  - `$slick-frozen-preheader-row-border-right`
  - `$slick-frozen-header-row-border-right`
  - `$slick-frozen-filter-row-border-right`

### before

![image](https://github.com/user-attachments/assets/51ef8cf2-7413-4007-b380-80398771386b)

### after

![image](https://github.com/user-attachments/assets/64000fe7-c5b8-4e04-b4e5-7fd9e805de51)
