### PR TITLE
chore(deps): fix Vitest failing because of a recent breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "@lerna-lite/run": "^3.12.1",
     "@lerna-lite/watch": "^3.12.1",
     "@types/node": "catalog:",
-    "@vitest/coverage-v8": "3.0.5",
+    "@vitest/coverage-v8": "^3.0.7",
     "@vitest/eslint-plugin": "^1.1.36",
-    "@vitest/ui": "3.0.5",
+    "@vitest/ui": "^3.0.7",
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "cross-env": "catalog:",
     "cypress": "catalog:",
@@ -105,7 +105,7 @@
     "sortablejs": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "^8.25.0",
-    "vitest": "3.0.5",
+    "vitest": "^3.0.7",
     "whatwg-fetch": "catalog:"
   },
   "funding": {

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
@@ -1012,7 +1012,6 @@ describe('SlickRowDetailView plugin', () => {
       plugin.expandDetailView(itemMock.id);
       plugin.rowIdsOutOfViewport = [0, 2];
 
-      const onRowBackToViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
       const eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
       gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 33, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
@@ -1032,7 +1031,6 @@ describe('SlickRowDetailView plugin', () => {
         _height: 150,
         _sizePadding: 6,
       });
-      expect(onRowBackToViewportSpy).toHaveBeenCalled();
 
       // -- out of range
       const onRowBackViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
@@ -1042,7 +1040,6 @@ describe('SlickRowDetailView plugin', () => {
       plugin.collapseDetailView(1);
 
       vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
-        // 99: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
@@ -1052,8 +1049,6 @@ describe('SlickRowDetailView plugin', () => {
 
       gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 53, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
-
-      expect(onRowOutOfViewportSpy).toHaveBeenCalled();
 
       vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 125, bottom: 150, left: 33, right: 18 } as any);
       plugin.expandDetailView(123);

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
@@ -931,7 +931,7 @@ describe('SlickRowDetailView plugin', () => {
       vi.spyOn(dataviewStub, 'getRowById').mockReturnValueOnce(1).mockReturnValueOnce(1);
       const loadingTemplate = () => '<span>loading...</span>';
       vi.spyOn(dataviewStub, 'getIdxById').mockReturnValue(3);
-      vi.spyOn(dataviewStub, 'getRowById').mockReturnValue(50);
+      vi.spyOn(dataviewStub, 'getRowById').mockReturnValueOnce(50);
       vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 20, bottom: 44, left: 33, right: 18 } as any);
       divContainer.appendChild(cellDetailViewElm);
       Object.defineProperty(detailViewContainerElm, 'scrollHeight', { writable: true, configurable: true, value: 4 });
@@ -984,7 +984,12 @@ describe('SlickRowDetailView plugin', () => {
       vi.spyOn(dataviewStub, 'getItemById').mockReturnValue(itemMock);
       const loadingTemplate = () => '<span>loading...</span>';
       vi.spyOn(dataviewStub, 'getIdxById').mockReturnValue(3);
-      vi.spyOn(dataviewStub, 'getRowById').mockReturnValue(100).mockReturnValueOnce(123);
+      vi.spyOn(dataviewStub, 'getRowById')
+        .mockReturnValueOnce(123)
+        .mockReturnValueOnce(123)
+        .mockReturnValueOnce(123)
+        .mockReturnValueOnce(123)
+        .mockReturnValueOnce(123);
       vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
         121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
@@ -1012,6 +1017,7 @@ describe('SlickRowDetailView plugin', () => {
       plugin.expandDetailView(itemMock.id);
       plugin.rowIdsOutOfViewport = [0, 2];
 
+      const onRowBackToViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
       const eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
       gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 33, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
@@ -1031,6 +1037,7 @@ describe('SlickRowDetailView plugin', () => {
         _height: 150,
         _sizePadding: 6,
       });
+      expect(onRowBackToViewportSpy).toHaveBeenCalled();
 
       // -- out of range
       const onRowBackViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
@@ -1040,6 +1047,7 @@ describe('SlickRowDetailView plugin', () => {
       plugin.collapseDetailView(1);
 
       vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
+        // 99: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
         124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
@@ -1049,6 +1057,8 @@ describe('SlickRowDetailView plugin', () => {
 
       gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 53, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
+
+      expect(onRowOutOfViewportSpy).toHaveBeenCalled();
 
       vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 125, bottom: 150, left: 33, right: 18 } as any);
       plugin.expandDetailView(123);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 0.1.2
       '@lerna-lite/cli':
         specifier: ^3.12.1
-        version: 3.12.1(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+        version: 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/publish':
         specifier: ^3.12.2
         version: 3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
@@ -99,14 +99,14 @@ importers:
         specifier: 'catalog:'
         version: 22.13.8
       '@vitest/coverage-v8':
-        specifier: 3.0.5
-        version: 3.0.5(vitest@3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0))
+        specifier: ^3.0.7
+        version: 3.0.7(vitest@3.0.7)
       '@vitest/eslint-plugin':
         specifier: ^1.1.36
-        version: 1.1.36(@typescript-eslint/utils@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0))
+        version: 1.1.36(@typescript-eslint/utils@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7)
       '@vitest/ui':
-        specifier: 3.0.5
-        version: 3.0.5(vitest@3.0.5)
+        specifier: ^3.0.7
+        version: 3.0.7(vitest@3.0.7)
       conventional-changelog-conventionalcommits:
         specifier: ^7.0.2
         version: 7.0.2
@@ -171,8 +171,8 @@ importers:
         specifier: ^8.25.0
         version: 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
       vitest:
-        specifier: 3.0.5
-        version: 3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
+        specifier: ^3.0.7
+        version: 3.0.7(@types/node@22.13.8)(@vitest/ui@3.0.7)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
       whatwg-fetch:
         specifier: 'catalog:'
         version: 3.6.20
@@ -1755,11 +1755,11 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@3.0.5':
-    resolution: {integrity: sha512-zOOWIsj5fHh3jjGwQg+P+J1FW3s4jBu1Zqga0qW60yutsBtqEqNEJKWYh7cYn1yGD+1bdPsPdC/eL4eVK56xMg==}
+  '@vitest/coverage-v8@3.0.7':
+    resolution: {integrity: sha512-Av8WgBJLTrfLOer0uy3CxjlVuWK4CzcLBndW1Nm2vI+3hZ2ozHututkfc7Blu1u6waeQ7J8gzPK/AsBRnWA5mQ==}
     peerDependencies:
-      '@vitest/browser': 3.0.5
-      vitest: 3.0.5
+      '@vitest/browser': 3.0.7
+      vitest: 3.0.7
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -1777,11 +1777,11 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@3.0.5':
-    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
+  '@vitest/expect@3.0.7':
+    resolution: {integrity: sha512-QP25f+YJhzPfHrHfYHtvRn+uvkCFCqFtW9CktfBxmB+25QqWsx7VB2As6f4GmwllHLDhXNHvqedwhvMmSnNmjw==}
 
-  '@vitest/mocker@3.0.5':
-    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
+  '@vitest/mocker@3.0.7':
+    resolution: {integrity: sha512-qui+3BLz9Eonx4EAuR/i+QlCX6AUZ35taDQgwGkK/Tw6/WgwodSrjN1X2xf69IA/643ZX5zNKIn2svvtZDrs4w==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -1791,28 +1791,25 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.5':
-    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
-
   '@vitest/pretty-format@3.0.7':
     resolution: {integrity: sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==}
 
-  '@vitest/runner@3.0.5':
-    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
+  '@vitest/runner@3.0.7':
+    resolution: {integrity: sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==}
 
-  '@vitest/snapshot@3.0.5':
-    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
+  '@vitest/snapshot@3.0.7':
+    resolution: {integrity: sha512-eqTUryJWQN0Rtf5yqCGTQWsCFOQe4eNz5Twsu21xYEcnFJtMU5XvmG0vgebhdLlrHQTSq5p8vWHJIeJQV8ovsA==}
 
-  '@vitest/spy@3.0.5':
-    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
+  '@vitest/spy@3.0.7':
+    resolution: {integrity: sha512-4T4WcsibB0B6hrKdAZTM37ekuyFZt2cGbEGd2+L0P8ov15J1/HUsUaqkXEQPNAWr4BtPPe1gI+FYfMHhEKfR8w==}
 
-  '@vitest/ui@3.0.5':
-    resolution: {integrity: sha512-gw2noso6WI+2PeMVCZFntdATS6xl9qhQcbhkPQ9sOmx/Xn0f4Bx4KDSbD90jpJPF0l5wOzSoGCmKyVR3W612mg==}
+  '@vitest/ui@3.0.7':
+    resolution: {integrity: sha512-bogkkSaVdSTRj02TfypjrqrLCeEc/tA5V4gAVM843Rp5JtIub3xaij+qjsSnS6CseLQJUSdDCFaFqPMmymRJKQ==}
     peerDependencies:
-      vitest: 3.0.5
+      vitest: 3.0.7
 
-  '@vitest/utils@3.0.5':
-    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
+  '@vitest/utils@3.0.7':
+    resolution: {integrity: sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==}
 
   '@volar/language-core@2.4.11':
     resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
@@ -4826,8 +4823,8 @@ packages:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
 
-  vite-node@3.0.5:
-    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+  vite-node@3.0.7:
+    resolution: {integrity: sha512-2fX0QwX4GkkkpULXdT1Pf4q0tC1i1lFOyseKoonavXUNlQ77KpW2XqBGGNIm/J4Ows4KxgGJzDguYVPKwG/n5A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -4880,16 +4877,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.0.5:
-    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
+  vitest@3.0.7:
+    resolution: {integrity: sha512-IP7gPK3LS3Fvn44x30X1dM9vtawm0aesAa2yBIZ9vQf+qB69NXC5776+Qmcr7ohUXIQuLhk7xQR0aSUIDPqavg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.5
-      '@vitest/ui': 3.0.5
+      '@vitest/browser': 3.0.7
+      '@vitest/ui': 3.0.7
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5529,7 +5526,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lerna-lite/cli@3.12.1(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)':
+  '@lerna-lite/cli@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)':
     dependencies:
       '@lerna-lite/core': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/init': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
@@ -5542,7 +5539,7 @@ snapshots:
     optionalDependencies:
       '@lerna-lite/publish': 3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/run': 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
-      '@lerna-lite/version': 3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+      '@lerna-lite/version': 3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/watch': 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -5629,10 +5626,10 @@ snapshots:
 
   '@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)':
     dependencies:
-      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/core': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/npmlog': 3.12.1
-      '@lerna-lite/version': 3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+      '@lerna-lite/version': 3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.1
       byte-size: 9.0.1
@@ -5668,7 +5665,7 @@ snapshots:
 
   '@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)':
     dependencies:
-      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/core': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/npmlog': 3.12.1
       '@lerna-lite/profiler': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
@@ -5687,9 +5684,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)':
+  '@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)':
     dependencies:
-      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/core': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/npmlog': 3.12.1
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -5736,7 +5733,7 @@ snapshots:
 
   '@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)':
     dependencies:
-      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/run@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@types/node@22.13.8)(typescript@5.8.2)
+      '@lerna-lite/cli': 3.12.1(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/version@3.12.2(@lerna-lite/publish@3.12.2)(@lerna-lite/run@3.12.1)(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2))(@lerna-lite/watch@3.12.1)(@types/node@22.13.8)(typescript@5.8.2)
       '@lerna-lite/core': 3.12.1(@types/node@22.13.8)(typescript@5.8.2)
       chokidar: 3.6.0
     transitivePeerDependencies:
@@ -6331,7 +6328,7 @@ snapshots:
       vite: 6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.8.2)
 
-  '@vitest/coverage-v8@3.0.5(vitest@3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.7(vitest@3.0.7)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6345,70 +6342,66 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@22.13.8)(@vitest/ui@3.0.7)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.36(@typescript-eslint/utils@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0))':
+  '@vitest/eslint-plugin@1.1.36(@typescript-eslint/utils@8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7)':
     dependencies:
       '@typescript-eslint/utils': 8.25.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.21.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.8.2
-      vitest: 3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@22.13.8)(@vitest/ui@3.0.7)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
 
-  '@vitest/expect@3.0.5':
+  '@vitest/expect@3.0.7':
     dependencies:
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
+      '@vitest/spy': 3.0.7
+      '@vitest/utils': 3.0.7
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.0.5
+      '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0)
 
-  '@vitest/pretty-format@3.0.5':
-    dependencies:
-      tinyrainbow: 2.0.0
-
   '@vitest/pretty-format@3.0.7':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.5':
+  '@vitest/runner@3.0.7':
     dependencies:
-      '@vitest/utils': 3.0.5
+      '@vitest/utils': 3.0.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.0.5':
+  '@vitest/snapshot@3.0.7':
     dependencies:
-      '@vitest/pretty-format': 3.0.5
+      '@vitest/pretty-format': 3.0.7
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.0.5':
+  '@vitest/spy@3.0.7':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/ui@3.0.5(vitest@3.0.5)':
+  '@vitest/ui@3.0.7(vitest@3.0.7)':
     dependencies:
-      '@vitest/utils': 3.0.5
+      '@vitest/utils': 3.0.7
       fflate: 0.8.2
       flatted: 3.3.3
       pathe: 2.0.3
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
+      vitest: 3.0.7(@types/node@22.13.8)(@vitest/ui@3.0.7)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0)
 
-  '@vitest/utils@3.0.5':
+  '@vitest/utils@3.0.7':
     dependencies:
-      '@vitest/pretty-format': 3.0.5
+      '@vitest/pretty-format': 3.0.7
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -9497,7 +9490,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@3.0.5(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0):
+  vite-node@3.0.7(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
@@ -9549,15 +9542,15 @@ snapshots:
       sass: 1.85.1
       yaml: 2.7.0
 
-  vitest@3.0.5(@types/node@22.13.8)(@vitest/ui@3.0.5)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0):
+  vitest@3.0.7(@types/node@22.13.8)(@vitest/ui@3.0.7)(happy-dom@17.1.8)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.85.1)(yaml@2.7.0):
     dependencies:
-      '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0))
+      '@vitest/expect': 3.0.7
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.7
-      '@vitest/runner': 3.0.5
-      '@vitest/snapshot': 3.0.5
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
+      '@vitest/runner': 3.0.7
+      '@vitest/snapshot': 3.0.7
+      '@vitest/spy': 3.0.7
+      '@vitest/utils': 3.0.7
       chai: 5.2.0
       debug: 4.4.0(supports-color@8.1.1)
       expect-type: 1.2.0
@@ -9569,11 +9562,11 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.2.0(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0)
-      vite-node: 3.0.5(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0)
+      vite-node: 3.0.7(@types/node@22.13.8)(jiti@2.4.2)(sass@1.85.1)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.8
-      '@vitest/ui': 3.0.5(vitest@3.0.5)
+      '@vitest/ui': 3.0.7(vitest@3.0.7)
       happy-dom: 17.1.8
       jsdom: 26.0.0
     transitivePeerDependencies:

--- a/test/vitest.config.mts
+++ b/test/vitest.config.mts
@@ -26,7 +26,7 @@ export default defineConfig({
     },
     environment: 'happy-dom',
     fakeTimers: {
-      toFake: ['setTimeout', 'setInterval', 'queueMicrotask'],
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'queueMicrotask'],
     },
     pool: 'threads',
     globalSetup: './test/vitest-global-setup.ts',

--- a/test/vitest.config.mts
+++ b/test/vitest.config.mts
@@ -25,6 +25,9 @@ export default defineConfig({
       reportOnFailure: true,
     },
     environment: 'happy-dom',
+    fakeTimers: {
+      toFake: ['setTimeout', 'setInterval', 'queueMicrotask'],
+    },
     pool: 'threads',
     globalSetup: './test/vitest-global-setup.ts',
     setupFiles: ['./test/vitest-pretest.ts', './test/vitest-global-mocks.ts'],


### PR DESCRIPTION
Vitest reintroduced a breaking change that they had originally put in v3.0 but reverted and now reintroduced which broke my unit tests. The breaking change is in this Vitest [commit](https://github.com/vitest-dev/vitest/commit/167a98d77c8095288fcf193f8dfff0dd5cd44fa1) which is that `['setTimeout', 'setInterval', 'queueMicrotask']` are no longer mocked and must be added manually in our Vitest config. This PR fixes this so that I can keep up again with latest Vitest version