### PR TITLE
chore: use older Vitest v3.0.5 to avoid regression in tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   extends: ['config:base', 'group:allNonMajor'],
   labels: ['dependencies'],
   dependencyDashboard: false,
-  lockFileMaintenance: { 
+  lockFileMaintenance: {
     enabled: false,
   },
   pin: false,
@@ -18,10 +18,6 @@
       matchFileNames: ['frameworks/slickgrid-vue/**', 'demos/vue/**'],
       groupName: 'Vue.JS dependencies',
     },
-    {
-      packageNames: ['vitest'],
-      allowedVersions: '3.0.6', // latest version seems to be causing regression in tests, maybe because of https://github.com/vitest-dev/vitest/pull/7499
-    },
     // rimraf new major releases dropped support for Node 18, we'll have to wait our next major to upgrade them
     {
       packageNames: ['rimraf'],
@@ -30,6 +26,10 @@
     {
       packageNames: ['vite-plugin-dts'],
       allowedVersions: '4.5.0',
+    },
+    {
+      packageNames: ['vitest'],
+      allowedVersions: '3.0.5', // latest version seems to be causing regression in tests, maybe because of https://github.com/vitest-dev/vitest/pull/7499
     },
   ],
   ignoreDeps: ['node', 'pnpm'],

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "@lerna-lite/run": "^3.12.0",
     "@lerna-lite/watch": "^3.12.0",
     "@types/node": "catalog:",
-    "@vitest/coverage-v8": "^3.0.5",
+    "@vitest/coverage-v8": "3.0.5",
     "@vitest/eslint-plugin": "^1.1.25",
-    "@vitest/ui": "^3.0.5",
+    "@vitest/ui": "3.0.5",
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "cross-env": "catalog:",
     "cypress": "catalog:",
@@ -105,7 +105,7 @@
     "sortablejs": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "^8.23.0",
-    "vitest": "^3.0.5",
+    "vitest": "3.0.5",
     "whatwg-fetch": "catalog:"
   },
   "funding": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 0.1.2
       '@lerna-lite/cli':
         specifier: ^3.12.0
-        version: 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+        version: 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/publish':
         specifier: ^3.12.0
         version: 3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
@@ -99,13 +99,13 @@ importers:
         specifier: 'catalog:'
         version: 22.13.1
       '@vitest/coverage-v8':
-        specifier: ^3.0.5
-        version: 3.0.5(vitest@3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.83.4)(yaml@2.7.0))
+        specifier: 3.0.5
+        version: 3.0.5(vitest@3.0.5)
       '@vitest/eslint-plugin':
         specifier: ^1.1.25
-        version: 1.1.25(@typescript-eslint/utils@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.83.4)(yaml@2.7.0))
+        version: 1.1.25(@typescript-eslint/utils@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5)
       '@vitest/ui':
-        specifier: ^3.0.5
+        specifier: 3.0.5
         version: 3.0.5(vitest@3.0.5)
       conventional-changelog-conventionalcommits:
         specifier: ^7.0.2
@@ -171,7 +171,7 @@ importers:
         specifier: ^8.23.0
         version: 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       vitest:
-        specifier: ^3.0.5
+        specifier: 3.0.5
         version: 3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.83.4)(yaml@2.7.0)
       whatwg-fetch:
         specifier: 'catalog:'
@@ -1763,6 +1763,9 @@ packages:
   '@vitest/pretty-format@3.0.5':
     resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
 
+  '@vitest/pretty-format@3.0.7':
+    resolution: {integrity: sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==}
+
   '@vitest/runner@3.0.5':
     resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
@@ -2091,8 +2094,8 @@ packages:
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
-  chai@5.1.2:
-    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
   chalk@2.4.2:
@@ -2759,6 +2762,14 @@ packages:
 
   fdir@6.4.2:
     resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.3:
+    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -3461,8 +3472,8 @@ packages:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
     engines: {node: '>=10'}
 
-  loupe@3.1.2:
-    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3895,8 +3906,8 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
-  pathe@2.0.2:
-    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -4403,8 +4414,8 @@ packages:
     resolution: {integrity: sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  sirv@3.0.0:
-    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
 
   slash@5.1.0:
@@ -4602,6 +4613,10 @@ packages:
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.12:
+    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.0.2:
@@ -5504,7 +5519,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lerna-lite/cli@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)':
+  '@lerna-lite/cli@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)':
     dependencies:
       '@lerna-lite/core': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/init': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
@@ -5517,7 +5532,7 @@ snapshots:
     optionalDependencies:
       '@lerna-lite/publish': 3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/run': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
-      '@lerna-lite/version': 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+      '@lerna-lite/version': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/watch': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -5604,10 +5619,10 @@ snapshots:
 
   '@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)':
     dependencies:
-      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/core': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/npmlog': 3.12.0
-      '@lerna-lite/version': 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+      '@lerna-lite/version': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.1
       byte-size: 9.0.1
