### PR TITLE
fix: add an explicit check to bound element

### DIFF
--- a/packages/binding/src/__tests__/bindingEvent.service.spec.ts
+++ b/packages/binding/src/__tests__/bindingEvent.service.spec.ts
@@ -32,6 +32,21 @@ describe('BindingEvent Service', () => {
     expect(addEventSpy).toHaveBeenCalledWith('click', mockCallback, undefined);
   });
 
+  it('should not use forEach if the element is a single HTMLElement but with a monkey patched forEach', () => {
+    const elm = document.createElement('input');
+    div.appendChild(elm);
+    const forEachSpy = vi.fn();
+    (elm as any).forEach = forEachSpy;
+    const mockCallback = vi.fn();
+    const addEventSpy = vi.spyOn(elm, 'addEventListener');
+
+    service.bind(elm, 'click', mockCallback);
+
+    expect(service.boundedEvents.length).toBe(1);
+    expect(addEventSpy).toHaveBeenCalledWith('click', mockCallback, undefined);
+    expect(forEachSpy).not.toHaveBeenCalled();
+  });
+
   it('should be able to bind and unbindByEventName an event', () => {
     const mockElm = { addEventListener: vi.fn() } as unknown as HTMLElement;
     const mockCallback = vi.fn();

--- a/packages/binding/src/bindingEvent.service.ts
+++ b/packages/binding/src/bindingEvent.service.ts
@@ -28,7 +28,10 @@ export class BindingEventService {
     // convert to array for looping in next task
     const eventNames = Array.isArray(eventNameOrNames) ? eventNameOrNames : [eventNameOrNames];
 
-    if ((elementOrElements as NodeListOf<HTMLElement>)?.forEach) {
+    if (
+      !(elementOrElements instanceof HTMLElement || elementOrElements instanceof DocumentFragment) &&
+      (elementOrElements as NodeListOf<HTMLElement>)?.forEach
+    ) {
       // multiple elements to bind to
       (elementOrElements as NodeListOf<HTMLElement>).forEach((element) => {
         for (const eventName of eventNames) {


### PR DESCRIPTION
checks that the bound element is not an input with a monkey patched forEach. See https://github.com/ghiscoding/Angular-Slickgrid/discussions/1446#discussioncomment-10194750

closes #1835