### PR TITLE
Fix: error in CSS

### DIFF
--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -641,7 +641,7 @@ $slick-editor-modal-validation-summary-font-style:          italic !default;
 /* Compound Filters */
 $slick-compound-filter-bgcolor:                             #ffffff !default;
 $slick-compound-filter-operator-select-font-family:         "Cascadia Mono", Consolas, "Lucida Console" !default; // use a monospace font so the operator descriptions are all aligned
-$slick-compound-filter-operator-select-font-size:           14px !important !default;
+$slick-compound-filter-operator-select-font-size:           14px !default;
 $slick-compound-filter-operator-select-border:              1px solid #{color.adjust($slick-primary-color, $lightness: 15%)} !default;
 $slick-compound-filter-operator-select-width:               25px !default;
 $slick-compound-filter-operator-border-radius:              4px 0 0 4px !default;

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -801,7 +801,7 @@ li.hidden {
 
     select {
       font-family: var(--slick-compound-filter-operator-select-font-family, v.$slick-compound-filter-operator-select-font-family);
-      font-size: var(--slick-compound-filter-operator-select-font-size, v.$slick-compound-filter-operator-select-font-size);
+      font-size: var(--slick-compound-filter-operator-select-font-size, v.$slick-compound-filter-operator-select-font-size) !important;
       border: var(--slick-compound-filter-operator-select-border, v.$slick-compound-filter-operator-select-border);
       width: var(--slick-compound-filter-operator-select-width, v.$slick-compound-filter-operator-select-width);
 

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -789,7 +789,7 @@ li.hidden {
     .form-control {
       border-radius: var(--slick-compound-filter-operator-border-radius, v.$slick-compound-filter-operator-border-radius);
       // border-right: none;
-      padding: var(--slick-compound-filter-text-padding, v.$slick-compound-filter-text-padding) !important;
+      padding: var(--slick-compound-filter-text-padding, v.$slick-compound-filter-text-padding);
       font-size: var(--slick-compound-filter-text-font-size, v.$slick-compound-filter-text-font-size);
       color: var(--slick-compound-filter-text-color, v.$slick-compound-filter-text-color);
       font-weight: var(--slick-compound-filter-text-weight, v.$slick-compound-filter-text-weight);
@@ -801,7 +801,7 @@ li.hidden {
 
     select {
       font-family: var(--slick-compound-filter-operator-select-font-family, v.$slick-compound-filter-operator-select-font-family);
-      font-size: var(--slick-compound-filter-operator-select-font-size, v.$slick-compound-filter-operator-select-font-size) !important;
+      font-size: var(--slick-compound-filter-operator-select-font-size, v.$slick-compound-filter-operator-select-font-size);
       border: var(--slick-compound-filter-operator-select-border, v.$slick-compound-filter-operator-select-border);
       width: var(--slick-compound-filter-operator-select-width, v.$slick-compound-filter-operator-select-width);
 


### PR DESCRIPTION
importing the stylesheet in angular with
`@import '@slickgrid-universal/common/dist/styles/css/slickgrid-theme-default.css';`

throws an error
`✘ [ERROR] Missing closing } at .slickgrid-container .search-filter .operator.input-group-addon select [plugin angular-css]`

the `_variables.scss` included `!important` which caused the error, moved `!important` to the `.scss` file where the variable is used.



