### PR TITLE
chore: add more rowspan test coverage

### DIFF
--- a/demos/vanilla/src/examples/example32.html
+++ b/demos/vanilla/src/examples/example32.html
@@ -23,7 +23,7 @@
       in the grid by itself and that is why they these features are all disabled in this example). Also, column/row freezing (pinning) are
       also not supported, or at least not recommended unless you know exactly what you're doing (like in this demo here because we know our
       pinning doesn't intersect)! Any freezing column/row that could intersect with a <code>colspan</code>/<code>rowspan</code>
-      <b>will cause problems</b>.
+      <b>&nbsp;will cause problems</b>.
     </p>
   </div>
 </div>

--- a/demos/vue/src/components/Example43.vue
+++ b/demos/vue/src/components/Example43.vue
@@ -440,7 +440,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
       in the grid by itself and that is why they these features are all disabled in this example). Also, column/row freezing (pinning) are
       also not supported, or at least not recommended unless you know exactly what you're doing (like in this demo here because we know our
       pinning doesn't intersect)! Any freezing column/row that could intersect with a <code>colspan</code>/<code>rowspan</code>
-      <b>will cause problems</b>.
+      <b>&nbsp;will cause problems</b>.
     </p>
   </div>
 

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4529,7 +4529,7 @@ describe('SlickGrid core file', () => {
       expect(onActiveCellSpy).toHaveBeenCalled();
     });
 
