### PR TITLE
fix: frozen lines overflowing outside the grid

### DIFF
--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -56,6 +56,7 @@
   outline: 0;
   position: relative;
   box-sizing: content-box;
+  overflow: hidden;
   width: 100%;
   border-top: var(--slick-container-border-top, v.$slick-container-border-top);
   border-bottom: var(--slick-container-border-bottom, v.$slick-container-border-bottom);


### PR DESCRIPTION
- frozen lines (pinning) shouldn't overflow outside the grid container

![image](https://github.com/user-attachments/assets/6871dc69-4b85-4276-bd13-d85627c68ffa)
