### PR TITLE
fix: remove "active" CSS classes before navigating to another cell

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -6637,6 +6637,7 @@ describe('SlickGrid core file', () => {
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigateTopSpy = vi.spyOn(grid, 'navigateTop');
+        const unsetActiveCellSpy = vi.spyOn(grid, 'unsetActiveCell');
         const event = new CustomEvent('keydown');
         Object.defineProperty(event, 'key', { writable: true, value: 'ArrowUp' });
         Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
@@ -6644,6 +6645,7 @@ describe('SlickGrid core file', () => {
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigateTopSpy).toHaveBeenCalled();
+        expect(unsetActiveCellSpy).toHaveBeenCalled();
       });
 
       it('should call navigatePageDown() when triggering PageDown key', () => {
@@ -6654,12 +6656,14 @@ describe('SlickGrid core file', () => {
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigatePageDownSpy = vi.spyOn(grid, 'navigatePageDown');
+        const unsetActiveCellSpy = vi.spyOn(grid, 'unsetActiveCell');
         const event = new CustomEvent('keydown');
         Object.defineProperty(event, 'key', { writable: true, value: 'PageDown' });
         container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigatePageDownSpy).toHaveBeenCalled();
+        expect(unsetActiveCellSpy).toHaveBeenCalled();
       });
 
       it('should call navigatePageUp() when triggering PageDown key', () => {
@@ -6670,12 +6674,14 @@ describe('SlickGrid core file', () => {
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigatePageUpSpy = vi.spyOn(grid, 'navigatePageUp');
+        const unsetActiveCellSpy = vi.spyOn(grid, 'unsetActiveCell');
         const event = new CustomEvent('keydown');
         Object.defineProperty(event, 'key', { writable: true, value: 'PageUp' });
         container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigatePageUpSpy).toHaveBeenCalled();
+        expect(unsetActiveCellSpy).toHaveBeenCalled();
       });
 
       it('should call navigateLeft() when triggering PageDown key', () => {
@@ -6750,12 +6756,14 @@ describe('SlickGrid core file', () => {
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigateNextSpy = vi.spyOn(grid, 'navigateNext');
+        const unsetActiveCellSpy = vi.spyOn(grid, 'unsetActiveCell');
         const event = new CustomEvent('keydown');
         Object.defineProperty(event, 'key', { writable: true, value: 'Tab' });
         container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigateNextSpy).toHaveBeenCalled();
+        expect(unsetActiveCellSpy).toHaveBeenCalled();
       });
 
       it('should call navigatePrev() when triggering Enter key', () => {
@@ -6766,6 +6774,7 @@ describe('SlickGrid core file', () => {
         grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true, editable: true });
         const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
         const navigatePrevSpy = vi.spyOn(grid, 'navigatePrev');
+        const unsetActiveCellSpy = vi.spyOn(grid, 'unsetActiveCell');
         const event = new CustomEvent('keydown');
         Object.defineProperty(event, 'key', { writable: true, value: 'Tab' });
         Object.defineProperty(event, 'shiftKey', { writable: true, value: true });
@@ -6773,6 +6782,7 @@ describe('SlickGrid core file', () => {
 
         expect(onKeyDownSpy).toHaveBeenCalled();
         expect(navigatePrevSpy).toHaveBeenCalled();
+        expect(unsetActiveCellSpy).toHaveBeenCalled();
       });
 
       it('should do nothing when triggering Escape key without any editor to cancel', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5599,9 +5599,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // Cell switching
 
-  /**  Resets active cell. */
+  /** Resets active cell by making cell normal and other internal resets. */
   resetActiveCell(): void {
     this.setActiveCellInternal(null, false);
+  }
+
+  /** Clear active cell by making cell normal & removing "active" CSS class. */
+  unsetActiveCell(): void {
+    if (isDefined(this.activeCellNode)) {
+      this.makeActiveCellNormal();
+      this.activeCellNode.classList.remove('active');
+      this.rowsCache[this.activeRow]?.rowNode?.forEach((node) => node.classList.remove('active'));
+    }
   }
 
   /** @alias `setFocus` */
@@ -5659,11 +5668,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     suppressActiveCellChangedEvent?: boolean,
     e?: Event | SlickEvent
   ): void {
-    if (isDefined(this.activeCellNode)) {
-      this.makeActiveCellNormal();
-      this.activeCellNode.classList.remove('active');
-      this.rowsCache[this.activeRow]?.rowNode?.forEach((node) => node.classList.remove('active'));
-    }
+    // make current active cell as normal cell & remove "active" CSS classes
+    this.unsetActiveCell();
 
     // let activeCellChanged = (this.activeCellNode !== newCell);
     this.activeCellNode = newCell;
@@ -6106,11 +6112,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to the top of the grid */
   navigateTop(): void {
+    this.unsetActiveCell();
     this.navigateToRow(0);
   }
 
   /** Navigate to the bottom of the grid */
   navigateBottom(): boolean {
+    this.unsetActiveCell();
     return this.navigateToRow(this.getDataLength() - 1);
   }
 
@@ -6436,12 +6444,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to coordinate 0,0 (top left home) */
   navigateTopStart(): boolean | undefined {
+    this.unsetActiveCell();
     this.navigateToRow(0);
     return this.navigate('home');
   }
 
   /** Navigate to bottom row end (bottom right end) */
   navigateBottomEnd(): boolean | undefined {
+    this.unsetActiveCell();
     this.navigateBottom();
     return this.navigate('end');
   }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6102,11 +6102,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate (scroll) by a page down */
   navigatePageDown(): void {
+    this.unsetActiveCell();
     this.scrollPage(1);
   }
 
   /** Navigate (scroll) by a page up */
   navigatePageUp(): void {
+    this.unsetActiveCell();
     this.scrollPage(-1);
   }
 
@@ -6444,14 +6446,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Navigate to coordinate 0,0 (top left home) */
   navigateTopStart(): boolean | undefined {
-    this.unsetActiveCell();
     this.navigateToRow(0);
     return this.navigate('home');
   }
 
   /** Navigate to bottom row end (bottom right end) */
   navigateBottomEnd(): boolean | undefined {
-    this.unsetActiveCell();
     this.navigateBottom();
     return this.navigate('end');
   }
@@ -6469,6 +6469,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return true;
     }
     this.setFocus();
+    this.unsetActiveCell();
 
     const tabbingDirections = {
       up: -1,


### PR DESCRIPTION
- certain nav commands are navigating away from current viewport and when re-navigating back to another cell that is in the same viewport (like 0,0 with Ctrl+Home) then it sometimes has 2 active cells instead of never more than 1.
- this can probably occur a little more after recent PR #1788