### PR TITLE
fix: shift + a should not select all cells upwards

### DIFF
--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -186,8 +186,18 @@ export class SlickCellSelectionModel implements SelectionModel {
     this.setSelectedRanges([args.range]);
   }
 
-  protected isKeyAllowed(key: string): boolean {
-    return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End', 'a', 'A'].some((k) => k === key);
+  protected isKeyAllowed(key: string, isShiftKeyPressed?: boolean): boolean {
+    return [
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'PageDown',
+      'PageUp',
+      'Home',
+      'End',
+      ...(!isShiftKeyPressed ? ['a', 'A'] : []),
+    ].some((k) => k === key);
   }
 
   protected handleKeyDown(e: SlickEventData): void {
@@ -203,7 +213,7 @@ export class SlickCellSelectionModel implements SelectionModel {
       dataLn = this._grid.getDataLength();
     }
 
-    if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key as string)) {
+    if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key as string, e.shiftKey)) {
       ranges = this.getSelectedRanges().slice();
       if (!ranges.length) {
         ranges.push(new SlickRange(active.row, active.cell));


### PR DESCRIPTION
Hi there @ghiscoding,

it seems we introduced a bug back in the December release where SHIFT + A inside an editor would perform a cell selection instead of writing the capital A letter.

You can try it out on https://ghiscoding.github.io/Angular-Slickgrid/#/editor, editing a Country of Origin Name cell and trying to type SHIFT + A.