### PR TITLE
chore(deps): update `vue-tsc` to allow latest TypeScript update & fix flaky E2E test

### DIFF
--- a/demos/vue/package.json
+++ b/demos/vue/package.json
@@ -44,7 +44,7 @@
     "cypress": "^13.16.1",
     "cypress-real-events": "^1.13.0",
     "sass": "^1.83.0",
-    "typescript": "~5.6.2",
+    "typescript": "^5.7.2",
     "vite": "^6.0.3"
   }
 }

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -868,7 +868,7 @@ function loadData(count: number) {
       start: new Date(randomYear, randomMonth, randomDay, randomDay, randomTime, randomTime, randomTime),
       finish: isCompleted || (i % 3 === 0 && randomFinish > new Date() && i > 3) ? (isCompleted ? new Date() : randomFinish) : '', // make sure the random date is earlier than today and it's index is bigger than 3
       cost: i % 33 === 0 ? null : Math.round(Math.random() * 10000) / 100,
-      completed: isCompleted || (i % 3 === 0 && randomFinish > new Date() && i > 3),
+      completed: (isCompleted && i > 5) || (i % 3 === 0 && randomFinish > new Date() && i > 3),
       product: { id: mockProducts()[randomItemId]?.id, itemName: mockProducts()[randomItemId]?.itemName },
       origin: i % 2 ? { code: 'CA', name: 'Canada' } : { code: 'US', name: 'United States' },
     };

--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^22.5.1",
     "@types/whatwg-fetch": "^0.0.33",
     "sass": "^1.79.3",
-    "typescript": "~5.6.2",
+    "typescript": "^5.7.2",
     "vite": "^6.0.0"
   }
 }

--- a/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
+++ b/examples/vite-demo-vanilla-bundle/src/examples/example12.ts
@@ -620,7 +620,7 @@ export default class Example12 {
         start: new Date(randomYear, randomMonth, randomDay, randomDay, randomTime, randomTime, randomTime),
         finish: isCompleted || (i % 3 === 0 && randomFinish > new Date() && i > 3) ? (isCompleted ? new Date() : randomFinish) : '', // make sure the random date is earlier than today and it's index is bigger than 3
         cost: i % 33 === 0 ? null : Math.round(Math.random() * 10000) / 100,
-        completed: isCompleted || (i % 3 === 0 && randomFinish > new Date() && i > 3),
+        completed: (isCompleted && i > 5) || (i % 3 === 0 && randomFinish > new Date() && i > 3),
         product: { id: this.mockProducts()[randomItemId]?.id, itemName: this.mockProducts()[randomItemId]?.itemName },
         origin: i % 2 ? { code: 'CA', name: 'Canada' } : { code: 'US', name: 'United States' },
       };

--- a/frameworks/slickgrid-vue/package.json
+++ b/frameworks/slickgrid-vue/package.json
@@ -84,11 +84,11 @@
     "strong-log-transformer": "^2.1.0",
     "tinyexec": "^0.3.1",
     "tinyrainbow": "^1.2.0",
-    "typescript": "~5.6.2",
+    "typescript": "^5.7.2",
     "vite": "^6.0.3",
     "vite-plugin-dts": "^4.3.0",
     "vue": "^3.5.13",
-    "vue-tsc": "^2.1.10",
+    "vue-tsc": "^2.2.0",
     "yargs": "^17.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "rxjs": "^7.8.1",
     "servor": "^4.0.2",
     "sortablejs": "^1.15.6",
-    "typescript": "~5.6.2",
+    "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.0",
     "vitest": "^3.0.0-beta.2",
     "whatwg-fetch": "^3.6.20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.2.5(cypress@13.16.1)
       '@commitlint/cli':
         specifier: ^19.6.0
-        version: 19.6.0(@types/node@22.10.2)(typescript@5.6.3)
+        version: 19.6.0(@types/node@22.10.2)(typescript@5.7.2)
       '@commitlint/config-conventional':
         specifier: ^19.6.0
         version: 19.6.0
