### PR TITLE
feat(vue): make I18Next totally optional in Slickgrid-Vue

### DIFF
--- a/demos/vue/src/App.vue
+++ b/demos/vue/src/App.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { provide } from 'vue';
+
 import VueLogo from './assets/vue.svg?url';
 import { routes } from './router';
+
+provide('i18next', useTranslation().i18next);
 </script>
 
 <template>

--- a/demos/vue/src/main.ts
+++ b/demos/vue/src/main.ts
@@ -32,4 +32,5 @@ i18next.use(Backend).init({
     escapeValue: false,
   },
 });
+
 createApp(App).use(I18NextVue, { i18next }).use(router).mount('#app');

--- a/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
+++ b/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
@@ -6,10 +6,10 @@ The easiest is to simply clone the [Slickgrid-Vue-Demos](https://github.com/ghis
 
 ### 1. Install NPM Package
 
-Install `Vue`, `Slickgrid-Vue`, `i18next` and `i18next-vue` while `Bootstrap` is optional (or any other UI framework)
+Install `Vue`, `Slickgrid-Vue` and any UI framework you wish to install and use, for example `Bootstrap`.
 
 ```bash
-npm install --save slickgrid-vue i18next i18next-vue bootstrap
+npm install --save slickgrid-vue bootstrap
 # or with yarn add
 ```
 
@@ -17,24 +17,12 @@ _Note: `Bootstrap` is totally optional, you can use any other framework_
 
 ### 2. Import all necessary dependencies in `main.ts`
 
-At this point both `i18next` and `i18next-vue` are required to be installed for this project to work.
-
-```vue
-<script setup lang="ts">
+```ts
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap';
 
-import i18next from 'i18next';
-import I18NextVue from 'i18next-vue';
-import { createApp } from 'vue';
-
-createApp(App).use(I18NextVue, { i18next });
-</script>
+createApp(App);
 ```
-
-> **Note** if anyone knows how to make this optional, please reach out and/or contribute a Pull Request to the project.
->
-> **Note 2** some of you might prefer to use `vue-i18n` but this also goes with previous Note, I don't know how to make the i18n plugin(s) optional(s) in the project while keeping translations. So again if anyone knows how to address that, please reach out!
 
 <a name="step3"></a>
 ### 3. CSS / SASS Styles
@@ -66,10 +54,29 @@ You could also compile the SASS files with your own customization, for that simp
 );
 ```
 
-### 4. Install/Setup `I18N` for Localization (optional)
-To provide locales other than English (default locale), you have 2 options that you can go with. If you only use English, there is nothing to do (you can still change some of the texts in the grid via option 1.)
-1. Using [Custom Locale](../localization/localization-with-custom-locales.md), that is when you use **only 1** locale (other thank English)...
-2. Using [Localization with I18N](../localization/localization.md), that is when you want to use multiple locales dynamically.
+### 4. Install/Setup `I18Next` for Localization (optional)
+This step is totally optional and will allow you to provide different locales, other than English (which is the default), in your project. You have 2 options to approach this use case. If you only use English, then there is nothing to do (you can still change some of the texts in the grid via option 1.). The 2 approach are as follow:
+1. Using [Custom Locale](../localization/localization-with-custom-locales.md), that is when you use **only 1** locale (other than English)...
+2. Using [Localization with I18Next](../localization/localization.md), that is when you want to use multiple locales dynamically.
+
+##### add it to your `main.ts`
+```ts
+import i18next from 'i18next';
+import I18NextVue from 'i18next-vue';
+import { createApp } from 'vue';
+
+createApp(App).use(I18NextVue, { i18next })
+```
+
+##### then add it to your App
+```vue
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { provide } from 'vue';
+
+provide('i18next', useTranslation().i18next);
+</script>
+```
 
 ### 5. Create a basic grid
 
@@ -160,8 +167,8 @@ The last step is really to explore all the pages that are available in this Wiki
   - it gets updated very frequently, we usually mention any new/updated wikis in any new version release
 
 ### 7. Get Started
-The best way to get started is to clone the [Slickgrid-Vue-Demos](https://github.com/ghiscoding/slickgrid-vue-demos), it has multiple examples and it is also updated frequently since it is used for the GitHub Bootstrap 4 demo page. `Slickgrid-Vue` has 2 `Bootstrap` themes, you can see a demo of each one below.
-- [Bootstrap 5 demo](https://ghiscoding.github.io/slickgrid-vue-demos) / [examples repo](https://github.com/ghiscoding/slickgrid-vue-demos) (with `I18N` Service)
+The best way to get started is to clone the [Slickgrid-Vue-Demos](https://github.com/ghiscoding/slickgrid-vue-demos), it is updated frequently since it is used for the GitHub Bootstrap 4 demo page. `Slickgrid-Vue` has 2 `Bootstrap` themes, you can see a demo of each one below.
+- [Bootstrap 5 demo](https://ghiscoding.github.io/slickgrid-vue-demos) / [examples repo](https://github.com/ghiscoding/slickgrid-vue-demos) (with `I18Next` Service)
 
 ##### All Live Demo Examples have links to the actual code
 Like to see the code to a particular Example? Just click on the "see code" that is available in every live examples.

--- a/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
+++ b/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
@@ -78,6 +78,8 @@ provide('i18next', useTranslation().i18next);
 </script>
 ```
 
+> Currently only `i18next` (and `i18next-vue`) is implemented and supported. If anyone is interested in implementing `vue-i18n` then please reach out. Side note, `i18next` is easier to implement and is also being used in a couple of SlickGrid framework ports which help in consistency.
+
 ### 5. Create a basic grid
 
 ```vue

--- a/frameworks/slickgrid-vue/docs/localization/localization-with-custom-locales.md
+++ b/frameworks/slickgrid-vue/docs/localization/localization-with-custom-locales.md
@@ -1,5 +1,5 @@
 ## Description
-Most of example that you will find across this library were made with `I18N` (dynamic translation) support. However a few users of the lib only use 1 locale (English or any other locale). Since not all users requires multiple translations, it is now possible to use `slickgrid-vue` without `I18N`. If you don't provide `I18N`, it will simply try to use Custom Locales, you can provide your own locales (see instruction below), or if none are provided it will use English locales by default.
+Most of the examples that you will find across this library were written with `I18Next` usage (dynamic translation) support. However a few users of the library are only interested in using only 1 locale (English or any other locale). Since not every users require multiple translations, it is now possible to use `slickgrid-vue` without `I18Next`. If you don't provide `I18Next`, it will simply try to use Custom Locales, you can provide your own locales (see instruction below), or if none are provided it will use English locales by default.
 
 ## Installation
 There are 2 ways of using and defining Custom Locales, see below on how to achieve that.
@@ -9,7 +9,8 @@ There are 2 ways of using and defining Custom Locales, see below on how to achie
 English is the default, if that is the locale you want to use then there's nothing to do, move along...
 
 #### Any other Locales (not English)
-To use any other Locales, you will need to create a TypeScript (or JavaScript) of all the Locale Texts required for the library to work properly (if you forget to define a locale text, it will simply show up in English). For example, if we define a French Locale, it would look like this (for the complete list of required field take a look at the default [English Locale](https://github.com/ghiscoding/slickgrid-vue-demos/blob/main/bootstrap5-i18n-demo/src/assets/locales/en/translation.json))
+To use any other Locales, you will need to create a TypeScript (or JavaScript) of all the Locale Texts required for the library to work properly (if you forget to define a locale text, it will simply show up in English). For example, if we define a French Locale, it would look like this (for the complete list of required field take a look at the default [English Locale](https://github.com/ghiscoding/slickgrid-vue-demos/blob/main/src/assets/locales/en/translation.json)).
+
 ```ts
 // localeFrench.ts or fr.ts
 export const localeFrench = {
@@ -19,6 +20,7 @@ export const localeFrench = {
   TEXT_CLEAR_ALL_FILTERS: 'Supprimer tous les filtres',
   TEXT_CLEAR_ALL_SORTING: 'Supprimer tous les tris',
   // ... the rest of the text
+}
 ```
 
 #### 2. Use the Custom Locales
@@ -42,5 +44,5 @@ function defineGrid() {
 </script>
 ```
 
-#### 3. Use the lib (without I18N)
-There's nothing else to do, just use the library without defining or providing I18N and you're good to go. Read through the Wiki of the [HOWTO - Quick Start](../getting-started/quick-start.md) for basic grid samples.
+#### 3. Use the lib (without I18Next)
+There's nothing else to do, just use the library without defining or providing I18Next and you're good to go. Read through the Wiki of the [HOWTO - Quick Start](../getting-started/quick-start.md) for basic grid samples.

--- a/frameworks/slickgrid-vue/docs/localization/localization.md
+++ b/frameworks/slickgrid-vue/docs/localization/localization.md
@@ -3,19 +3,49 @@
 
 ### Installation
 
-Install the `i18next` library with a backend loader, typically `i18next-xhr-backend`
+Install the `i18next` and `i18next-vue` libraries with an optional backend loader, like `i18next-xhr-backend`
 
 ##### Install NPM package
 
 ```sh
-npm install i18next i18next-xhr-backend
+npm install i18next i18next-vue i18next-xhr-backend
 ```
 
-##### Main.ts
-###### configure i18n loader with assets folder
+##### add it to your `main.ts`
+
+Start by using the plugin in your `main.ts`
+
+```ts
+import i18next from 'i18next';
+import I18NextVue from 'i18next-vue';
+import { createApp } from 'vue';
+
+createApp(App).use(I18NextVue, { i18next })
+```
+
+##### then add it to your App
+
+Then to finally use translations in Slickgrid-Vue, you must first `provide` the I18Next instance in your App so that it can be `inject`ed in Slickgrid-Vue.
+
+```vue
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { provide } from 'vue';
+
+provide('i18next', useTranslation().i18next);
+</script>
+```
+
+##### optionally configure i18n loader with assets folder
+
+You can use the optional `i18next-http-backend` to load JSON files asynchronously. This is just 1 in multiple ways to load translations, just choose whichever ways that best fits your use case.
+
 ```ts
 import i18next from 'i18next';
 import Backend from 'i18next-http-backend';
+
+import localeEn from './assets/locales/en/translation.json';
+import localeFr from './assets/locales/fr/translation.json';
 
 i18next
   .use(Backend)

--- a/frameworks/slickgrid-vue/src/index.ts
+++ b/frameworks/slickgrid-vue/src/index.ts
@@ -19,7 +19,7 @@ import type { SlickgridConfig } from './slickgrid-config.js';
 
 // expose all public classes
 export type { SlickgridVueProps } from './components/slickgridVueProps.interface.js';
-export { disposeAllSubscriptions, TranslaterService } from './services/index.js';
+export { disposeAllSubscriptions, TranslaterI18NextService } from './services/index.js';
 
 export {
   Aggregators,

--- a/frameworks/slickgrid-vue/src/services/index.ts
+++ b/frameworks/slickgrid-vue/src/services/index.ts
@@ -1,3 +1,3 @@
 export * from './container.service.js';
-export * from './translater.service.js';
+export * from './translaterI18Next.service.js';
 export * from './utilities.js';

--- a/frameworks/slickgrid-vue/src/services/translaterI18Next.service.ts
+++ b/frameworks/slickgrid-vue/src/services/translaterI18Next.service.ts
@@ -1,16 +1,16 @@
 import type { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
 import { type i18n } from 'i18next';
-import { useTranslation } from 'i18next-vue';
 
 /**
  * This is a Translate Service Wrapper for Slickgrid-Universal monorepo lib to work properly,
  * it must implement Slickgrid-Universal TranslaterService interface to work properly
  */
-export class TranslaterService implements UniversalTranslateService {
-  public i18n: i18n;
+export class TranslaterI18NextService implements UniversalTranslateService {
+  public i18n?: i18n;
 
-  constructor() {
-    this.i18n = useTranslation().i18next;
+  /** I18Next instance setter */
+  set i18nInstance(i18n: i18n) {
+    this.i18n = i18n;
   }
 
   /**
@@ -18,7 +18,7 @@ export class TranslaterService implements UniversalTranslateService {
    * @return {string} current language
    */
   getCurrentLanguage(): string {
-    return this.i18n.language;
+    return this.i18n?.language || '';
   }
 
   /**
@@ -27,7 +27,7 @@ export class TranslaterService implements UniversalTranslateService {
    * @return {Promise} output
    */
   async use(newLang: string): Promise<any> {
-    return this.i18n.changeLanguage(newLang);
+    return this.i18n?.changeLanguage(newLang);
   }
 
   /**
@@ -36,6 +36,6 @@ export class TranslaterService implements UniversalTranslateService {
    * @return {string} translated value
    */
   translate(translationKey: string): string {
-    return this.i18n.t(translationKey);
+    return this.i18n?.t(translationKey) || '';
   }
 }


### PR DESCRIPTION
⚠️ this is a breaking change compare to previous implementation since the user now needs to be `provide` the I18Next instance themselves. However the benefit is that I18Next is now totally optional making build smaller in size for users who don't need I18N