### PR TITLE
fix(resizer): add `autoResize.autoHeight` to resize by dataset length

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # never EVER use CRLF, Windows
-* text eol=lf
+* text=auto eol=lf

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -154,6 +154,7 @@ function defineGrid() {
 
   gridOptions.value = {
     autoResize: {
+      autoHeight: false,
       container: '#demo-container',
       rightPadding: 10,
     },

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -310,7 +310,7 @@ function deleteFile() {
     if (songIdx >= 0) {
       popFolderItem.files.splice(songIdx, 1);
       lastInsertedPopSongId.value = undefined;
-      // isRemoveLastInsertedPopSongDisabled.value = true;
+      isRemoveLastInsertedPopSongDisabled.value = true;
 
       // overwrite hierarchical dataset which will also trigger a grid sort and rendering
       datasetHierarchical.value = tmpDatasetHierarchical;

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -309,7 +309,7 @@ function deleteFile() {
     if (songIdx >= 0) {
       popFolderItem.files.splice(songIdx, 1);
       lastInsertedPopSongId.value = undefined;
-      isRemoveLastInsertedPopSongDisabled.value = true;
+      // isRemoveLastInsertedPopSongDisabled.value = true;
 
       // overwrite hierarchical dataset which will also trigger a grid sort and rendering
       datasetHierarchical.value = tmpDatasetHierarchical;

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -1225,6 +1225,11 @@ function handleOnItemCountChanged(currentPageRowItemCount: number, totalItemCoun
   if (isLocalGrid && _gridOptions.value?.enableEmptyDataWarningMessage) {
     displayEmptyDataWarning(currentPageRowItemCount === 0);
   }
+
+  // when autoResize.autoHeight is enabled, we'll want to call a resize
+  if (_gridOptions.value.enableAutoResize && resizerService.isAutoHeightEnabled && currentPageRowItemCount > 0) {
+    resizerService.resizeGrid();
+  }
 }
 
 /** Initialize the Pagination Service once */

--- a/frameworks/slickgrid-vue/src/global-grid-options.ts
+++ b/frameworks/slickgrid-vue/src/global-grid-options.ts
@@ -20,9 +20,11 @@ export const GlobalGridOptions: Partial<GridOption> = {
   autoFitColumnsOnFirstLoad: true,
   autoResize: {
     applyResizeToContainer: true,
+    autoHeight: true,
+    autoHeightRecalcRow: 100,
     calculateAvailableSizeBy: 'window',
     bottomPadding: 20,
-    minHeight: 180,
+    minHeight: 250,
     minWidth: 300,
     rightPadding: 0,
   },

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -729,7 +729,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return this.items.length;
   }
 
-  /** Get row count (rows displayed in current page) */
+  /** Get row count (rows displayed in current page which also exclude any filtered items) */
   getLength(): number {
     return this.rows.length;
   }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3339,7 +3339,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     const originalOptions = extend(true, {}, this._options);
-    this._options = extend(true, {}, this._options, newOptions);
+    this._options = extend(true, this._options, newOptions);
     this.triggerEvent(this.onSetOptions, { optionsBefore: originalOptions, optionsAfter: this._options });
 
     this.internal_setOptions(suppressRender, suppressColumnSet, suppressSetOverflow);

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3339,7 +3339,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     const originalOptions = extend(true, {}, this._options);
-    this._options = extend(true, this._options, newOptions);
+    this._options = extend(true, {}, this._options, newOptions);
     this.triggerEvent(this.onSetOptions, { optionsBefore: originalOptions, optionsAfter: this._options });
 
     this.internal_setOptions(suppressRender, suppressColumnSet, suppressSetOverflow);

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -16,9 +16,11 @@ export const GlobalGridOptions: Partial<GridOption> = {
   autoParseInputFilterOperator: true,
   autoResize: {
     applyResizeToContainer: true,
+    autoHeight: true,
+    autoHeightRecalcRow: 100,
     calculateAvailableSizeBy: 'window',
     bottomPadding: 20,
-    minHeight: 180,
+    minHeight: 250,
     minWidth: 300,
     rightPadding: 0,
   },

--- a/packages/common/src/interfaces/autoResizeOption.interface.ts
+++ b/packages/common/src/interfaces/autoResizeOption.interface.ts
@@ -1,6 +1,12 @@
 import type { ResizerOption } from './resizerOption.interface.js';
 
 export interface AutoResizeOption extends ResizerOption {
+  /** defaults to true, should it try to auto-resize the grid height by the data length */
+  autoHeight?: boolean;
+
+  /** defaults to 100, what is the row count that we'll start recalculating the grid height by the dataset length */
+  autoHeightRecalcRow?: number;
+
   /** defaults to 10ms, delay before triggering the auto-resize (only on 1st page load) */
   delay?: number;
 }

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -33,6 +33,7 @@ const mockDataView = {
   getItemMetadata: vi.fn(),
   getItemCount: vi.fn(),
   getItems: vi.fn(),
+  getLength: vi.fn(),
 };
 
 const gridStub = {
@@ -232,6 +233,7 @@ describe('Resizer Service', () => {
       // @ts-ignore
       navigator.__defineGetter__('userAgent', () => 'Netscape');
       mockGridOptions.gridId = 'grid1';
+      vi.spyOn(mockDataView, 'getLength').mockReturnValue(10);
     });
 
     afterEach(() => {
@@ -333,6 +335,23 @@ describe('Resizer Service', () => {
 
       // same comment as previous test, the height dimension will work because calculateGridNewDimensions() uses "window.innerHeight"
       expect(serviceCalculateSpy).toHaveReturnedWith({ height: newHeight - DATAGRID_BOTTOM_PADDING, width: fixedWidth });
+    });
+
+    it('should calculate new dimensions from dataset length when calculateGridNewDimensions is called and autoResize.autoHeight is enabled', () => {
+      const newHeight = 440;
+      const fixedWidth = 800;
+      mockGridOptions.gridWidth = fixedWidth;
+      mockGridOptions.autoResize!.autoHeight = true;
+      mockGridOptions.rowHeight = 33;
+      service.init(gridStub, divContainer);
+      const serviceCalculateSpy = vi.spyOn(service, 'calculateGridNewDimensions');
+
+      Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: newHeight });
+      window.dispatchEvent(new Event('resize'));
+      service.calculateGridNewDimensions(mockGridOptions);
+
+      // same comment as previous test, the height dimension will work because calculateGridNewDimensions() uses "window.innerHeight"
+      expect(serviceCalculateSpy).toHaveReturnedWith({ height: mockGridOptions.rowHeight * 10, width: fixedWidth });
     });
 
     it('should calculate new dimensions, minus the custom footer height, when calculateGridNewDimensions is called', () => {

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -165,6 +165,8 @@ const paginationServiceStub = {
 } as unknown as PaginationService;
 
 const resizerServiceStub = {
+  isAutoHeightEnabled: true,
+  autoHeightRecalcRow: 100,
   dispose: vi.fn(),
   init: vi.fn(),
   resizeGrid: vi.fn(),
@@ -2175,6 +2177,32 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(invalidateSpy).toHaveBeenCalled();
         expect(component.metrics).toEqual(expectation);
         expect(footerSpy).toHaveBeenCalledWith(expectation);
+      });
+
+      it('should call a grid resize when the DataView "onRowCountChanged" event is triggered with a low dataset length and autoResize.autoHeight is enabled', () => {
+        const mockData = [
+          { firstName: 'John', lastName: 'Doe' },
+          { firstName: 'Jane', lastName: 'Smith' },
+        ];
+        const invalidateSpy = vi.spyOn(mockGrid, 'invalidate');
+        const expectation = {
+          startTime: expect.any(Date),
+          endTime: expect.any(Date),
+          itemCount: 2,
+          totalItemCount: 2,
+        };
+        vi.spyOn(mockDataView, 'getItemCount').mockReturnValue(mockData.length);
+        vi.spyOn(mockDataView, 'getFilteredItemCount').mockReturnValue(mockData.length);
+        vi.spyOn(mockDataView, 'getLength').mockReturnValue(mockData.length);
+        const resizerSpy = vi.spyOn(resizerServiceStub, 'resizeGrid');
+
+        component.gridOptions = { enableAutoResize: true, autoResize: { autoHeight: true } };
+        component.initialization(divContainer, slickEventHandler);
+        mockDataView.onRowCountChanged.notify({ current: 2, previous: 0, dataView: mockDataView, itemCount: 0, callingOnRowsChanged: false });
+
+        expect(invalidateSpy).toHaveBeenCalled();
+        expect(component.metrics).toEqual(expectation);
+        expect(resizerSpy).toHaveBeenCalled();
       });
 
       it('should have custom footer with metrics when the DataView "onSetItemsCalled" event is triggered', () => {

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -1310,12 +1310,7 @@ export class SlickVanillaGridBundle<TData = any> {
     }
 
     // when autoResize.autoHeight is enabled, we'll want to call a resize
-    if (
-      this._gridOptions.enableAutoResize &&
-      this.resizerService.isAutoHeightEnabled &&
-      currentPageRowItemCount > 0 &&
-      currentPageRowItemCount < this.resizerService.autoHeightRecalcRow
-    ) {
+    if (this._gridOptions.enableAutoResize && this.resizerService.isAutoHeightEnabled && currentPageRowItemCount > 0) {
       this.resizerService.resizeGrid();
     }
   }

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -65,6 +65,7 @@ import { UniversalContainerService } from '../services/universalContainer.servic
 const WARN_NO_PREPARSE_DATE_SIZE = 10000; // data size to warn user when pre-parse isn't enabled
 
 export class SlickVanillaGridBundle<TData = any> {
+  protected _autoHeightRecalcRow = 0;
   protected _currentDatasetLength = 0;
   protected _eventPubSubService!: EventPubSubService;
   protected _darkMode = false;
@@ -1306,6 +1307,16 @@ export class SlickVanillaGridBundle<TData = any> {
     // when using local (in-memory) dataset, we'll display a warning message when filtered data is empty
     if (this._isLocalGrid && this._gridOptions?.enableEmptyDataWarningMessage) {
       this.displayEmptyDataWarning(currentPageRowItemCount === 0);
+    }
+
+    // when autoResize.autoHeight is enabled, we'll want to call a resize
+    if (
+      this._gridOptions.enableAutoResize &&
+      this.resizerService.isAutoHeightEnabled &&
+      currentPageRowItemCount > 0 &&
+      currentPageRowItemCount < this.resizerService.autoHeightRecalcRow
+    ) {
+      this.resizerService.resizeGrid();
     }
   }
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -65,7 +65,6 @@ import { UniversalContainerService } from '../services/universalContainer.servic
 const WARN_NO_PREPARSE_DATE_SIZE = 10000; // data size to warn user when pre-parse isn't enabled
 
 export class SlickVanillaGridBundle<TData = any> {
-  protected _autoHeightRecalcRow = 0;
   protected _currentDatasetLength = 0;
   protected _eventPubSubService!: EventPubSubService;
   protected _darkMode = false;


### PR DESCRIPTION
The auto-resize is great but it had a flaw that always bothered me but wasn't sure on how to fix it. The problem is that it always resized the grid with all available viewport space regardless of the dataset and in some cases when the dataset was small, it showed a full size grid in the UI with in some cases a rather large empty whitespace area at the bottom of the grid. This PR fixes it once and for all. We always had the grid option `autoHeight` which was good when the user knows its dataset is small, but most of the time we don't know dataset length at all, it could be small today but large next month, so we can't use `autoHeight` grid option for that reason.... this PR adds the grid option `autoResize.autoHeight` (yes it's the same flag name but it's not under the same property), it's enabled by default but user could disable it if he wants and it doesn't do anything unless `enableAutoResize` is enabled which is why it's under that group. Another thing that is useful to know is that it's re-validated every time the dataset count changes (by either new data assignment OR data filtering). Lastly we should also note that the we have a `autoResize.minHeight` to avoid resizing too small (it was always in place but I increased it to 250px)

![image](https://github.com/user-attachments/assets/21bdf14d-2774-4d8c-945e-c73e2a8ecb86)

#### after fix

![brave_wvRzO9334t](https://github.com/user-attachments/assets/b6259cfe-2e8d-4f94-bd90-131ff2c495ef)