@@ -22,16 +22,16 @@ importers:
         version: 0.1.2
       '@lerna-lite/cli':
         specifier: ^3.10.1
-        version: 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
+        version: 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/publish':
         specifier: ^3.10.1
-        version: 3.10.1(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
+        version: 3.10.1(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/run':
         specifier: ^3.10.1
-        version: 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
+        version: 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/watch':
         specifier: ^3.10.1
-        version: 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
+        version: 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@types/node':
         specifier: ^22.10.2
         version: 22.10.2
@@ -40,7 +40,7 @@ importers:
         version: 3.0.0-beta.2(vitest@3.0.0-beta.2)
       '@vitest/eslint-plugin':
         specifier: ^1.1.16
-        version: 1.1.16(@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)(vitest@3.0.0-beta.2)
+        version: 1.1.16(@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)(vitest@3.0.0-beta.2)
       '@vitest/ui':
         specifier: ^3.0.0-beta.2
         version: 3.0.0-beta.2(vitest@3.0.0-beta.2)
@@ -105,11 +105,11 @@ importers:
         specifier: ^1.15.6
         version: 1.15.6
       typescript:
-        specifier: ~5.6.2
-        version: 5.6.3
+        specifier: ^5.7.2
+        version: 5.7.2
       typescript-eslint:
         specifier: ^8.18.0
-        version: 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
+        version: 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       vitest:
         specifier: ^3.0.0-beta.2
         version: 3.0.0-beta.2(@types/node@22.10.2)(@vitest/ui@3.0.0-beta.2)(happy-dom@16.0.1)(jiti@1.21.6)(jsdom@25.0.1)(sass@1.83.0)(yaml@2.6.0)
@@ -169,13 +169,13 @@ importers:
         version: 3.2.3
       i18next:
         specifier: ^24.1.0
-        version: 24.1.0(typescript@5.6.3)
+        version: 24.1.0(typescript@5.7.2)
       i18next-http-backend:
         specifier: ^3.0.1
         version: 3.0.1(encoding@0.1.13)
       i18next-vue:
         specifier: ^5.0.0
-        version: 5.0.0(i18next@24.1.0(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3))
+        version: 5.0.0(i18next@24.1.0(typescript@5.7.2))(vue@3.5.13(typescript@5.7.2))
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -184,10 +184,10 @@ importers:
         version: link:../../frameworks/slickgrid-vue
       vue:
         specifier: ^3.5.13
-        version: 3.5.13(typescript@5.6.3)
+        version: 3.5.13(typescript@5.7.2)
       vue-router:
         specifier: ^4.5.0
-        version: 4.5.0(vue@3.5.13(typescript@5.6.3))
+        version: 4.5.0(vue@3.5.13(typescript@5.7.2))
     devDependencies:
       '@4tw/cypress-drag-drop':
         specifier: ^2.2.5
@@ -197,7 +197,7 @@ importers:
         version: 0.3.7
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))(vue@3.5.13(typescript@5.7.2))
       cypress:
         specifier: ^13.16.1
         version: 13.16.1
@@ -208,8 +208,8 @@ importers:
         specifier: ^1.83.0
         version: 1.83.0
       typescript:
-        specifier: ~5.6.2
-        version: 5.6.3
+        specifier: ^5.7.2
+        version: 5.7.2
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0)
@@ -290,8 +290,8 @@ importers:
         specifier: ^1.79.3
         version: 1.80.4
       typescript:
-        specifier: ~5.6.2
-        version: 5.6.3
+        specifier: ^5.7.2
+        version: 5.7.2
       vite:
         specifier: ^6.0.0
         version: 6.0.0(@types/node@22.7.9)(jiti@1.21.6)(sass@1.80.4)(yaml@2.6.0)
@@ -331,7 +331,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))(vue@3.5.13(typescript@5.7.2))
       conventional-changelog:
         specifier: ^6.0.0
         version: 6.0.0(conventional-commits-filter@5.0.0)
