### PR TITLE
fix(vue): prefer `Ref<Column[]>` to avoid template type mismatch

### DIFF
--- a/demos/vue/src/components/Example01.vue
+++ b/demos/vue/src/components/Example01.vue
@@ -7,7 +7,7 @@ import {
   SlickgridVue,
   type SlickgridVueInstance,
 } from 'slickgrid-vue';
-import { onBeforeMount, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onUnmounted, ref, type Ref } from 'vue';
 
 import { zeroPadding } from './utilities';
 
@@ -18,8 +18,8 @@ let _darkModeGrid1 = false;
 let vueGrid1!: SlickgridVueInstance;
 const gridOptions1 = ref<GridOption>();
 const gridOptions2 = ref<GridOption>();
-const columnDefinitions1 = ref<Column[]>([]);
-const columnDefinitions2 = ref<Column[]>([]);
+const columnDefinitions1: Ref<Column[]> = ref([]);
+const columnDefinitions2: Ref<Column[]> = ref([]);
 const dataset1 = ref<any[]>([]);
 const dataset2 = ref<any[]>([]);
 

--- a/demos/vue/src/components/Example01.vue
+++ b/demos/vue/src/components/Example01.vue
@@ -18,8 +18,8 @@ let _darkModeGrid1 = false;
 let vueGrid1!: SlickgridVueInstance;
 const gridOptions1 = ref<GridOption>();
 const gridOptions2 = ref<GridOption>();
-const columnDefinitions1 = ref<Column[]>();
-const columnDefinitions2 = ref<Column[]>();
+const columnDefinitions1 = ref<Column[]>([]);
+const columnDefinitions2 = ref<Column[]>([]);
 const dataset1 = ref<any[]>([]);
 const dataset2 = ref<any[]>([]);
 
