### PR TITLE
fix: internal PubSub Service shouldn't need event bubbling

### DIFF
--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -44,7 +44,7 @@ describe('EventPubSub Service', () => {
 
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true, undefined);
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, false, true, undefined);
     });
 
     it('should call publish method and expect it to return it a simple boolean (without delay argument provided)', () => {
@@ -55,7 +55,7 @@ describe('EventPubSub Service', () => {
 
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true, undefined);
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, false, true, undefined);
     });
 
     it('should call publish method and expect it to return it a boolean in a Promise when a delay is provided', async () => {
@@ -66,7 +66,7 @@ describe('EventPubSub Service', () => {
 
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true, undefined);
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, false, true, undefined);
     });
 
     it('should define a different event name styling and expect "dispatchCustomEvent" and "getEventNameByNamingConvention" to be called', () => {
@@ -78,7 +78,7 @@ describe('EventPubSub Service', () => {
 
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onclick', { name: 'John' }, true, true, undefined);
+      expect(dispatchSpy).toHaveBeenCalledWith('onclick', { name: 'John' }, false, true, undefined);
     });
 
     it('should call publish method with an externalize event callback and expect it to receive the custom event used by the pubsub', () => {
@@ -91,7 +91,7 @@ describe('EventPubSub Service', () => {
       expect(obj.nativeEvent).toBeInstanceOf(CustomEvent);
       expect(publishResult).toBeTruthy();
       expect(getEventNameSpy).toHaveBeenCalledWith('onClick', '');
-      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, true, true, expect.any(Function));
+      expect(dispatchSpy).toHaveBeenCalledWith('onClick', { name: 'John' }, false, true, expect.any(Function));
     });
   });
 

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -119,12 +119,12 @@ export class EventPubSubService implements BasePubSubService {
       return new Promise((resolve) => {
         window.clearTimeout(this._timer);
         this._timer = window.setTimeout(
-          () => resolve(this.dispatchCustomEvent<T>(eventNameByConvention, data, true, true, externalizeEventCallback)),
+          () => resolve(this.dispatchCustomEvent<T>(eventNameByConvention, data, false, true, externalizeEventCallback)),
           delay
         );
       });
     } else {
-      return this.dispatchCustomEvent<T>(eventNameByConvention, data, true, true, externalizeEventCallback);
+      return this.dispatchCustomEvent<T>(eventNameByConvention, data, false, true, externalizeEventCallback);
     }
   }
 


### PR DESCRIPTION
- this side effect is causing issues in a new feature that I'm working on (Row Detail with inner grid) and I'm pretty sure that event bubbling is completely unnecessary when used as a simple PubSub Service and that fixes the new feature issue