@@ -340,10 +340,10 @@ importers:
         version: 7.0.3
       i18next:
         specifier: ^24.1.0
-        version: 24.1.0(typescript@5.6.3)
+        version: 24.1.0(typescript@5.7.2)
       i18next-vue:
         specifier: ^5.0.0
-        version: 5.0.0(i18next@24.1.0(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3))
+        version: 5.0.0(i18next@24.1.0(typescript@5.7.2))(vue@3.5.13(typescript@5.7.2))
       sass:
         specifier: ^1.83.0
         version: 1.83.0
@@ -360,20 +360,20 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       typescript:
-        specifier: ~5.6.2
-        version: 5.6.3
+        specifier: ^5.7.2
+        version: 5.7.2
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0)
       vite-plugin-dts:
         specifier: ^4.3.0
-        version: 4.3.0(@types/node@22.10.2)(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))
+        version: 4.3.0(@types/node@22.10.2)(rollup@4.24.0)(typescript@5.7.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))
       vue:
         specifier: ^3.5.13
-        version: 3.5.13(typescript@5.6.3)
+        version: 3.5.13(typescript@5.7.2)
       vue-tsc:
-        specifier: ^2.1.10
-        version: 2.1.10(typescript@5.6.3)
+        specifier: ^2.2.0
+        version: 2.2.0(typescript@5.7.2)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1700,11 +1700,20 @@ packages:
   '@volar/language-core@2.4.10':
     resolution: {integrity: sha512-hG3Z13+nJmGaT+fnQzAkS0hjJRa2FCeqZt6Bd+oGNhUkQ+mTFsDETg5rqUTxyzIh5pSOGY7FHCWUS8G82AzLCA==}
 
+  '@volar/language-core@2.4.11':
+    resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
+
   '@volar/source-map@2.4.10':
     resolution: {integrity: sha512-OCV+b5ihV0RF3A7vEvNyHPi4G4kFa6ukPmyVocmqm5QzOd8r5yAtiNvaPEjl8dNvgC/lj4JPryeeHLdXd62rWA==}
 
+  '@volar/source-map@2.4.11':
+    resolution: {integrity: sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==}
+
   '@volar/typescript@2.4.10':
     resolution: {integrity: sha512-F8ZtBMhSXyYKuBfGpYwqA5rsONnOwAVvjyE7KPYJ7wgZqo2roASqNWUnianOomJX5u1cxeRooHV59N0PhvEOgw==}
