### PR TITLE
fix(core): add missing key shortcuts for navigation & cell selections

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -6504,13 +6504,48 @@ describe('SlickGrid core file', () => {
         const navigateRowStartSpy = vi.spyOn(grid, 'navigateRowStart');
         const event = new CustomEvent('keydown');
         Object.defineProperty(event, 'key', { writable: true, value: 'Home' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: false });
         container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigateRowStartSpy).toHaveBeenCalled();
       });
 
-      it('should call navigateTop() when triggering Ctrl+Home key', () => {
+      it('should call navigateRowStart() when triggering Ctrl+ArrowLeft key', () => {
+        const columns = [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
+        ] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
+        const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
+        const navigateRowStartSpy = vi.spyOn(grid, 'navigateRowStart');
+        const event = new CustomEvent('keydown');
+        Object.defineProperty(event, 'key', { writable: true, value: 'ArrowLeft' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
+        container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
+
+        expect(onKeyDownSpy).toHaveBeenCalled();
+        expect(navigateRowStartSpy).toHaveBeenCalled();
+      });
+
+      it('should call navigateTopStart() when triggering Ctrl+Home key', () => {
+        const columns = [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
+        ] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
+        const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
+        const navigateTopStartSpy = vi.spyOn(grid, 'navigateTopStart');
+        const event = new CustomEvent('keydown');
+        Object.defineProperty(event, 'key', { writable: true, value: 'Home' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
+        container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
+
+        expect(onKeyDownSpy).toHaveBeenCalled();
+        expect(navigateTopStartSpy).toHaveBeenCalled();
+      });
+
+      it('should call navigateTop() when triggering Ctrl+ArrowUp key', () => {
         const columns = [
           { id: 'name', field: 'name', name: 'Name' },
           { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
@@ -6519,12 +6554,29 @@ describe('SlickGrid core file', () => {
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigateTopSpy = vi.spyOn(grid, 'navigateTop');
         const event = new CustomEvent('keydown');
-        Object.defineProperty(event, 'key', { writable: true, value: 'Home' });
+        Object.defineProperty(event, 'key', { writable: true, value: 'ArrowUp' });
         Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
         container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigateTopSpy).toHaveBeenCalled();
+      });
+
+      it('should call navigateBottomEnd() when triggering Ctrl+End key', () => {
+        const columns = [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
+        ] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
+        const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
+        const navigateBottomEndSpy = vi.spyOn(grid, 'navigateBottomEnd');
+        const event = new CustomEvent('keydown');
+        Object.defineProperty(event, 'key', { writable: true, value: 'End' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
+        container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
+
+        expect(onKeyDownSpy).toHaveBeenCalled();
+        expect(navigateBottomEndSpy).toHaveBeenCalled();
       });
 
       it('should call navigateRowEnd() when triggering End key', () => {
@@ -6543,7 +6595,24 @@ describe('SlickGrid core file', () => {
         expect(navigateRowEndSpy).toHaveBeenCalled();
       });
 
-      it('should call navigateBottom() when triggering Ctrl+End key', () => {
+      it('should call navigateRowEnd() when triggering Ctrl+ArrowRight key', () => {
+        const columns = [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
+        ] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
+        const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
+        const navigateRowEndSpy = vi.spyOn(grid, 'navigateRowEnd');
+        const event = new CustomEvent('keydown');
+        Object.defineProperty(event, 'key', { writable: true, value: 'ArrowRight' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
+        container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
+
+        expect(onKeyDownSpy).toHaveBeenCalled();
+        expect(navigateRowEndSpy).toHaveBeenCalled();
+      });
+
+      it('should call navigateBottom() when triggering Ctrl+ArrowDown key', () => {
         const columns = [
           { id: 'name', field: 'name', name: 'Name' },
           { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
@@ -6552,12 +6621,29 @@ describe('SlickGrid core file', () => {
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigateBottomSpy = vi.spyOn(grid, 'navigateBottom');
         const event = new CustomEvent('keydown');
-        Object.defineProperty(event, 'key', { writable: true, value: 'End' });
+        Object.defineProperty(event, 'key', { writable: true, value: 'ArrowDown' });
         Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
         container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigateBottomSpy).toHaveBeenCalled();
+      });
+
+      it('should call navigateTop() when triggering Ctrl+ArrowUp key', () => {
+        const columns = [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
+        ] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
+        const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
+        const navigateTopSpy = vi.spyOn(grid, 'navigateTop');
+        const event = new CustomEvent('keydown');
+        Object.defineProperty(event, 'key', { writable: true, value: 'ArrowUp' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
+        container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
+
+        expect(onKeyDownSpy).toHaveBeenCalled();
+        expect(navigateTopSpy).toHaveBeenCalled();
       });
 
       it('should call navigatePageDown() when triggering PageDown key', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5191,10 +5191,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             return;
           }
         }
-        if (e.key === 'Home') {
-          handled = e.ctrlKey ? this.navigateTop() : this.navigateRowStart();
-        } else if (e.key === 'End') {
-          handled = e.ctrlKey ? this.navigateBottom() : this.navigateRowEnd();
+        if (e.ctrlKey && e.key === 'Home') {
+          this.navigateTopStart();
+        } else if (e.ctrlKey && e.key === 'End') {
+          this.navigateBottomEnd();
+        } else if (e.ctrlKey && e.key === 'ArrowUp') {
+          this.navigateTop();
+        } else if (e.ctrlKey && e.key === 'ArrowDown') {
+          this.navigateBottom();
+        } else if ((e.ctrlKey && e.key === 'ArrowLeft') || (!e.ctrlKey && e.key === 'Home')) {
+          this.navigateRowStart();
+        } else if ((e.ctrlKey && e.key === 'ArrowRight') || (!e.ctrlKey && e.key === 'End')) {
+          this.navigateRowEnd();
         }
       }
     }
@@ -6106,7 +6114,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return this.navigateToRow(this.getDataLength() - 1);
   }
 
-  protected navigateToRow(row: number): boolean {
+  navigateToRow(row: number): boolean {
     const num_rows = this.getDataLength();
     if (!num_rows) {
       return true;
@@ -6423,6 +6431,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to the end row in the grid */
   navigateRowEnd(): boolean | undefined {
+    return this.navigate('end');
+  }
+
+  /** Navigate to coordinate 0,0 (top left home) */
+  navigateTopStart(): boolean | undefined {
+    this.navigateToRow(0);
+    return this.navigate('home');
+  }
+
+  /** Navigate to bottom row end (bottom right end) */
+  navigateBottomEnd(): boolean | undefined {
+    this.navigateBottom();
     return this.navigate('end');
   }
 

--- a/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
@@ -489,6 +489,30 @@ describe('CellSelectionModel Plugin', () => {
     expect(scrollCellSpy).toHaveBeenCalledWith(100, 2, false);
   });
 
+  it('should call "setSelectedRanges" with Slick Range from current position to row index 0 horizontally when using Shift+Ctrl+ArrowLeft key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    const expectedRowZeroIdx = 0;
+    vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = vi.spyOn(gridStub, 'scrollCellIntoView');
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false },
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), ['ctrlKey', 'shiftKey'], 'ArrowLeft');
+    gridStub.onKeyDown.notify({ cell: 2, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.any(Function) } as unknown as SlickRange,
+      { fromCell: expectedRowZeroIdx, fromRow: notifyingRowNumber, toCell: 2, toRow: 100 },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(100, 2, false);
+  });
+
   it('should call "setSelectedRanges" with Slick Range from current position to same row last cell index horizontally when using Shift+End key combo when triggered by "onKeyDown"', () => {
     const notifyingRowNumber = 100;
     const columnsLn = mockColumns.length;
@@ -511,6 +535,76 @@ describe('CellSelectionModel Plugin', () => {
     ];
     expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
     expect(scrollCellSpy).toHaveBeenCalledWith(100, 2, false);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to same row last cell index horizontally when using Shift+Ctrl+ArrowRight key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    const columnsLn = mockColumns.length;
+    vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = vi.spyOn(gridStub, 'scrollCellIntoView');
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false },
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), ['ctrlKey', 'shiftKey'], 'ArrowRight');
+    gridStub.onKeyDown.notify({ cell: 1, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.any(Function) } as unknown as SlickRange,
+      { fromCell: columnsLn - 1, fromRow: notifyingRowNumber, toCell: 2, toRow: 100 },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(100, 2, false);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to grid top on same column when using Ctrl+Shift+ArrowUp key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = vi.spyOn(gridStub, 'scrollCellIntoView');
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false },
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), ['ctrlKey', 'shiftKey'], 'ArrowUp');
+    gridStub.onKeyDown.notify({ cell: 2, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.any(Function) } as unknown as SlickRange,
+      { fromCell: 2, fromRow: 0, toCell: 2, toRow: 100 },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(100, 2, false);
+  });
+
+  it('should call "setSelectedRanges" with Slick Range from current position to grid bottom on same column when using Ctrl+Shift+ArrowDown key combo when triggered by "onKeyDown"', () => {
+    const notifyingRowNumber = 100;
+    vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 2, row: notifyingRowNumber });
+    vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const scrollCellSpy = vi.spyOn(gridStub, 'scrollCellIntoView');
+
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: () => false },
+      { fromCell: 2, fromRow: notifyingRowNumber, toCell: 3, toRow: 120, contains: () => false },
+    ] as unknown as SlickRange[]);
+    const setSelectRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), ['ctrlKey', 'shiftKey'], 'ArrowDown');
+    gridStub.onKeyDown.notify({ cell: 2, row: 101, grid: gridStub }, keyDownEvent, gridStub);
+
+    const expectedRangeCalled = [
+      { fromCell: 1, fromRow: 99, toCell: 3, toRow: 120, contains: expect.any(Function) } as unknown as SlickRange,
+      { fromCell: 2, fromRow: 100, toCell: 2, toRow: NB_ITEMS - 1 },
+    ];
+    expect(setSelectRangeSpy).toHaveBeenCalledWith(expectedRangeCalled);
+    expect(scrollCellSpy).toHaveBeenCalledWith(NB_ITEMS - 1, 2, false);
   });
 
   it('should call "setSelectedRanges" with Slick Range from current position to cell,row index 0 when using Ctrl+Shift+Home key combo when triggered by "onKeyDown"', () => {

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -187,7 +187,7 @@ export class SlickCellSelectionModel implements SelectionModel {
   }
 
   protected isKeyAllowed(key: string): boolean {
-    return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End'].some((k) => k === key);
+    return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End', 'a', 'A'].some((k) => k === key);
   }
 
   protected handleKeyDown(e: SlickEventData): void {
@@ -218,13 +218,22 @@ export class SlickCellSelectionModel implements SelectionModel {
         }
         let dRow = last.toRow - last.fromRow;
         let dCell = last.toCell - last.fromCell;
+        let toCell: undefined | number;
+        let toRow = 0;
+
+        // when using Ctrl+{a, A} we will change our position to cell 0,0 and select all grid cells
+        if (e.ctrlKey && e.key?.toLowerCase() === 'a') {
+          this._grid.setActiveCell(0, 0, false, false, true);
+          active.row = 0;
+          active.cell = 0;
+          toCell = colLn - 1;
+          toRow = dataLn - 1;
+        }
 
         // walking direction
         const dirRow = active.row === last.fromRow ? 1 : -1;
         const dirCell = active.cell === last.fromCell ? 1 : -1;
         const isSingleKeyMove = e.key!.startsWith('Arrow');
-        let toCell: undefined | number;
-        let toRow = 0;
 
         if (isSingleKeyMove && !e.ctrlKey) {
           // single cell move: (Arrow{Up/ArrowDown/ArrowLeft/ArrowRight})

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -247,12 +247,16 @@ export class SlickCellSelectionModel implements SelectionModel {
             this._prevSelectedRow = active.row;
           }
 
-          if (e.shiftKey && !e.ctrlKey && e.key === 'Home') {
+          if ((!e.ctrlKey && e.shiftKey && e.key === 'Home') || (e.ctrlKey && e.shiftKey && e.key === 'ArrowLeft')) {
             toCell = 0;
             toRow = active.row;
-          } else if (e.shiftKey && !e.ctrlKey && e.key === 'End') {
+          } else if ((!e.ctrlKey && e.shiftKey && e.key === 'End') || (e.ctrlKey && e.shiftKey && e.key === 'ArrowRight')) {
             toCell = colLn - 1;
             toRow = active.row;
+          } else if (e.ctrlKey && e.shiftKey && e.key === 'ArrowUp') {
+            toRow = 0;
+          } else if (e.ctrlKey && e.shiftKey && e.key === 'ArrowDown') {
+            toRow = dataLn - 1;
           } else if (e.ctrlKey && e.shiftKey && e.key === 'Home') {
             toCell = 0;
             toRow = 0;

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -66,7 +66,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell B14 then Ctrl+Shift+End with selection B14-CV19', () => {
       cy.getCell(14, 3, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_B14').click();
 
-      cy.get('@cell_B14').type('{ctrl}{shift}{end}');
+      cy.get('@cell_B14').type('{ctrl}{shift}{end}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":14,"fromCell":3,"toRow":19,"toCell":101}');
     });
@@ -74,7 +74,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell CP3 then Ctrl+Shift+Home with selection A0-CP3', () => {
       cy.getCell(3, 94, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CP3').click();
 
-      cy.get('@cell_CP3').type('{ctrl}{shift}{home}');
+      cy.get('@cell_CP3').type('{ctrl}{shift}{home}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":0,"fromCell":0,"toRow":3,"toCell":94}');
     });
@@ -82,7 +82,15 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell CE7 then Shift+Home with selection A0-CE7', () => {
       cy.getCell(3, 83, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CE7').click();
 
-      cy.get('@cell_CE7').type('{shift}{home}');
+      cy.get('@cell_CE7').type('{shift}{home}', { release: false });
+
+      cy.get('#selectionRange').should('have.text', '{"fromRow":3,"fromCell":0,"toRow":3,"toCell":83}');
+    });
+
+    it('should click on cell CE7 then Shift+Ctrl+ArrowLeft with selection A0-CE7', () => {
+      cy.getCell(3, 83, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CE7').click();
+
+      cy.get('@cell_CE7').type('{shift}{ctrl}{leftarrow}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":3,"fromCell":0,"toRow":3,"toCell":83}');
     });
@@ -90,7 +98,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell CG3 then Shift+PageDown multiple times with current page selection starting at E3 with selection E3-19', () => {
       cy.getCell(3, 85, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CG3').click();
 
-      cy.get('@cell_CG3').type('{shift}{pagedown}{pagedown}{pagedown}');
+      cy.get('@cell_CG3').type('{shift}{pagedown}{pagedown}{pagedown}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":3,"fromCell":85,"toRow":19,"toCell":85}');
     });
@@ -154,18 +162,42 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
       cy.get('#selectionRange').should('have.text', '{"fromRow":46,"fromCell":6,"toRow":46,"toCell":101}');
     });
 
-    it('should click on cell CP54 then Ctrl+Shift+End keys with selection E46-CV99', () => {
-      cy.getCell(54, 95, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CP54').click();
+    it('should click on cell E46 then Shift+Ctrl+ArrowRight key with full row horizontal selection E46-CV46', () => {
+      cy.getCell(46, 6, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_E46').click();
 
-      cy.get('@cell_CP54').type('{ctrl}{shift}{end}');
+      cy.get('@cell_E46').type('{shift}{ctrl}{rightarrow}', { release: false });
 
-      cy.get('#selectionRange').should('have.text', '{"fromRow":54,"fromCell":95,"toRow":99,"toCell":101}');
+      cy.get('#selectionRange').should('have.text', '{"fromRow":46,"fromCell":6,"toRow":46,"toCell":101}');
+    });
+
+    it('should click on cell E46 then Shift+Ctrl+ArrowUp key with full column vertical top selection E0-E46', () => {
+      cy.getCell(46, 6, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_E46').click();
+
+      cy.get('@cell_E46').type('{shift}{ctrl}{uparrow}', { release: false });
+
+      cy.get('#selectionRange').should('have.text', '{"fromRow":0,"fromCell":6,"toRow":46,"toCell":6}');
+    });
+
+    it('should click on cell E46 then Shift+Ctrl+ArrowDown key with full column vertical bottom selection E46-E99', () => {
+      cy.getCell(46, 6, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_E46').click();
+
+      cy.get('@cell_E46').type('{shift}{ctrl}{downarrow}', { release: false });
+
+      cy.get('#selectionRange').should('have.text', '{"fromRow":46,"fromCell":6,"toRow":99,"toCell":6}');
+    });
+
+    it('should click on cell F85 then Ctrl+Shift+End keys with selection F85-CV99', () => {
+      cy.getCell(85, 7, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_F85').click();
+
+      cy.get('@cell_F85').type('{ctrl}{shift}{end}', { release: false });
+
+      cy.get('#selectionRange').should('have.text', '{"fromRow":85,"fromCell":7,"toRow":99,"toCell":101}');
     });
 
     it('should click on cell CP95 then Ctrl+Shift+Home keys with selection C0-CP95', () => {
       cy.getCell(95, 99, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CP95').click();
 
-      cy.get('@cell_CP95').type('{ctrl}{shift}{home}');
+      cy.get('@cell_CP95').type('{ctrl}{shift}{home}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":0,"fromCell":0,"toRow":95,"toCell":99}');
     });
@@ -173,7 +205,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell CR5 again then Ctrl+Home keys and expect to scroll back to cell A0 without any selection range', () => {
       cy.getCell(5, 95, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CR95').click();
 
-      cy.get('@cell_CR95').type('{ctrl}{home}');
+      cy.get('@cell_CR95').type('{ctrl}{home}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '');
     });
@@ -187,7 +219,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell B14 then Shift+End with selection B14-24', () => {
       cy.getCell(14, 3, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_B14').click();
 
-      cy.get('@cell_B14').type('{shift}{end}');
+      cy.get('@cell_B14').type('{shift}{end}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":14,"fromCell":3,"toRow":14,"toCell":101}');
     });
@@ -195,7 +227,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell CS14 then Shift+Home with selection A14-CS14', () => {
       cy.getCell(14, 97, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CS14').click();
 
-      cy.get('@cell_CS14').type('{shift}{home}');
+      cy.get('@cell_CS14').type('{shift}{home}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":14,"fromCell":0,"toRow":14,"toCell":97}');
     });
@@ -203,7 +235,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
     it('should click on cell CN3 then Shift+PageDown multiple times with current page selection starting at E3 w/selection E3-19', () => {
       cy.getCell(3, 95, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CN3').click();
 
-      cy.get('@cell_CN3').type('{shift}{pagedown}{pagedown}{pagedown}');
+      cy.get('@cell_CN3').type('{shift}{pagedown}{pagedown}{pagedown}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":3,"fromCell":95,"toRow":19,"toCell":95}');
     });
@@ -213,7 +245,7 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
 
       cy.getCell(15, 92, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_CN41').click();
 
-      cy.get('@cell_CN41').type('{shift}{pageup}{pageup}{pageup}');
+      cy.get('@cell_CN41').type('{shift}{pageup}{pageup}{pageup}', { release: false });
 
       cy.get('#selectionRange').should('have.text', '{"fromRow":0,"fromCell":92,"toRow":15,"toCell":92}');
     });

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -209,6 +209,14 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
 
       cy.get('#selectionRange').should('have.text', '');
     });
+
+    it('should click on cell E20 again then Ctrl+A keys and expect to scroll select everything in the grid', () => {
+      cy.getCell(20, 6, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_E20').click();
+
+      cy.get('@cell_E20').type('{ctrl}{a}', { release: false });
+
+      cy.get('#selectionRange').should('have.text', '{"fromRow":0,"fromCell":0,"toRow":99,"toCell":101}');
+    });
   });
 
   describe('with Pagination', () => {


### PR DESCRIPTION
- add a few missing key shortcuts to navigate in the grid
  - Ctrl+Home will now go to top left (coord 0, 0)
  - Ctrl+End will now go to bottom right of the grid
- add a few missing key shortcuts for cell selection
  - Shift+Ctrl+ArrowLeft, now same as Shift+Home, to select cells from current cell until starting index on same row
  - Shift+Ctrl+ArrowRight, now same as Shift+End, to select cells from current cell until end index on same row
  - Shift+Ctrl+ArrowUp to select cells from current cell up to first row on same column
  - Shift+Ctrl+ArrowDown to select cells from current cell down to last row on same column
  - Ctrl+a (or A) to select all cells in the grid