### PR TITLE
fix: `autoResize.autoHeight` should resize grid height even dataset is empty

### DIFF
--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -271,7 +271,7 @@ export class ResizerService {
     // when `autoResize.autoHeight` is enabled, we'll calculate the available height by the data length + header height
     if (gridOptions.enableAutoResize && this.isAutoHeightEnabled) {
       const dataLn = this.dataView.getLength();
-      if (dataLn > 0 && dataLn < this.autoHeightRecalcRow) {
+      if (dataLn < this.autoHeightRecalcRow) {
         this._allHeaderHeight || this.cacheHeaderHeightTotal();
         const dataHeight = dataLn * gridOptions.rowHeight!;
         const calcAutoHeight = this._allHeaderHeight + dataHeight;


### PR DESCRIPTION
- previous PR #1820 brought `autoHeight` to `autoResize` but it wasn't, and it should, resize the grid even when the dataset is an empty array