### PR TITLE
chore(deps): remove unnecessary `whatwg-fetch`

### DIFF
--- a/demos/vanilla/package.json
+++ b/demos/vanilla/package.json
@@ -28,8 +28,7 @@
     "bulma": "^1.0.3",
     "dompurify": "catalog:",
     "multiple-select-vanilla": "catalog:",
-    "rxjs": "catalog:",
-    "whatwg-fetch": "catalog:"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@types/fnando__sparkline": "catalog:",

--- a/demos/vanilla/src/translate.service.ts
+++ b/demos/vanilla/src/translate.service.ts
@@ -4,7 +4,6 @@ import {
   type TranslaterService,
   type TranslateServiceEventName,
 } from '@slickgrid-universal/common';
-import { fetch } from 'whatwg-fetch/fetch';
 
 interface Locales {
   [locale: string]: string;

--- a/docs/localization/localization-translate-service.md
+++ b/docs/localization/localization-translate-service.md
@@ -3,15 +3,7 @@
 
 ### Installation
 
-You can create your own Translate Service, for example installing the `whatwg-fetch` library (or anything similar) to load JSON files for translations.
-
-##### Install NPM package
-
-You can install `whatwg-fetch` or any other library that you wish to use to load your JSON translation files.
-
-```ts
-npm install whatwg-fetch
-```
+You can create your own Translate Service, for example using Fetch to load JSON files for translations.
 
 ##### Main.ts
 
@@ -29,7 +21,7 @@ export class TranslateService implements TranslaterService {
   use(language: string): Promise<any> | any {}
 }
 ```
-> for a full translater service implementation demo with `whatwg-fetch`, take a look at [translate.service.ts](https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vanilla/src/translate.service.ts).
+> for a full translater service implementation demo with Fetch, take a look at [translate.service.ts](https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vanilla/src/translate.service.ts).
 
 #### Class sample
 You need to add a translation key via the property `headerKey` to each column definition, for example: `headerKey: 'TITLE'`

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "comments": {
     "new-version": "To create a new version with Lerna-Lite, simply run the following script (1) 'roll-new-release'.",
-    "devDependencies": "The dev deps 'slickgrid', 'sortablejs' and 'whatwg-fetch' are simply installed for Vitest unit tests."
+    "devDependencies": "The dev deps 'slickgrid' and 'sortablejs' are simply installed for Vitest unit tests."
   },
   "engines": {
     "node": "^20.17.0 || >=22.9.0",
@@ -105,8 +105,7 @@
     "sortablejs": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "^8.28.0",
-    "vitest": "^3.0.9",
-    "whatwg-fetch": "catalog:"
+    "vitest": "^3.0.9"
   },
   "funding": {
     "type": "ko_fi",

--- a/packages/vanilla-bundle/README.md
+++ b/packages/vanilla-bundle/README.md
@@ -22,9 +22,6 @@ Vanilla Bundle implementation (no framework, plain TypeSript implementation). Th
 - [@slickgrid-universal/empty-warning-component](https://github.com/ghiscoding/slickgrid-universal/tree/master/packages/empty-warning-component)
 - [@slickgrid-universal/pagination-component](https://github.com/ghiscoding/slickgrid-universal/tree/master/packages/pagination-component)
 
-### External Dependencies
-- [whatwg-fetch](https://github.com/whatwg/fetch) - Fetch Standard
-
 ### Installation
 This Vanilla Bundle is used used by the standalone [demos/vanilla](https://github.com/ghiscoding/slickgrid-universal/tree/master/demos/vanilla) which serves for demo purposes.
 

--- a/packages/vanilla-bundle/package.json
+++ b/packages/vanilla-bundle/package.json
@@ -59,8 +59,7 @@
     "@slickgrid-universal/pagination-component": "workspace:*",
     "@slickgrid-universal/utils": "workspace:*",
     "dequal": "catalog:",
-    "sortablejs": "catalog:",
-    "whatwg-fetch": "catalog:"
+    "sortablejs": "catalog:"
   },
   "devDependencies": {
     "@slickgrid-universal/graphql": "workspace:*",

--- a/packages/vanilla-force-bundle/README.md
+++ b/packages/vanilla-force-bundle/README.md
@@ -31,9 +31,6 @@ This package does what other framework would do, that is to make all the feature
 - [@slickgrid-universal/text-export](https://github.com/ghiscoding/slickgrid-universal/tree/master/packages/text-export)
 - [@slickgrid-universal/vanilla-bundle](https://github.com/ghiscoding/slickgrid-universal/tree/master/packages/vanilla-bundle)
 
-### External Dependencies
-- [whatwg-fetch](https://github.com/whatwg/fetch) - Fetch Standard
-
 ### Installation
 This Vanilla Bundle is used in our SalesForce implementation (since it requires plain ES6) and is also used by the standalone [demos/vanilla](https://github.com/ghiscoding/slickgrid-universal/tree/master/demos/vanilla) which serves for demo purposes.
 

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -66,8 +66,7 @@
     "@slickgrid-universal/pagination-component": "workspace:*",
     "@slickgrid-universal/text-export": "workspace:*",
     "@slickgrid-universal/utils": "workspace:*",
-    "@slickgrid-universal/vanilla-bundle": "workspace:*",
-    "whatwg-fetch": "catalog:"
+    "@slickgrid-universal/vanilla-bundle": "workspace:*"
   },
   "devDependencies": {
     "fflate": "^0.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,9 @@ catalogs:
     typescript:
       specifier: ^5.8.2
       version: 5.8.2
-    whatwg-fetch:
-      specifier: ^3.6.20
-      version: 3.6.20
+    vite:
+      specifier: ^6.2.3
+      version: 6.2.4
 
 importers:
 
@@ -170,9 +170,6 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/node@22.13.14)(@vitest/ui@3.0.9)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@26.0.0)(sass@1.86.0)(yaml@2.7.0)
-      whatwg-fetch:
-        specifier: 'catalog:'
-        version: 3.6.20
 
   demos/vanilla:
     dependencies:
@@ -233,9 +230,6 @@ importers:
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
-      whatwg-fetch:
-        specifier: 'catalog:'
-        version: 3.6.20
     devDependencies:
       '@types/fnando__sparkline':
         specifier: 'catalog:'
@@ -651,9 +645,6 @@ importers:
       sortablejs:
         specifier: 'catalog:'
         version: 1.15.6
-      whatwg-fetch:
-        specifier: 'catalog:'
-        version: 3.6.20
     devDependencies:
       '@slickgrid-universal/graphql':
         specifier: workspace:*
@@ -700,9 +691,6 @@ importers:
       '@slickgrid-universal/vanilla-bundle':
         specifier: workspace:*
         version: link:../vanilla-bundle
-      whatwg-fetch:
-        specifier: 'catalog:'
-        version: 3.6.20
     devDependencies:
       fflate:
         specifier: ^0.8.2
@@ -4853,9 +4841,6 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -9415,8 +9400,6 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
-
-  whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,4 +24,3 @@ catalog:
   sortablejs: ^1.15.6
   typescript: ^5.8.2
   vite: ^6.2.3
-  whatwg-fetch: ^3.6.20

--- a/test/vitest-pretest.ts
+++ b/test/vitest-pretest.ts
@@ -1,5 +1,4 @@
 import 'jsdom-global/register';
-import 'whatwg-fetch';
 
 // (global as any).Storage = window.localStorage;
 (global as any).navigator = { userAgent: 'node.js' };


### PR DESCRIPTION
- `whatwg-fetch` polyfill is no longer necessary since Fetch is now native in Node 20