### PR TITLE
chore: remove unnecessary SASS quiet warnings

### DIFF
--- a/examples/vite-demo-vanilla-bundle/package.json
+++ b/examples/vite-demo-vanilla-bundle/package.json
@@ -25,7 +25,7 @@
     "@slickgrid-universal/text-export": "workspace:~",
     "@slickgrid-universal/vanilla-bundle": "workspace:~",
     "@slickgrid-universal/vanilla-force-bundle": "workspace:~",
-    "bulma": "^1.0.2",
+    "bulma": "^1.0.3",
     "dompurify": "^3.1.6",
     "multiple-select-vanilla": "^3.4.2",
     "rxjs": "^7.8.1",

--- a/examples/vite-demo-vanilla-bundle/vite.config.mts
+++ b/examples/vite-demo-vanilla-bundle/vite.config.mts
@@ -11,15 +11,8 @@ export default defineConfig(() => {
       emptyOutDir: true,
       outDir: '../../website',
     },
-    css: {
-      preprocessorOptions: {
-        scss: {
-          quietDeps: true,
-        },
-      },
-    },
     preview: {
-      port: 8888
+      port: 8888,
     },
     server: {
       port: 8888,
@@ -30,7 +23,7 @@ export default defineConfig(() => {
       },
       watch: {
         followSymlinks: false,
-      }
+      },
     },
   };
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
         specifier: workspace:~
         version: link:../../packages/vanilla-force-bundle
       bulma:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.0.3
+        version: 1.0.3
       dompurify:
         specifier: ^3.1.6
         version: 3.1.7
@@ -2124,8 +2124,8 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bulma@1.0.2:
-    resolution: {integrity: sha512-D7GnDuF6seb6HkcnRMM9E739QpEY9chDzzeFrHMyEns/EXyDJuQ0XA0KxbBl/B2NTsKSoDomW61jFGFaAxhK5A==}
+  bulma@1.0.3:
+    resolution: {integrity: sha512-9eVXBrXwlU337XUXBjIIq7i88A+tRbJYAjXQjT/21lwam+5tpvKF0R7dCesre9N+HV9c6pzCNEPKrtgvBBes2g==}
 
   byte-size@9.0.1:
     resolution: {integrity: sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw==}
@@ -6863,7 +6863,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bulma@1.0.2: {}
+  bulma@1.0.3: {}
 
   byte-size@9.0.1: {}
 


### PR DESCRIPTION
- Bulma fixed all their SASS warnings with their recent version, so we can remove the SASS warning silencing