### PR TITLE
fix: opening Header Menu shouldn't add Active Header Cell

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2077,7 +2077,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const sortableOptions = {
       animation: 50,
       direction: 'horizontal',
-      chosenClass: 'slick-header-column-active',
       ghostClass: 'slick-sortable-placeholder',
       draggable: '.slick-header-column',
       dragoverBubble: false,
@@ -2088,7 +2087,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       onMove: (event) => {
         return !event.related.classList.contains(this._options.unorderableColumnCssClass as string);
       },
-      onStart: (e: SortableEvent) => {
+      onStart: (e) => {
+        e.item.classList.add('slick-header-column-active');
         canDragScroll = !this.hasFrozenColumns() || getOffset(e.item).left > getOffset(this._viewportScrollContainerX).left;
 
         if (canDragScroll && (e as SortableEvent & { originalEvent: MouseEvent }).originalEvent.pageX > this._container.clientWidth) {
@@ -2107,6 +2107,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         }
       },
       onEnd: (e) => {
+        e.item.classList.remove('slick-header-column-active');
         window.clearInterval(columnScrollTimer);
 
         if (!this.getEditorLock()?.commitCurrentEdit()) {

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -300,7 +300,8 @@ describe('Draggable Grouping Plugin', () => {
       );
       vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['age', 'medals']);
 
-      fn.sortableLeftInstance!.options.onStart!({} as any);
+      const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+      fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
       let groupByRemoveElm = preHeaderDiv.querySelector('.slick-groupby-remove') as HTMLDivElement;
@@ -340,9 +341,12 @@ describe('Draggable Grouping Plugin', () => {
       );
       vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue([]);
 
-      fn.sortableLeftInstance!.options.onStart!({} as any);
+      const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+      fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
-      fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+      const endEvent = new CustomEvent('end');
+      Object.defineProperty(endEvent, 'item', { writable: true, configurable: true, value: headerColumnDiv3 });
+      fn.sortableLeftInstance.options.onEnd!(endEvent as any);
 
       const placeholderElm = preHeaderDiv.querySelector('.slick-draggable-dropzone-placeholder') as HTMLDivElement;
       const dropGroupingElm = preHeaderDiv.querySelector('.slick-dropped-grouping') as HTMLDivElement;
@@ -365,9 +369,12 @@ describe('Draggable Grouping Plugin', () => {
         triggerSpy
       );
 
-      fn.sortableLeftInstance!.options.onStart!({} as any);
+      const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+      fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
-      fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+      const endEvent = new CustomEvent('end');
+      Object.defineProperty(endEvent, 'item', { writable: true, configurable: true, value: headerColumnDiv3 });
+      fn.sortableLeftInstance.options.onEnd!(endEvent as any);
 
       const groupByRemoveElm = document.querySelector('.slick-groupby-remove.mdi-close') as HTMLDivElement;
       expect(groupByRemoveElm).toBeTruthy();
@@ -392,10 +399,13 @@ describe('Draggable Grouping Plugin', () => {
         triggerSpy
       );
 
-      fn.sortableLeftInstance!.options.onStart!({} as any);
+      const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+      fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
       plugin.clearDroppedGroups();
-      fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+      const endEvent = new CustomEvent('end');
+      Object.defineProperty(endEvent, 'item', { writable: true, configurable: true, value: headerColumnDiv3 });
+      fn.sortableLeftInstance.options.onEnd!(endEvent as any);
 
       const draggablePlaceholderElm = dropzoneElm.querySelector('.slick-draggable-dropzone-placeholder') as HTMLDivElement;
       expect(draggablePlaceholderElm.style.display).toEqual('inline-block');
@@ -420,13 +430,16 @@ describe('Draggable Grouping Plugin', () => {
       );
       vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['age', 'medals']);
 
-      fn.sortableLeftInstance!.options.onStart!({} as any);
+      const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+      fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
       const groupByRemoveElm = document.querySelector('.slick-groupby-remove.mdi-close');
       expect(groupByRemoveElm).toBeTruthy();
 
-      fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+      const endEvent = new CustomEvent('end');
+      Object.defineProperty(endEvent, 'item', { writable: true, configurable: true, value: headerColumnDiv3 });
+      fn.sortableLeftInstance.options.onEnd!(endEvent as any);
 
       expect(setColumnsSpy).toHaveBeenCalledWith([mockColumns[2], mockColumns[2]]);
       expect(setColumnResizeSpy).toHaveBeenCalled();
@@ -448,9 +461,12 @@ describe('Draggable Grouping Plugin', () => {
         triggerSpy
       );
 
-      fn.sortableLeftInstance!.options.onStart!({} as any);
+      const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+      fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
       plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
-      fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+      const endEvent = new CustomEvent('end');
+      Object.defineProperty(endEvent, 'item', { writable: true, configurable: true, value: headerColumnDiv3 });
+      fn.sortableLeftInstance.options.onEnd!(endEvent as any);
       const dropzonePlaceholderElm = dropzoneElm.querySelector('.slick-draggable-dropzone-placeholder');
 
       const dragoverEvent = new CustomEvent('dragover', { bubbles: true, detail: {} });
@@ -507,7 +523,8 @@ describe('Draggable Grouping Plugin', () => {
             triggerSpy
           );
           vi.spyOn(plugin.droppableInstance!, 'toArray').mockReturnValue(['age', 'medals']);
-          fn.sortableLeftInstance!.options.onStart!({} as any);
+          const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+          fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
           plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
           plugin.droppableInstance?.options.onUpdate!({ item: mockDivPaneContainer1, clone: mockDivPaneContainer1.cloneNode(true) } as any);
         });
@@ -660,7 +677,8 @@ describe('Draggable Grouping Plugin', () => {
           );
           vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['age', 'medals']);
 
-          fn.sortableLeftInstance!.options.onStart!({} as any);
+          const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+          fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
           plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
           expect(plugin.addonOptions.hideGroupSortIcons).toBe(true);
@@ -692,7 +710,8 @@ describe('Draggable Grouping Plugin', () => {
           );
           vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['age']);
 
-          fn.sortableLeftInstance!.options.onStart!({} as any);
+          const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+          fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
           plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
           const groupBySortElm = preHeaderDiv.querySelector('.slick-groupby-sort') as HTMLDivElement;
@@ -721,7 +740,8 @@ describe('Draggable Grouping Plugin', () => {
           vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['age', 'medals']);
           const invalidateSpy = vi.spyOn(gridStub, 'invalidate');
 
-          fn.sortableLeftInstance!.options.onStart!({} as any);
+          const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+          fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
           plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
           const groupBySortElm = preHeaderDiv.querySelector('.slick-groupby-sort') as HTMLDivElement;
@@ -779,7 +799,8 @@ describe('Draggable Grouping Plugin', () => {
           vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['age', 'medals']);
           const invalidateSpy = vi.spyOn(gridStub, 'invalidate');
 
-          fn.sortableLeftInstance!.options.onStart!({} as any);
+          const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+          fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
           plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
 
           const groupBySortElm = preHeaderDiv.querySelector('.slick-groupby-sort') as HTMLDivElement;
@@ -844,9 +865,12 @@ describe('Draggable Grouping Plugin', () => {
         vi.spyOn(fn.sortableLeftInstance, 'toArray').mockReturnValue(['firstName', 'lastName', 'age']);
         vi.spyOn(fn.sortableRightInstance, 'toArray').mockReturnValue(['gender']);
 
-        fn.sortableLeftInstance!.options.onStart!({} as any);
+        const onStartItem = createDomElement('div', { className: 'slick-header-column', id: `${GRID_UID}age`, dataset: { id: 'age' } }, preHeaderDiv);
+        fn.sortableLeftInstance!.options.onStart!({ item: onStartItem } as any);
         plugin.droppableInstance!.options.onAdd!({ item: headerColumnDiv3, clone: headerColumnDiv3.cloneNode(true) } as any);
-        fn.sortableLeftInstance.options.onEnd!(new CustomEvent('end') as any);
+        const endEvent = new CustomEvent('end');
+        Object.defineProperty(endEvent, 'item', { writable: true, configurable: true, value: headerColumnDiv3 });
+        fn.sortableLeftInstance.options.onEnd!(endEvent as any);
 
         const groupByRemoveElm = document.querySelector('.slick-groupby-remove.mdi-close') as HTMLDivElement;
         expect(groupByRemoveElm).toBeTruthy();

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -315,7 +315,6 @@ export class SlickDraggableGrouping {
 
     const sortableOptions = {
       animation: 50,
-      chosenClass: 'slick-header-column-active',
       ghostClass: 'slick-sortable-placeholder',
       draggable: '.slick-header-column',
       dataIdAttr: 'data-id',
@@ -330,7 +329,8 @@ export class SlickDraggableGrouping {
       //   // NOTE: need to disable for now since it also blocks the column reordering
       //   return columnsGroupBy.some(c => c.id === target.getAttribute('data-id'));
       // },
-      onStart: () => {
+      onStart: (e) => {
+        e.item.classList.add('slick-header-column-active');
         if (draggablePlaceholderElm) {
           draggablePlaceholderElm.style.display = 'inline-block';
         }
@@ -340,7 +340,8 @@ export class SlickDraggableGrouping {
           groupTogglerElm.style.display = 'none';
         }
       },
-      onEnd: (e: Event & { item: any; clone: HTMLElement }) => {
+      onEnd: (e) => {
+        e.item.classList.remove('slick-header-column-active');
         dropzoneElm?.classList.remove('slick-dropzone-hover');
         draggablePlaceholderElm?.parentElement?.classList.remove('slick-dropzone-placeholder-hover');
 


### PR DESCRIPTION
- we should add the CSS class `slick-column-header-active` to the Header Cell **only** when we start dragging that header, otherwise we shouldn't and that wasn't the case before which showed a the active header and a flickering especially in Dark Mode

![brave_VMzYmMpRr8](https://github.com/user-attachments/assets/e9a68dd1-b6ab-4a7f-981b-651100ba42c9)

#### after fix (gray background only shows when dragging)

![brave_2n7L06WIun](https://github.com/user-attachments/assets/d44c8cfc-77a7-4526-a159-862ddc3e12b8)

