### PR TITLE
feat!: upgrade Vanilla-Calendar-Pro to new major v3

### DIFF
--- a/demos/vanilla/src/examples/example03.ts
+++ b/demos/vanilla/src/examples/example03.ts
@@ -165,7 +165,7 @@ export default class Example03 {
         sortable: true,
         editor: {
           model: Editors.date,
-          editorOptions: { range: { min: 'today' } } as VanillaCalendarOption,
+          editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
         },
         // formatter: Formatters.dateIso,
         type: FieldType.date,

--- a/demos/vanilla/src/examples/example11.ts
+++ b/demos/vanilla/src/examples/example11.ts
@@ -227,7 +227,7 @@ export default class Example11 {
         field: 'finish',
         sortable: true,
         minWidth: 80,
-        editor: { model: Editors.date, massUpdate: true, editorOptions: { range: { min: 'today' } } as VanillaCalendarOption },
+        editor: { model: Editors.date, massUpdate: true, editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption },
         formatter: Formatters.dateIso,
         type: FieldType.date,
         outputType: FieldType.dateIso,

--- a/demos/vanilla/src/examples/example12.ts
+++ b/demos/vanilla/src/examples/example12.ts
@@ -349,16 +349,14 @@ export default class Example12 {
         editor: {
           model: Editors.date,
           editorOptions: {
-            range: { min: 'today' }, // set minimum date as today
+            displayDateMin: 'today', // set minimum date as today
 
             // if we want to preload the date picker with a different date,
-            // we could do it by assigning settings.seleted.dates
+            // we could do it by assigning `selectedDates: []`
             // NOTE: vanilla-calendar doesn't automatically focus the picker to the year/month and you need to do it yourself
-            // selected: {
-            //   dates: ['2021-06-04'],
-            //   month: 6 - 1, // Note: JS Date month (only) is zero index based, so June is 6-1 => 5
-            //   year: 2021
-            // }
+            //  selectedDates: ['2021-06-04'],
+            //  selectedMonth: 6 - 1, // Note: JS Date month (only) is zero index based, so June is 6-1 => 5
+            //  selectedYear: 2021
           } as VanillaCalendarOption,
           massUpdate: true,
           validator: (value, args) => {
@@ -729,7 +727,7 @@ export default class Example12 {
     if (columnDef.id === 'completed') {
       this.compositeEditorInstance.changeFormEditorOption('complexity', 'filter', true); // multiple-select dropdown editor
       this.compositeEditorInstance.changeFormEditorOption('percentComplete', 'hideSliderNumber', formValues['completed']); // slider editor
-      this.compositeEditorInstance.changeFormEditorOption('finish', 'range', { min: 'today' }); // calendar picker, change minDate to today
+      this.compositeEditorInstance.changeFormEditorOption('finish', 'displayDateMin', 'today'); // calendar picker, change minDate to today
     }
     */
   }

--- a/demos/vanilla/src/examples/example14.ts
+++ b/demos/vanilla/src/examples/example14.ts
@@ -355,7 +355,7 @@ export default class Example14 {
         exportCustomFormatter: Formatters.dateUs,
         editor: {
           model: Editors.date,
-          editorOptions: { range: { min: 'today' } } as VanillaCalendarOption,
+          editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
           validator: (value, args) => {
             const dataContext = args && args.item;
             if (dataContext && dataContext.completed && !value) {

--- a/demos/vanilla/src/examples/example16.ts
+++ b/demos/vanilla/src/examples/example16.ts
@@ -243,7 +243,7 @@ export default class Example16 {
         name: 'Finish',
         field: 'finish',
         sortable: true,
-        editor: { model: Editors.date, editorOptions: { range: { min: 'today' } } as VanillaCalendarOption },
+        editor: { model: Editors.date, editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption },
         // formatter: Formatters.dateIso,
         type: FieldType.date,
         outputType: FieldType.dateIso,

--- a/demos/vue/src/components/Example03.vue
+++ b/demos/vue/src/components/Example03.vue
@@ -268,7 +268,7 @@ function defineGrid() {
       editor: {
         model: Editors.date,
         // override any of the calendar options through "filterOptions"
-        editorOptions: { range: { min: 'today' } } as VanillaCalendarOption,
+        editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
       },
     },
     {

--- a/demos/vue/src/components/Example04.vue
+++ b/demos/vue/src/components/Example04.vue
@@ -177,7 +177,7 @@ function defineGrid() {
       filter: {
         model: Filters.compoundDate,
         // override any of the calendar options through "filterOptions"
-        filterOptions: { range: { min: 'today' } } as VanillaCalendarOption,
+        filterOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
       },
     },
     {

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -274,16 +274,14 @@ function defineGrid() {
       editor: {
         model: Editors.date,
         editorOptions: {
-          range: { min: 'today' },
+          displayDateMin: 'today',
 
           // if we want to preload the date picker with a different date,
-          // we could do it by assigning settings.seleted.dates
+          // we could do it by assigning `selectedDates: []`
           // NOTE: vanilla-calendar doesn't automatically focus the picker to the year/month and you need to do it yourself
-          // selected: {
-          //   dates: ['2021-06-04'],
-          //   month: 6 - 1, // Note: JS Date month (only) is zero index based, so June is 6-1 => 5
-          //   year: 2021
-          // }
+          //  selectedDates: ['2021-06-04'],
+          //  selectedMonth: 6 - 1, // Note: JS Date month (only) is zero index based, so June is 6-1 => 5
+          //  selectedYear: 2021
         } as VanillaCalendarOption,
         massUpdate: true,
         validator: (value, args) => {
@@ -624,7 +622,7 @@ function handleOnCompositeEditorChange(_e: Event, args: OnCompositeEditorChangeE
     if (columnDef.id === 'completed') {
       compositeEditorInstance.value.changeFormEditorOption('complexity', 'filter', true); // multiple-select dropdown editor
       compositeEditorInstance.value.changeFormEditorOption('percentComplete', 'hideSliderNumber', formValues['completed']); // slider editor
-      compositeEditorInstance.value.changeFormEditorOption('finish', 'range', { min: 'today' }); // calendar picker, change minDate to today
+      compositeEditorInstance.value.changeFormEditorOption('finish', 'displayDateMin', 'today'); // calendar picker, change minDate to today
     }
     */
 }

--- a/demos/vue/src/components/Example32.vue
+++ b/demos/vue/src/components/Example32.vue
@@ -268,7 +268,7 @@ function defineGrid() {
       exportCustomFormatter: Formatters.dateUs,
       editor: {
         model: Editors.date,
-        editorOptions: { range: { min: 'today' } } as VanillaCalendarOption,
+        editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
         validator: (value, args) => {
           const dataContext = args && args.item;
           if (dataContext && dataContext.completed && !value) {

--- a/demos/vue/src/components/Example33.vue
+++ b/demos/vue/src/components/Example33.vue
@@ -256,7 +256,7 @@ function defineGrid() {
       sortable: true,
       editor: {
         model: Editors.date,
-        editorOptions: { range: { min: 'today' } } as VanillaCalendarOption,
+        editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
       },
       // formatter: Formatters.dateIso,
       type: FieldType.date,

--- a/demos/vue/test/cypress/e2e/example03.cy.ts
+++ b/demos/vue/test/cypress/e2e/example03.cy.ts
@@ -76,11 +76,11 @@ describe('Example 3 - Grid with Editors', () => {
 
     // change Finish date
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).click();
-    cy.get('.vanilla-calendar-month:visible').click();
-    cy.get('.vanilla-calendar-months__month').contains('Jan').click();
-    cy.get('.vanilla-calendar-year').click();
-    cy.get('.vanilla-calendar-years__year').contains('2009').click();
-    cy.get('.vanilla-calendar-day__btn').contains('22').click();
+    cy.get('.vc:visible').click();
+    cy.get('.vc-months__month').contains('Jan').click();
+    cy.get('[data-vc="year"]').click();
+    cy.get('.vc-years__year').contains('2009').click();
+    cy.get('[data-vc-date-btn]').contains('22').click();
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).should('contain', '2009-01-22');
 
     // change City of Origin
@@ -160,11 +160,11 @@ describe('Example 3 - Grid with Editors', () => {
 
     // change Finish date
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).click();
-    cy.get('.vanilla-calendar-month:visible').click();
-    cy.get('.vanilla-calendar-months__month').contains('Jan').click();
-    cy.get('.vanilla-calendar-year').click();
-    cy.get('.vanilla-calendar-years__year').contains('2009').click();
-    cy.get('.vanilla-calendar-day__btn').contains('22').click();
+    cy.get('.vc:visible').click();
+    cy.get('.vc-months__month').contains('Jan').click();
+    cy.get('[data-vc="year"]').click();
+    cy.get('.vc-years__year').contains('2009').click();
+    cy.get('[data-vc-date-btn]').contains('22').click();
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('contain', '2009-01-22');
 
     // change Effort Driven
@@ -230,7 +230,7 @@ describe('Example 3 - Grid with Editors', () => {
 
     // change Finish date
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).click();
-    cy.get('.vanilla-calendar-day__btn').contains('21').click();
+    cy.get('[data-vc-date-btn]').contains('21').click();
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).should('contain', '2009-01-21');
 
     // // change Effort Driven

--- a/demos/vue/test/cypress/e2e/example03.cy.ts
+++ b/demos/vue/test/cypress/e2e/example03.cy.ts
@@ -76,7 +76,7 @@ describe('Example 3 - Grid with Editors', () => {
 
     // change Finish date
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).click();
-    cy.get('.vc:visible').click();
+    cy.get('.vc-month:visible').click();
     cy.get('.vc-months__month').contains('Jan').click();
     cy.get('[data-vc="year"]').click();
     cy.get('.vc-years__year').contains('2009').click();
@@ -160,7 +160,7 @@ describe('Example 3 - Grid with Editors', () => {
 
     // change Finish date
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`).click();
-    cy.get('.vc:visible').click();
+    cy.get('.vc-month:visible').click();
     cy.get('.vc-months__month').contains('Jan').click();
     cy.get('[data-vc="year"]').click();
     cy.get('.vc-years__year').contains('2009').click();

--- a/demos/vue/test/cypress/e2e/example04.cy.ts
+++ b/demos/vue/test/cypress/e2e/example04.cy.ts
@@ -248,7 +248,7 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
 
       cy.get('.search-filter.filter-start').click();
 
-      cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').should('not.exist');
+      cy.get('.vc:visible').find('[data-vc-date-selected]').should('not.exist');
 
       cy.get('h2').click();
     });

--- a/demos/vue/test/cypress/e2e/example06.cy.ts
+++ b/demos/vue/test/cypress/e2e/example06.cy.ts
@@ -403,11 +403,11 @@ describe('Example 6 - GraphQL Grid', () => {
 
     cy.get('[data-vc="year"]:nth(0)').should('have.text', currentYear);
 
-    cy.get('.vc:visible').find('[data-vc-date-selected]').should('have.length', 46);
+    cy.get('.vc:visible [data-vc-date-selected] button').should('have.length', 46);
 
-    cy.get('.vc:visible').find('[data-vc-date-selected]').first().should('have.text', '1');
+    cy.get('.vc:visible [data-vc-date-selected]').first().should('have.text', '1');
 
-    cy.get('.vc:visible').find('[data-vc-date-selected]').last().should('have.text', '15');
+    cy.get('.vc:visible [data-vc-date-selected]').last().should('have.text', '15');
   });
 
   describe('Set Dynamic Sorting', () => {

--- a/demos/vue/test/cypress/e2e/example06.cy.ts
+++ b/demos/vue/test/cypress/e2e/example06.cy.ts
@@ -395,19 +395,19 @@ describe('Example 6 - GraphQL Grid', () => {
   it('should open Date picker and expect date range between 01-Jan to 15-Feb', () => {
     cy.get('.search-filter.filter-finish.filled input').click({ force: true });
 
-    cy.get('.vanilla-calendar:visible');
+    cy.get('.vc:visible');
 
-    cy.get('.vanilla-calendar-column:nth(0) .vanilla-calendar-month').should('have.text', 'January');
+    cy.get('[data-vc="column"]:nth(0) [data-vc="month"]').should('have.text', 'January');
 
-    cy.get('.vanilla-calendar-column:nth(1) .vanilla-calendar-month').should('have.text', 'February');
+    cy.get('[data-vc="column"]:nth(1) [data-vc="month"]').should('have.text', 'February');
 
-    cy.get('.vanilla-calendar-year:nth(0)').should('have.text', currentYear);
+    cy.get('[data-vc="year"]:nth(0)').should('have.text', currentYear);
 
-    cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').should('have.length', 46);
+    cy.get('.vc:visible').find('[data-vc-date-selected]').should('have.length', 46);
 
-    cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').first().should('have.text', '1');
+    cy.get('.vc:visible').find('[data-vc-date-selected]').first().should('have.text', '1');
 
-    cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').last().should('have.text', '15');
+    cy.get('.vc:visible').find('[data-vc-date-selected]').last().should('have.text', '15');
   });
 
   describe('Set Dynamic Sorting', () => {
@@ -459,9 +459,9 @@ describe('Example 6 - GraphQL Grid', () => {
     it('should open Date picker and no longer expect date range selection in the picker', () => {
       cy.get('.search-filter.filter-finish').should('not.have.class', 'filled').click();
 
-      cy.get('.vanilla-calendar-year:nth(0)').should('have.text', currentYear);
+      cy.get('[data-vc="year"]:nth(0)').should('have.text', currentYear);
 
-      cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').should('not.exist');
+      cy.get('.vc:visible').find('[data-vc-date-selected]').should('not.exist');
     });
   });
 

--- a/demos/vue/test/cypress/e2e/example23.cy.ts
+++ b/demos/vue/test/cypress/e2e/example23.cy.ts
@@ -125,11 +125,11 @@ describe('Example 23 - Range Filters', () => {
   it('should change the "Finish" date in the picker and expect all rows to be within new dates range', () => {
     cy.get('.date-picker.search-filter.filter-finish').click();
 
-    cy.get('.vanilla-calendar-day_selected-first').should('exist');
+    cy.get('[data-vc-date-selected="first"]').should('exist');
 
-    cy.get('.vanilla-calendar-day_selected-intermediate').should('have.length.gte', 2);
+    cy.get('[data-vc-date-selected="middle"]').should('have.length.gte', 2);
 
-    cy.get('.vanilla-calendar-day_selected-last').should('exist');
+    cy.get('[data-vc-date-selected="last"]').should('exist');
   });
 
   it('should change the "Duration" input filter and expect all rows to be within new range', () => {

--- a/demos/vue/test/cypress/e2e/example30.cy.ts
+++ b/demos/vue/test/cypress/e2e/example30.cy.ts
@@ -142,12 +142,12 @@ describe('Example 30  Composite Editor Modal', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
       .click({ force: true }); // this date should also always be initially empty
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).should('not.exist');
+    cy.get('[data-vc-date-today]:visible button').should('not.exist');
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
       .click({ force: true }); // this date should also always be initially empty
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).should('not.exist');
+    cy.get('[data-vc-date-today]:visible button').should('not.exist');
   });
 
   it('should be able to change "Completed" values of row indexes 2-4', () => {
@@ -178,21 +178,21 @@ describe('Example 30  Composite Editor Modal', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
       .click(); // this date should also always be initially empty
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(8)`)
       .should('contain', `${zeroPadding(currentMonth)}/${zeroPadding(currentDate)}/${currentYear}`)
       .should('have.css', 'background-color')
       .and('eq', UNSAVED_RGB_COLOR);
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`).click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`)
       .should('contain', `${zeroPadding(currentMonth)}/${zeroPadding(currentDate)}/${currentYear}`)
       .should('have.css', 'background-color')
       .and('eq', UNSAVED_RGB_COLOR);
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(8)`).click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(8)`)
       .should('contain', `${zeroPadding(currentMonth)}/${zeroPadding(currentDate)}/${currentYear}`)
       .should('have.css', 'background-color')
@@ -204,7 +204,7 @@ describe('Example 30  Composite Editor Modal', () => {
   it('should undo last edit and expect the date editor to be opened as well when clicking the associated last undo with editor button', () => {
     cy.get('[data-test=undo-open-editor-btn]').click();
 
-    cy.get('.vanilla-calendar').should('exist');
+    cy.get('.vc').should('exist');
 
     cy.get('.unsaved-editable-field').should('have.length', 12);
 
@@ -217,7 +217,7 @@ describe('Example 30  Composite Editor Modal', () => {
   it('should undo last edit and expect the date editor to NOT be opened when clicking undo last edit button', () => {
     cy.get('[data-test=undo-last-edit-btn]').click();
 
-    cy.get('.vanilla-calendar:visible').should('not.exist');
+    cy.get('.vc:visible').should('not.exist');
 
     cy.get('.unsaved-editable-field').should('have.length', 11);
 
@@ -307,7 +307,7 @@ describe('Example 30  Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish input.date-picker').click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('c');
@@ -396,7 +396,7 @@ describe('Example 30  Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish .date-picker').click().click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click();
+    cy.get('[data-vc-date-today]:visible button').click();
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('bel');
@@ -474,7 +474,7 @@ describe('Example 30  Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish .date-picker').click().click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click();
+    cy.get('[data-vc-date-today]:visible button').click();
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('bel');
@@ -531,7 +531,7 @@ describe('Example 30  Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish input.date-picker').click({ force: true });
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('ze');

--- a/docs/column-functionalities/Editors.md
+++ b/docs/column-functionalities/Editors.md
@@ -204,7 +204,7 @@ this.columnDefinitions = [{
   id: 'start', name: 'Start Date', field: 'start',
   editor: {
     model: Editors.date,
-    editorOptions: { range: { min: 'today' } } as VanillaCalendarOption
+    editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption
   }
 }];
 ```
@@ -216,7 +216,7 @@ You could also define certain options as a global level (for the entire grid or 
 this.gridOptions = {
   defaultEditorOptions: {
     autocompleter: { debounceWaitMs: 150 }, // typed as AutocompleterOption
-    date: { range: { min: 'today' } },
+    date: { displayDateMin: 'today' },
     longText: { cols: 50, rows: 5 }
   }
 }
@@ -406,7 +406,7 @@ Using the [Row Based Editing Plugin](../grid-functionalities/Row-based-edit.md) 
 
 ## Dynamically change Column Editor
 
-You can dynamically change a column editor by taking advantage of the `onBeforeEditCell` event and change the editor just before the cell editor opens. However please note that the library keeps 2 references and you need to update both references as shown below. 
+You can dynamically change a column editor by taking advantage of the `onBeforeEditCell` event and change the editor just before the cell editor opens. However please note that the library keeps 2 references and you need to update both references as shown below.
 
 With the code sample shown below, we are using an input checkbox to toggle the Editor between `Editors.longText` to `Editors.text` and vice/versa
 

--- a/docs/column-functionalities/editors/Date-Editor-(flatpickr).md
+++ b/docs/column-functionalities/editors/Date-Editor-(flatpickr).md
@@ -42,7 +42,7 @@ You could also define certain options as a global level (for the entire grid or 
 ```ts
 this.gridOptions = {
   defaultEditorOptions: {
-    date: { range: { min: 'today' } }, // typed as FlatpickrOption
+    date: { displayDateMin: 'today' }, // typed as FlatpickrOption
   }
 }
 ```

--- a/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
+++ b/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
@@ -28,10 +28,8 @@ prepareGrid() {
       editor: {
         model: Editors.date,
         editorOptions: {
-          range: {
-            max: 'today',
-            disabled: ['2022-08-15', '2022-08-20'],
-          }
+          displayDateMax: 'today',
+          disableDates: ['2022-08-15', '2022-08-20'],
         } as VanillaCalendarOption,
       },
     },
@@ -50,7 +48,7 @@ You could also define certain options as a global level (for the entire grid or 
 ```ts
 this.gridOptions = {
   defaultEditorOptions: {
-    date: { range: { min: 'today' } }, // typed as VanillaCalendarOption
+    date: { displayDateMin: 'today' }, // typed as VanillaCalendarOption
   }
 }
 ```

--- a/docs/column-functionalities/filters/compound-filters.md
+++ b/docs/column-functionalities/filters/compound-filters.md
@@ -135,7 +135,7 @@ All the available options that can be provided as `filterOptions` to your column
 filter: {
   model: Filters.compoundDate,
   filterOptions: {
-    range: { min: 'today' }
+    displayDateMin: 'today'
   } as VanillaCalendarOption
 }
 ```
@@ -147,7 +147,7 @@ You could also define certain options as a global level (for the entire grid or 
 this.gridOptions = {
   defaultFilterOptions: {
     // Note: that `date`, `select` and `slider` are combining both compound & range filters together
-    date: { range: { min: 'today' } },  // typed as VanillaCalendarOption
+    date: { displayDateMin: 'today' },  // typed as VanillaCalendarOption
     select: { minHeight: 350 },         // typed as MultipleSelectOption
     slider: { sliderStartValue: 10 }
   }

--- a/docs/column-functionalities/filters/range-filters.md
+++ b/docs/column-functionalities/filters/range-filters.md
@@ -126,7 +126,7 @@ You could also define certain options as a global level (for the entire grid or 
 this.gridOptions = {
   defaultFilterOptions: {
     // Note: that `date`, `select` and `slider` are combining both compound & range filters together
-    date: { range: { min: 'today' } },
+    date: { displayDateMin: 'today' },
     select: { minHeight: 350 }, // typed as MultipleSelectOption
     slider: { sliderStartValue: 10 }
   }
@@ -160,7 +160,7 @@ export class GridBasicComponent {
           model: Filters.dateRange,
 
           // override any of the Vanilla-Calendar options through "filterOptions"
-          filterOptions: { range: { min: 'today' } } as VanillaCalendarOption
+          filterOptions: { displayDateMin: 'today' } as VanillaCalendarOption
         }
       },
     ];
@@ -179,7 +179,7 @@ All the available options that can be provided as `filterOptions` to your column
 filter: {
   model: Filters.compoundDate,
   filterOptions: {
-    range: { min: 'today' }
+    displayDateMin: 'today'
   } as VanillaCalendarOption
 }
 ```

--- a/docs/migrations/migration-to-5.x.md
+++ b/docs/migrations/migration-to-5.x.md
@@ -17,7 +17,7 @@ Another noticeable UI change is the migration from [Flatpickr](https://flatpickr
   - cons:
     - build size is slightly larger but its UI/UX is just awesome (especially when changing month/year)
     - settings are a bit different and are not using flat config (complex object settings) and requires code change
-      - for example Flatpickr `minDate: 'today'` becomes `range: { min: 'today' }` in VC
+      - for example Flatpickr `minDate: 'today'` becomes `displayDateMin: 'today'` in VC
     - some settings were missing, like the `'today'` shortcut, so I also contributed back to that project.
 
 To summarize, the goal of this new release was mainly to improve UI/UX (mostly for Dark Mode) and also to make it fully ESM ready. Also noteworthy, the project is smaller in size (~100Kb smaller) compared to what it was in v2.x (that was when the user had to install jQuery/jQueryUI separately). So, considering that we're no longer requiring the install of jQuery/jQueryUI, and also considering that these 2 dependencies had a total of well over 200kb. We can safely assume that our project build size is in fact a lot smaller than it was 2 years ago, that is really nice to know considering that we kept adding features (like Dark Mode and other features) while still decreasing its size over the years :)
@@ -199,7 +199,7 @@ prepareGrid() {
     editor: {
       model: Editors.date,
 -      editorOptions: { minDate: 'today' } as FlatpickrOption,
-+      editorOptions: { range: { min: 'today' } } as VanillaCalendarOption,
++      editorOptions: { displayDateMin: 'today' } as VanillaCalendarOption,
     }
   }];
 }

--- a/frameworks/slickgrid-vue/docs/column-functionalities/editors/date-editor-vanilla-calendar.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/editors/date-editor-vanilla-calendar.md
@@ -37,10 +37,8 @@ function defineGrid() {
       editor: {
         model: Editors.date,
         editorOptions: {
-          range: {
-            max: 'today',
-            disabled: ['2022-08-15', '2022-08-20'],
-          }
+          displayDateMax: 'today',
+          disableDates: ['2022-08-15', '2022-08-20'],
         } as VanillaCalendarOption,
       },
     },
@@ -54,7 +52,7 @@ You could also define certain options as a global level (for the entire grid or 
 ```ts
 gridOptions.value = {
   defaultEditorOptions: {
-    date: { range: { min: 'today' } }, // typed as VanillaCalendarOption
+    date: { displayDateMin: 'today' }, // typed as VanillaCalendarOption
   }
 }
 ```

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/compound-filters.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/compound-filters.md
@@ -133,7 +133,7 @@ All the available options that can be provided as `filterOptions` to your column
 filter: {
   model: Filters.compoundDate,
   filterOptions: {
-    range: { min: 'today' }
+    displayDateMin: 'today'
   } as VanillaCalendarOption
 }
 ```
@@ -145,7 +145,7 @@ You could also define certain options as a global level (for the entire grid or 
 gridOptions.value = {
   defaultFilterOptions: {
     // Note: that `date`, `select` and `slider` are combining both compound & range filters together
-    date: { range: { min: 'today' } },  // typed as VanillaCalendarOption
+    date: { displayDateMin: 'today' },  // typed as VanillaCalendarOption
     select: { minHeight: 350 },         // typed as MultipleSelectOption
     slider: { sliderStartValue: 10 }
   }

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/range-filters.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/range-filters.md
@@ -136,7 +136,7 @@ You could also define certain options as a global level (for the entire grid or 
 gridOptions.value = {
   defaultFilterOptions: {
     // Note: that `date`, `select` and `slider` are combining both compound & range filters together
-    date: { range: { min: 'today' } },
+    date: { displayDateMin: 'today' },
     select: { minHeight: 350 }, // typed as MultipleSelectOption
     slider: { sliderStartValue: 10 }
   }
@@ -177,7 +177,7 @@ function defineGrid() {
         model: Filters.dateRange,
 
         // override any of the Vanilla-Calendar options through "filterOptions"
-        filterOptions: { range: { min: 'today' } } as VanillaCalendarOption
+        filterOptions: { displayDateMin: 'today' } as VanillaCalendarOption
       }
     },
   ];
@@ -196,7 +196,7 @@ All the available options that can be provided as `filterOptions` to your column
 filter: {
   model: Filters.compoundDate,
   filterOptions: {
-    range: { min: 'today' }
+    displayDateMin: 'today'
   } as VanillaCalendarOption
 }
 ```

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -81,7 +81,7 @@
     "multiple-select-vanilla": "catalog:",
     "sortablejs": "catalog:",
     "un-flatten-tree": "^2.0.12",
-    "vanilla-calendar-pro": "^2.9.10"
+    "vanilla-calendar-pro": "^3.0.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -275,6 +275,10 @@ describe('DateEditor', () => {
 
     it('should call the "changeEditorOption" method and expect new option to be merged with the previous Editor options', () => {
       editor = new DateEditor(editorArguments);
+
+      vi.runAllTimers();
+
+      const setSpy = vi.spyOn(editor.calendarInstance!, 'set');
       const calendarElm = document.body.querySelector<HTMLDivElement>('.vc');
       editor.changeEditorOption('disableDatesPast', true);
       editor.changeEditorOption('selectedDates', ['2001-02-04']);
@@ -292,6 +296,14 @@ describe('DateEditor', () => {
       expect(editor.pickerOptions.enableEdgeDatesOnly).toEqual(true);
       expect(editor.pickerOptions.selectedDates).toEqual(['2020-03-10', 'today']);
       expect(editor.pickerOptions.selectedMonth).toEqual(2);
+
+      expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ selectedDates: ['2020-03-10', 'today'] }), {
+        dates: true,
+        locale: true,
+        month: true,
+        time: true,
+        year: true,
+      });
     });
 
     describe('isValueChanged method', () => {

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { format } from '@formkit/tempo';
-import type VanillaCalendar from 'vanilla-calendar-pro';
-import type { ISelected } from 'vanilla-calendar-pro/types';
+import type { Calendar } from 'vanilla-calendar-pro';
 
 import { Editors } from '../index.js';
 import { DateEditor } from '../dateEditor.js';
@@ -252,7 +251,7 @@ describe('DateEditor', () => {
       vi.runAllTimers();
 
       const spy = vi.spyOn(editor.calendarInstance!, 'hide');
-      const calendarElm = document.body.querySelector<HTMLDivElement>('.vanilla-calendar');
+      const calendarElm = document.body.querySelector<HTMLDivElement>('.vc');
       editor.hide();
 
       expect(calendarElm).toBeTruthy();
@@ -265,7 +264,7 @@ describe('DateEditor', () => {
       vi.runAllTimers();
 
       const spy = vi.spyOn(editor.calendarInstance!, 'show');
-      const calendarElm = document.body.querySelector<HTMLDivElement>('.vanilla-calendar');
+      const calendarElm = document.body.querySelector<HTMLDivElement>('.vc');
       editor.show();
       editor.focus();
 
@@ -276,19 +275,23 @@ describe('DateEditor', () => {
 
     it('should call the "changeEditorOption" method and expect new option to be merged with the previous Editor options', () => {
       editor = new DateEditor(editorArguments);
-      const calendarElm = document.body.querySelector<HTMLDivElement>('.vanilla-calendar');
-      editor.changeEditorOption('range', { disablePast: true });
-      editor.changeEditorOption('selected', { dates: ['2001-02-04'], month: 2 });
+      const calendarElm = document.body.querySelector<HTMLDivElement>('.vc');
+      editor.changeEditorOption('disableDatesPast', true);
+      editor.changeEditorOption('selectedDates', ['2001-02-04']);
+      editor.changeEditorOption('selectedMonth', 2);
 
       expect(calendarElm).toBeTruthy();
-      expect(editor.pickerOptions.settings?.range?.disablePast).toBeTruthy();
-      expect(editor.pickerOptions.settings?.selected).toEqual({ dates: ['2001-02-04'], month: 2 });
+      expect(editor.pickerOptions.disableDatesPast).toBeTruthy();
+      expect(editor.pickerOptions.selectedDates).toEqual(['2001-02-04']);
+      expect(editor.pickerOptions.selectedMonth).toEqual(2);
 
-      editor.changeEditorOption('range', { edgesOnly: true });
-      editor.changeEditorOption('selected', { dates: ['2020-03-10', 'today'] } as ISelected);
+      editor.changeEditorOption('enableEdgeDatesOnly', true);
+      editor.changeEditorOption('selectedDates', ['2020-03-10', 'today']);
 
-      expect(editor.pickerOptions.settings?.range).toEqual({ disablePast: true, edgesOnly: true });
-      expect(editor.pickerOptions.settings?.selected).toEqual({ dates: ['2020-03-10', 'today'], month: 2 });
+      expect(editor.pickerOptions.disableDatesPast).toEqual(true);
+      expect(editor.pickerOptions.enableEdgeDatesOnly).toEqual(true);
+      expect(editor.pickerOptions.selectedDates).toEqual(['2020-03-10', 'today']);
+      expect(editor.pickerOptions.selectedMonth).toEqual(2);
     });
 
     describe('isValueChanged method', () => {
@@ -303,19 +306,14 @@ describe('DateEditor', () => {
         editor.focus();
         const editorInputElm = editor.editorDomElement;
         editorInputElm.value = '2024-04-02T16:02:02.239Z';
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [dateMock],
-          selectedHours: 11,
-          selectedMinutes: 2,
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [dateMock],
-          selectedHours: 11,
-          selectedMinutes: 2,
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!(
+          { context: { inputElement: editorInputElm, selectedDates: [dateMock], selectedHours: 11, selectedMinutes: 2 } } as unknown as Calendar,
+          new MouseEvent('click')
+        );
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: [dateMock], selectedHours: 11, selectedMinutes: 2 }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
 
         expect(editor.isValueChanged()).toBe(true);
         expect(editor.isValueTouched()).toBe(true);
@@ -354,17 +352,13 @@ describe('DateEditor', () => {
         const clearBtnElm = divContainer.querySelector('.btn-clear') as HTMLInputElement;
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
         clearBtnElm.click();
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!({ context: { inputElement: editorInputElm, selectedDates: [] } } as unknown as Calendar, new MouseEvent('click'));
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
 
-        expect(editor.calendarInstance?.settings.selected.dates).toEqual([]);
+        expect(editor.calendarInstance?.context.selectedDates).toEqual([]);
         expect(editorInputElm.value).toBe('');
         expect(editor.isValueChanged()).toBe(true);
         expect(editor.isValueTouched()).toBe(true);
@@ -379,21 +373,20 @@ describe('DateEditor', () => {
         editor.loadValue(mockItemData);
         editor.focus();
 
-        const today = new Date();
-        let calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
-        let yearElm = calendarElm.querySelector('.vanilla-calendar-year') as HTMLButtonElement;
+        let calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
+        let yearElm = calendarElm.querySelector('[data-vc="year"]') as HTMLButtonElement;
         const clearBtnElm = divContainer.querySelector('.btn-clear') as HTMLInputElement;
 
-        expect(+yearElm.innerText).not.toBe(today.getFullYear());
+        expect(yearElm.innerText).toBe('2001');
 
         clearBtnElm.click();
-        editor.reset();
+        editor.reset('2025-01-01');
         editor.show();
 
-        calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
-        yearElm = calendarElm.querySelector('.vanilla-calendar-year') as HTMLButtonElement;
+        calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
+        yearElm = calendarElm.querySelector('[data-vc="year"]') as HTMLButtonElement;
 
-        expect(+yearElm.innerText).toBe(today.getFullYear());
+        expect(yearElm.innerText).toBe('2025');
       });
 
       it('should also return True when date is reset by the clear date button even if the previous date was empty', () => {
@@ -406,19 +399,15 @@ describe('DateEditor', () => {
         editor.focus();
         const clearBtnElm = divContainer.querySelector('.btn-clear') as HTMLInputElement;
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!({ context: { inputElement: editorInputElm, selectedDates: [] } } as unknown as Calendar, new MouseEvent('click'));
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
         clearBtnElm.click();
 
         expect(editorInputElm.value).toBe('');
-        expect(editor.calendarInstance?.settings.selected.dates).toEqual([]);
+        expect(editor.calendarInstance?.context.selectedDates).toEqual([]);
         expect(editor.isValueChanged()).toBe(true);
         expect(editor.isValueTouched()).toBe(true);
       });
@@ -434,19 +423,18 @@ describe('DateEditor', () => {
         editor.loadValue(mockItemData);
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
         editorInputElm.value = dateMock;
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [dateMock],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [dateMock],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!(
+          { context: { inputElement: editorInputElm, selectedDates: ['2001-01-02'] } } as unknown as Calendar,
+          new MouseEvent('click')
+        );
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
         editor.reset();
 
         expect(editorInputElm.value).toBe(dateMock);
-        expect(editor.calendarInstance?.settings.selected.dates).toEqual(['2020-02-25']); // picker only deals with ISO formatted dates
+        expect(editor.calendarInstance?.selectedDates).toEqual(['2020-02-25']); // picker only deals with ISO formatted dates
         expect(editor.isValueChanged()).toBe(false);
         expect(editor.isValueTouched()).toBe(false);
       });
@@ -462,15 +450,14 @@ describe('DateEditor', () => {
 
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
         editorInputElm.value = '2001-01-02';
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: ['2001-01-02'],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: ['2001-01-02'],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!(
+          { context: { inputElement: editorInputElm, selectedDates: ['2001-01-02'] } } as unknown as Calendar,
+          new MouseEvent('click')
+        );
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
 
         expect(editor.isValueChanged()).toBe(false);
         expect(editor.isValueTouched()).toBe(true);
@@ -487,15 +474,14 @@ describe('DateEditor', () => {
         editor.loadValue(mockItemData);
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
         editorInputElm.value = dateMock;
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [dateMock],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [dateMock],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!(
+          { context: { inputElement: editorInputElm, selectedDates: [dateMock] } } as unknown as Calendar,
+          new MouseEvent('click')
+        );
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: [dateMock] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
 
         expect(editor.isValueChanged()).toBe(false);
         expect(editor.isValueTouched()).toBe(true);
@@ -662,7 +648,7 @@ describe('DateEditor', () => {
       });
 
       it('should not throw any error when date is lower than required "minDate" defined in the "editorOptions" and "autoCommitEdit" is enabled', () => {
-        mockColumn.editor!.editorOptions = { range: { min: 'today' } };
+        mockColumn.editor!.editorOptions = { displayDateMin: 'today' };
         mockItemData = { id: 1, startDate: '500-01-02T11:02:02.000Z', isActive: true };
         gridOptionMock.autoCommitEdit = true;
         gridOptionMock.autoEdit = true;
@@ -673,15 +659,11 @@ describe('DateEditor', () => {
         editor.loadValue(mockItemData);
         editor.calendarInstance?.show();
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!({ context: { inputElement: editorInputElm, selectedDates: [] } } as unknown as Calendar, new MouseEvent('click'));
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
 
         expect(editor.pickerOptions).toBeTruthy();
         expect(editorInputElm.value).toBe('');
@@ -691,7 +673,7 @@ describe('DateEditor', () => {
       it('should not throw any error when date is invalid when lower than required "minDate" defined in the global default editorOptions and "autoCommitEdit" is enabled', () => {
         // change to allow input value only for testing purposes & use the regular date picker input to test that one too
         gridOptionMock.defaultEditorOptions = {
-          date: { range: { min: 'today' } },
+          date: { displayDateMin: 'today' },
         };
         mockItemData = { id: 1, startDate: '500-01-02T11:02:02.000Z', isActive: true };
         gridOptionMock.autoCommitEdit = true;
@@ -703,15 +685,11 @@ describe('DateEditor', () => {
         editor.loadValue(mockItemData);
         editor.calendarInstance?.show();
         const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
-        editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-        } as unknown as VanillaCalendar);
-        editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-          HTMLInputElement: editorInputElm,
-          selectedDates: [],
-          hide: vi.fn(),
-        } as unknown as VanillaCalendar);
+        editor.calendarInstance!.onClickDate!({ context: { inputElement: editorInputElm, selectedDates: [] } } as unknown as Calendar, new MouseEvent('click'));
+        editor.calendarInstance!.onChangeToInput!(
+          { context: { inputElement: editorInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+          new MouseEvent('click')
+        );
 
         expect(editor.pickerOptions).toBeTruthy();
         expect(editorInputElm.value).toBe('');
@@ -747,12 +725,12 @@ describe('DateEditor', () => {
         editor = new DateEditor(editorArguments);
         vi.runAllTimers();
 
-        const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
-        const monthElm = calendarElm.querySelector('.vanilla-calendar-month') as HTMLButtonElement;
+        const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
+        const monthElm = calendarElm.querySelector('[data-vc="month"]') as HTMLButtonElement;
 
         expect(calendarElm).toBeTruthy();
         expect(monthElm).toBeTruthy();
-        expect(editor.calendarInstance?.settings.lang).toBe('fr');
+        expect(editor.calendarInstance?.locale).toBe('fr');
         // expect(monthElm.textContent).toBe('janvier');
       });
     });
@@ -858,8 +836,8 @@ describe('DateEditor', () => {
         expect.anything()
       );
       expect(disableSpy).toHaveBeenCalledWith(true);
-      expect(editor.calendarInstance?.HTMLInputElement?.disabled).toEqual(true);
-      expect(editor.calendarInstance?.HTMLInputElement?.value).toEqual('');
+      expect(editor.calendarInstance?.context.inputElement?.disabled).toEqual(true);
+      expect(editor.calendarInstance?.context.inputElement?.value).toEqual('');
     });
 
     it('should call "show" and expect the DOM element to become disabled and empty when "onBeforeEditCell" returns false and also expect "onBeforeComposite" to not be called because the value is blank', () => {
@@ -892,8 +870,8 @@ describe('DateEditor', () => {
       });
       expect(onCompositeEditorSpy).not.toHaveBeenCalled();
       expect(disableSpy).toHaveBeenCalledWith(true);
-      expect(editor.calendarInstance?.HTMLInputElement?.disabled).toEqual(true);
-      expect(editor.calendarInstance?.HTMLInputElement?.value).toEqual('');
+      expect(editor.calendarInstance?.context.inputElement?.disabled).toEqual(true);
+      expect(editor.calendarInstance?.context.inputElement?.value).toEqual('');
     });
 
     it('should call "disable" method and expect the DOM element to become disabled and have an empty formValues be passed in the onCompositeEditorChange event', () => {
@@ -925,8 +903,8 @@ describe('DateEditor', () => {
         },
         expect.anything()
       );
-      expect(editor.calendarInstance?.HTMLInputElement?.disabled).toEqual(true);
-      expect(editor.calendarInstance?.HTMLInputElement?.value).toEqual('');
+      expect(editor.calendarInstance?.context.inputElement?.disabled).toEqual(true);
+      expect(editor.calendarInstance?.context.inputElement?.value).toEqual('');
     });
 
     it('should expect "onCompositeEditorChange" to have been triggered with the new value showing up in its "formValues" object', () => {
@@ -949,15 +927,14 @@ describe('DateEditor', () => {
       editor.focus();
       const editorInputElm = divContainer.querySelector('input.date-picker') as HTMLInputElement;
       editorInputElm.value = dateMock;
-      editor.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-        HTMLInputElement: editorInputElm,
-        selectedDates: [dateMock],
-      } as unknown as VanillaCalendar);
-      editor.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-        HTMLInputElement: editorInputElm,
-        selectedDates: [dateMock],
-        hide: vi.fn(),
-      } as unknown as VanillaCalendar);
+      editor.calendarInstance!.onClickDate!(
+        { context: { inputElement: editorInputElm, selectedDates: [dateMock] } } as unknown as Calendar,
+        new MouseEvent('click')
+      );
+      editor.calendarInstance!.onChangeToInput!(
+        { context: { inputElement: editorInputElm, selectedDates: [dateMock] }, hide: vi.fn() } as unknown as Calendar,
+        new MouseEvent('click')
+      );
 
       expect(getCellSpy).toHaveBeenCalled();
       expect(onBeforeEditSpy).toHaveBeenCalledWith({

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -280,7 +280,7 @@ export class DateEditor implements Editor {
     this.columnEditor.editorOptions[optionName] = newValue;
     this._pickerMergedOptions = extend(true, {}, this._pickerMergedOptions, { [optionName]: newValue });
     if (this.calendarInstance) {
-      (this.calendarInstance as any)[optionName as T] = newValue as K;
+      this.calendarInstance.set(this._pickerMergedOptions, { dates: true, locale: true, month: true, time: true, year: true });
     }
   }
 

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -1,8 +1,7 @@
 import { parse } from '@formkit/tempo';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, setDeepValue } from '@slickgrid-universal/utils';
-import VanillaCalendar from 'vanilla-calendar-pro';
-import type { FormatDateString, IOptions } from 'vanilla-calendar-pro/types';
+import { Calendar, type FormatDateString, type Options } from 'vanilla-calendar-pro';
 
 import { Constants } from './../constants.js';
 import { FieldType } from '../enums/index.js';
@@ -15,7 +14,6 @@ import type {
   EditorValidator,
   EditorValidationResult,
   GridOption,
-  VanillaCalendarOption,
 } from './../interfaces/index.js';
 import { getDescendantProperty } from './../services/utilities.js';
 import type { TranslaterService } from '../services/translater.service.js';
@@ -35,9 +33,9 @@ export class DateEditor implements Editor {
   protected _lastClickIsDate = false;
   protected _lastTriggeredByClearDate = false;
   protected _originalDate?: string;
-  protected _pickerMergedOptions!: IOptions;
+  protected _pickerMergedOptions!: Options;
   protected _lastInputKeyEvent?: KeyboardEvent;
-  calendarInstance?: VanillaCalendar;
+  calendarInstance?: Calendar;
   defaultDate?: string;
   hasTimePicker = false;
 
@@ -87,7 +85,7 @@ export class DateEditor implements Editor {
   }
 
   /** Get options passed to the editor by the user */
-  get editorOptions(): IOptions {
+  get editorOptions(): Options {
     return { ...this.gridOptions.defaultEditorOptions?.date, ...this.columnEditor?.editorOptions };
   }
 
@@ -95,7 +93,7 @@ export class DateEditor implements Editor {
     return this.gridOptions.autoCommitEdit ?? false;
   }
 
-  get pickerOptions(): IOptions {
+  get pickerOptions(): Options {
     return this._pickerMergedOptions;
   }
 
@@ -120,59 +118,51 @@ export class DateEditor implements Editor {
       }
       const pickerFormat = mapTempoDateFormatWithFieldType(this.hasTimePicker ? FieldType.dateTimeIsoAM_PM : FieldType.dateIso);
 
-      const pickerOptions: IOptions = {
-        input: true,
-        jumpToSelectedDate: true,
-        sanitizer: (dirtyHtml) => this.grid.sanitizeHtmlString(dirtyHtml),
-        toggleSelected: false,
-        actions: {
-          clickDay: () => {
-            this._lastClickIsDate = true;
-          },
-          changeToInput: (_e, self) => {
-            if (self.HTMLInputElement) {
-              let selectedDate = '';
-              if (self.selectedDates[0]) {
-                selectedDate = self.selectedDates[0];
-                self.HTMLInputElement.value = formatDateByFieldType(self.selectedDates[0], undefined, outputFieldType);
-              } else {
-                self.HTMLInputElement.value = '';
-              }
-
-              if (selectedDate && this.hasTimePicker) {
-                const tempoDate = parse(selectedDate, pickerFormat);
-                tempoDate.setHours(+(self.selectedHours || 0));
-                tempoDate.setMinutes(+(self.selectedMinutes || 0));
-                self.HTMLInputElement.value = formatDateByFieldType(tempoDate, undefined, outputFieldType);
-              }
-
-              if (this._lastClickIsDate) {
-                this.handleOnDateChange();
-                self.hide();
-              }
-            }
-          },
+      const pickerOptions: Options = {
+        inputMode: true,
+        enableJumpToSelectedDate: true,
+        firstWeekday: 0,
+        enableDateToggle: false,
+        locale: currentLocale,
+        selectedTheme: this.gridOptions?.darkMode ? 'dark' : 'light',
+        positionToInput: 'auto',
+        sanitizerHTML: (dirtyHtml) => this.grid.sanitizeHtmlString(dirtyHtml),
+        selectedWeekends: [],
+        onClickDate: () => {
+          this._lastClickIsDate = true;
         },
-        settings: {
-          lang: currentLocale,
-          iso8601: false,
-          visibility: {
-            theme: this.gridOptions?.darkMode ? 'dark' : 'light',
-            positionToInput: 'auto',
-            weekend: false,
-          },
+        onChangeToInput: (self) => {
+          if (self.context.inputElement) {
+            let selectedDate = '';
+            if (self.context.selectedDates[0]) {
+              selectedDate = self.context.selectedDates[0];
+              self.context.inputElement.value = formatDateByFieldType(self.context.selectedDates[0], undefined, outputFieldType);
+            } else {
+              self.context.inputElement.value = '';
+            }
+
+            if (selectedDate && this.hasTimePicker) {
+              const tempoDate = parse(selectedDate, pickerFormat);
+              tempoDate.setHours(+(self.context.selectedHours || 0));
+              tempoDate.setMinutes(+(self.context.selectedMinutes || 0));
+              self.context.inputElement.value = formatDateByFieldType(tempoDate, undefined, outputFieldType);
+            }
+
+            if (this._lastClickIsDate) {
+              this.handleOnDateChange();
+              self.hide();
+            }
+          }
         },
       };
 
       // add the time picker when format includes time (hours/minutes)
       if (this.hasTimePicker) {
-        pickerOptions.settings!.selection = {
-          time: 24,
-        };
+        pickerOptions.selectionTimeMode = 24;
       }
 
       // merge options with optional user's custom options
-      this._pickerMergedOptions = extend(true, {}, pickerOptions, { settings: this.editorOptions, type: 'default' });
+      this._pickerMergedOptions = extend(true, {}, pickerOptions, this.editorOptions, { type: 'default' });
 
       const inputCssClasses = `.editor-text.date-picker.editor-${columnId}.form-control.input-group-editor`;
       this._editorInputGroupElm = createDomElement('div', { className: 'vanilla-picker input-group' });
@@ -219,7 +209,7 @@ export class DateEditor implements Editor {
       }) as EventListener);
 
       queueMicrotask(() => {
-        this.calendarInstance = new VanillaCalendar(this._inputElm, this._pickerMergedOptions);
+        this.calendarInstance = new Calendar(this._inputElm, this._pickerMergedOptions);
         this.calendarInstance.init();
         if (!compositeEditorOptions) {
           this.show();
@@ -283,15 +273,15 @@ export class DateEditor implements Editor {
    * @param {string} optionName
    * @param {newValue} newValue
    */
-  changeEditorOption<T extends keyof Required<VanillaCalendarOption>, K extends Required<VanillaCalendarOption>[T]>(
-    optionName: T,
-    newValue: K
-  ): void {
+  changeEditorOption<T extends keyof Options, K extends Options[T]>(optionName: T, newValue: K): void {
     if (!this.columnEditor.editorOptions) {
       this.columnEditor.editorOptions = {};
     }
     this.columnEditor.editorOptions[optionName] = newValue;
-    this._pickerMergedOptions = extend(true, {}, this._pickerMergedOptions, { settings: { [optionName]: newValue } });
+    this._pickerMergedOptions = extend(true, {}, this._pickerMergedOptions, { [optionName]: newValue });
+    if (this.calendarInstance) {
+      (this.calendarInstance as any)[optionName as T] = newValue as K;
+    }
   }
 
   focus(): void {
@@ -325,7 +315,6 @@ export class DateEditor implements Editor {
       setPickerDates(this.columnEditor, this._inputElm, this.calendarInstance, {
         columnDef: this.columnDef,
         newVal: val,
-        updatePickerUI: true,
       });
     }
 
@@ -409,7 +398,7 @@ export class DateEditor implements Editor {
     const inputValue = value ?? this._originalDate ?? '';
     if (this.calendarInstance) {
       this._originalDate = inputValue;
-      this.calendarInstance.settings.selected.dates = [inputValue as FormatDateString];
+      this.calendarInstance.selectedDates = [inputValue as FormatDateString];
       if (inputValue) {
         setPickerDates(this.columnEditor, this._inputElm, this.calendarInstance, {
           columnDef: this.columnDef,

--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type VanillaCalendar from 'vanilla-calendar-pro';
+import type { Calendar } from 'vanilla-calendar-pro';
 import { format } from '@formkit/tempo';
 
 import { Filters } from '../filters.index.js';
@@ -100,7 +100,7 @@ describe('CompoundDateFilter', () => {
     const spy = vi.spyOn(filter.calendarInstance!, 'hide');
     const inputElm = document.body.querySelector('input.date-picker') as HTMLInputElement;
     inputElm.dispatchEvent(new MouseEvent('click'));
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
     filter.hide();
 
     expect(calendarElm).toBeTruthy();
@@ -111,7 +111,7 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     const spy = vi.spyOn(filter.calendarInstance!, 'show');
     filter.show();
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
 
     expect(calendarElm).toBeTruthy();
     expect(spy).toHaveBeenCalled();
@@ -122,23 +122,17 @@ describe('CompoundDateFilter', () => {
 
     expect(filter.calendarInstance).toBeTruthy();
     expect(filter.pickerOptions).toEqual({
-      actions: {
-        changeToInput: expect.any(Function),
-        clickDay: expect.any(Function),
-      },
-      input: true,
-      jumpToSelectedDate: true,
-      sanitizer: expect.any(Function),
-      toggleSelected: false,
-      settings: {
-        iso8601: false,
-        lang: 'en',
-        visibility: {
-          positionToInput: 'auto',
-          theme: 'light',
-          weekend: false,
-        },
-      },
+      enableDateToggle: true,
+      enableJumpToSelectedDate: true,
+      firstWeekday: 0,
+      inputMode: true,
+      locale: 'en',
+      onChangeToInput: expect.any(Function),
+      onClickDate: expect.any(Function),
+      positionToInput: 'auto',
+      sanitizerHTML: expect.any(Function),
+      selectedTheme: 'light',
+      selectedWeekends: [],
       type: 'default',
     });
   });
@@ -187,16 +181,14 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02T16:02:02.239Z';
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2001-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2001-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -214,16 +206,14 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02T16:02:02.239Z';
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: [],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: [],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(0);
@@ -237,16 +227,14 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02T16:02:02.239Z';
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2001-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2001-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -321,7 +309,7 @@ describe('CompoundDateFilter', () => {
 
     filter.init(filterArguments);
     filter.show();
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
 
     expect(calendarElm).toBeTruthy();
 
@@ -334,7 +322,7 @@ describe('CompoundDateFilter', () => {
 
     filter.init(filterArguments);
     filter.show();
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
 
     expect(calendarElm).toBeTruthy();
 
@@ -351,7 +339,7 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     filter.show();
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
 
     expect(calendarElm).toBeTruthy();
     expect(filterInputElm.value).toBe('2000-01-01');
@@ -373,16 +361,14 @@ describe('CompoundDateFilter', () => {
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-01T05:00:00.000Z'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-01T05:00:00.000Z'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-01T05:00:00.000Z'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-01T05:00:00.000Z'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -407,11 +393,10 @@ describe('CompoundDateFilter', () => {
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -422,7 +407,7 @@ describe('CompoundDateFilter', () => {
 
   it('should have a value with date & time in the picker when "enableTime" option is set as a global default filter option and we trigger a change', () => {
     gridOptionMock.defaultFilterOptions = {
-      date: { selected: { dates: ['2001-01-02'] } },
+      date: { selectedDates: ['2001-01-02'] },
     };
     mockColumn.filter!.operator = '<=';
     const spyCallback = vi.spyOn(filterArguments, 'callback');
@@ -431,11 +416,10 @@ describe('CompoundDateFilter', () => {
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -490,23 +474,21 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     filter.show();
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
-    const monthElm = calendarElm.querySelector('.vanilla-calendar-month') as HTMLButtonElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
+    const monthElm = calendarElm.querySelector('[data-vc="month"]') as HTMLButtonElement;
 
     filter.show();
 
     filterInputElm.focus();
 
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-01T05:00:00.000Z'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-01T05:00:00.000Z'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-01T05:00:00.000Z'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-01T05:00:00.000Z'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -560,18 +542,14 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02T16:02:00.000Z';
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2001-01-02'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2001-01-02'],
-      selectedHours: 16,
-      selectedMinutes: 2,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2001-01-02'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2001-01-02'], selectedHours: 16, selectedMinutes: 2 }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -595,16 +573,14 @@ describe('CompoundDateFilter', () => {
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-01'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: ['2000-01-01'],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-01'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: ['2000-01-01'] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);

--- a/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type VanillaCalendar from 'vanilla-calendar-pro';
+import type { Calendar } from 'vanilla-calendar-pro';
 
 import { FieldType } from '../../enums/index.js';
 import type { Column, FilterArguments, GridOption } from '../../interfaces/index.js';
@@ -88,7 +88,7 @@ describe('DateRangeFilter', () => {
     const spy = vi.spyOn(filter.calendarInstance!, 'hide');
     const inputElm = document.body.querySelector('input.date-picker') as HTMLInputElement;
     inputElm.dispatchEvent(new MouseEvent('click'));
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
     filter.hide();
 
     expect(calendarElm).toBeTruthy();
@@ -99,7 +99,7 @@ describe('DateRangeFilter', () => {
     filter.init(filterArguments);
     const spy = vi.spyOn(filter.calendarInstance!, 'show');
     filter.show();
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
 
     expect(calendarElm).toBeTruthy();
     expect(spy).toHaveBeenCalled();
@@ -110,28 +110,22 @@ describe('DateRangeFilter', () => {
 
     expect(filter.calendarInstance).toBeTruthy();
     expect(filter.pickerOptions).toEqual({
-      actions: {
-        changeToInput: expect.any(Function),
-        clickDay: expect.any(Function),
-      },
-      input: true,
-      jumpMonths: 2,
-      jumpToSelectedDate: true,
-      months: 2,
-      sanitizer: expect.any(Function),
-      settings: {
-        iso8601: false,
-        lang: 'en',
-        range: { edgesOnly: true },
-        selection: { day: 'multiple-ranged' },
-        visibility: {
-          daysOutside: false,
-          positionToInput: 'auto',
-          theme: 'light',
-          weekend: false,
-        },
-      },
-      toggleSelected: false,
+      displayDatesOutside: false,
+      displayMonthsCount: 2,
+      enableDateToggle: true,
+      enableEdgeDatesOnly: true,
+      enableJumpToSelectedDate: true,
+      firstWeekday: 0,
+      inputMode: true,
+      locale: 'en',
+      monthsToSwitch: 2,
+      onChangeToInput: expect.any(Function),
+      onClickDate: expect.any(Function),
+      positionToInput: 'auto',
+      sanitizerHTML: expect.any(Function),
+      selectionDatesMode: 'multiple-ranged',
+      selectedTheme: 'light',
+      selectedWeekends: [],
       type: 'multiple',
     });
   });
@@ -157,16 +151,14 @@ describe('DateRangeFilter', () => {
 
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('div.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -185,16 +177,14 @@ describe('DateRangeFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02T16:02:02.239Z';
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: [],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new Event('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates: [],
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates: [] }, hide: vi.fn() } as unknown as Calendar,
+      new Event('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(0);
@@ -208,16 +198,14 @@ describe('DateRangeFilter', () => {
 
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -239,7 +227,7 @@ describe('DateRangeFilter', () => {
     filter.init(filterArguments);
     filter.show();
     const filterInputElm = divContainer.querySelector('.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
 
     expect(calendarElm).toBeTruthy();
     expect(filterInputElm.value).toBe('2001-01-02 — 2001-01-13');
@@ -265,16 +253,14 @@ describe('DateRangeFilter', () => {
     const filterInputElm = divContainer.querySelector('.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -297,16 +283,14 @@ describe('DateRangeFilter', () => {
     const filterInputElm = divContainer.querySelector('.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
 
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
@@ -344,22 +328,20 @@ describe('DateRangeFilter', () => {
     filter.init(filterArguments);
     filter.show();
     const filterInputElm = divContainer.querySelector('.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
-    const calendarElm = document.body.querySelector('.vanilla-calendar') as HTMLDivElement;
-    const monthElm = calendarElm.querySelector('.vanilla-calendar-month') as HTMLButtonElement;
+    const calendarElm = document.body.querySelector('.vc') as HTMLDivElement;
+    const monthElm = calendarElm.querySelector('[data-vc="month"]') as HTMLButtonElement;
 
     filter.show();
 
     filterInputElm.focus();
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -412,16 +394,14 @@ describe('DateRangeFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02 — 2001-01-13';
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
 
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
@@ -446,16 +426,14 @@ describe('DateRangeFilter', () => {
     filter.init(filterArguments);
     const filterInputElm = divContainer.querySelector('div.date-picker.search-filter.filter-finish input.date-picker') as HTMLInputElement;
     filterInputElm.value = '2001-01-02 — 2001-01-13';
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
@@ -481,16 +459,14 @@ describe('DateRangeFilter', () => {
 
     filterInputElm.focus();
     filterInputElm.value = '2001-01-02 — 2001-01-13';
-    filter.calendarInstance!.actions!.changeToInput!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
-    filter.calendarInstance!.actions!.clickDay!(new MouseEvent('click'), {
-      HTMLInputElement: filterInputElm,
-      selectedDates,
-      hide: vi.fn(),
-    } as unknown as VanillaCalendar);
+    filter.calendarInstance!.onChangeToInput!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
+    filter.calendarInstance!.onClickDate!(
+      { context: { inputElement: filterInputElm, selectedDates }, hide: vi.fn() } as unknown as Calendar,
+      new MouseEvent('click')
+    );
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.date-picker.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);

--- a/packages/common/src/interfaces/vanillaCalendarOption.interface.ts
+++ b/packages/common/src/interfaces/vanillaCalendarOption.interface.ts
@@ -1,15 +1,6 @@
-import type { IRange, ISelected, ISelection, ISettings, IVisibility } from 'vanilla-calendar-pro/types';
+import type { Options } from 'vanilla-calendar-pro';
 
-export type IPartialSettings = Partial<
-  Pick<ISettings, 'iso8601' | 'lang'> & {
-    range: Partial<IRange>;
-    selection: Partial<ISelection>;
-    selected: Partial<ISelected>;
-    visibility: Partial<IVisibility>;
-  }
->;
-
-export interface VanillaCalendarOption extends IPartialSettings {
+export interface VanillaCalendarOption extends Partial<Options> {
   //-- extra options used by SlickGrid
 
   /** defaults to false, do we want to hide the clear date button? */

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -7,7 +7,7 @@
 @use 'sass:color';
 
 // import external lib CSS files (without the .css extension)
-@use 'vanilla-calendar-pro/build/vanilla-calendar.min';
+@use 'vanilla-calendar-pro/styles/index';
 
 // SASS utils to generate SVGs
 @use './svg-utilities';

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -916,16 +916,9 @@ li.hidden {
 // Date Picker Filter
 // ----------------------------------------------
 
-.vanilla-calendar {
+.vc {
   padding: 0.9rem;
   z-index: 9999;
-
-  // when setting filters dynamically, the calendar picker is appended to the body
-  // making the body taller and unnecessary scrollable
-  &.vanilla-calendar_hidden {
-    left: 0;
-    top: 0;
-  }
 }
 
 // ----------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,8 +461,8 @@ importers:
         specifier: ^2.0.12
         version: 2.0.12
       vanilla-calendar-pro:
-        specifier: ^2.9.10
-        version: 2.9.10
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       autoprefixer:
         specifier: ^10.4.21
@@ -4724,8 +4724,8 @@ packages:
     resolution: {integrity: sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  vanilla-calendar-pro@2.9.10:
-    resolution: {integrity: sha512-0yqWqlvitfQSRqjyVVr613whIgp62qC1JHgXyLalcJkNkMRZXRqEr+QQQvRdQavB2PBgB4HW+GM6VU4KU0K3Ng==}
+  vanilla-calendar-pro@3.0.3:
+    resolution: {integrity: sha512-bfmeGFaDeakk/OrwgM+22qDiRvIx1Zu+GG3+E/sCPjaKwbJR7AsDyRBfJQzVHRw3eeavU8jQQTRSFt8EPIPOGw==}
 
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
@@ -9277,7 +9277,7 @@ snapshots:
 
   validate-npm-package-name@6.0.0: {}
 
-  vanilla-calendar-pro@2.9.10: {}
+  vanilla-calendar-pro@3.0.3: {}
 
   verror@1.10.0:
     dependencies:

--- a/test/cypress/e2e/example03.cy.ts
+++ b/test/cypress/e2e/example03.cy.ts
@@ -80,31 +80,31 @@ describe('Example 03 - Draggable Grouping', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(3)`)
       .should('contain', '')
       .click();
-    cy.get('.vanilla-calendar-year').should('have.text', firstRowStartYear);
-    cy.get('.vanilla-calendar-month').should(($button) => {
+    cy.get('[data-vc="year"]').should('have.text', firstRowStartYear);
+    cy.get('[data-vc="month"]').should(($button) => {
       pickerMonth = $button.text();
       expect(pickerMonth).not.to.eq('');
     });
-    cy.get('.vanilla-calendar-day__btn_selected').should(($button) => {
+    cy.get('[data-vc-date-selected]').should(($button) => {
       selectedDate = $button.text();
       expect(pickerMonth).not.to.eq('');
     });
-    cy.get('.vanilla-calendar-day__btn_selected').click(); // reselect it to close the picker
+    cy.get('[data-vc-date-selected]').click(); // reselect it to close the picker
 
     // reopen date picker should have same date
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(3)`)
       .should('contain', '')
       .click();
-    cy.get('.vanilla-calendar-year').should('have.text', firstRowStartYear);
+    cy.get('[data-vc="year"]').should('have.text', firstRowStartYear);
 
-    cy.get('.vanilla-calendar-month').should(($button) => {
+    cy.get('[data-vc="month"]').should(($button) => {
       expect($button.text()).to.eq(pickerMonth);
     });
-    cy.get('.vanilla-calendar-day__btn_selected').should(($button) => {
+    cy.get('[data-vc-date-selected]').should(($button) => {
       expect($button.text()).to.eq(selectedDate);
     });
 
-    cy.get('.vanilla-calendar-day__btn_selected').click(); // reselect it to close the picker
+    cy.get('[data-vc-date-selected]').click(); // reselect it to close the picker
   });
 
   describe('Grouping tests', () => {

--- a/test/cypress/e2e/example07.cy.ts
+++ b/test/cypress/e2e/example07.cy.ts
@@ -153,7 +153,7 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`)
       .should('contain', '2009-01-05')
       .click();
-    cy.get('.vanilla-calendar:visible .vanilla-calendar-day:contains("22"):visible').first().click();
+    cy.get('.vc:visible [data-vc-date-btn]:visible').contains(/22$/).first().click();
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(7)`).should('contain', '2009-01-22');
 
     cy.get('.slick-viewport.slick-viewport-top.slick-viewport-left').scrollTo('top');
@@ -286,7 +286,7 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`)
       .should('contain', '2009-01-05')
       .click();
-    cy.get('.vanilla-calendar:visible .vanilla-calendar-day:contains("22"):visible').first().click();
+    cy.get('.vc:visible [data-vc-date-btn]:visible').contains(/22$/).first().click();
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(7)`).should('contain', '2009-01-22');
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(10)`).should('contain', 'Task 0000');

--- a/test/cypress/e2e/example10.cy.ts
+++ b/test/cypress/e2e/example10.cy.ts
@@ -397,19 +397,19 @@ describe('Example 10 - GraphQL Grid', () => {
   it('should open Date picker and expect date range between 01-Jan to 15-Feb', () => {
     cy.get('.search-filter.filter-finish.filled input').click({ force: true });
 
-    cy.get('.vanilla-calendar:visible');
+    cy.get('.vc:visible');
 
-    cy.get('.vanilla-calendar-column:nth(0) .vanilla-calendar-month').should('have.text', 'January');
+    cy.get('[data-vc="column"]:nth(0) [data-vc="month"]').should('have.text', 'January');
 
-    cy.get('.vanilla-calendar-column:nth(1) .vanilla-calendar-month').should('have.text', 'February');
+    cy.get('[data-vc="column"]:nth(1) [data-vc="month"]').should('have.text', 'February');
 
-    cy.get('.vanilla-calendar-year:nth(0)').should('have.text', currentYear);
+    cy.get('[data-vc="year"]:nth(0)').should('have.text', currentYear);
 
-    cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').should('have.length', 46);
+    cy.get('.vc:visible [data-vc-date-selected] button').should('have.length', 46);
 
-    cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').first().should('have.text', '1');
+    cy.get('.vc:visible').find('[data-vc-date-selected]').first().should('have.text', '1');
 
-    cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').last().should('have.text', '15');
+    cy.get('.vc:visible').find('[data-vc-date-selected]').last().should('have.text', '15');
   });
 
   describe('Set Dynamic Sorting', () => {
@@ -461,9 +461,9 @@ describe('Example 10 - GraphQL Grid', () => {
     it('should open Date picker and no longer expect date range selection in the picker', () => {
       cy.get('.search-filter.filter-finish').should('not.have.class', 'filled').click();
 
-      cy.get('.vanilla-calendar-year:nth(0)').should('have.text', currentYear);
+      cy.get('[data-vc="year"]:nth(0)').should('have.text', currentYear);
 
-      cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').should('not.exist');
+      cy.get('.vc:visible').find('[data-vc-date-selected]').should('not.exist');
     });
   });
 
@@ -885,7 +885,7 @@ describe('Example 10 - GraphQL Grid', () => {
 
       cy.get('.search-filter.filter-finish').click();
 
-      cy.get('.vanilla-calendar:visible').find('.vanilla-calendar-day__btn_selected').should('not.exist');
+      cy.get('.vc:visible').find('[data-vc-date-selected]').should('not.exist');
 
       cy.get('h3').click();
     });

--- a/test/cypress/e2e/example10.cy.ts
+++ b/test/cypress/e2e/example10.cy.ts
@@ -407,9 +407,9 @@ describe('Example 10 - GraphQL Grid', () => {
 
     cy.get('.vc:visible [data-vc-date-selected] button').should('have.length', 46);
 
-    cy.get('.vc:visible').find('[data-vc-date-selected]').first().should('have.text', '1');
+    cy.get('.vc:visible [data-vc-date-selected]').first().should('have.text', '1');
 
-    cy.get('.vc:visible').find('[data-vc-date-selected]').last().should('have.text', '15');
+    cy.get('.vc:visible [data-vc-date-selected]').last().should('have.text', '15');
   });
 
   describe('Set Dynamic Sorting', () => {

--- a/test/cypress/e2e/example11.cy.ts
+++ b/test/cypress/e2e/example11.cy.ts
@@ -359,21 +359,21 @@ describe('Example 11 - Batch Editing', () => {
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`)
         .should('contain', '')
         .click(); // this date should also always be initially empty
-      cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+      cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(6)`)
         .should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
         .should('have.css', 'background-color')
         .and('eq', UNSAVED_RGB_COLOR);
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`).click();
-      cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+      cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(6)`)
         .should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
         .should('have.css', 'background-color')
         .and('eq', UNSAVED_RGB_COLOR);
 
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`).click();
-      cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+      cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`)
         .should('contain', `${currentYear}-${zeroPadding(currentMonth)}-${zeroPadding(currentDate)}`)
         .should('have.css', 'background-color')
@@ -387,7 +387,7 @@ describe('Example 11 - Batch Editing', () => {
     it('should undo last edit and expect the date editor to be opened as well when clicking the associated last undo with editor button', () => {
       cy.get('[data-test=undo-open-editor-btn]').click();
 
-      cy.get('.vanilla-calendar').should('exist');
+      cy.get('.vc').should('exist');
 
       cy.get('.unsaved-editable-field').should('have.length', 12);
 
@@ -400,10 +400,9 @@ describe('Example 11 - Batch Editing', () => {
     it('should undo last edit and expect the date editor to NOT be opened when clicking undo last edit button', () => {
       cy.get('[data-test=undo-last-edit-btn]').click();
 
-      cy.get('.vanilla-calendar').should('not.be.visible');
+      cy.get('.vc').should('not.exist');
 
       cy.get('.unsaved-editable-field').should('have.length', 11);
-
       cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(6)`)
         .should('contain', '')
         .should('have.css', 'background-color')
@@ -576,11 +575,11 @@ describe('Example 11 - Batch Editing', () => {
 
       cy.get('.search-filter.filter-finish.filled input').click({ force: true });
 
-      cy.get('.vanilla-calendar:visible');
+      cy.get('.vc:visible');
 
-      cy.get('.vanilla-calendar-day__btn_selected').should('have.length', 1);
+      cy.get('[data-vc-date-selected]').should('have.length', 1);
 
-      cy.get('.vanilla-calendar-day__btn_selected').should('have.text', '1');
+      cy.get('[data-vc-date-selected]').should('have.text', '1');
 
       cy.get('.slick-column-name').contains('Finish').find('~ .slick-sort-indicator.slick-sort-indicator-asc').should('have.length', 1);
 
@@ -700,7 +699,7 @@ describe('Example 11 - Batch Editing', () => {
 
       cy.get('.search-filter.filter-finish').should('not.have.class', 'filled').click();
 
-      cy.get('.vanilla-calendar-day__btn_selected').should('have.length', 0);
+      cy.get('[data-vc-date-selected]').should('have.length', 0);
 
       cy.get('.search-filter.filter-completed .ms-choice').should('contain', '');
 

--- a/test/cypress/e2e/example12.cy.ts
+++ b/test/cypress/e2e/example12.cy.ts
@@ -150,12 +150,12 @@ describe('Example 12 - Composite Editor Modal', () => {
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
       .click({ force: true }); // this date should also always be initially empty
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).should('not.exist');
+    cy.get('[data-vc-date-today]:visible button').should('not.exist');
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(8)`)
       .should('contain', '')
       .click({ force: true }); // this date should also always be initially empty
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).should('not.exist');
+    cy.get('[data-vc-date-today]:visible button').should('not.exist');
   });
 
   it('should be able to change "Completed" values of row indexes 2-4', () => {
@@ -200,9 +200,9 @@ describe('Example 12 - Composite Editor Modal', () => {
       .should('contain', '')
       .click(); // this date should also always be initially empty
     // any dates lower than today should be disabled
-    cy.get(`[data-calendar-day=${yesterdayDate}]`).should('have.class', 'vanilla-calendar-day__btn_disabled');
-    cy.get(`[data-calendar-day=${todayDate}]`).should('not.have.class', 'vanilla-calendar-day__btn_disabled');
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+    cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(8)`)
       .should('contain', `${zeroPadding(currentMonth)}/${zeroPadding(currentDate)}/${currentYear}`)
       .get('.editing-field')
@@ -210,7 +210,7 @@ describe('Example 12 - Composite Editor Modal', () => {
       .and('contain', `solid ${UNSAVED_RGB_COLOR}`);
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`).click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(8)`)
       .should('contain', `${zeroPadding(currentMonth)}/${zeroPadding(currentDate)}/${currentYear}`)
       .get('.editing-field')
@@ -218,7 +218,7 @@ describe('Example 12 - Composite Editor Modal', () => {
       .and('contain', `solid ${UNSAVED_RGB_COLOR}`);
 
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(8)`).click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get(`[style="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(8)`)
       .should('contain', `${zeroPadding(currentMonth)}/${zeroPadding(currentDate)}/${currentYear}`)
       .get('.editing-field')
@@ -231,7 +231,7 @@ describe('Example 12 - Composite Editor Modal', () => {
   it('should undo last edit and expect the date editor to be opened as well when clicking the associated last undo with editor button', () => {
     cy.get('[data-test=undo-open-editor-btn]').click();
 
-    cy.get('.vanilla-calendar').should('exist');
+    cy.get('.vc').should('exist');
 
     cy.get('.unsaved-editable-field').should('have.length', 12);
 
@@ -245,7 +245,7 @@ describe('Example 12 - Composite Editor Modal', () => {
   it('should undo last edit and expect the date editor to NOT be opened when clicking undo last edit button', () => {
     cy.get('[data-test=undo-last-edit-btn]').click();
 
-    cy.get('.vanilla-calendar:visible').should('not.exist');
+    cy.get('.vc:visible').should('not.exist');
 
     cy.get('.unsaved-editable-field').should('have.length', 11);
 
@@ -399,7 +399,7 @@ describe('Example 12 - Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish input.date-picker').click({ force: true });
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('c');
@@ -509,7 +509,7 @@ describe('Example 12 - Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish .date-picker').click().click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click();
+    cy.get('[data-vc-date-today]:visible button').click();
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('bel');
@@ -587,7 +587,7 @@ describe('Example 12 - Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish .date-picker').click().click();
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click();
+    cy.get('[data-vc-date-today]:visible button').click();
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('bel');
@@ -644,7 +644,7 @@ describe('Example 12 - Composite Editor Modal', () => {
       '* You must provide a "Finish" date when "Completed" is checked.'
     );
     cy.get('.item-details-container.editor-finish input.date-picker').click({ force: true });
-    cy.get(`.vanilla-calendar-day__btn_today:visible`).click('bottom', { force: true });
+    cy.get('[data-vc-date-today]:visible button').click('bottom', { force: true });
     cy.get('.item-details-container.editor-finish .modified').should('have.length', 1);
 
     cy.get('.item-details-container.editor-origin .autocomplete').type('ze');
@@ -877,7 +877,7 @@ describe('Example 12 - Composite Editor Modal', () => {
     const today = new Date();
     cy.get('.editor-start .vanilla-picker input').click();
 
-    cy.get('.vanilla-calendar:visible .vanilla-calendar-year').should('not.contain', today.getFullYear());
+    cy.get('.vc:visible .vc-year').should('have.attr', 'data-vc-year').should('not.contain', today.getFullYear());
 
     // clear start date
     cy.get('.editor-start .vanilla-picker .btn-clear').click();
@@ -885,7 +885,7 @@ describe('Example 12 - Composite Editor Modal', () => {
     // reopen start date and expect today's year
     cy.get('.editor-start .vanilla-picker input').click();
 
-    cy.get('.vanilla-calendar:visible .vanilla-calendar-year').should('contain', today.getFullYear());
+    cy.get('.vc:visible .vc-year').should('have.attr', 'data-vc-year').should('contain', today.getFullYear());
 
     cy.get('.slick-editor-modal-footer .btn-cancel').click();
   });

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -191,8 +191,8 @@ describe('Example 14 - Columns Resize by Content', () => {
       const yesterdayDate = format(addDay(new Date(), -1), 'YYYY-MM-DD');
       const todayDate = format(new Date(), 'YYYY-MM-DD');
 
-      cy.get(`[data-calendar-day=${yesterdayDate}]`).should('have.class', 'vanilla-calendar-day__btn_disabled');
-      cy.get(`[data-calendar-day=${todayDate}]`).should('not.have.class', 'vanilla-calendar-day__btn_disabled');
+      cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+      cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
 
       // make grid readonly again
       cy.get('[data-test="toggle-readonly-btn"]').click();

--- a/test/cypress/e2e/example25.cy.ts
+++ b/test/cypress/e2e/example25.cy.ts
@@ -129,11 +129,11 @@ describe('Example 25 - Range Filters', () => {
   it('should change the "Finish" date in the picker and expect all rows to be within new dates range', () => {
     cy.get('.date-picker.search-filter.filter-finish').click();
 
-    cy.get('.vanilla-calendar-day_selected-first').should('exist');
+    cy.get('[data-vc-date-selected="first"]').should('exist');
 
-    cy.get('.vanilla-calendar-day_selected-intermediate').should('have.length.gte', 2);
+    cy.get('[data-vc-date-selected="middle"]').should('have.length.gte', 2);
 
-    cy.get('.vanilla-calendar-day_selected-last').should('exist');
+    cy.get('[data-vc-date-selected="last"]').should('exist');
   });
 
   it('should change the "Duration" input filter and expect all rows to be within new range', () => {


### PR DESCRIPTION
- upgrading to Vanilla-Calendar-Pro v3, the main different is that it's now using flat config (instead of complex), for example we need to migrate from `{ range: { min: 'today' } }` to a simpler single flat config as `{ displayDateMin: 'today' }`

TODO
- [x] unit tests
- [x] Cypress tests
- [x] check if we can use `.set()` (i.e. CompositeEditor), see [comment](https://github.com/uvarov-frontend/vanilla-calendar-pro/issues/331#issuecomment-2466150694)