### PR TITLE
fix(tree): findItemInTreeStructure() shouldn't throw w/large dataset, fix #1885

### DIFF
--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -458,7 +458,8 @@ describe('Service/Utilies', () => {
         },
       ];
 
-      for (let i = 20; i < 300_000; i++) {
+      // add large set of data for testing
+      for (let i = 20; i < 300_200; i++) {
         mockColumns[1].files.push({ id: i, file: `file-${i}.txt`, dateModified: '2020-02-01', size: 123 });
       }
     });
@@ -479,7 +480,7 @@ describe('Service/Utilies', () => {
       expect(item).toEqual(undefined as any);
     });
 
-    it('should return item found', () => {
+    it('should return item found in large dataset', () => {
       const item = findItemInTreeStructure(mockColumns, (x) => x.file === 'file-125000.txt', 'files');
       expect(item).toEqual({
         dateModified: '2020-02-01',

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -457,6 +457,10 @@ describe('Service/Utilies', () => {
           ],
         },
       ];
+
+      for (let i = 20; i < 300_000; i++) {
+        mockColumns[1].files.push({ id: i, file: `file-${i}.txt`, dateModified: '2020-02-01', size: 123 });
+      }
     });
 
     it('should throw an error when the children property name argument is missing', () => {
@@ -473,6 +477,16 @@ describe('Service/Utilies', () => {
     it('should return undefined when item is not found', () => {
       const item = findItemInTreeStructure(mockColumns, (x) => x.file === 'pop2', 'files');
       expect(item).toEqual(undefined as any);
+    });
+
+    it('should return item found', () => {
+      const item = findItemInTreeStructure(mockColumns, (x) => x.file === 'file-125000.txt', 'files');
+      expect(item).toEqual({
+        dateModified: '2020-02-01',
+        file: 'file-125000.txt',
+        id: 125000,
+        size: 123,
+      });
     });
   });
 

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -274,7 +274,7 @@ export function findItemInTreeStructure<T extends object = any>(
     const childElements: T[] = [];
     for (const item of elementsWithChildren) {
       if (childrenPropertyName in item) {
-        childElements.push(...(item as any)[childrenPropertyName]);
+        (item as any)[childrenPropertyName].forEach((el: any) => childElements.push(el));
       }
     }
     return findItemInTreeStructure<T>(childElements, predicate, childrenPropertyName);


### PR DESCRIPTION
fixes #1885