### PR TITLE
fix: add missing collection observer in Vue grid implementation

### DIFF
--- a/demos/vue/src/components/Example03.vue
+++ b/demos/vue/src/components/Example03.vue
@@ -592,9 +592,7 @@ function dynamicallyAddTitleHeader() {
   };
 
   // you can dynamically add your column to your column definitions
-  // and then use the spread operator [...cols] OR slice to force Vue to review the changes
   columnDefinitions.value.push(newCol);
-  columnDefinitions.value = [...columnDefinitions.value];
 
   // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
   // you MUST use "getAllColumnDefinitions()" from the GridService, using this will be ALL columns including the 1st column that is created internally
@@ -602,19 +600,16 @@ function dynamicallyAddTitleHeader() {
   /*
     const allColumns = vueGrid.gridService.getAllColumnDefinitions();
     allColumns.push(newCol);
-    columnDefinitions = [...allColumns]; // (or use slice) reassign to column definitions for Vue to do dirty checking
     */
 }
 
 function dynamicallyRemoveLastColumn() {
   columnDefinitions.value.pop();
-  columnDefinitions.value = [...columnDefinitions.value];
 
   /*
     // remove your column the full set of columns
-    // and use slice or spread [...] to trigger an Vue dirty change
     allOriginalColumns.pop();
-    */
+  */
 }
 
 function setAutoEdit(autoEdit: boolean) {

--- a/demos/vue/src/components/Example16.vue
+++ b/demos/vue/src/components/Example16.vue
@@ -260,7 +260,6 @@ function addEditDeleteColumns() {
     // for example if you use the Checkbox Selector (row selection), you MUST use the code below
     const allColumns = vueGrid.gridService.getAllColumnDefinitions();
     allColumns.unshift(newCols[0], newCols[1]);
-    columnDefinitions.value = [...allColumns]; // (or use slice) reassign to column definitions for Vue to do dirty checking
   }
 }
 

--- a/demos/vue/src/components/Example16.vue
+++ b/demos/vue/src/components/Example16.vue
@@ -260,6 +260,7 @@ function addEditDeleteColumns() {
     // for example if you use the Checkbox Selector (row selection), you MUST use the code below
     const allColumns = vueGrid.gridService.getAllColumnDefinitions();
     allColumns.unshift(newCols[0], newCols[1]);
+    columnDefinitions.value = [...allColumns]; // (or use slice) reassign to column definitions for Vue to do dirty checking
   }
 }
 

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -7,6 +7,7 @@ import {
   BackendUtilityService,
   type BasePaginationComponent,
   type BasePaginationModel,
+  collectionObserver,
   CollectionService,
   type Column,
   type DataViewOption,
@@ -93,6 +94,7 @@ const backendService = computed(() => gridOptionsModel.value?.backendServiceApi?
 let currentDatasetLength = 0;
 let dataview: SlickDataView<any> | null = null;
 let grid: SlickGrid;
+let collectionObservers: Array<null | ({ disconnect: () => void; })> = [];
 let groupItemMetadataProvider: SlickGroupItemMetadataProvider | undefined;
 let hideHeaderRowAfterPageLoad = false;
 let isAutosizeColsCalled = false;
@@ -342,7 +344,11 @@ onMounted(() => {
   if (dataHierarchicalModel.value) {
     sharedService.hierarchicalDataset = dataHierarchicalModel.value || [];
   }
+
   suggestDateParsingWhenHelpful();
+
+  // subscribe to column definitions assignment changes
+  observeColumnDefinitions();
 });
 
 function columnDefinitionsChanged(columnDefinitions?: Column[]) {
@@ -596,7 +602,7 @@ function disposing(shouldEmptyDomElementContainer = false) {
   if (shouldEmptyDomElementContainer) {
     emptyGridContainerElm();
   }
-
+  collectionObservers.forEach(obs => obs?.disconnect());
   eventPubSubService.publish('onAfterGridDestroyed', true);
 
   // dispose of all Services
@@ -1185,15 +1191,14 @@ function updateColumnDefinitionsList(newColumnDefinitions: Column<any>[]) {
 }
 
 /**
- * assignment changes are not triggering a "columnDefinitionsChanged" event https://stackoverflow.com/a/30286225/1212166
- * we can use array observer for these other changes done via (push, pop, ...)
- * see docs https://docs.aurelia.io/components/bindable-properties#calling-a-change-function-when-bindable-is-modified
+ * assignment changes are not triggering on the column definitions, for that
+ * we can use our internal array observer for any changes done via (push, pop, shift, ...)
  */
-// function observeColumnDefinitions() {
-//   _columnDefinitionObserver?.unsubscribe(columnDefinitionsModel.valueSubscriber);
-//   _columnDefinitionObserver = observerLocator.getArrayObserver(columnDefinitions);
-//   _columnDefinitionObserver.subscribe(columnDefinitionsModel.valueSubscriber);
-// }
+function observeColumnDefinitions() {
+  collectionObservers.push(
+    collectionObserver(columnDefinitionsModel.value, columnDefinitionsChanged)
+  );
+}
 
 /**
  * Loop through all column definitions and copy the original optional `width` properties optionally provided by the user.

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -94,7 +94,7 @@ const backendService = computed(() => gridOptionsModel.value?.backendServiceApi?
 let currentDatasetLength = 0;
 let dataview: SlickDataView<any> | null = null;
 let grid: SlickGrid;
-let collectionObservers: Array<null | ({ disconnect: () => void; })> = [];
+let collectionObservers: Array<null | { disconnect: () => void }> = [];
 let groupItemMetadataProvider: SlickGroupItemMetadataProvider | undefined;
 let hideHeaderRowAfterPageLoad = false;
 let isAutosizeColsCalled = false;
@@ -602,7 +602,7 @@ function disposing(shouldEmptyDomElementContainer = false) {
   if (shouldEmptyDomElementContainer) {
     emptyGridContainerElm();
   }
-  collectionObservers.forEach(obs => obs?.disconnect());
+  collectionObservers.forEach((obs) => obs?.disconnect());
   eventPubSubService.publish('onAfterGridDestroyed', true);
 
   // dispose of all Services
@@ -1195,9 +1195,7 @@ function updateColumnDefinitionsList(newColumnDefinitions: Column<any>[]) {
  * we can use our internal array observer for any changes done via (push, pop, shift, ...)
  */
 function observeColumnDefinitions() {
-  collectionObservers.push(
-    collectionObserver(columnDefinitionsModel.value, columnDefinitionsChanged)
-  );
+  collectionObservers.push(collectionObserver(columnDefinitionsModel.value, columnDefinitionsChanged));
 }
 
 /**


### PR DESCRIPTION
use our custom collection observer to watch for column definitions changes push/pop since that is not observed by default in the Vue watch (not without deep watch anyway)