-    it('should add rowspan, then navigate to left then bottom and expect active cell to change with previous cell position that was activated by the left navigation', () => {
+    it('should add rowspan, then navigate to all possible sides', () => {
       const data = [
         { id: 0, firstName: 'John', lastName: 'Doe', age: 30 },
         { id: 1, firstName: 'Jane', lastName: 'Doe', age: 28 },
@@ -4547,14 +4547,14 @@ describe('SlickGrid core file', () => {
       grid.setActiveCell(0, 3);
       grid.navigateUp();
       grid.navigateBottomEnd();
-      let canNav = grid.navigateNext();
-      expect(canNav).toBe(true);
-      canNav = grid.navigatePrev();
-      expect(canNav).toBe(true);
-      canNav = grid.navigatePrev();
-      expect(canNav).toBe(true);
-      canNav = grid.navigateRowStart();
-      expect(canNav).toBe(true);
+      expect(grid.navigateNext()).toBe(true);
+      expect(grid.navigatePrev()).toBe(true);
+      expect(grid.navigatePrev()).toBe(true);
+      expect(grid.navigateRowStart()).toBe(true);
+      expect(grid.navigateRowEnd()).toBe(true);
+      expect(grid.navigateNext()).toBe(true);
+      expect(grid.navigateNext()).toBe(true);
+      expect(grid.navigateDown()).toBe(true);
     });
 
     it('should navigate to left then page down and expect active cell to change with previous cell position that was activated by the left navigation', () => {

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -866,6 +866,7 @@ describe('SlickGrid core file', () => {
       grid.setActiveCell(200, 1);
       grid.updateCell(344, 5);
       vi.spyOn(grid, 'getRowSpanIntersect').mockReturnValueOnce(1); // add a rowspan mandatory row to always render
+      vi.spyOn(grid, 'getParentRowSpanByCell').mockReturnValue(null).mockReturnValueOnce({ start: 0, end: 1, range: '0:1' }); // add a rowspan mandatory row to always render
       grid.setFooterRowVisibility(true);
       grid.updateColumns(); // this will trigger onBeforeFooterRowCellDestroySpy
 

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -872,6 +872,51 @@ describe('SlickGrid core file', () => {
       expect(grid.getFooterRowColumn('firstName')).toEqual(footerElms[0].querySelector('.slick-footerrow-column'));
     });
 
+    it('should define rowspan and test mandatory rows are always rendered', () => {
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name', colspan: 2, rowspan: 2 },
+        { id: 'lastName', field: 'lastName', name: 'Last Name' },
+        { id: 'age', field: 'age', name: 'Age' },
+        { id: 'gender', field: 'gender', name: 'gender' },
+        { id: 'scholarity', field: 'scholarity', name: 'scholarity', colspan: '*' },
+        { id: 'bornCity', field: 'bornCity', name: 'bornCity' },
+      ] as Column[];
+      const gridOptions = { ...defaultOptions, enableCellRowSpan: true, createFooterRow: true, showFooterRow: false, minRowBuffer: 10 } as GridOption;
+      const data: any[] = [];
+      for (let i = 0; i < 1000; i++) {
+        data.push({ id: i, firstName: 'John', lastName: 'Doe', age: 30 });
+      }
+      const dv = new SlickDataView({});
+      dv.setItems(data);
+      grid = new SlickGrid<any, Column>(container, dv, columns, gridOptions);
+      vi.spyOn(grid, 'getRowSpanIntersect') // add a rowspan mandatory row to always render
+        .mockReturnValue(2);
+      const getDataSpy = vi.spyOn(grid, 'getDataItem');
+
+      grid.init();
+      vi.spyOn(grid, 'getRenderedRange').mockReturnValue({ leftPx: 200, rightPx: 12, bottom: 80, top: 42 });
+      vi.spyOn(dv, 'getItemMetadata').mockReturnValue({
+        cssClasses: 'text-bold',
+        focusable: true,
+        formatter: (r, c, val) => val,
+        columns: { 0: { colspan: '2:30' } },
+      });
+
+      grid.scrollCellIntoView(200, 0);
+      vi.spyOn(grid, 'getRowSpanIntersect').mockReturnValueOnce(1); // add a rowspan mandatory row to always render
+      vi.spyOn(grid, 'getDataLength').mockReturnValueOnce(data.length + 1); // add 1 more to force a full rowspan cache remap
+      const remapRowspanSpy = vi.spyOn(grid, 'remapAllColumnsRowSpan');
+      grid.updateRowCount();
+
+      const slickCells = document.querySelectorAll<HTMLDivElement>('.slick-cell');
+      const slickCell0 = document.querySelector('.slick-cell.l0.r0') as HTMLDivElement;
+
+      expect(remapRowspanSpy).toHaveBeenCalled();
+      expect(slickCell0).toBeTruthy();
+      expect(slickCells.length).toBe(48);
+      expect(getDataSpy).toHaveBeenCalledTimes(32);
+    });
+
     it('should define colspan and rowspan but get a warning when enableCellRowSpan is disabled', () => {
       const consoleWarnSpy = vi.spyOn(global.console, 'warn').mockReturnValue();
       const columns = [

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5163,7 +5163,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (vScrollDist < this.viewportH) {
         this.scrollTo(this.scrollTop + this.offset);
       } else {
-        const oldOffset = this.offset;
         if (this.h === this.viewportH) {
           this.page = 0;
         } else {
@@ -5173,9 +5172,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           );
         }
         this.offset = Math.round(this.page * this.cj);
-        if (oldOffset !== this.offset) {
-          this.invalidateAllRows();
-        }
       }
     }
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3742,8 +3742,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         const ncolspan = colspan as number; // at this point colspan is for sure a number
 
         // don't render child cell of a rowspan cell
-        const prs = this.getParentRowSpanByCell(row, i);
-        if (prs) {
+        if (this.getParentRowSpanByCell(row, i)) {
           continue;
         }
 
@@ -4792,8 +4791,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             const ncolspan = colspan as number; // at this point colspan is for sure a number
 
             // don't render child cell of a rowspan cell
-            const prs = this.getParentRowSpanByCell(row, i);
-            if (prs) {
+            /* v8 ignore next 3 */
+            if (this.getParentRowSpanByCell(row, i)) {
               continue;
             }
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6009,8 +6009,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       }
 
       const cell = this.getCellFromPoint(activeCellOffset.left, Math.ceil(activeCellOffset.top) - rowOffset);
-      this.activeRow = cell.row;
-      this.activePosY = cell.row;
+      this.activeRow = this.activePosY = cell.row;
       this.activeCell = this.activePosX = this.getCellFromNode(this.activeCellNode);
 
       if (!isDefined(opt_editMode) && this._options.autoEditNewRow) {
@@ -6654,7 +6653,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     const ff = this.findFirstFocusableCell(row);
-    if (ff.cell === null || ff.cell >= cell) {
+    if (ff.cell >= cell) {
       return null;
     }
 
@@ -6764,15 +6763,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       let ff;
       while (!pos && ++posY < this.getDataLength() + (this._options.enableAddRow ? 1 : 0)) {
         ff = this.findFirstFocusableCell(posY);
-        if (ff.cell !== null) {
-          row = this.getParentRowSpanByCell(posY, ff.cell)?.start ?? posY;
-          pos = {
-            row,
-            cell: ff.cell,
-            posX: ff.cell,
-            posY,
-          };
-        }
+        row = this.getParentRowSpanByCell(posY, ff.cell)?.start ?? posY;
+        pos = {
+          row,
+          cell: ff.cell,
+          posX: ff.cell,
+          posY,
+        };
       }
     }
     return pos;
@@ -6823,10 +6820,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     _posX: number
   ): { row: number; cell: number; posX: number; posY: number } | null {
     const ff = this.findFirstFocusableCell(row);
-    if (ff.cell === null) {
-      return null;
-    }
-
     return {
       row: ff.row,
       cell: ff.cell,

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6615,29 +6615,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     posY: number,
     _posX?: number
   ): { row: number; cell: number; posX: number; posY: number } | null {
-    if (cell >= this.columns.length) {
-      return null;
-    }
-    let fc = cell + 1;
-    let fr = posY;
+    if (cell < this.columns.length) {
+      let fc = cell + 1;
+      let fr = posY;
 
-    do {
-      const sc = this.findSpanStartingCell(posY, fc);
-      fr = sc.row;
-      fc = sc.cell;
-      if (this.canCellBeActive(fr, fc) && fc > cell) {
-        break;
+      do {
+        const sc = this.findSpanStartingCell(posY, fc);
+        fr = sc.row;
+        fc = sc.cell;
+        if (this.canCellBeActive(fr, fc) && fc > cell) {
+          break;
+        }
+        fc += this.getColspan(fr, sc.cell);
+      } while (fc < this.columns.length);
+
+      if (fc < this.columns.length) {
+        return {
+          row: fr,
+          cell: fc,
+          posX: fc,
+          posY,
+        };
       }
-      fc += this.getColspan(fr, sc.cell);
-    } while (fc < this.columns.length);
-
-    if (fc < this.columns.length) {
-      return {
-        row: fr,
-        cell: fc,
-        posX: fc,
-        posY,
-      };
     }
     return null;
   }
@@ -6648,12 +6647,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     posY: number,
     _posX?: number
   ): { row: number; cell: number; posX: number; posY: number } | null {
-    if (cell <= 0) {
-      return null;
-    }
-
     const ff = this.findFirstFocusableCell(row);
-    if (ff.cell >= cell) {
+    if (cell <= 0 || ff.cell >= cell) {
       return null;
     }
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3978,7 +3978,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    *  1- if 2nd row of the 1st column has a metadata.rowspan of 3 then the cache will be: `{ 0: '1:4' }`
    *  2- if 2nd row if the 1st column has a metadata.rowspan of 3 AND a colspan of 2 then the cache will be: `{ 0: '1:4', 1: '1:4' }`
    */
-  protected remapAllColumnsRowSpan(): void {
+  remapAllColumnsRowSpan(): void {
     const ln = this.getDataLength();
     if (ln > 0) {
       this._colsWithRowSpanCache = {};

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4791,7 +4791,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             const ncolspan = colspan as number; // at this point colspan is for sure a number
 
             // don't render child cell of a rowspan cell
-            /* v8 ignore next 3 */
             if (this.getParentRowSpanByCell(row, i)) {
               continue;
             }
@@ -6712,25 +6711,24 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     posX: number
   ): { row: number; cell: number; posX: number; posY: number } | null {
     let prevCell;
-    if (row <= 0) {
-      return null;
-    }
-    do {
-      row = this.findFocusableRow(row - 1, posX, 'up');
-      prevCell = cell = 0;
-      while (cell <= posX) {
-        prevCell = cell;
-        cell += this.getColspan(row, cell);
-      }
-    } while (row >= 0 && !this.canCellBeActive(row, prevCell));
+    if (row > 0) {
+      do {
+        row = this.findFocusableRow(row - 1, posX, 'up');
+        prevCell = cell = 0;
+        while (cell <= posX) {
+          prevCell = cell;
+          cell += this.getColspan(row, cell);
+        }
+      } while (row >= 0 && !this.canCellBeActive(row, prevCell));
 
-    if (cell <= this.columns.length) {
-      return {
-        row,
-        cell: prevCell,
-        posX,
-        posY: row,
-      };
+      if (cell <= this.columns.length) {
+        return {
+          row,
+          cell: prevCell,
+          posX,
+          posY: row,
+        };
+      }
     }
     return null;
   }


### PR DESCRIPTION
compare with previous codecov test coverage report (lines: 5177, 6671)
https://app.codecov.io/gh/ghiscoding/slickgrid-universal/pull/1798