### PR TITLE
fix: some browsers show grid viewport too wide by 1px

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1330,7 +1330,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Get the grid canvas width */
   getCanvasWidth(): number {
-    const availableWidth = this.viewportHasVScroll ? this.viewportW - (this.scrollbarDimensions?.width || 0) : this.viewportW;
+    const availableWidth = this.getViewportInnerWidth();
     let i = this.columns.length;
 
     this.canvasWidthL = this.canvasWidthR = 0;
@@ -1375,7 +1375,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.canvasWidth !== oldCanvasWidth || this.canvasWidthL !== oldCanvasWidthL || this.canvasWidthR !== oldCanvasWidthR;
 
     if (widthChanged || this.hasFrozenColumns() || this.hasFrozenRows) {
-      Utils.width(this._canvasTopL, this.canvasWidthL);
+      if (this.canvasWidthL > this.getViewportInnerWidth()) {
+        Utils.width(this._canvasTopL, this.canvasWidthL);
+      }
 
       this.getHeadersWidth();
 
@@ -2261,7 +2263,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             let x;
             let newCanvasWidthL = 0;
             let newCanvasWidthR = 0;
-            const viewportWidth = this.viewportHasVScroll ? this.viewportW - (this.scrollbarDimensions?.width || 0) : this.viewportW;
+            const viewportWidth = this.getViewportInnerWidth();
 
             if (d < 0) {
               // shrink column
@@ -2923,7 +2925,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     let total = 0;
     let prevTotal = 0;
     const widths: number[] = [];
-    const availWidth = this.viewportHasVScroll ? this.viewportW - (this.scrollbarDimensions?.width || 0) : this.viewportW;
+    const availWidth = this.getViewportInnerWidth();
 
     for (i = 0; i < this.columns.length; i++) {
       c = this.columns[i];
@@ -4353,6 +4355,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this.numVisibleRows = Math.ceil(this.viewportH / this._options.rowHeight!);
     return this.viewportH;
+  }
+
+  /** returns the available viewport inner width, that is the viewport width minus the scrollbar when shown */
+  protected getViewportInnerWidth(): number {
+    return this.viewportHasVScroll ? this.viewportW - (this.scrollbarDimensions?.width || 0) : this.viewportW;
   }
 
   getViewportWidth(): number {


### PR DESCRIPTION
- so in some rare cases, some browsers incorrectly show the horizontal scrollbar for the grid when it shouldn't. The weird thing is that the scrollbar is only showing for 1px. We can fix this by simply looking at the available viewport inner width (that is the viewport minus the scrollbar width), and if the width is the same then there's no need to apply this width to the grid pane (prior to this PR, the calculated inner width was always applied to the grid pane, but now it won't be applied when it doesn't need it.... or in other words, only apply the grid pane width when it is larger than the available viewport width)
- in my case it happened with Ms Edge, though it probably could be any browsers

#### before fix, some browsers showed the scrollbar

![image](https://github.com/user-attachments/assets/42668bfa-d419-4a90-b495-ecff72f43e11)

#### with the fix in the same browser

![image](https://github.com/user-attachments/assets/695f8264-375e-48a3-b86b-1800df8aa1cd)