+
+  '@volar/typescript@2.4.11':
+    resolution: {integrity: sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -1724,16 +1733,16 @@ packages:
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
-  '@vue/language-core@2.1.10':
-    resolution: {integrity: sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==}
+  '@vue/language-core@2.1.6':
+    resolution: {integrity: sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@vue/language-core@2.1.6':
-    resolution: {integrity: sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==}
+  '@vue/language-core@2.2.0':
+    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1814,8 +1823,8 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
-  alien-signals@0.2.2:
-    resolution: {integrity: sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==}
+  alien-signals@0.4.12:
+    resolution: {integrity: sha512-Og0PgAihxlp1R22bsoBsyhhMG4+qhU+fkkLPoGBQkYVc3qt9rYnrwYTf+M6kqUqUZpf3rXDnpL90iKa0QcSVVg==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4660,8 +4669,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4875,8 +4884,8 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
-  vue-tsc@2.1.10:
-    resolution: {integrity: sha512-RBNSfaaRHcN5uqVqJSZh++Gy/YUzryuv9u1aFWhsammDJXNtUiJMNoJ747lZcQ68wUQFx6E73y4FY3D8E7FGMA==}
+  vue-tsc@2.2.0:
+    resolution: {integrity: sha512-gtmM1sUuJ8aSb0KoAFmK9yMxb8TxjewmxqTJ1aKphD5Cbu0rULFY6+UQT51zW7SpUcenfPUuflKyVwyx9Qdnxg==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -5103,11 +5112,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@19.6.0(@types/node@22.10.2)(typescript@5.6.3)':
+  '@commitlint/cli@19.6.0(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.6.0
-      '@commitlint/load': 19.5.0(@types/node@22.10.2)(typescript@5.6.3)
+      '@commitlint/load': 19.5.0(@types/node@22.10.2)(typescript@5.7.2)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.1
@@ -5154,15 +5163,15 @@ snapshots:
       '@commitlint/rules': 19.6.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.5.0(@types/node@22.10.2)(typescript@5.6.3)':
+  '@commitlint/load@19.5.0(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
       '@commitlint/resolve-extends': 19.5.0
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
-      cosmiconfig: 9.0.0(typescript@5.6.3)
-      cosmiconfig-typescript-loader: 5.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
+      cosmiconfig: 9.0.0(typescript@5.7.2)
+      cosmiconfig-typescript-loader: 5.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5459,10 +5468,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lerna-lite/cli@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/cli@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/init': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/init': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/npmlog': 3.10.1
       dedent: 1.5.3
       dotenv: 16.4.7
@@ -5470,10 +5479,10 @@ snapshots:
       load-json-file: 7.0.1
       yargs: 17.7.2
     optionalDependencies:
-      '@lerna-lite/publish': 3.10.1(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/run': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/version': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/watch': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/publish': 3.10.1(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/run': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/version': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/watch': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5481,7 +5490,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/core@3.10.1(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/core@3.10.1(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
       '@inquirer/expand': 4.0.2(@types/node@22.10.2)
       '@inquirer/input': 4.0.2(@types/node@22.10.2)
@@ -5490,7 +5499,7 @@ snapshots:
       '@npmcli/run-script': 8.1.0
       clone-deep: 4.0.1
       config-chain: 1.1.13
-      cosmiconfig: 9.0.0(typescript@5.6.3)
+      cosmiconfig: 9.0.0(typescript@5.7.2)
       dedent: 1.5.3
       execa: 8.0.1
       fs-extra: 11.2.0
@@ -5519,9 +5528,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/init@3.10.1(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/init@3.10.1(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       fs-extra: 11.2.0
       p-map: 7.0.2
       write-json-file: 6.0.0
@@ -5543,9 +5552,9 @@ snapshots:
       string-width: 7.2.0
       wide-align: 1.1.5
 
-  '@lerna-lite/profiler@3.10.1(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/profiler@3.10.1(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/npmlog': 3.10.1
       fs-extra: 11.2.0
       upath: 2.0.1
@@ -5556,12 +5565,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/publish@3.10.1(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/publish@3.10.1(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/npmlog': 3.10.1
-      '@lerna-lite/version': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/version': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.1
       byte-size: 9.0.0
@@ -5594,12 +5603,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/run@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/run@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/npmlog': 3.10.1
-      '@lerna-lite/profiler': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/profiler': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       fs-extra: 11.2.0
       p-map: 7.0.2
       tinyrainbow: 1.2.0
@@ -5615,10 +5624,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       '@lerna-lite/npmlog': 3.10.1
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 21.0.2
@@ -5662,10 +5671,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/watch@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)':
+  '@lerna-lite/watch@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)':
     dependencies:
-      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.6.3)
-      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1)(@lerna-lite/run@3.10.1)(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2))(@lerna-lite/watch@3.10.1)(@types/node@22.10.2)(typescript@5.7.2)
+      '@lerna-lite/core': 3.10.1(@types/node@22.10.2)(typescript@5.7.2)
       chokidar: 3.6.0
     transitivePeerDependencies:
       - '@lerna-lite/exec'
@@ -6166,32 +6175,32 @@ snapshots:
       '@types/node': 22.10.2
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       '@typescript-eslint/scope-manager': 8.18.0
-      '@typescript-eslint/type-utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 8.18.0
       eslint: 9.17.0(jiti@1.21.6)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-api-utils: 1.3.0(typescript@5.7.2)
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.18.0
       '@typescript-eslint/types': 8.18.0
-      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 8.18.0
       debug: 4.3.7(supports-color@8.1.1)
       eslint: 9.17.0(jiti@1.21.6)
-      typescript: 5.6.3
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6200,20 +6209,20 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
 
-  '@typescript-eslint/type-utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       debug: 4.3.7(supports-color@8.1.1)
       eslint: 9.17.0(jiti@1.21.6)
-      ts-api-utils: 1.3.0(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-api-utils: 1.3.0(typescript@5.7.2)
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.18.0': {}
 
-  '@typescript-eslint/typescript-estree@8.18.0(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.18.0(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
@@ -6222,19 +6231,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-api-utils: 1.3.0(typescript@5.7.2)
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@1.21.6))
       '@typescript-eslint/scope-manager': 8.18.0
       '@typescript-eslint/types': 8.18.0
-      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.2)
       eslint: 9.17.0(jiti@1.21.6)
-      typescript: 5.6.3
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6243,10 +6252,10 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))(vue@3.5.13(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0))(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0)
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@vitest/coverage-v8@3.0.0-beta.2(vitest@3.0.0-beta.2)':
     dependencies:
@@ -6266,12 +6275,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.16(@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)(vitest@3.0.0-beta.2)':
+  '@vitest/eslint-plugin@1.1.16(@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)(vitest@3.0.0-beta.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       eslint: 9.17.0(jiti@1.21.6)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
       vitest: 3.0.0-beta.2(@types/node@22.10.2)(@vitest/ui@3.0.0-beta.2)(happy-dom@16.0.1)(jiti@1.21.6)(jsdom@25.0.1)(sass@1.83.0)(yaml@2.6.0)
 
   '@vitest/expect@3.0.0-beta.2':
@@ -6329,11 +6338,23 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.4.10
 
+  '@volar/language-core@2.4.11':
+    dependencies:
+      '@volar/source-map': 2.4.11
+
   '@volar/source-map@2.4.10': {}
+
+  '@volar/source-map@2.4.11': {}
 
   '@volar/typescript@2.4.10':
     dependencies:
       '@volar/language-core': 2.4.10
+      path-browserify: 1.0.1
+      vscode-uri: 3.0.8
+
+  '@volar/typescript@2.4.11':
+    dependencies:
+      '@volar/language-core': 2.4.11
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
@@ -6374,20 +6395,7 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/language-core@2.1.10(typescript@5.6.3)':
-    dependencies:
-      '@volar/language-core': 2.4.10
-      '@vue/compiler-dom': 3.5.13
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.13
-      alien-signals: 0.2.2
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.6.3
-
-  '@vue/language-core@2.1.6(typescript@5.6.3)':
+  '@vue/language-core@2.1.6(typescript@5.7.2)':
     dependencies:
       '@volar/language-core': 2.4.10
       '@vue/compiler-dom': 3.5.13
@@ -6398,7 +6406,20 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
+
+  '@vue/language-core@2.2.0(typescript@5.7.2)':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      alien-signals: 0.4.12
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.7.2
 
   '@vue/reactivity@3.5.13':
     dependencies:
@@ -6416,11 +6437,11 @@ snapshots:
       '@vue/shared': 3.5.13
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.6.3))':
+  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@vue/shared@3.5.13': {}
 