@@ -149,7 +149,7 @@ function toggleDarkModeGrid1() {
   <div class="grid-container1">
     <SlickgridVue
       v-model:options="gridOptions1!"
-      v-model:columns="columnDefinitions1 as Column[]"
+      v-model:columns="columnDefinitions1"
       v-model:data="dataset1"
       grid-id="grid1-1"
       @onVueGridCreated="vueGrid1Ready($event.detail)"
@@ -163,7 +163,7 @@ function toggleDarkModeGrid1() {
 
   <slickgrid-vue
     v-model:options="gridOptions2!"
-    v-model:columns="columnDefinitions2 as Column[]"
+    v-model:columns="columnDefinitions2"
     v-model:data="dataset2"
     grid-id="grid1-2"
     @on-pagination-changed="paginationChanged($event.detail)"

--- a/demos/vue/src/components/Example02.vue
+++ b/demos/vue/src/components/Example02.vue
@@ -8,7 +8,7 @@ import {
   SlickgridVue,
   type SlickgridVueInstance,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 interface DataItem {
@@ -25,7 +25,7 @@ interface DataItem {
 }
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const resizerPaused = ref(false);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example02.vue
+++ b/demos/vue/src/components/Example02.vue
@@ -282,7 +282,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid2"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example03.vue
+++ b/demos/vue/src/components/Example03.vue
@@ -757,7 +757,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions as GridOption"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid3"
     @on-cell-change="onCellChanged($event.detail.eventData, $event.detail.args)"

--- a/demos/vue/src/components/Example03.vue
+++ b/demos/vue/src/components/Example03.vue
@@ -17,7 +17,7 @@ import {
   SortComparers,
   type VanillaCalendarOption,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 import { CustomInputEditor } from './custom-inputEditor';
 import { CustomInputFilter } from './custom-inputFilter';
@@ -53,7 +53,7 @@ const gridOptions = ref<GridOption>({
   },
   // i18n: i18n,
 });
-const columnDefinitions = ref<Array<Column>>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 let vueGrid!: SlickgridVueInstance;
 

--- a/demos/vue/src/components/Example04.vue
+++ b/demos/vue/src/components/Example04.vue
@@ -436,7 +436,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid4"
     @onGridStateChanged="gridStateChanged($event.detail)"

--- a/demos/vue/src/components/Example04.vue
+++ b/demos/vue/src/components/Example04.vue
@@ -15,7 +15,7 @@ import {
   type SlickgridVueInstance,
   type VanillaCalendarOption,
 } from 'slickgrid-vue';
-import { onBeforeMount, onBeforeUnmount, onMounted, ref } from 'vue';
+import { onBeforeMount, onBeforeUnmount, onMounted, ref, type Ref } from 'vue';
 
 import { CustomInputFilter } from './custom-inputFilter';
 import URL_SAMPLE_COLLECTION_DATA from './data/collection_500_numbers.json';
@@ -24,7 +24,7 @@ const NB_ITEMS = 10500;
 
 const metrics = ref<Metrics>({} as Metrics);
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 let vueGrid!: SlickgridVueInstance;

--- a/demos/vue/src/components/Example05.vue
+++ b/demos/vue/src/components/Example05.vue
@@ -643,7 +643,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     v-model:pagination="paginationOptions"
     grid-id="grid5"

--- a/demos/vue/src/components/Example05.vue
+++ b/demos/vue/src/components/Example05.vue
@@ -14,7 +14,7 @@ import {
   SlickgridVue,
   type SlickgridVueInstance,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 import Data from './data/customers_100.json';
 
@@ -23,7 +23,7 @@ const CARET_HTML_ESCAPED = '%5E';
 const PERCENT_HTML_ESCAPED = '%25';
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const metrics = ref<Metrics>({} as Metrics);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example06.vue
+++ b/demos/vue/src/components/Example06.vue
@@ -18,7 +18,7 @@ import {
   type SlickgridVueInstance,
   SortDirection,
 } from 'slickgrid-vue';
-import { onBeforeMount, onMounted, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onMounted, onUnmounted, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
@@ -27,7 +27,7 @@ const GRAPHQL_QUERY_DATASET_NAME = 'users';
 const LOCAL_STORAGE_KEY = 'gridStateGraphql';
 const FAKE_SERVER_DELAY = 250;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const metrics = ref<Metrics>({} as Metrics);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example06.vue
+++ b/demos/vue/src/components/Example06.vue
@@ -608,7 +608,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid6"
     @onGridStateChanged="gridStateChanged($event.detail)"

--- a/demos/vue/src/components/Example07.vue
+++ b/demos/vue/src/components/Example07.vue
@@ -277,7 +277,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions1!"
-    v-model:columns="columnDefinitions1 as Column[]"
+    v-model:columns="columnDefinitions1"
     v-model:data="dataset1"
     grid-id="grid7-1"
     @onVueGridCreated="vueGrid1Ready($event.detail)"
@@ -290,7 +290,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions2!"
-    v-model:columns="columnDefinitions2 as Column[]"
+    v-model:columns="columnDefinitions2"
     v-model:data="dataset2"
     grid-id="grid7-2"
     @onVueGridCreated="vueGrid2Ready($event.detail)"

--- a/demos/vue/src/components/Example07.vue
+++ b/demos/vue/src/components/Example07.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type GridOption, type SlickgridVueInstance, type Column, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 200;
 let columns1WithHighlightingById: any = {};
@@ -8,8 +8,8 @@ let columns2WithHighlightingById: any = {};
 
 const gridOptions1 = ref<GridOption>();
 const gridOptions2 = ref<GridOption>();
-const columnDefinitions1 = ref<Column[]>([]);
-const columnDefinitions2 = ref<Column[]>([]);
+const columnDefinitions1: Ref<Column[]> = ref([]);
+const columnDefinitions2: Ref<Column[]> = ref([]);
 const dataset1 = ref<any[]>([]);
 const dataset2 = ref<any[]>([]);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example08.vue
+++ b/demos/vue/src/components/Example08.vue
@@ -250,7 +250,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid8"
       @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example08.vue
+++ b/demos/vue/src/components/Example08.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { useTranslation } from 'i18next-vue';
 import { type GridOption, type SlickgridVueInstance, type Column, Formatters, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
 const NB_ITEMS = 1000;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const selectedLanguage = ref('en');

--- a/demos/vue/src/components/Example09.vue
+++ b/demos/vue/src/components/Example09.vue
@@ -359,7 +359,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid9"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example09.vue
+++ b/demos/vue/src/components/Example09.vue
@@ -10,13 +10,13 @@ import {
   Formatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const selectedLanguage = ref('en');
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example10.vue
+++ b/demos/vue/src/components/Example10.vue
@@ -9,13 +9,13 @@ import {
   Formatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const isGrid2WithPagination = ref(true);
 const gridOptions1 = ref<GridOption>();
 const gridOptions2 = ref<GridOption>();
-const columnDefinitions1 = ref<Column[]>([]);
-const columnDefinitions2 = ref<Column[]>([]);
+const columnDefinitions1: Ref<Column[]> = ref([]);
+const columnDefinitions2: Ref<Column[]> = ref([]);
 const dataset1 = ref<any[]>([]);
 const dataset2 = ref<any[]>([]);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example10.vue
+++ b/demos/vue/src/components/Example10.vue
@@ -376,7 +376,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions1!"
-    v-model:columns="columnDefinitions1 as Column[]"
+    v-model:columns="columnDefinitions1"
     v-model:data="dataset1"
     grid-id="grid1"
     @onGridStateChanged="grid1StateChanged($event.detail)"
@@ -421,7 +421,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions2!"
-    v-model:columns="columnDefinitions2 as Column[]"
+    v-model:columns="columnDefinitions2"
     v-model:data="dataset2"
     grid-id="grid2"
     @onGridStateChanged="grid2StateChanged($event.detail)"

--- a/demos/vue/src/components/Example11.vue
+++ b/demos/vue/src/components/Example11.vue
@@ -341,7 +341,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid11"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example11.vue
+++ b/demos/vue/src/components/Example11.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { type GridOption, type SlickgridVueInstance, type Column, Editors, FieldType, Formatters, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 1000;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 let vueGrid!: SlickgridVueInstance;

--- a/demos/vue/src/components/Example12.vue
+++ b/demos/vue/src/components/Example12.vue
@@ -402,7 +402,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid12"
     @onGridStateChanged="gridStateChanged($event.detail)"

--- a/demos/vue/src/components/Example12.vue
+++ b/demos/vue/src/components/Example12.vue
@@ -15,13 +15,13 @@ import {
   SlickgridVue,
   SlickgridVueInstance,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
 const NB_ITEMS = 1500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const selectedLanguage = ref('en');

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -16,11 +16,11 @@ import {
   SortComparers,
   SortDirectionNumber,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const processing = ref(false);

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -459,7 +459,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid13"
     @onBeforeExportToExcel="processing = true"

--- a/demos/vue/src/components/Example14.vue
+++ b/demos/vue/src/components/Example14.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { type GridOption, type ItemMetadata, type SlickgridVueInstance, type Column, FieldType, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const gridOptions1 = ref<GridOption>();
 const gridOptions2 = ref<GridOption>();
-const columnDefinitions1 = ref<Column[]>([]);
-const columnDefinitions2 = ref<Column[]>([]);
+const columnDefinitions1: Ref<Column[]> = ref([]);
+const columnDefinitions2: Ref<Column[]> = ref([]);
 const dataset1 = ref<any[]>([]);
 const dataset2 = ref<any[]>([]);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example14.vue
+++ b/demos/vue/src/components/Example14.vue
@@ -196,7 +196,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions1!"
-    v-model:columns="columnDefinitions1 as Column[]"
+    v-model:columns="columnDefinitions1"
     v-model:data="dataset1"
     grid-id="grid1"
     @onVueGridCreated="vueGrid1Ready($event.detail)"
@@ -218,7 +218,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions2!"
-    v-model:columns="columnDefinitions2 as Column[]"
+    v-model:columns="columnDefinitions2"
     v-model:data="dataset2"
     grid-id="grid2"
     @onVueGridCreated="vueGrid2Ready($event.detail)"

--- a/demos/vue/src/components/Example15.vue
+++ b/demos/vue/src/components/Example15.vue
@@ -13,7 +13,7 @@ import {
   Formatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, onMounted, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onMounted, onUnmounted, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
@@ -21,7 +21,7 @@ const DEFAULT_PAGE_SIZE = 25;
 const LOCAL_STORAGE_KEY = 'gridState';
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const selectedLanguage = ref('en');

--- a/demos/vue/src/components/Example15.vue
+++ b/demos/vue/src/components/Example15.vue
@@ -328,7 +328,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid15"
     @onGridStateChanged="gridStateChanged($event.detail)"

--- a/demos/vue/src/components/Example16.vue
+++ b/demos/vue/src/components/Example16.vue
@@ -357,7 +357,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid16"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example16.vue
+++ b/demos/vue/src/components/Example16.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { type GridOption, type SlickgridVueInstance, type Column, Filters, Formatters, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 let vueGrid!: SlickgridVueInstance;

--- a/demos/vue/src/components/Example17.vue
+++ b/demos/vue/src/components/Example17.vue
@@ -143,7 +143,7 @@ function toggleSubTitle() {
   <slickgrid-vue
     v-if="gridCreated"
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid17"
   >

--- a/demos/vue/src/components/Example17.vue
+++ b/demos/vue/src/components/Example17.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { type Column, type GridOption, SlickgridVue, toCamelCase } from 'slickgrid-vue';
-import { ref } from 'vue';
+import { ref, type Ref } from 'vue';
 
 const gridCreated = ref(false);
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const templateUrl = ref(new URL('./data/users.csv', import.meta.url).href);
 const uploadFileRef = ref('');

--- a/demos/vue/src/components/Example18.vue
+++ b/demos/vue/src/components/Example18.vue
@@ -536,7 +536,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid18"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example18.vue
+++ b/demos/vue/src/components/Example18.vue
@@ -17,12 +17,12 @@ import {
   SortComparers,
   SortDirectionNumber,
 } from 'slickgrid-vue';
-import { onBeforeMount, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onUnmounted, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const darkMode = ref(false);
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 let draggableGroupingPlugin: any;
 let durationOrderByCount = false;

--- a/demos/vue/src/components/Example19.vue
+++ b/demos/vue/src/components/Example19.vue
@@ -382,7 +382,7 @@ defineExpose({
 
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid19"
       @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example19.vue
+++ b/demos/vue/src/components/Example19.vue
@@ -10,7 +10,7 @@ import {
   Formatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { computed, onBeforeMount, onUnmounted, ref } from 'vue';
+import { computed, onBeforeMount, onUnmounted, ref, type Ref } from 'vue';
 
 import Example19Detail from './Example19Detail.vue';
 import Example19Preload from './Example19Preload.vue';
@@ -18,7 +18,7 @@ import Example19Preload from './Example19Preload.vue';
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
 const detailViewRowCount = ref(9);
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const isDarkMode = ref(false);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example20.vue
+++ b/demos/vue/src/components/Example20.vue
@@ -12,11 +12,11 @@ import {
   SlickEventHandler,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const frozenColumnCount = ref(2);

--- a/demos/vue/src/components/Example20.vue
+++ b/demos/vue/src/components/Example20.vue
@@ -412,7 +412,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid20"
     @onValidationError="onCellValidationError($event.detail.eventData, $event.detail.args)"

--- a/demos/vue/src/components/Example21.vue
+++ b/demos/vue/src/components/Example21.vue
@@ -237,7 +237,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid21"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example21.vue
+++ b/demos/vue/src/components/Example21.vue
@@ -8,11 +8,11 @@ import {
   type OperatorString,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 25;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const operatorList = ref<OperatorString[]>(['=', '<', '<=', '>', '>=', '<>', 'StartsWith', 'EndsWith']);

--- a/demos/vue/src/components/Example22.vue
+++ b/demos/vue/src/components/Example22.vue
@@ -193,7 +193,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
 
         <slickgrid-vue
           v-model:options="gridOptions1!"
-          v-model:columns="columnDefinitions1 as Column[]"
+          v-model:columns="columnDefinitions1"
           v-model:data="dataset1"
           grid-id="grid1"
           @onVueGridCreated="vueGrid1Ready($event.detail)"
@@ -204,7 +204,7 @@ function vueGrid2Ready(grid: SlickgridVueInstance) {
         <h4>Grid 2 - Load a JSON dataset through Fetch-Client</h4>
         <slickgrid-vue
           v-model:options="gridOptions2!"
-          v-model:columns="columnDefinitions2 as Column[]"
+          v-model:columns="columnDefinitions2"
           v-model:data="dataset2"
           grid-id="grid2"
           @onVueGridCreated="vueGrid2Ready($event.detail)"

--- a/demos/vue/src/components/Example22.vue
+++ b/demos/vue/src/components/Example22.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { type GridOption, type SlickgridVueInstance, type Column, Filters, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 import URL_CUSTOMERS_URL from './data/customers_100.json?url';
 
 const NB_ITEMS = 500;
 const gridOptions1 = ref<GridOption>();
 const gridOptions2 = ref<GridOption>();
-const columnDefinitions1 = ref<Column[]>([]);
-const columnDefinitions2 = ref<Column[]>([]);
+const columnDefinitions1: Ref<Column[]> = ref([]);
+const columnDefinitions2: Ref<Column[]> = ref([]);
 const dataset1 = ref<any[]>([]);
 const dataset2 = ref<any[]>([]);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example23.vue
+++ b/demos/vue/src/components/Example23.vue
@@ -19,7 +19,7 @@ import {
   OperatorType,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, onBeforeUnmount, ref } from 'vue';
+import { onBeforeMount, onBeforeUnmount, ref, type Ref } from 'vue';
 
 import { CustomInputFilter } from './custom-inputFilter';
 
@@ -27,7 +27,7 @@ const { i18next } = useTranslation();
 
 const NB_ITEMS = 1500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const selectedLanguage = ref('en');
 const metrics = ref<Metrics>();

--- a/demos/vue/src/components/Example23.vue
+++ b/demos/vue/src/components/Example23.vue
@@ -406,7 +406,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid23"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example24.vue
+++ b/demos/vue/src/components/Example24.vue
@@ -752,7 +752,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid24"
       @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example24.vue
+++ b/demos/vue/src/components/Example24.vue
@@ -14,14 +14,14 @@ import {
   Formatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onUnmounted, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
 const NB_ITEMS = 1000;
 const darkMode = ref(false);
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const selectedLanguage = ref('en');
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example25.vue
+++ b/demos/vue/src/components/Example25.vue
@@ -357,7 +357,7 @@ function getLanguages(): Promise<GraphqlResult<{ code: string; name: string; nat
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid25"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example25.vue
+++ b/demos/vue/src/components/Example25.vue
@@ -12,7 +12,7 @@ import {
   OperatorType,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const COUNTRIES_API = 'https://countries.trevorblades.com/';
 
@@ -31,7 +31,7 @@ export interface Country {
 }
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const metrics = ref<Metrics>();
 const processing = ref(false);

--- a/demos/vue/src/components/Example26.vue
+++ b/demos/vue/src/components/Example26.vue
@@ -454,7 +454,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
   <slickgrid-vue
     grid-id="grid26"
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     @onCellChange.trigger="onCellChanged($event.detail.eventData, $event.detail.args)"
     @on@click="onCellClicked($event.detail.eventData, $event.detail.args)"

--- a/demos/vue/src/components/Example26.vue
+++ b/demos/vue/src/components/Example26.vue
@@ -14,7 +14,7 @@ import {
   SlickgridVue,
   type ViewModelBindableInputData,
 } from 'slickgrid-vue';
-import { ComponentPublicInstance, createApp, onBeforeMount, ref } from 'vue';
+import { ComponentPublicInstance, createApp, onBeforeMount, ref, type Ref } from 'vue';
 
 import { CustomVueComponentEditor } from './custom-viewModelEditor';
 import { CustomVueComponentFilter } from './custom-viewModelFilter';
@@ -26,7 +26,7 @@ type AppData = Record<string, unknown>;
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 let vueGrid!: SlickgridVueInstance;

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -11,11 +11,11 @@ import {
   Formatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const loadingClass = ref('');
 const isLargeDataset = ref(false);

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -494,7 +494,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
   <div id="grid-container" class="col-sm-12">
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid27"
       @onBeforeFilterChange="showSpinner()"

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -581,7 +581,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
   <div id="grid-container" class="col-sm-12">
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:hierarchical="datasetHierarchical"
       grid-id="grid28"
       @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -16,10 +16,10 @@ import {
   isNumber,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const datasetHierarchical = ref<any[]>([]);
 const isExcludingChildWhenFiltering = ref(false);
 const isAutoApproveParentItemWhenTreeColumnIsValid = ref(true);

--- a/demos/vue/src/components/Example29.vue
+++ b/demos/vue/src/components/Example29.vue
@@ -87,7 +87,7 @@ function toggleSubTitle() {
 
   <hr />
 
-  <slickgrid-vue v-model:options="gridOptions" v-model:columns="columnDefinitions as Column[]" v-model:data="dataset" grid-id="grid2">
+  <slickgrid-vue v-model:options="gridOptions" v-model:columns="columnDefinitions" v-model:data="dataset" grid-id="grid2">
     <template #header>
       <div class="custom-header-slot">
         <h3>Grid with header and footer slot</h3>

--- a/demos/vue/src/components/Example29.vue
+++ b/demos/vue/src/components/Example29.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { type GridOption, type SlickgridVueInstance, type Column, Formatters, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 import CustomFooter from './CustomFooterComponent.vue';
 
 const NB_ITEMS = 995;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 let vueGrid!: SlickgridVueInstance;

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -24,13 +24,13 @@ import {
   SlickgridVue,
   SortComparers,
 } from 'slickgrid-vue';
-import { onBeforeMount, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onUnmounted, ref, type Ref } from 'vue';
 
 import URL_COUNTRIES_COLLECTION from './data/countries.json';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const editQueue = ref<any[]>([]);
 const editedItems = ref<any>({});

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -1149,7 +1149,7 @@ function renderItemCallbackWith4Corners(item: any): string {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid30"
     @onBeforeEditCell="handleOnBeforeEditCell($event.detail.eventData, $event.detail.args)"

--- a/demos/vue/src/components/Example31.vue
+++ b/demos/vue/src/components/Example31.vue
@@ -16,13 +16,13 @@ import {
   OperatorType,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 import Data from './data/customers_100.json';
 
 const defaultPageSize = 20;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const metrics = ref<Metrics>({} as Metrics);
 const paginationOptions = ref<Pagination>();

--- a/demos/vue/src/components/Example31.vue
+++ b/demos/vue/src/components/Example31.vue
@@ -545,7 +545,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:pagination="paginationOptions"
     v-model:data="dataset"
     grid-id="grid31"

--- a/demos/vue/src/components/Example32.vue
+++ b/demos/vue/src/components/Example32.vue
@@ -893,7 +893,7 @@ function renderItemCallbackWith4Corners(item: any): string {
   <div id="smaller-container" style="width: 950px">
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid32"
       @onSelectedRowIdsChanged="handleOnSelectedRowIdsChanged($event.detail.args)"

--- a/demos/vue/src/components/Example32.vue
+++ b/demos/vue/src/components/Example32.vue
@@ -19,13 +19,13 @@ import {
   SlickgridVue,
   SortComparers,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 import URL_COUNTRIES_COLLECTION_URL from './data/countries.json?url';
 
 const NB_ITEMS = 400;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const editQueue = ref<any[]>([]);
 const editedItems = ref<any>({});

--- a/demos/vue/src/components/Example33.vue
+++ b/demos/vue/src/components/Example33.vue
@@ -17,11 +17,11 @@ import {
   OperatorType,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const editCommandQueue = ref<EditCommand[]>([]);
 const serverApiDelay = ref(500);

--- a/demos/vue/src/components/Example33.vue
+++ b/demos/vue/src/components/Example33.vue
@@ -594,7 +594,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid33"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example34.vue
+++ b/demos/vue/src/components/Example34.vue
@@ -15,11 +15,11 @@ import {
   GroupTotalFormatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, onMounted, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onMounted, onUnmounted, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 200;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const isDarkMode = ref(false);
 const isFullScreen = ref(false);

--- a/demos/vue/src/components/Example34.vue
+++ b/demos/vue/src/components/Example34.vue
@@ -513,7 +513,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid34"
       @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example35.vue
+++ b/demos/vue/src/components/Example35.vue
@@ -2,13 +2,13 @@
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { useTranslation } from 'i18next-vue';
 import { type GridOption, type SlickgridVueInstance, type Column, Editors, FieldType, Formatters, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const { i18next } = useTranslation();
 
 const NB_ITEMS = 20;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const selectedLanguage = ref('');
 const fetchResult = ref('');

--- a/demos/vue/src/components/Example35.vue
+++ b/demos/vue/src/components/Example35.vue
@@ -329,7 +329,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid35"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example36.vue
+++ b/demos/vue/src/components/Example36.vue
@@ -575,7 +575,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid36"
     @onCellChange="invalidateAll()"

--- a/demos/vue/src/components/Example36.vue
+++ b/demos/vue/src/components/Example36.vue
@@ -18,7 +18,7 @@ import {
   GroupTotalFormatters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 interface GroceryItem {
   id: number;
@@ -32,7 +32,7 @@ interface GroceryItem {
 }
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const excelExportService = new ExcelExportService();
 const isDataGrouped = ref(false);

--- a/demos/vue/src/components/Example37.vue
+++ b/demos/vue/src/components/Example37.vue
@@ -8,11 +8,11 @@ import {
   FieldType,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { onBeforeMount, onMounted, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onMounted, onUnmounted, ref, type Ref } from 'vue';
 
 const NB_ITEMS = 100;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const isDarkMode = ref(false);
 const showSubTitle = ref(true);

--- a/demos/vue/src/components/Example37.vue
+++ b/demos/vue/src/components/Example37.vue
@@ -160,7 +160,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid37"
     @onCellChange="handleOnCellChange($event.detail.eventData, $event.detail.args)"

--- a/demos/vue/src/components/Example38.vue
+++ b/demos/vue/src/components/Example38.vue
@@ -14,14 +14,14 @@ import {
   SlickgridVue,
   SortComparers,
 } from 'slickgrid-vue';
-import { computed, onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref, type Ref } from 'vue';
 
 import Data from './data/customers_100.json';
 
 const CARET_HTML_ESCAPED = '%5E';
 const PERCENT_HTML_ESCAPED = '%25';
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const isPageErrorTest = ref(false);
 const metrics = ref<Partial<Metrics>>({});

--- a/demos/vue/src/components/Example38.vue
+++ b/demos/vue/src/components/Example38.vue
@@ -531,7 +531,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid38"
       @onRowCountChanged="refreshMetrics($event.detail.args)"

--- a/demos/vue/src/components/Example39.vue
+++ b/demos/vue/src/components/Example39.vue
@@ -14,7 +14,7 @@ import {
   Filters,
   SlickgridVue,
 } from 'slickgrid-vue';
-import { computed, onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref, type Ref } from 'vue';
 
 import SAMPLE_COLLECTION_DATA_URL from './data/customers_100.json?url';
 
@@ -23,7 +23,7 @@ const { i18next } = useTranslation();
 const GRAPHQL_QUERY_DATASET_NAME = 'users';
 const FAKE_SERVER_DELAY = 250;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const metrics = ref<Partial<Metrics>>({});
 const tagDataClass = ref('');

--- a/demos/vue/src/components/Example39.vue
+++ b/demos/vue/src/components/Example39.vue
@@ -474,7 +474,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
     <slickgrid-vue
       v-model:options="gridOptions"
-      v-model:columns="columnDefinitions as Column[]"
+      v-model:columns="columnDefinitions"
       v-model:data="dataset"
       grid-id="grid38"
       @onRowCountChanged="refreshMetrics($event.detail.args)"

--- a/demos/vue/src/components/Example40.vue
+++ b/demos/vue/src/components/Example40.vue
@@ -275,7 +275,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid40"
     @onRowCountChanged="refreshMetrics($event.detail.args)"

--- a/demos/vue/src/components/Example40.vue
+++ b/demos/vue/src/components/Example40.vue
@@ -15,11 +15,11 @@ import {
   SortComparers,
   SortDirectionNumber,
 } from 'slickgrid-vue';
-import { computed, onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref, type Ref } from 'vue';
 
 const FETCH_SIZE = 50;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const metrics = ref<Partial<Metrics>>({});
 const shouldResetOnSort = ref(false);

--- a/demos/vue/src/components/Example41.vue
+++ b/demos/vue/src/components/Example41.vue
@@ -244,7 +244,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
     <div class="col">
       <slickgrid-vue
         v-model:options="gridOptions"
-        v-model:columns="columnDefinitions as Column[]"
+        v-model:columns="columnDefinitions"
         v-model:data="dataset"
         grid-id="grid2"
         @onDragInit="handleOnDragInit($event.detail.eventData)"

--- a/demos/vue/src/components/Example41.vue
+++ b/demos/vue/src/components/Example41.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { type GridOption, type SlickgridVueInstance, type Column, Formatters, SlickGlobalEditorLock, SlickgridVue } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 let dragHelper: HTMLElement | null = null;
 const dragRows = ref<number[]>([]);

--- a/demos/vue/src/components/Example42.vue
+++ b/demos/vue/src/components/Example42.vue
@@ -236,7 +236,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid42"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example42.vue
+++ b/demos/vue/src/components/Example42.vue
@@ -12,13 +12,13 @@ import {
   type SlickgridVueInstance,
   type SliderRangeOption,
 } from 'slickgrid-vue';
-import { DefineComponent, onBeforeMount, ref } from 'vue';
+import { DefineComponent, onBeforeMount, ref, type Ref } from 'vue';
 
 import CustomPagerComponent from './CustomPagerComponent.vue';
 
 const NB_ITEMS = 5000;
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 const pageSize = ref(50);

--- a/demos/vue/src/components/Example43.vue
+++ b/demos/vue/src/components/Example43.vue
@@ -484,7 +484,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid43"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example43.vue
+++ b/demos/vue/src/components/Example43.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { type Column, Editors, type GridOption, type ItemMetadata, SlickgridVue, type SlickgridVueInstance } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const isEditable = ref(false);
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 const dataset = ref<any[]>([]);
 const showSubTitle = ref(true);
 let vueGrid!: SlickgridVueInstance;

--- a/demos/vue/src/components/Example44.vue
+++ b/demos/vue/src/components/Example44.vue
@@ -284,7 +284,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
 
   <slickgrid-vue
     v-model:options="gridOptions"
-    v-model:columns="columnDefinitions as Column[]"
+    v-model:columns="columnDefinitions"
     v-model:data="dataset"
     grid-id="grid44"
     @onVueGridCreated="vueGridReady($event.detail)"

--- a/demos/vue/src/components/Example44.vue
+++ b/demos/vue/src/components/Example44.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { type Column, type Formatter, type GridOption, type ItemMetadata, SlickgridVue, type SlickgridVueInstance } from 'slickgrid-vue';
-import { onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]);
 let vueGrid!: SlickgridVueInstance;
 const dataLn = ref<number | string>('loading...');
 const scrollToRow = ref(100);

--- a/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
+++ b/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
@@ -100,10 +100,10 @@ provide('i18next', useTranslation().i18next);
 ```vue
 <script setup lang="ts">
 import { Column, FieldType, Formatter, Formatters, GridOption, SlickgridVue, SlickgridVueInstance } from 'slickgrid-vue';
-import { onBeforeMount } from 'vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
 
 const gridOptions = ref<GridOption>();
-const columnDefinitions = ref<Column[]>([]);
+const columnDefinitions: Ref<Column[]> = ref([]); // to avoid type mismatch use `Ref<Column[]>` instead of `ref<Column[]>`
 const dataset = ref<any[]>([]);
 
 onBeforeMount(() => {

--- a/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
+++ b/frameworks/slickgrid-vue/docs/getting-started/quick-start.md
@@ -155,7 +155,11 @@ function getData(count: number) {
 </script>
 
 <template>
-  <SlickgridVue grid-id="grid1" v-model:columns="columnDefinitions as Column[]" v-model:options="gridOptions" v-model:data="dataset" />
+  <SlickgridVue
+    grid-id="grid1"
+    v-model:columns="columnDefinitions"
+    v-model:options="gridOptions"
+    v-model:data="dataset" />
 </template>
 ```
 


### PR DESCRIPTION
- partially rollback previous PR #1815 by using `Ref<Column[]>`
- instead of using `const cols = ref<Column[]>([])`, we should use `const cols = Ref<Column[]> = ([]);` to keep the ref as the right `Column` type