### PR TITLE
feat: allow overriding the position of the textarea savebutton

### DIFF
--- a/packages/common/src/editors/__tests__/longTextEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/longTextEditor.spec.ts
@@ -177,6 +177,14 @@ describe('LongTextEditor', () => {
       expect(editor.editorDomElement.rows).toBe(8);
     });
 
+    it('should initialize the editor with cols & rows define in user editor options', () => {
+      mockColumn.editor!.editorOptions = { cols: 9, rows: 8 } as LongTextEditorOption;
+      editor = new LongTextEditor(editorArguments);
+
+      expect(editor.editorDomElement.cols).toBe(9);
+      expect(editor.editorDomElement.rows).toBe(8);
+    });
+
     it('should initialize the editor with cols & rows define in global default user editor options', () => {
       gridOptionMock.defaultEditorOptions = {
         longText: { cols: 7, rows: 6 },
@@ -195,6 +203,15 @@ describe('LongTextEditor', () => {
       const editorElm = document.body.querySelector('.slick-large-editor-text.editor-title textarea') as HTMLTextAreaElement;
 
       expect(editorElm.placeholder).toBe(testValue);
+    });
+
+    it('should allow overriding the save button position', () => {
+      mockColumn.editor!.editorOptions = { saveButtonPosition: 'left' } as LongTextEditorOption;
+      editor = new LongTextEditor(editorArguments);
+      const cancelButtonElm = document.body.querySelector('.slick-large-editor-text.editor-title .btn-cancel') as HTMLButtonElement;
+      const saveButtonElm = document.body.querySelector('.slick-large-editor-text.editor-title .btn-save') as HTMLButtonElement;
+
+      expect(saveButtonElm.nextSibling).toBe(cancelButtonElm);
     });
 
     it('should have a title (tooltip) when defined in its column definition', () => {

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -154,16 +154,17 @@ export class LongTextEditor implements Editor {
     editorFooterElm.appendChild(countContainerElm);
 
     if (!compositeEditorOptions) {
-      const cancelBtnElm = createDomElement(
-        'button',
-        { className: 'btn btn-cancel btn-default btn-xs', textContent: cancelText },
-        editorFooterElm
-      );
-      const saveBtnElm = createDomElement(
-        'button',
-        { className: 'btn btn-save btn-primary btn-xs', textContent: saveText },
-        editorFooterElm
-      );
+      const cancelBtnElm = createDomElement('button', { className: 'btn btn-cancel btn-default btn-xs', textContent: cancelText });
+      const saveBtnElm = createDomElement('button', { className: 'btn btn-save btn-primary btn-xs', textContent: saveText });
+
+      if (this.editorOptions.saveButtonPosition === 'left') {
+        editorFooterElm.appendChild(saveBtnElm);
+        editorFooterElm.appendChild(cancelBtnElm);
+      } else {
+        editorFooterElm.appendChild(cancelBtnElm);
+        editorFooterElm.appendChild(saveBtnElm);
+      }
+
       this._bindEventService.bind(cancelBtnElm, 'click', this.cancel.bind(this) as EventListener);
       this._bindEventService.bind(saveBtnElm, 'click', this.save.bind(this) as EventListener);
       this.position(this.args?.position as ElementPosition);

--- a/packages/common/src/interfaces/longTextEditorOption.interface.ts
+++ b/packages/common/src/interfaces/longTextEditorOption.interface.ts
@@ -25,7 +25,8 @@ export interface LongTextEditorOption {
    * we might need to tweak the right margin and add an extra margin (in pixel) depending on some CSS styling.
    */
   marginRight?: number;
-
+  // should the save button be rendered right (default) or left of the cancel button
+  saveButtonPosition?: 'right' | 'left';
   /** Configurable Button Texts */
   buttonTexts?: {
     /** Cancel button text, defaults to "Cancel" */


### PR DESCRIPTION
as windows users, my customers argue the save/cancel button order is super important ... *sigh*