### PR TITLE
fix(core): using SlickGrid `setOptions()` was overriding object prop

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3339,7 +3339,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     const originalOptions = extend(true, {}, this._options);
-    this._options = extend(this._options, newOptions);
+    this._options = extend(true, this._options, newOptions);
     this.triggerEvent(this.onSetOptions, { optionsBefore: originalOptions, optionsAfter: this._options });
 
     this.internal_setOptions(suppressRender, suppressColumnSet, suppressSetOverflow);


### PR DESCRIPTION
while working on another PR #1820 I found a bug in core SlickGrid file, when using `setOptions()` it was overriding a complete object property instead of merging (or extending it). For my use case, the grid option prior to using the `setOptions` was `autoResize` with about 10 other props under it but after I use the `setOptions` it took the only 2 options I had define in my grid and overrode my previous 10 props (global defaults) and that broke my Cypress tests. The problem is that `node-extend` is a perfect copy of `jQuery.extend` and when we're not doing a deep copy of an object, the behavior seems to be to override existing object props, however if we pass `true` to make a deep copy then the behavior changes to be a object props merge. So my quick fix is to use the deep copy, even if it's a bit unexpected. 

See this Stack Overflow for more info: https://stackoverflow.com/a/17913938/1212166
also more info on this old jQuery issue: https://bugs.jquery.com/ticket/9477/