### PR TITLE
fix(vue): don't rely on `i18next` interface since dep is optional

### DIFF
--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -50,7 +50,6 @@ import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickPaginationComponent } from '@slickgrid-universal/pagination-component';
 import { extend } from '@slickgrid-universal/utils';
 import { dequal } from 'dequal/lite';
-import { type i18n } from 'i18next';
 import {
   type ComponentPublicInstance,
   computed,
@@ -67,7 +66,7 @@ import {
 
 import { SlickRowDetailView } from '../extensions/slickRowDetailView.js';
 import { GlobalGridOptions } from '../global-grid-options.js';
-import type { GridOption, SlickgridVueInstance } from '../models/index.js';
+import type { GridOption, I18Next, SlickgridVueInstance } from '../models/index.js';
 import { ContainerService, disposeAllSubscriptions } from '../services/index.js';
 import { TranslaterI18NextService } from '../services/translaterI18Next.service.js';
 import type { SlickgridVueProps } from './slickgridVueProps.interface.js';
@@ -98,7 +97,7 @@ let grid: SlickGrid;
 let collectionObservers: Array<null | { disconnect: () => void }> = [];
 let groupItemMetadataProvider: SlickGroupItemMetadataProvider | undefined;
 let hideHeaderRowAfterPageLoad = false;
-let i18next: i18n | null;
+let i18next: I18Next | null;
 let isAutosizeColsCalled = false;
 let isGridInitialized = false;
 let isDatasetInitialized = false;
@@ -397,7 +396,7 @@ function initialization() {
 
   // inject the I18Next instance when translation is enabled
   if (_gridOptions.value?.enableTranslate || _gridOptions.value?.i18n) {
-    i18next = inject<i18n | null>('i18next', null);
+    i18next = inject<I18Next | null>('i18next', null);
     if (i18next) {
       translaterService.i18nInstance = i18next;
     } else {

--- a/frameworks/slickgrid-vue/src/models/gridOption.interface.ts
+++ b/frameworks/slickgrid-vue/src/models/gridOption.interface.ts
@@ -1,7 +1,7 @@
 import type { BasePaginationModel, Column, GridOption as UniversalGridOption } from '@slickgrid-universal/common';
-import type * as i18next from 'i18next';
 import type { DefineComponent } from 'vue';
 
+import type { I18Next } from './i18next.interface.js';
 import type { RowDetailView } from './rowDetailView.interface.js';
 
 export interface GridOption<C extends Column = Column> extends UniversalGridOption<C> {
@@ -9,7 +9,7 @@ export interface GridOption<C extends Column = Column> extends UniversalGridOpti
   customPaginationComponent?: DefineComponent<any, BasePaginationModel, any>;
 
   /** I18N translation service instance */
-  i18n?: i18next.i18n;
+  i18n?: I18Next;
 
   /** Row Detail View Plugin options & events (columnId, cssClass, toolTip, width) */
   rowDetailView?: RowDetailView;

--- a/frameworks/slickgrid-vue/src/models/i18next.interface.ts
+++ b/frameworks/slickgrid-vue/src/models/i18next.interface.ts
@@ -1,0 +1,34 @@
+export type Callback = (error: any, t: Function) => void;
+
+export interface I18Next {
+  /**
+   * Is set to the current detected or set language.
+   * If you need the primary used language depending on your configuration (supportedLngs, load) you will prefer using i18next.languages[0].
+   */
+  language: string;
+
+  /**
+   * Changes the language. The callback will be called as soon translations were loaded or an error occurs while loading.
+   * HINT: For easy testing - setting lng to 'cimode' will set t function to always return the key.
+   */
+  changeLanguage(lng?: string, callback?: Callback): Promise<Function>;
+
+  /**
+   * Gets fired when changeLanguage got called.
+   */
+  on(event: 'languageChanged', callback: (lng: string) => void): void;
+
+  /**
+   * Event listener
+   */
+  on(event: string, listener: (...args: any[]) => void): void;
+
+  /**
+   * Remove event listener
+   * removes all callback when callback not specified
+   */
+  off(event: string, listener?: (...args: any[]) => void): void;
+
+  // Expose parameterized t in the i18next interface hierarchy
+  t(key: string, options?: any): string;
+}

--- a/frameworks/slickgrid-vue/src/models/index.ts
+++ b/frameworks/slickgrid-vue/src/models/index.ts
@@ -1,4 +1,5 @@
 export type * from './gridOption.interface.js';
+export type * from './i18next.interface.js';
 export type * from './rowDetailView.interface.js';
 export type * from './viewModelBindableData.interface.js';
 export type * from './viewModelBindableInputData.interface.js';

--- a/frameworks/slickgrid-vue/src/services/translaterI18Next.service.ts
+++ b/frameworks/slickgrid-vue/src/services/translaterI18Next.service.ts
@@ -1,15 +1,16 @@
 import type { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
-import { type i18n } from 'i18next';
+
+import type { I18Next } from '../models/i18next.interface.js';
 
 /**
  * This is a Translate Service Wrapper for Slickgrid-Universal monorepo lib to work properly,
  * it must implement Slickgrid-Universal TranslaterService interface to work properly
  */
 export class TranslaterI18NextService implements UniversalTranslateService {
-  public i18n?: i18n;
+  public i18n?: I18Next;
 
   /** I18Next instance setter */
-  set i18nInstance(i18n: i18n) {
+  set i18nInstance(i18n: I18Next) {
     this.i18n = i18n;
   }
 


### PR DESCRIPTION
- we shouldn't rely on the `i18next` dependency since it's optional, let's just create a very basic `I18Next` interface that provides the minimal list of functions & props that we use in Slickgrid-Vue