### PR TITLE
fix: Header Menu was offset when header/footer slots provided

### DIFF
--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -175,6 +175,7 @@ describe('HeaderMenu Plugin', () => {
     let gridContainerDiv: HTMLDivElement;
     let headerDiv: HTMLDivElement;
     let headersDiv: HTMLDivElement;
+    let parentContainer: HTMLDivElement;
 
     beforeEach(() => {
       sharedService.slickGrid = gridStub;
@@ -190,11 +191,14 @@ describe('HeaderMenu Plugin', () => {
       gridContainerDiv.className = 'slickgrid-container';
       headersDiv = document.createElement('div');
       headersDiv.className = 'slick-header-columns';
-      vi.spyOn(gridStub, 'getContainerNode').mockReturnValue(gridContainerDiv);
-      vi.spyOn(gridStub, 'getGridPosition').mockReturnValue({ top: 10, bottom: 5, left: 15, right: 22, width: 225 } as ElementPosition);
       headersDiv.appendChild(headerDiv);
       gridContainerDiv.appendChild(headersDiv);
-      document.body.appendChild(gridContainerDiv);
+      parentContainer = document.createElement('div');
+      parentContainer.appendChild(gridContainerDiv);
+      document.body.appendChild(parentContainer);
+      sharedService.gridContainerElement = parentContainer;
+      vi.spyOn(gridStub, 'getContainerNode').mockReturnValue(gridContainerDiv);
+      vi.spyOn(gridStub, 'getGridPosition').mockReturnValue({ top: 10, bottom: 5, left: 15, right: 22, width: 225 } as ElementPosition);
     });
 
     afterEach(() => {

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -145,7 +145,8 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     const isSubMenu = menuElm.classList.contains('slick-submenu');
     const parentElm = isSubMenu ? ((e.target as HTMLElement).closest('.slick-menu-item') as HTMLDivElement) : (buttonElm as HTMLElement);
 
-    const relativePos = getOffsetRelativeToParent(this.sharedService.gridContainerElement, buttonElm);
+    const containerElm = this.sharedService.gridContainerElement.querySelector('.slickgrid-container') as HTMLElement;
+    const relativePos = getOffsetRelativeToParent(containerElm, buttonElm);
     const gridPos = this.grid.getGridPosition();
     const menuWidth = menuElm.offsetWidth;
     const parentOffset = getOffset(parentElm);

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -145,7 +145,8 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     const isSubMenu = menuElm.classList.contains('slick-submenu');
     const parentElm = isSubMenu ? ((e.target as HTMLElement).closest('.slick-menu-item') as HTMLDivElement) : (buttonElm as HTMLElement);
 
-    const containerElm = this.sharedService.gridContainerElement.querySelector('.slickgrid-container') as HTMLElement;
+    const containerElm: HTMLElement =
+      this.sharedService.gridContainerElement.querySelector('.slickgrid-container') ?? this.sharedService.gridContainerElement;
     const relativePos = getOffsetRelativeToParent(containerElm, buttonElm);
     const gridPos = this.grid.getGridPosition();
     const menuWidth = menuElm.offsetWidth;

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -364,7 +364,7 @@ describe('Example 14 - Columns Resize by Content', () => {
         .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
 
       // click on Feedback->ContactUs
-      cy.get('.slick-header-menu.slick-menu-level-1.dropright')
+      cy.get('.slick-header-menu.slick-menu-level-1.dropleft') // left align
         .find('.slick-menu-item.slick-menu-item')
         .contains('Contact Us')
         .should('exist')

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -364,7 +364,7 @@ describe('Example 14 - Columns Resize by Content', () => {
         .each(($command, index) => expect($command.text()).to.contain(subCommands2[index]));
 
       // click on Feedback->ContactUs
-      cy.get('.slick-header-menu.slick-menu-level-1.dropleft') // left align
+      cy.get('.slick-header-menu.slick-menu-level-1.dropright')
         .find('.slick-menu-item.slick-menu-item')
         .contains('Contact Us')
         .should('exist')


### PR DESCRIPTION
- when a Header slot is provided within the slickgrid component of any framework (Angular-Slickgrid, Slickgrid-Vue, ...) then the Header Menu position had the wrong top offset and the header slot height was being added to the calculation when it shouldn't. The fix was simply to make our top offset calculation relative to the SlickGrid container without the header slot, basically the real slickgrid container that holds the slick-header-columns and everything else (which is the one highlighted in blue below)

![image](https://github.com/user-attachments/assets/ac47200b-4180-4054-a9fc-af0d008bd03b)

here's the real `.slickgrid-container` that we should be making our "relative to" offset calculation

![image](https://github.com/user-attachments/assets/3b930508-f65a-4412-86e0-02c11a4b9857)
