### PR TITLE
feat: add Custom Global Item Data Provider

### DIFF
--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -144,6 +144,23 @@ describe('SlickDatView core file', () => {
       dv.setItems(items);
       expect(dv.mapRowsToIds([0, 1, 999])).toEqual([4, 3]);
     });
+
+    it('should work with a custom global item metadata provider provided to the DataView constructor options', () => {
+      dv = new SlickDataView({
+        globalItemMetadataProvider: {
+          getRowMetadata(item, row) {
+            return `row ${row} with name: ${item.name}`;
+          },
+        },
+      });
+      const items = [
+        { id: 4, name: 'John', age: 20 },
+        { id: 3, name: 'Jane', age: 24 },
+      ];
+      dv.setItems(items);
+      expect(dv.getItemMetadata(0)).toBe('row 0 with name: John');
+      expect(dv.getItemMetadata(1)).toBe('row 1 with name: Jane');
+    });
   });
 
   describe('CRUD methods', () => {

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -85,7 +85,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     this._options = { ...this._options, ...inputOptions };
   }
 
-  getGroupRowMetadata(item: GroupingFormatterItem): ItemMetadata {
+  getGroupRowMetadata(item: GroupingFormatterItem, _row: number): ItemMetadata {
     return {
       selectable: false,
       focusable: this._options.groupFocusable,
@@ -101,7 +101,8 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     };
   }
 
-  getTotalsRowMetadata(item: { group: GroupingFormatterItem }): {
+  // prettier-ignore
+  getTotalsRowMetadata(item: { group: GroupingFormatterItem }, _row: number): {
     selectable: boolean;
     focusable: boolean | undefined;
     cssClasses: string;

--- a/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
+++ b/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
@@ -1,6 +1,10 @@
 import type { Formatter } from './formatter.interface.js';
 import type { SlickCheckboxSelectColumn } from '../extensions/slickCheckboxSelectColumn.js';
 
+export interface ItemMetadataProvider {
+  getRowMetadata(item: any, row: number): any;
+}
+
 export interface GroupItemMetadataProviderOption {
   /** Whether or not we want to use group select checkbox. */
   checkboxSelect?: boolean;


### PR DESCRIPTION
- allow providing a custom global item metadata provider by passing it through the `groupItemMetadataProvider` DataView constructor option
- implementation copied from https://github.com/GerHobbelt/SlickGrid fork