@@ -6486,7 +6507,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alien-signals@0.2.2: {}
+  alien-signals@0.4.12: {}
 
   ansi-colors@4.1.3: {}
 
@@ -6941,21 +6962,21 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@5.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3):
+  cosmiconfig-typescript-loader@5.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2):
     dependencies:
       '@types/node': 22.10.2
-      cosmiconfig: 9.0.0(typescript@5.6.3)
+      cosmiconfig: 9.0.0(typescript@5.7.2)
       jiti: 1.21.6
-      typescript: 5.6.3
+      typescript: 5.7.2
 
-  cosmiconfig@9.0.0(typescript@5.6.3):
+  cosmiconfig@9.0.0(typescript@5.7.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
 
   cross-env@7.0.3:
     dependencies:
@@ -7786,16 +7807,16 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  i18next-vue@5.0.0(i18next@24.1.0(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3)):
+  i18next-vue@5.0.0(i18next@24.1.0(typescript@5.7.2))(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      i18next: 24.1.0(typescript@5.6.3)
-      vue: 3.5.13(typescript@5.6.3)
+      i18next: 24.1.0(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
-  i18next@24.1.0(typescript@5.6.3):
+  i18next@24.1.0(typescript@5.7.2):
     dependencies:
       '@babel/runtime': 7.26.0
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -9354,9 +9375,9 @@ snapshots:
 
   treeverse@3.0.0: {}
 
-  ts-api-utils@1.3.0(typescript@5.6.3):
+  ts-api-utils@1.3.0(typescript@5.7.2):
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
 
   tslib@2.8.0: {}
 
@@ -9386,19 +9407,19 @@ snapshots:
 
   type-fest@4.26.1: {}
 
-  typescript-eslint@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3):
+  typescript-eslint@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       eslint: 9.17.0(jiti@1.21.6)
-      typescript: 5.6.3
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.4.2: {}
 
-  typescript@5.6.3: {}
+  typescript@5.7.2: {}
 
   ufo@1.5.4: {}
 
@@ -9483,18 +9504,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.3.0(@types/node@22.10.2)(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0)):
+  vite-plugin-dts@4.3.0(@types/node@22.10.2)(rollup@4.24.0)(typescript@5.7.2)(vite@6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0)):
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.10.2)
       '@rollup/pluginutils': 5.1.3(rollup@4.24.0)
       '@volar/typescript': 2.4.10