@@ -5643,7 +5658,7 @@ snapshots:
 
   '@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)':
     dependencies:
-      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/core': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/npmlog': 3.12.0
       '@lerna-lite/profiler': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
@@ -5662,9 +5677,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)':
+  '@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)':
     dependencies:
-      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/core': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/npmlog': 3.12.0
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -5711,7 +5726,7 @@ snapshots:
 
   '@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)':
     dependencies:
-      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/run@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@types/node@22.13.1)(typescript@5.7.3)
+      '@lerna-lite/cli': 3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/version@3.12.0(@lerna-lite/publish@3.12.0)(@lerna-lite/run@3.12.0)(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3))(@lerna-lite/watch@3.12.0)(@types/node@22.13.1)(typescript@5.7.3)
       '@lerna-lite/core': 3.12.0(@types/node@22.13.1)(typescript@5.7.3)
       chokidar: 3.6.0
     transitivePeerDependencies:
@@ -6298,7 +6313,7 @@ snapshots:
       vite: 6.0.11(@types/node@22.13.1)(jiti@2.4.2)(sass@1.83.4)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.7.3)
 
-  '@vitest/coverage-v8@3.0.5(vitest@3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.83.4)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.5(vitest@3.0.5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6316,7 +6331,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.25(@typescript-eslint/utils@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.83.4)(yaml@2.7.0))':
+  '@vitest/eslint-plugin@1.1.25(@typescript-eslint/utils@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.5)':
     dependencies:
       '@typescript-eslint/utils': 8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.19.0(jiti@2.4.2)
@@ -6328,7 +6343,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.0.5
       '@vitest/utils': 3.0.5
-      chai: 5.1.2
+      chai: 5.2.0
       tinyrainbow: 2.0.0
 
   '@vitest/mocker@3.0.5(vite@6.0.11(@types/node@22.13.1)(jiti@2.4.2)(sass@1.83.4)(yaml@2.7.0))':
@@ -6343,16 +6358,20 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.0.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@3.0.5':
     dependencies:
       '@vitest/utils': 3.0.5
-      pathe: 2.0.2
+      pathe: 2.0.3
 
   '@vitest/snapshot@3.0.5':
     dependencies:
       '@vitest/pretty-format': 3.0.5
       magic-string: 0.30.17
-      pathe: 2.0.2
+      pathe: 2.0.3
 
   '@vitest/spy@3.0.5':
     dependencies:
@@ -6363,16 +6382,16 @@ snapshots:
       '@vitest/utils': 3.0.5
       fflate: 0.8.2
       flatted: 3.3.2
-      pathe: 2.0.2
-      sirv: 3.0.0
-      tinyglobby: 0.2.10
+      pathe: 2.0.3
+      sirv: 3.0.1
+      tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
       vitest: 3.0.5(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.83.4)(yaml@2.7.0)
 
   '@vitest/utils@3.0.5':
     dependencies:
       '@vitest/pretty-format': 3.0.5
-      loupe: 3.1.2
+      loupe: 3.1.3
       tinyrainbow: 2.0.0
 
   '@volar/language-core@2.4.11':
@@ -6702,12 +6721,12 @@ snapshots:
 
   caseless@0.12.0: {}
 
-  chai@5.1.2:
+  chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.2
+      loupe: 3.1.3
       pathval: 2.0.0
 
   chalk@2.4.2:
@@ -7488,6 +7507,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fdir@6.4.3(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -8164,7 +8187,7 @@ snapshots:
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
 
-  loupe@3.1.2: {}
+  loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
 
@@ -8623,7 +8646,7 @@ snapshots:
 
   pathe@1.1.2: {}
 
-  pathe@2.0.2: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 
@@ -9098,7 +9121,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sirv@3.0.0:
+  sirv@3.0.1:
     dependencies:
       '@polka/url': 1.0.0-next.28
       mrmime: 2.0.0
@@ -9306,6 +9329,11 @@ snapshots:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.12:
+    dependencies:
+      fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinypool@1.0.2: {}
 
   tinyrainbow@2.0.0: {}
@@ -9453,7 +9481,7 @@ snapshots:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
-      pathe: 2.0.2
+      pathe: 2.0.3
       vite: 6.0.11(@types/node@22.13.1)(jiti@2.4.2)(sass@1.83.4)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -9504,16 +9532,16 @@ snapshots:
     dependencies:
       '@vitest/expect': 3.0.5
       '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.13.1)(jiti@2.4.2)(sass@1.83.4)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.5
+      '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
       '@vitest/spy': 3.0.5
       '@vitest/utils': 3.0.5
-      chai: 5.1.2
+      chai: 5.2.0
       debug: 4.4.0(supports-color@8.1.1)
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 2.0.2
+      pathe: 2.0.3
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
- latest Vitest v3.0.6 and higher seem to cause regression issues, need to investigate further but for now let's use a fixed version that still works