### PR TITLE
fix: auto-resize with autoHeight should use all grid section heights

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
       "request": "launch",
       "name": "Vue - Edge Debugger",
       "url": "http://localhost:7000",
-      "webRoot": "${workspaceFolder}/demos/vanilla",
+      "webRoot": "${workspaceFolder}/demos/vue",
       "pathMapping": {
         "/@fs/": ""
       }

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -56,6 +56,7 @@ const gridStub = {
   setOptions: vi.fn(),
   setSortColumns: vi.fn(),
   updateColumns: vi.fn(),
+  onAutosizeColumns: new SlickEvent(),
   onColumnsResizeDblClick: new SlickEvent(),
   onSort: new SlickEvent(),
 } as unknown as SlickGrid;
@@ -690,6 +691,14 @@ describe('Resizer Service', () => {
 
         expect(reRenderSpy).toHaveBeenCalledWith(false);
         expect(mockColDefs[7].width).toBeLessThan(30);
+      });
+
+      it('should recalculate header totals when onAutosizeColumns is trigged', () => {
+        const cacheSpy = vi.spyOn(service, 'cacheHeaderHeightTotal');
+
+        gridStub.onAutosizeColumns.notify({ columns: [], grid: gridStub });
+
+        expect(cacheSpy).toHaveBeenCalled();
       });
 
       it('should call the resize and expect to call "autosizeColumns" when total column widths is smaller than the grid viewport', () => {

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -696,6 +696,7 @@ describe('Resizer Service', () => {
       it('should recalculate header totals when onAutosizeColumns is trigged', () => {
         const cacheSpy = vi.spyOn(service, 'cacheHeaderHeightTotal');
 
+        service.init(gridStub, divContainer);
         gridStub.onAutosizeColumns.notify({ columns: [], grid: gridStub });
 
         expect(cacheSpy).toHaveBeenCalled();

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -142,6 +142,11 @@ export class ResizerService {
       this._subscriptions.push(this.pubSubService.subscribe('onFullResizeByContentRequested', () => this.resizeColumnsByCellContent(true)));
     }
 
+    // whenever the autosizeColumns() is called, we'll recalculate our header height total cache
+    this._eventHandler.subscribe(this._grid.onAutosizeColumns, () => {
+      this.cacheHeaderHeightTotal();
+    });
+
     // on double-click resize, should we resize the cell by its cell content?
     // the same action can be called from a double-click and/or from column header menu
     if (this.gridOptions.enableColumnResizeOnDoubleClick) {


### PR DESCRIPTION
- problem detected in Slickgrid-Vue, for unknown reason the `autoResize.autoHeight` wasn't calculating the height correctly on the initial load because the grid is not always available at that time. Subscribing to `grid.onAutosizeColumns` event seems like the best option, I also tried `grid.onRendered` but that event was triggered too early and too many times. 