-      '@vue/language-core': 2.1.6(typescript@5.6.3)
+      '@vue/language-core': 2.1.6(typescript@5.7.2)
       compare-versions: 6.1.1
       debug: 4.3.7(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.12
-      typescript: 5.6.3
+      typescript: 5.7.2
     optionalDependencies:
       vite: 6.0.3(@types/node@22.10.2)(jiti@1.21.6)(sass@1.83.0)(yaml@2.6.0)
     transitivePeerDependencies:
@@ -9569,27 +9590,26 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-router@4.5.0(vue@3.5.13(typescript@5.6.3)):
+  vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.13(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.7.2)
 
-  vue-tsc@2.1.10(typescript@5.6.3):
+  vue-tsc@2.2.0(typescript@5.7.2):
     dependencies:
-      '@volar/typescript': 2.4.10
-      '@vue/language-core': 2.1.10(typescript@5.6.3)
-      semver: 7.6.3
-      typescript: 5.6.3
+      '@volar/typescript': 2.4.11
+      '@vue/language-core': 2.2.0(typescript@5.7.2)
+      typescript: 5.7.2
 
-  vue@3.5.13(typescript@5.6.3):
+  vue@3.5.13(typescript@5.7.2):
     dependencies:
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-sfc': 3.5.13
       '@vue/runtime-dom': 3.5.13
-      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.6.3))
+      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.7.2))
       '@vue/shared': 3.5.13
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/test/cypress/e2e/example12.cy.ts
+++ b/test/cypress/e2e/example12.cy.ts
@@ -149,12 +149,12 @@ describe('Example 12 - Composite Editor Modal', () => {
   it('should not be able to change the "Finish" dates on first 2 rows', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
-      .click(); // this date should also always be initially empty
+      .click({ force: true }); // this date should also always be initially empty
     cy.get(`.vanilla-calendar-day__btn_today:visible`).should('not.exist');
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
-      .click(); // this date should also always be initially empty
+      .click({ force: true }); // this date should also always be initially empty
     cy.get(`.vanilla-calendar-day__btn_today:visible`).should('not.exist');
   });
 


### PR DESCRIPTION
- latest `vue-tsc` fixed the issue they had with updating to latest TypeScript v5.7.x
- also for good the Composite example flaky Cypress test which failed a lot recently