### PR TITLE
feat(react)!: use simpler input attribute names

### DIFF
--- a/demos/react/package.json
+++ b/demos/react/package.json
@@ -32,7 +32,8 @@
     "react:dev": "vite",
     "react:preview": "vite preview",
     "react:cypress": "cypress open --config-file test/cypress.config.ts",
-    "build": "vite build"
+    "build": "vite build && pnpm type-check",
+    "type-check": "tsc --noEmit"
   },
   "browserslist": [
     "last 2 version",

--- a/demos/react/src/examples/slickgrid/Example1.tsx
+++ b/demos/react/src/examples/slickgrid/Example1.tsx
@@ -129,8 +129,8 @@ const Example1: React.FC = () => {
       <div className="grid-container1">
         <SlickgridReact
           gridId="grid1"
-          columnDefinitions={columnDefinitions1}
-          gridOptions={gridOptions1!}
+          columns={columnDefinitions1}
+          options={gridOptions1!}
           dataset={dataset1}
           onReactGridCreated={($event) => reactGrid1Ready($event.detail)}
         />
@@ -141,7 +141,7 @@ const Example1: React.FC = () => {
       <h3>
         Grid 2 <small>(with local Pagination)</small>
       </h3>
-      <SlickgridReact gridId="grid2" columnDefinitions={columnDefinitions2} gridOptions={gridOptions2!} dataset={dataset2} />
+      <SlickgridReact gridId="grid2" columns={columnDefinitions2} options={gridOptions2!} dataset={dataset2} />
     </div>
   );
 };

--- a/demos/react/src/examples/slickgrid/Example10.tsx
+++ b/demos/react/src/examples/slickgrid/Example10.tsx
@@ -380,8 +380,8 @@ const Example10: React.FC = () => {
       <div className="overflow-hidden">
         <SlickgridReact
           gridId="grid1"
-          columnDefinitions={columnDefinitions1}
-          gridOptions={gridOptions1!}
+          columns={columnDefinitions1}
+          options={gridOptions1!}
           dataset={dataset1}
           onReactGridCreated={($event) => reactGrid1Ready($event.detail)}
           onGridStateChanged={($event) => grid1StateChanged($event.detail)}
@@ -427,8 +427,8 @@ const Example10: React.FC = () => {
       <div className="overflow-hidden">
         <SlickgridReact
           gridId="grid2"
-          columnDefinitions={columnDefinitions2}
-          gridOptions={gridOptions2!}
+          columns={columnDefinitions2}
+          options={gridOptions2!}
           dataset={dataset2}
           onReactGridCreated={($event) => reactGrid2Ready($event.detail)}
           onGridStateChanged={($event) => grid2StateChanged($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example11.tsx
+++ b/demos/react/src/examples/slickgrid/Example11.tsx
@@ -375,8 +375,8 @@ const Example11: React.FC = () => {
 
       <SlickgridReact
         gridId="grid11"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example12.tsx
+++ b/demos/react/src/examples/slickgrid/Example12.tsx
@@ -395,8 +395,8 @@ const Example12: React.FC = () => {
       </div>
       <SlickgridReact
         gridId="grid12"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onGridStateChanged={($event) => gridStateChanged($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example13.tsx
+++ b/demos/react/src/examples/slickgrid/Example13.tsx
@@ -490,8 +490,8 @@ const Example13: React.FC = () => {
 
       <SlickgridReact
         gridId="grid13"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions!}
+        columns={columnDefinitions}
+        options={gridOptions!}
         dataset={dataset}
         onBeforeExportToExcel={() => changeProcessing(true)}
         onAfterExportToExcel={() => changeProcessing(false)}

--- a/demos/react/src/examples/slickgrid/Example14.tsx
+++ b/demos/react/src/examples/slickgrid/Example14.tsx
@@ -197,7 +197,7 @@ const Example14: React.FC = () => {
       <h3>
         Grid 1 <small>(with Header Grouping &amp; Colspan)</small>
       </h3>
-      <SlickgridReact gridId="grid1" columnDefinitions={columnDefinitions1} gridOptions={gridOptions1} dataset={dataset1} />
+      <SlickgridReact gridId="grid1" columns={columnDefinitions1} options={gridOptions1} dataset={dataset1} />
 
       <hr />
 
@@ -224,8 +224,8 @@ const Example14: React.FC = () => {
 
       <SlickgridReact
         gridId="grid2"
-        columnDefinitions={columnDefinitions2}
-        gridOptions={gridOptions2}
+        columns={columnDefinitions2}
+        options={gridOptions2}
         dataset={dataset2}
         onReactGridCreated={($event) => reactGrid2Ready($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example15.tsx
+++ b/demos/react/src/examples/slickgrid/Example15.tsx
@@ -369,8 +369,8 @@ const Example15: React.FC = () => {
 
       <SlickgridReact
         gridId="grid15"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onGridStateChanged={($event) => gridStateChanged($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example16.tsx
+++ b/demos/react/src/examples/slickgrid/Example16.tsx
@@ -390,8 +390,8 @@ const Example16: React.FC = () => {
 
       <SlickgridReact
         gridId="grid16"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions!}
+        columns={columnDefinitions}
+        options={gridOptions!}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example17.tsx
+++ b/demos/react/src/examples/slickgrid/Example17.tsx
@@ -155,9 +155,7 @@ const Example17: React.FC = () => {
       <hr />
 
       <div className="grid-container-zone">
-        {gridCreated && (
-          <SlickgridReact gridId="grid17" columnDefinitions={columnDefinitions} gridOptions={gridOptions} dataset={dataset} />
-        )}
+        {gridCreated && <SlickgridReact gridId="grid17" columns={columnDefinitions} options={gridOptions} dataset={dataset} />}
       </div>
     </div>
   );

--- a/demos/react/src/examples/slickgrid/Example18.tsx
+++ b/demos/react/src/examples/slickgrid/Example18.tsx
@@ -615,8 +615,8 @@ const Example18: React.FC = () => {
 
       <SlickgridReact
         gridId="grid18"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example19.tsx
+++ b/demos/react/src/examples/slickgrid/Example19.tsx
@@ -380,8 +380,8 @@ const Example19: React.FC = () => {
 
         <SlickgridReact
           gridId="grid19"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={($event) => (reactGridRef.current = $event.detail)}
         />

--- a/demos/react/src/examples/slickgrid/Example2.tsx
+++ b/demos/react/src/examples/slickgrid/Example2.tsx
@@ -278,8 +278,8 @@ const Example2: React.FC = () => {
 
       <SlickgridReact
         gridId="grid2"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example20.tsx
+++ b/demos/react/src/examples/slickgrid/Example20.tsx
@@ -434,8 +434,8 @@ const Example20: React.FC = () => {
 
       <SlickgridReact
         gridId="grid20"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onValidationError={($event) => onCellValidationError($event.detail.eventData, $event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example21.tsx
+++ b/demos/react/src/examples/slickgrid/Example21.tsx
@@ -273,8 +273,8 @@ const Example21: React.FC = () => {
 
       <SlickgridReact
         gridId="grid21"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example22.tsx
+++ b/demos/react/src/examples/slickgrid/Example22.tsx
@@ -195,14 +195,14 @@ const Example22: React.FC = () => {
         <div className="tab-content" id="myTabContent">
           <div className="tab-pane fade show active" id="javascript" role="tabpanel" aria-labelledby="javascript-tab">
             <h4>Grid 1 - Load Local Data</h4>
-            <SlickgridReact gridId="grid1" columnDefinitions={columnDefinitions1} gridOptions={gridOptions1} dataset={dataset1} />
+            <SlickgridReact gridId="grid1" columns={columnDefinitions1} options={gridOptions1} dataset={dataset1} />
           </div>
           <div className="tab-pane fade" id="fetch" role="tabpanel" aria-labelledby="fetch-tab">
             <h4>Grid 2 - Load a JSON dataset through Fetch</h4>
             <SlickgridReact
               gridId="grid2"
-              columnDefinitions={columnDefinitions2}
-              gridOptions={gridOptions2}
+              columns={columnDefinitions2}
+              options={gridOptions2}
               dataset={dataset2}
               onReactGridCreated={($event) => reactGrid2Ready($event.detail)}
             />

--- a/demos/react/src/examples/slickgrid/Example23.tsx
+++ b/demos/react/src/examples/slickgrid/Example23.tsx
@@ -462,8 +462,8 @@ const Example23: React.FC = () => {
 
       <SlickgridReact
         gridId="grid23"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onGridStateChanged={($event) => gridStateChanged($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example24.tsx
+++ b/demos/react/src/examples/slickgrid/Example24.tsx
@@ -759,8 +759,8 @@ const Example24: React.FC = () => {
 
       <SlickgridReact
         gridId="grid24"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example25.tsx
+++ b/demos/react/src/examples/slickgrid/Example25.tsx
@@ -370,7 +370,7 @@ const Example25: React.FC = () => {
         </div>
       </div>
 
-      <SlickgridReact gridId="grid25" columnDefinitions={columnDefinitions} gridOptions={gridOptions} dataset={dataset} />
+      <SlickgridReact gridId="grid25" columns={columnDefinitions} options={gridOptions} dataset={dataset} />
     </div>
   );
 };

--- a/demos/react/src/examples/slickgrid/Example27.tsx
+++ b/demos/react/src/examples/slickgrid/Example27.tsx
@@ -477,8 +477,8 @@ const Example27: React.FC = () => {
       <div id="grid-container" className="col-sm-12">
         <SlickgridReact
           gridId="grid27"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onBeforeFilterChange={() => showSpinner()}
           onFilterChanged={() => hideSpinner()}

--- a/demos/react/src/examples/slickgrid/Example28.tsx
+++ b/demos/react/src/examples/slickgrid/Example28.tsx
@@ -578,8 +578,8 @@ const Example28: React.FC = () => {
       <div id="grid-container" className="col-sm-12">
         <SlickgridReact
           gridId="grid28"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           datasetHierarchical={datasetHierarchical}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
         />

--- a/demos/react/src/examples/slickgrid/Example29.tsx
+++ b/demos/react/src/examples/slickgrid/Example29.tsx
@@ -97,8 +97,8 @@ const Example29: React.FC = () => {
 
       <SlickgridReact
         gridId="grid"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         header={<Header />}
         footer={<Footer />}

--- a/demos/react/src/examples/slickgrid/Example3.tsx
+++ b/demos/react/src/examples/slickgrid/Example3.tsx
@@ -786,8 +786,8 @@ const Example3: React.FC = () => {
       <div className="col-sm-12">
         <SlickgridReact
           gridId="grid3"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={(e) => {
             reactGridReady(e.detail);

--- a/demos/react/src/examples/slickgrid/Example30.tsx
+++ b/demos/react/src/examples/slickgrid/Example30.tsx
@@ -1200,8 +1200,8 @@ const Example30: React.FC = () => {
 
       <SlickgridReact
         gridId="grid30"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onBeforeEditCell={($event) => handleOnBeforeEditCell($event.detail.eventData, $event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example31.tsx
+++ b/demos/react/src/examples/slickgrid/Example31.tsx
@@ -617,8 +617,8 @@ const Example31: React.FC = () => {
 
       <SlickgridReact
         gridId="grid31"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptionsRef.current}
+        columns={columnDefinitions}
+        options={gridOptionsRef.current}
         dataset={dataset}
         paginationOptions={paginationOptions}
         onReactGridCreated={($event) => reactGridReady($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example32.tsx
+++ b/demos/react/src/examples/slickgrid/Example32.tsx
@@ -941,8 +941,8 @@ const Example32: React.FC = () => {
       <div id="smaller-container" style={{ width: '950px' }}>
         <SlickgridReact
           gridId="grid32"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
           onSelectedRowIdsChanged={($event) => handleOnSelectedRowIdsChanged($event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example33.tsx
+++ b/demos/react/src/examples/slickgrid/Example33.tsx
@@ -619,8 +619,8 @@ const Example33: React.FC = () => {
       <div id="smaller-container" style={{ width: '950px' }}>
         <SlickgridReact
           gridId="grid33"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
         />

--- a/demos/react/src/examples/slickgrid/Example34.tsx
+++ b/demos/react/src/examples/slickgrid/Example34.tsx
@@ -587,8 +587,8 @@ const Example34: React.FC = () => {
 
         <SlickgridReact
           gridId="grid34"
-          columnDefinitions={columnDefinitionsRef.current}
-          gridOptions={gridOptions}
+          columns={columnDefinitionsRef.current}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
         />

--- a/demos/react/src/examples/slickgrid/Example35.tsx
+++ b/demos/react/src/examples/slickgrid/Example35.tsx
@@ -344,8 +344,8 @@ const Example35: React.FC = () => {
 
       <SlickgridReact
         gridId="grid35"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptionsRef.current}
+        columns={columnDefinitions}
+        options={gridOptionsRef.current}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example36.tsx
+++ b/demos/react/src/examples/slickgrid/Example36.tsx
@@ -589,8 +589,8 @@ const Example36: React.FC = () => {
 
       <SlickgridReact
         gridId="grid36"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onCellChange={(_) => invalidateAll()}

--- a/demos/react/src/examples/slickgrid/Example37.tsx
+++ b/demos/react/src/examples/slickgrid/Example37.tsx
@@ -165,8 +165,8 @@ const Example37: React.FC = () => {
 
       <SlickgridReact
         gridId="grid37"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onCellChange={($event) => handleOnCellChange($event.detail.eventData, $event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example38.tsx
+++ b/demos/react/src/examples/slickgrid/Example38.tsx
@@ -545,8 +545,8 @@ const Example38: React.FC = () => {
 
         <SlickgridReact
           gridId="grid38"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptionsRef.current}
+          columns={columnDefinitions}
+          options={gridOptionsRef.current}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
           onRowCountChanged={($event) => refreshMetrics($event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example39.tsx
+++ b/demos/react/src/examples/slickgrid/Example39.tsx
@@ -501,8 +501,8 @@ const Example39: React.FC = () => {
 
         <SlickgridReact
           gridId="grid39"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptionsRef.current}
+          columns={columnDefinitions}
+          options={gridOptionsRef.current}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
           onRowCountChanged={($event) => refreshMetrics($event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example4.tsx
+++ b/demos/react/src/examples/slickgrid/Example4.tsx
@@ -443,8 +443,8 @@ const Example4: React.FC = () => {
 
       <SlickgridReact
         gridId="grid4"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onGridStateChanged={($event) => gridStateChanged($event.detail)}
         onReactGridCreated={($event) => reactGridReady($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example40.tsx
+++ b/demos/react/src/examples/slickgrid/Example40.tsx
@@ -280,8 +280,8 @@ const Example40: React.FC = () => {
 
         <SlickgridReact
           gridId="grid40"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptionsRef.current}
+          columns={columnDefinitions}
+          options={gridOptionsRef.current}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
           onRowCountChanged={($event) => refreshMetrics($event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example41.tsx
+++ b/demos/react/src/examples/slickgrid/Example41.tsx
@@ -260,8 +260,8 @@ const Example41: React.FC = () => {
           <div className="col">
             <SlickgridReact
               gridId="grid41"
-              columnDefinitions={columnDefinitions}
-              gridOptions={gridOptions}
+              columns={columnDefinitions}
+              options={gridOptions}
               dataset={dataset}
               onReactGridCreated={($event) => reactGridReady($event.detail)}
               onDragInit={($event) => handleOnDragInit($event.detail.eventData)}

--- a/demos/react/src/examples/slickgrid/Example42.tsx
+++ b/demos/react/src/examples/slickgrid/Example42.tsx
@@ -244,8 +244,8 @@ const Example42: React.FC = () => {
 
         <SlickgridReact
           gridId="grid42"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={($event) => reactGridReady($event.detail)}
         />

--- a/demos/react/src/examples/slickgrid/Example43.tsx
+++ b/demos/react/src/examples/slickgrid/Example43.tsx
@@ -538,8 +538,8 @@ export default function Example43() {
 
       <SlickgridReact
         gridId="grid43"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example44.tsx
+++ b/demos/react/src/examples/slickgrid/Example44.tsx
@@ -474,8 +474,8 @@ export default function Example44() {
 
       <SlickgridReact
         gridId="grid44"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example45-detail-view.tsx
+++ b/demos/react/src/examples/slickgrid/Example45-detail-view.tsx
@@ -112,8 +112,8 @@ const Example45DetailView: React.FC<RowDetailViewProps<Distributor, typeof Examp
         {showGrid && (
           <SlickgridReact
             gridId={`innergrid-${props.model.id}`}
-            columnDefinitions={innerColDefs}
-            gridOptions={innerGridOptions}
+            columns={innerColDefs}
+            options={innerGridOptions}
             dataset={innerDataset}
             onReactGridCreated={($event) => reactGridReady($event.detail)}
             onBeforeGridDestroy={handleBeforeGridDestroy}

--- a/demos/react/src/examples/slickgrid/Example45.tsx
+++ b/demos/react/src/examples/slickgrid/Example45.tsx
@@ -374,8 +374,8 @@ const Example45: React.FC = () => {
 
         <SlickgridReact
           gridId="grid45"
-          columnDefinitions={columnDefinitions}
-          gridOptions={gridOptions}
+          columns={columnDefinitions}
+          options={gridOptions}
           dataset={dataset}
           onReactGridCreated={($event) => (reactGridRef.current = $event.detail)}
         />

--- a/demos/react/src/examples/slickgrid/Example5.tsx
+++ b/demos/react/src/examples/slickgrid/Example5.tsx
@@ -714,8 +714,8 @@ const Example5: React.FC = () => {
 
       <SlickgridReact
         gridId="grid5"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         paginationOptions={paginationOptions}
         onReactGridCreated={($event) => reactGridReady($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example6.tsx
+++ b/demos/react/src/examples/slickgrid/Example6.tsx
@@ -621,8 +621,8 @@ const Example6: React.FC = () => {
 
       <SlickgridReact
         gridId="grid6"
-        columnDefinitions={columnDefinitions}
-        gridOptions={gridOptions}
+        columns={columnDefinitions}
+        options={gridOptions}
         dataset={dataset}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
         onGridStateChanged={($event) => gridStateChanged($event.detail)}

--- a/demos/react/src/examples/slickgrid/Example7.tsx
+++ b/demos/react/src/examples/slickgrid/Example7.tsx
@@ -267,8 +267,8 @@ const Example7: React.FC = () => {
       <h5>Grid 1</h5>
       <SlickgridReact
         gridId="grid7-1"
-        columnDefinitions={columnDefinitions1}
-        gridOptions={gridOptions1}
+        columns={columnDefinitions1}
+        options={gridOptions1}
         dataset={dataset1}
         onReactGridCreated={($event) => reactGrid1Ready($event.detail)}
       />
@@ -280,8 +280,8 @@ const Example7: React.FC = () => {
       </h5>
       <SlickgridReact
         gridId="grid7-2"
-        columnDefinitions={columnDefinitions2}
-        gridOptions={gridOptions2}
+        columns={columnDefinitions2}
+        options={gridOptions2}
         dataset={dataset2}
         onReactGridCreated={($event) => reactGrid2Ready($event.detail)}
       />

--- a/demos/react/src/examples/slickgrid/Example8.tsx
+++ b/demos/react/src/examples/slickgrid/Example8.tsx
@@ -228,7 +228,7 @@ const Example8: React.FC = () => {
       <span style={{ fontStyle: 'italic' }} data-test="selected-locale">
         {selectedLanguage + '.json'}
       </span>
-      <SlickgridReact gridId="grid8" columnDefinitions={columnDefinitions} gridOptions={gridOptions} dataset={dataset} />
+      <SlickgridReact gridId="grid8" columns={columnDefinitions} options={gridOptions} dataset={dataset} />
     </div>
   );
 };

--- a/demos/react/src/examples/slickgrid/Example9.tsx
+++ b/demos/react/src/examples/slickgrid/Example9.tsx
@@ -379,9 +379,9 @@ const Example9: React.FC = () => {
       </span>
       <SlickgridReact
         gridId="grid9"
-        columnDefinitions={columnDefinitions}
+        columns={columnDefinitions}
         dataset={dataset}
-        gridOptions={gridOptions}
+        options={gridOptions}
         onReactGridCreated={($event) => reactGridReady($event.detail)}
       />
     </div>

--- a/frameworks/slickgrid-react/README.md
+++ b/frameworks/slickgrid-react/README.md
@@ -60,8 +60,8 @@ export default function Example() {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
      />
   );

--- a/frameworks/slickgrid-react/docs/column-functionalities/editors.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/editors.md
@@ -380,7 +380,7 @@ Some of the Editors could receive extra options, which is mostly the case for Ed
 ```ts
 const columnDefinitions = [{
   id: 'start', name: 'Start Date', field: 'start',
-  editor: { 
+  editor: {
     model: Editors.date,
     editorOptions: { range: { date: 'today' } } as VanillaCalendarOption
   }
@@ -392,10 +392,10 @@ You could also define certain options as a global level (for the entire grid or 
 
 ```ts
 const gridOptions = {
-  defaultEditorOptions: { 
+  defaultEditorOptions: {
     autocompleter: { debounceWaitMs: 150 }, // typed as AutocompleterOption
     date: { range: { date: 'today' } }, // typed as VanillaCalendarOption,
-    longText: { cols: 50, rows: 5 } 
+    longText: { cols: 50, rows: 5 }
   }
 }
 ```
@@ -499,8 +499,8 @@ const Example: React.FC = () => {
   render() {
     return (
       <SlickgridReact gridId="grid1"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)}
       />
@@ -533,8 +533,8 @@ const Example: React.FC = () => {
     return !options ? null : (
       <SlickgridReact
           gridId='grid3'
-          columnDefinitions={columns}
-          gridOptions={options}
+          columns={columns}
+          options={options}
           dataset={dataset}
           onReactGridCreated={e => { reactGridRef.current?Ready(e.detail); }}
           onBeforeEditCell={e => {onBeforeEditCell($event.detail.eventData, $event.detail.args)}}
@@ -552,7 +552,7 @@ Using the [Row Based Editing Plugin](../grid-functionalities/Row-based-edit.md) 
 
 ## Dynamically change Column Editor
 
-You can dynamically change a column editor by taking advantage of the `onBeforeEditCell` event and change the editor just before the cell editor opens. However please note that the library keeps 2 references and you need to update both references as shown below. 
+You can dynamically change a column editor by taking advantage of the `onBeforeEditCell` event and change the editor just before the cell editor opens. However please note that the library keeps 2 references and you need to update both references as shown below.
 
 With the code sample shown below, we are using an input checkbox to toggle the Editor between `Editors.longText` to `Editors.text` and vice/versa
 

--- a/frameworks/slickgrid-react/docs/column-functionalities/filters/input-filter.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/filters/input-filter.md
@@ -136,8 +136,8 @@ const Example: React.FC = () => {
     </button>
 
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onGridStateChanged={$event => gridStateChanged($event.detail)}

--- a/frameworks/slickgrid-react/docs/column-functionalities/filters/single-search-filter.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/filters/single-search-filter.md
@@ -109,8 +109,8 @@ const Example: React.FC = () => {
       <hr />
 
       <SlickgridReact gridId="grid21"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)}
       />

--- a/frameworks/slickgrid-react/docs/column-functionalities/sorting.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/sorting.md
@@ -22,7 +22,7 @@ const Example: React.FC = () => {
   const [dataset, setDataset] = useState<any[]>([]);
   const [columns, setColumns] = useState<Column[]>([]);
   const [options, setOptions] = useState<GridOption | undefined>(undefined);
-  
+
   function defineGrid() {
     setColumns([
       { id: 'title', name: 'Title', field: 'title', sortable: true },
@@ -110,8 +110,8 @@ const Example: React.FC = () => {
     </button>
 
     <SlickgridReact gridId="grid4"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onGridStateChanged={$event => gridStateChanged($event.detail)}
       onReactGridCreated={$event => reactGridReady($event.detail)}

--- a/frameworks/slickgrid-react/docs/events/available-events.md
+++ b/frameworks/slickgrid-react/docs/events/available-events.md
@@ -20,8 +20,8 @@ handleOnCellChange(e, args) {
 render() {
   <SlickgridReact
       gridId='grid3'
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={e => { reactGridReady(e.detail); }}
       onCellChange={e => { handleOnCellChange(e.detail.eventData, e.detail.args); }}
@@ -44,8 +44,8 @@ handleOnHeaderMenuCommand(e) {
 render() {
   <SlickgridReact
       gridId='grid3'
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={e => { reactGridReady(e.detail); }}
       onHeaderMenuCommand={e => { handleOnHeaderMenuCommand(e.detail); }}

--- a/frameworks/slickgrid-react/docs/events/grid-dataview-events.md
+++ b/frameworks/slickgrid-react/docs/events/grid-dataview-events.md
@@ -36,8 +36,8 @@ const Example: React.FC = () => {
   return !options ? null : (
       <SlickgridReact
           gridId='grid3'
-          columnDefinitions={columns}
-          gridOptions={options}
+          columns={columns}
+          options={options}
           dataset={dataset}
           onReactGridCreated={e => { reactGridReady(e.detail); }}
           onCellChange={e => { onCellChanged(e.detail.eventData, e.detail.args); }}
@@ -112,8 +112,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid12"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onGridStateChanged={$event => gridStateChanged($event.detail)}

--- a/frameworks/slickgrid-react/docs/getting-started/quick-start.md
+++ b/frameworks/slickgrid-react/docs/getting-started/quick-start.md
@@ -123,8 +123,8 @@ const Example: React.FC = () => {
 
   return !options ? '' : (
     <SlickgridReact gridId="grid1"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
     />
   );

--- a/frameworks/slickgrid-react/docs/grid-functionalities/add-update-highlight.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/add-update-highlight.md
@@ -48,12 +48,12 @@ const Example: React.FC = () => {
 
     // add the item to the grid
     reactGridRef.current?.gridService.addItem(newItem);
-  }    
+  }
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onGridStateChanged={$event => gridStateChanged($event.detail)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/composite-editor-modal.md
@@ -455,8 +455,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid30"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onBeforeEditCell={$event => handleOnBeforeEditCell($event.detail.eventData, $event.detail.args)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/dynamic-item-metadata.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/dynamic-item-metadata.md
@@ -59,8 +59,8 @@ const Example: React.FC = () => {
   return !options ? null : (
     <button class="btn btn-default" onClick={() => changeDurationBackgroundColor()}>Highlight Rows with Duration over 50</button>
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
     />
@@ -81,7 +81,7 @@ const Example: React.FC = () => {
 
   function reactGridReady(reactGrid: SlickgridReactInstance) {
     reactGridRef.current = reactGrid;
-  
+
     // if you want to change background color of Duration over 50 right after page load,
     // you would put the code here, also make sure to re-render the grid for the styling to be applied right away
     reactGrid.dataView.getItemMetadata = updateItemMetadataForDurationOver50(reactGrid.dataView.getItemMetadata);

--- a/frameworks/slickgrid-react/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/export-to-excel.md
@@ -251,7 +251,7 @@ const Example: React.FC = () => {
   function reactGridReady(reactGrid: SlickgridReactInstance) {
     reactGridRef.current = reactGrid;
   }
-  
+
   function defineGrid() {
     setColumns([]);
     setOptions({
@@ -280,8 +280,8 @@ return !options ? null : (
   </span>}
 
   <SlickgridReact gridId="grid5"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       paginationOptions={paginationOptions}
       onReactGridCreated={$event => reactGridReady($event.detail)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/export-to-text-file.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/export-to-text-file.md
@@ -165,8 +165,8 @@ return !options ? null : (
   </span>}
 
   <SlickgridReact gridId="grid5"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       paginationOptions={paginationOptions}
       onReactGridCreated={$event => reactGridReady($event.detail)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/frozen-columns-rows.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/frozen-columns-rows.md
@@ -33,8 +33,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onGridStateChanged={$event => gridStateChanged($event.detail)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/grid-auto-resize.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/grid-auto-resize.md
@@ -87,8 +87,8 @@ const Example: React.FC = () => {
       </button>
 
       <SlickgridReact gridId="grid1"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)}
         onGridStateChanged={$event => gridStateChanged($event.detail)}
@@ -167,8 +167,8 @@ const Example: React.FC = () => {
   return !options ? null : (
     <div id="demo-container" style="resize:both; overflow:auto;">
       <SlickgridReact gridId="grid1"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)}
         onGridStateChanged={$event => gridStateChanged($event.detail)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/grid-state-preset.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/grid-state-preset.md
@@ -63,8 +63,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onGridStateChanged={$event => gridStateChanged($event.detail)}
@@ -186,8 +186,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onGridStateChanged={$event => gridStateChanged($event.detail)}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/grouping-aggregators.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/grouping-aggregators.md
@@ -53,8 +53,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
     />

--- a/frameworks/slickgrid-react/docs/grid-functionalities/header-footer-slots.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/header-footer-slots.md
@@ -11,8 +11,8 @@ You can add Header and/or Footer to your grid by using the `#header` and `#foote
 
 ```tsx
 <SlickgridReact gridId="grid"
-    columnDefinitions={columns}
-    gridOptions={options}
+    columns={columns}
+    options={options}
     dataset={dataset}
     header={<Header />}
     footer={<Footer />}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/infinite-scroll.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/infinite-scroll.md
@@ -67,8 +67,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
       onScroll={$event => handleOnScroll($event.$detail.args)}
@@ -157,8 +157,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       dataset={dataset}
       onReactGridCreated={$event => reactGridReady($event.detail)}
     />

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-detail.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-detail.md
@@ -20,9 +20,9 @@ A Row Detail allows you to open a detail panel which can contain extra and/or mo
 > - Tree Data
 > - RowSpan
 
-> **NOTE 2** Also please note that because SlickGrid is using its built-in Virtual Scroll feature by default (for perf reasons), this will call render and re-render multiple times and that happens whenever the Row Detail gets out of the grid viewport. 
-> For this reason, you should avoid using dynamic elements (i.e. form inputs) because whenever a re-render kicks in, it will reset and re-render these elements as if nothing happened. 
-> So you should consider using Row Detail mainly for showing static data (hence where its name comes from "Row Detail" to show more detailed info) and even though it works with dynamic elements, you have to know its limitation. 
+> **NOTE 2** Also please note that because SlickGrid is using its built-in Virtual Scroll feature by default (for perf reasons), this will call render and re-render multiple times and that happens whenever the Row Detail gets out of the grid viewport.
+> For this reason, you should avoid using dynamic elements (i.e. form inputs) because whenever a re-render kicks in, it will reset and re-render these elements as if nothing happened.
+> So you should consider using Row Detail mainly for showing static data (hence where its name comes from "Row Detail" to show more detailed info) and even though it works with dynamic elements, you have to know its limitation.
 
 ##### NOTE
 There is currently a known problem with Row Detail when loading the Row Detail Components, it currently shows console warnings (see below), however these are just warnings and they don't show up in Production code. If anyone knows how to fix it please provide a Pull Request as a contribution (please note that the suggestion to use `root.render()` does NOT work as intended hence why we call `createRoot()` every time a row detail is rendered).
@@ -47,7 +47,7 @@ const Example: React.FC = () => {
   }
 
   function defineGrid() {
-    setColumns([ /*...*/ ]); 
+    setColumns([ /*...*/ ]);
     setOptions({
       enableRowDetailView: true,
       rowSelectionOptions: {
@@ -97,8 +97,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid40"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)} />
   );
@@ -202,7 +202,7 @@ const ExampleDetail: React.FC = (props: Props) => {
   }
 
   // ...
-  // 
+  //
 
   return !options ? null : (
     <div className="container-fluid" style={{ marginTop: '10px' }}>
@@ -277,7 +277,7 @@ const Example: React.FC = () => {
         process: (item) => http.get(`api/item/${item.id}`),
 
         // ...
-        
+
         // Preload Component
         preloadComponent: Example19Preload,
 
@@ -292,8 +292,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid40"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)} />
   );
@@ -371,9 +371,9 @@ import type { SlickDataView, SlickGrid, SlickRowDetailView } from 'slickgrid-rea
 
 import './example19-detail-view.scss';
 
-interface Props { 
+interface Props {
   model: {
-    assignee: string; 
+    assignee: string;
   }
 }
 
@@ -509,8 +509,8 @@ const Example: React.FC = () => {
   return !options ? '' : (
     <div id="demo-container" className="container-fluid">
       <SlickgridReact gridId="grid45"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)}
       />
@@ -550,7 +550,7 @@ const Example: React.FC = () => {
       { id: 'freight', field: 'freight', name: 'Freight', filterable: true, sortable: true, type: 'number' },
       { id: 'shipName', field: 'shipName', name: 'Ship Name', filterable: true, sortable: true },
     ]);
-  
+
     // OPTIONALLY reapply Grid State as Presets before unmounting the compoment
     const gridStateStr = sessionStorage.getItem(`gridstate_${innerGridClass.value}`);
     let gridState: GridState | undefined;
@@ -583,8 +583,8 @@ const Example: React.FC = () => {
       <h4>Order Details (id: {props.model.id})</h4>
       <div className="container-fluid">
         {!showGrid ? '' : <SlickgridReact gridId={`innergrid-${props.model.id}`}
-          columnDefinitions={innerColDefs}
-          gridOptions={innerGridOptions}
+          columns={innerColDefs}
+          options={innerGridOptions}
           dataset={innerDataset}
           onReactGridCreated={$event => reactGridReady($event.detail)}
           onBeforeGridDestroy={() => handleBeforeGridDestroy()}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -50,8 +50,8 @@ const Example: React.FC = () => {
 
   return !options ? '' : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columnDefinitions1}
-      gridOptions={gridOptions1!}
+      columns={columnDefinitions1}
+      options={gridOptions1!}
       dataset={dataset1}
       onReactGridCreated={$event => reactGrid1Ready($event.detail)}
       onSelectedRowsChanged={$event => onGrid1SelectedRowsChanged($event.detail.eventData, $event.detail.args)}
@@ -116,8 +116,8 @@ const Example: React.FC = () => {
 
   return !options ? '' : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columnDefinitions1}
-      gridOptions={gridOptions1!}
+      columns={columnDefinitions1}
+      options={gridOptions1!}
       dataset={dataset1}
       onReactGridCreated={$event => reactGrid1Ready($event.detail)}
       onSelectedRowsChanged={$event => onGrid1SelectedRowsChanged($event.detail.eventData, $event.detail.args)}
@@ -182,8 +182,8 @@ const Example: React.FC = () => {
 
   return !options ? '' : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columnDefinitions1}
-      gridOptions={gridOptions1!}
+      columns={columnDefinitions1}
+      options={gridOptions1!}
       dataset={dataset1}
       onReactGridCreated={$event => reactGrid1Ready($event.detail)}
       onClick={$event => { onCellClicked($event.detail.eventData, $event.detail.args); }}
@@ -221,7 +221,7 @@ const Example: React.FC = () => {
 ```
 
 ### Disable External Button when having Empty Selection
-When having an external button that you want to work only when there's row selection, there are 2 ways of doing 
+When having an external button that you want to work only when there's row selection, there are 2 ways of doing
 1. use the `onSelectedRowsChanged` event (via your View in HTML or via ViewModel)
 ```tsx
 const [isMyButtonDisabled, setIsMyButtonDisabled] = useState(false);
@@ -232,8 +232,8 @@ function handleOnSelectedRowsChanged(args) {
 
 return !options ? '' : (
   <SlickgridReact gridId="grid1"
-    columnDefinitions={columnDefinitions1}
-    gridOptions={gridOptions1!}
+    columns={columnDefinitions1}
+    options={gridOptions1!}
     dataset={dataset1}
     onReactGridCreated={$event => reactGrid1Ready($event.detail)}
     onClick={$event => { onCellClicked($event.detail.eventData, $event.detail.args); }}
@@ -255,8 +255,8 @@ function handleOngridStateChanged(gridState) {
 
 return !options ? '' : (
   <SlickgridReact gridId="grid1"
-    columnDefinitions={columnDefinitions1}
-    gridOptions={gridOptions1!}
+    columns={columnDefinitions1}
+    options={gridOptions1!}
     dataset={dataset1}
     onReactGridCreated={$event => reactGrid1Ready($event.detail)}
     onClick={$event => { onCellClicked($event.detail.eventData, $event.detail.args); }}
@@ -289,8 +289,8 @@ const Example: React.FC = () => {
 
   return !options ? null : (
     <SlickgridReact gridId="grid1"
-      columnDefinitions={columnDefinitions1}
-      gridOptions={gridOptions1!}
+      columns={columnDefinitions1}
+      options={gridOptions1!}
       dataset={dataset1}
       onReactGridCreated={$event => reactGrid1Ready($event.detail)}
       onClick={$event => { onCellClicked($event.detail.eventData, $event.detail.args); }}

--- a/frameworks/slickgrid-react/docs/grid-functionalities/tree-data-grid.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/tree-data-grid.md
@@ -15,7 +15,7 @@
 ## Description
 Tree Data allows you to display a hierarchical (tree) dataset into the grid, it is visually very similar to Grouping but also very different in its implementation. A hierarchical dataset is commonly used for a parent/child relation and a great example is a Bill of Material (BOM), which you can't do with Grouping because parent/child relationship could be infinite tree level while Grouping is a defined and known level of Grouping.
 
-## Important Notes 
+## Important Notes
 
 #### data mutation
 
@@ -151,8 +151,8 @@ const Example: React.FC = () => {
 
   return !options ? '' : (
     <SlickgridReact gridId="grid28"
-      columnDefinitions={columns}
-      gridOptions={options}
+      columns={columns}
+      options={options}
       datasetHierarchical={datasetHierarchical}
     />
   );

--- a/frameworks/slickgrid-react/docs/slick-grid-dataview-objects/slickgrid-dataview-objects.md
+++ b/frameworks/slickgrid-react/docs/slick-grid-dataview-objects/slickgrid-dataview-objects.md
@@ -25,7 +25,7 @@ const Example: React.FC = () => {
   function reactGridReady(reactGrid: SlickgridReactInstance) {
     reactGridRef.current = reactGrid;
   }
-  
+
   /** Change dynamically `autoEdit` grid options */
   function setAutoEdit(isAutoEdit) {
     setIsAutoEdit(isAutoEdit);
@@ -71,8 +71,8 @@ const Example: React.FC = () => {
       <div className='col-sm-12'>
         <SlickgridReact
           gridId='grid3'
-          columnDefinitions={columns}
-          gridOptions={options}
+          columns={columns}
+          options={options}
           dataset={dataset}
           onReactGridCreated={e => { reactGridReady(e.detail); }}
           onCellChange={e => { onCellChanged(e.detail.eventData, e.detail.args); }}
@@ -115,8 +115,8 @@ const Example: React.FC = () => {
   render() {
     return (
       <SlickgridReact gridId="grid1"
-        columnDefinitions={columns}
-        gridOptions={options}
+        columns={columns}
+        options={options}
         dataset={dataset}
         onReactGridCreated={$event => reactGridReady($event.detail)}
       />

--- a/frameworks/slickgrid-react/package.json
+++ b/frameworks/slickgrid-react/package.json
@@ -49,7 +49,8 @@
   "scripts": {
     "react:dev": "tsc --watch",
     "prebuild": "rimraf dist",
-    "build": "tsc",
+    "build": "tsc && pnpm type-check",
+    "type-check": "tsc --noEmit",
     "postbuild": "npm run copy-i18n:dist && npm run copy-asset-lib",
     "copy-asset-lib": "copyfiles src/assets/lib/** dist --up 2 --stat",
     "copy-i18n:dist": "copyfiles src/assets/locales/**/*.* dist/i18n --up 3 --stat",

--- a/frameworks/slickgrid-react/src/slickgrid-react/components/slickgridReactProps.ts
+++ b/frameworks/slickgrid-react/src/slickgrid-react/components/slickgridReactProps.ts
@@ -75,8 +75,8 @@ export interface SlickgridReactProps {
   datasetHierarchical?: any[] | null;
   extensions?: ExtensionList<SlickControlList | SlickPluginList>;
   gridId: string;
-  gridOptions?: GridOption;
-  columnDefinitions: Column[];
+  options?: GridOption;
+  columns: Column[];
   instances?: SlickgridReactInstance;
   paginationOptions?: Pagination;
 


### PR DESCRIPTION
- renaming input attributes for shorter and simpler names, I'm not sure why I decided to use longer name at first but anyway, better late than never

```diff
<SlickgridReact
    gridId="grid2"
-   columnDefinitions={columnDefinitions}
-   gridOptions={gridOptions}
+   columns={columnDefinitions}
+   options={gridOptions}
    dataset={dataset}
/>
```
