### PR TITLE
feat(services): pluralize CRUD events (ie: onItemsAdded, ...)

### DIFF
--- a/demos/react/src/examples/slickgrid/Example30.tsx
+++ b/demos/react/src/examples/slickgrid/Example30.tsx
@@ -609,7 +609,7 @@ const Example30: React.FC = () => {
     return false;
   }
 
-  function handleItemDeleted(itemId: string) {
+  function handleItemsDeleted(itemId: string) {
     console.log('item deleted with id:', itemId);
   }
 
@@ -1211,7 +1211,7 @@ const Example30: React.FC = () => {
         onCellChange={($event) => handleOnCellChange($event.detail.eventData, $event.detail.args)}
         onClick={($event) => handleOnCellClicked($event.detail.eventData, $event.detail.args)}
         onCompositeEditorChange={($event) => handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)}
-        onItemsDeleted={($event) => handleItemDeleted($event.detail)}
+        onItemsDeleted={($event) => handleItemsDeleted($event.detail)}
         onGridStateChanged={($event) => handleOnGridStateChanged($event.detail)}
         onRowsOrCountChanged={() => handleReRenderUnsavedStyling()}
         onValidationError={($event) => handleValidationError($event.detail.eventData, $event.detail.args)}

--- a/demos/react/src/examples/slickgrid/Example30.tsx
+++ b/demos/react/src/examples/slickgrid/Example30.tsx
@@ -1211,7 +1211,7 @@ const Example30: React.FC = () => {
         onCellChange={($event) => handleOnCellChange($event.detail.eventData, $event.detail.args)}
         onClick={($event) => handleOnCellClicked($event.detail.eventData, $event.detail.args)}
         onCompositeEditorChange={($event) => handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)}
-        onItemDeleted={($event) => handleItemDeleted($event.detail)}
+        onItemsDeleted={($event) => handleItemDeleted($event.detail)}
         onGridStateChanged={($event) => handleOnGridStateChanged($event.detail)}
         onRowsOrCountChanged={() => handleReRenderUnsavedStyling()}
         onValidationError={($event) => handleValidationError($event.detail.eventData, $event.detail.args)}

--- a/demos/vanilla/src/examples/example03.ts
+++ b/demos/vanilla/src/examples/example03.ts
@@ -61,7 +61,7 @@ export default class Example03 {
     this._bindingEventService.bind(gridContainerElm, 'onclick', this.handleOnClick.bind(this));
     this._bindingEventService.bind(gridContainerElm, 'oncellchange', this.handleOnCellChange.bind(this));
     this._bindingEventService.bind(gridContainerElm, 'onvalidationerror', this.handleValidationError.bind(this));
-    this._bindingEventService.bind(gridContainerElm, 'onitemdeleted', this.handleItemDeleted.bind(this));
+    this._bindingEventService.bind(gridContainerElm, 'onitemsdeleted', this.handleItemDeleted.bind(this));
     this._bindingEventService.bind(
       gridContainerElm,
       'onbeforeexporttoexcel',

--- a/demos/vanilla/src/examples/example03.ts
+++ b/demos/vanilla/src/examples/example03.ts
@@ -61,7 +61,7 @@ export default class Example03 {
     this._bindingEventService.bind(gridContainerElm, 'onclick', this.handleOnClick.bind(this));
     this._bindingEventService.bind(gridContainerElm, 'oncellchange', this.handleOnCellChange.bind(this));
     this._bindingEventService.bind(gridContainerElm, 'onvalidationerror', this.handleValidationError.bind(this));
-    this._bindingEventService.bind(gridContainerElm, 'onitemsdeleted', this.handleItemDeleted.bind(this));
+    this._bindingEventService.bind(gridContainerElm, 'onitemsdeleted', this.handleItemsDeleted.bind(this));
     this._bindingEventService.bind(
       gridContainerElm,
       'onbeforeexporttoexcel',
@@ -559,14 +559,14 @@ export default class Example03 {
 
   handleValidationError(event) {
     console.log('handleValidationError', event.detail);
-    const args = event.detail && event.detail.args;
+    const args = event?.detail?.args;
     if (args.validationResults) {
       alert(args.validationResults.msg);
     }
   }
 
-  handleItemDeleted(event) {
-    const itemId = event && event.detail;
+  handleItemsDeleted(event) {
+    const itemId = event?.detail;
     console.log('item deleted with id:', itemId);
   }
 

--- a/demos/vanilla/src/examples/example04.ts
+++ b/demos/vanilla/src/examples/example04.ts
@@ -571,7 +571,7 @@ export default class Example04 {
 
   handleOnValidationError(event) {
     console.log('handleOnValidationError', event.detail);
-    const args = event.detail && event.detail.args;
+    const args = event?.detail?.args;
     if (args.validationResults) {
       alert(args.validationResults.msg);
       return false;
@@ -579,7 +579,7 @@ export default class Example04 {
   }
 
   handleOnItemsDeleted(event) {
-    const itemId = event && event.detail;
+    const itemId = event?.detail;
     console.log('item deleted with id:', itemId);
   }
 

--- a/demos/vanilla/src/examples/example04.ts
+++ b/demos/vanilla/src/examples/example04.ts
@@ -71,7 +71,7 @@ export default class Example04 {
 
     // this._bindingEventService.bind(gridContainerElm, 'onclick', handleOnClick);
     this._bindingEventService.bind(gridContainerElm, 'onvalidationerror', this.handleOnValidationError.bind(this));
-    this._bindingEventService.bind(gridContainerElm, 'onitemdeleted', this.handleOnItemDeleted.bind(this));
+    this._bindingEventService.bind(gridContainerElm, 'onitemsdeleted', this.handleOnItemsDeleted.bind(this));
     this.sgb = new Slicker.GridBundle(gridContainerElm, this.columnDefinitions, { ...ExampleGridOptions, ...this.gridOptions }, dataset);
   }
 
@@ -578,7 +578,7 @@ export default class Example04 {
     }
   }
 
-  handleOnItemDeleted(event) {
+  handleOnItemsDeleted(event) {
     const itemId = event && event.detail;
     console.log('item deleted with id:', itemId);
   }

--- a/demos/vanilla/src/examples/example11.ts
+++ b/demos/vanilla/src/examples/example11.ts
@@ -514,7 +514,7 @@ export default class Example11 {
 
   handleValidationError(event) {
     console.log('handleValidationError', event.detail);
-    const args = event.detail && event.detail.args;
+    const args = event?.detail?.args;
     if (args.validationResults) {
       alert(args.validationResults.msg);
     }
@@ -522,7 +522,7 @@ export default class Example11 {
   }
 
   handleItemsDeleted(event) {
-    const itemId = event && event.detail;
+    const itemId = event?.detail;
     console.log('item deleted with id:', itemId);
   }
 

--- a/demos/vanilla/src/examples/example11.ts
+++ b/demos/vanilla/src/examples/example11.ts
@@ -134,7 +134,7 @@ export default class Example11 {
 
     // bind any of the grid events
     this._bindingEventService.bind(this.gridContainerElm, 'onvalidationerror', this.handleValidationError.bind(this));
-    this._bindingEventService.bind(this.gridContainerElm, 'onitemdeleted', this.handleItemDeleted.bind(this));
+    this._bindingEventService.bind(this.gridContainerElm, 'onitemsdeleted', this.handleItemsDeleted.bind(this));
     this.recreatePredefinedViews();
   }
 
@@ -521,7 +521,7 @@ export default class Example11 {
     return false;
   }
 
-  handleItemDeleted(event) {
+  handleItemsDeleted(event) {
     const itemId = event && event.detail;
     console.log('item deleted with id:', itemId);
   }

--- a/demos/vanilla/src/examples/example12.ts
+++ b/demos/vanilla/src/examples/example12.ts
@@ -138,7 +138,7 @@ export default class Example12 {
 
     // bind any of the grid events
     this._bindingEventService.bind(this.gridContainerElm, 'onvalidationerror', this.handleValidationError.bind(this));
-    this._bindingEventService.bind(this.gridContainerElm, 'onitemdeleted', this.handleItemDeleted.bind(this));
+    this._bindingEventService.bind(this.gridContainerElm, 'onitemsdeleted', this.handleItemsDeleted.bind(this));
     this._bindingEventService.bind(this.gridContainerElm, 'onbeforeeditcell', this.handleOnBeforeEditCell.bind(this));
     this._bindingEventService.bind(this.gridContainerElm, 'oncellchange', this.handleOnCellChange.bind(this));
     this._bindingEventService.bind(this.gridContainerElm, 'onclick', this.handleOnCellClicked.bind(this));
@@ -655,7 +655,7 @@ export default class Example12 {
     return false;
   }
 
-  handleItemDeleted(event) {
+  handleItemsDeleted(event) {
     const itemId = event?.detail;
     console.log('item deleted with id:', itemId);
   }

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -558,7 +558,7 @@ function handleValidationError(e: Event, args: any) {
   return false;
 }
 
-function handleItemDeleted(itemId: string) {
+function handleItemsDeleted(itemId: string) {
   console.log('item deleted with id:', itemId);
 }
 
@@ -1154,7 +1154,7 @@ function renderItemCallbackWith4Corners(item: any): string {
     @onCellChange="handleOnCellChange($event.detail.eventData, $event.detail.args)"
     @onClick="handleOnCellClicked($event.detail.eventData, $event.detail.args)"
     @onCompositeEditorChange="handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)"
-    @onItemDeleted="handleItemDeleted($event.detail)"
+    @onItemsDeleted="handleItemsDeleted($event.detail)"
     @onGridStateChanged="handleOnGridStateChanged($event.detail)"
     @onRowsOrCountChanged="handleReRenderUnsavedStyling()"
     @onValidationError="handleValidationError($event.detail.eventData, $event.detail.args)"

--- a/docs/events/Available-Events.md
+++ b/docs/events/Available-Events.md
@@ -90,10 +90,10 @@ handleOnHeaderMenuCommand(e) {
 
 #### Grid Service
   - `onHeaderMenuHideColumns`
-  - `onItemAdded`
-  - `onItemDeleted`
-  - `onItemUpdated`
-  - `onItemUpserted`
+  - `onItemsAdded`
+  - `onItemsDeleted`
+  - `onItemsUpdated`
+  - `onItemsUpserted`
 
 #### GridState Service
   - `onFullResizeByContentRequested`

--- a/frameworks/angular-slickgrid/docs/events/Available-Events.md
+++ b/frameworks/angular-slickgrid/docs/events/Available-Events.md
@@ -109,10 +109,10 @@ handleOnHeaderMenuCommand(e) {
 
 #### Grid Service
   - `onHeaderMenuHideColumns`
-  - `onItemAdded`
-  - `onItemDeleted`
-  - `onItemUpdated`
-  - `onItemUpserted`
+  - `onItemsAdded`
+  - `onItemsDeleted`
+  - `onItemsUpdated`
+  - `onItemsUpserted`
 
 #### GridState Service
   - `onFullResizeByContentRequested`

--- a/frameworks/angular-slickgrid/src/demos/examples/grid-composite-editor.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/grid-composite-editor.component.html
@@ -101,7 +101,7 @@
     (onCellChange)="handleOnCellChange($event.detail.eventData, $event.detail.args)"
     (onClick)="handleOnCellClicked($event.detail.eventData, $event.detail.args)"
     (onCompositeEditorChange)="handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)"
-    (onItemDeleted)="handleItemDeleted($event.detail)"
+    (onItemsDeleted)="handleItemDeleted($event.detail)"
     (onGridStateChanged)="handleOnGridStateChanged($event.detail)"
     (onRowsOrCountChanged)="handleReRenderUnsavedStyling()"
     (onValidationError)="handleValidationError($event.detail.eventData, $event.detail.args)"

--- a/frameworks/aurelia-slickgrid/docs/events/available-events.md
+++ b/frameworks/aurelia-slickgrid/docs/events/available-events.md
@@ -109,10 +109,10 @@ handleOnHeaderMenuCommand(e) {
 
 #### Grid Service
   - `onHeaderMenuHideColumns`
-  - `onItemAdded`
-  - `onItemDeleted`
-  - `onItemUpdated`
-  - `onItemUpserted`
+  - `onItemsAdded`
+  - `onItemsDeleted`
+  - `onItemsUpdated`
+  - `onItemsUpserted`
 
 #### GridState Service
   - `onFullResizeByContentRequested`

--- a/frameworks/slickgrid-react/docs/events/available-events.md
+++ b/frameworks/slickgrid-react/docs/events/available-events.md
@@ -111,10 +111,10 @@ render() {
 
 #### Grid Service
   - `onHeaderMenuHideColumns`
-  - `onItemAdded`
-  - `onItemDeleted`
-  - `onItemUpdated`
-  - `onItemUpserted`
+  - `onItemsAdded`
+  - `onItemsDeleted`
+  - `onItemsUpdated`
+  - `onItemsUpserted`
 
 #### GridState Service
   - `onFullResizeByContentRequested`

--- a/frameworks/slickgrid-react/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/composite-editor-modal.md
@@ -462,7 +462,7 @@ const Example: React.FC = () => {
       onBeforeEditCell={$event => handleOnBeforeEditCell($event.detail.eventData, $event.detail.args)}
       onCellChange={$event => handleOnCellChange($event.detail.eventData, $event.detail.args)}
       onCompositeEditorChange={$event => handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)}
-      onItemDeleted={$event => handleItemDeleted($event.detail)}
+      onItemsDeleted={$event => handleItemsDeleted($event.detail)}
       onGridStateChanged={$event => handleOnGridStateChanged($event.detail)}
       onFilterChanged={() => handleReRenderUnsavedStyling()}
       onPaginationChanged={() => handleReRenderUnsavedStyling()}

--- a/frameworks/slickgrid-react/src/components/slickgridReactProps.ts
+++ b/frameworks/slickgrid-react/src/components/slickgridReactProps.ts
@@ -220,10 +220,10 @@ export interface SlickgridReactProps {
   onHeaderMenuColumnResizeByContent?: (e: CustomEvent<{ eventData: any; args: { columnId: string } }>) => void;
   onHeaderMenuBeforeMenuShow?: (e: CustomEvent<{ eventData: any; args: HeaderMenuCommandItemCallbackArgs }>) => void;
   onHeaderMenuAfterMenuShow?: (e: CustomEvent<{ eventData: any; args: HeaderMenuCommandItemCallbackArgs }>) => void;
-  onItemAdded?: (e: CustomEvent<any>) => void;
-  onItemDeleted?: (e: CustomEvent<any>) => void;
-  onItemUpdated?: (e: CustomEvent<any>) => void;
-  onItemUpserted?: (e: CustomEvent<any>) => void;
+  onItemsAdded?: (e: CustomEvent<any>) => void;
+  onItemsDeleted?: (e: CustomEvent<any>) => void;
+  onItemsUpdated?: (e: CustomEvent<any>) => void;
+  onItemsUpserted?: (e: CustomEvent<any>) => void;
   onFullResizeByContentRequested?: (e: CustomEvent<any>) => void;
   onGridStateChanged?: (e: CustomEvent<any>) => void;
   onBeforePaginationChange?: (e: CustomEvent<any>) => void;

--- a/frameworks/slickgrid-vue/docs/events/available-events.md
+++ b/frameworks/slickgrid-vue/docs/events/available-events.md
@@ -124,10 +124,10 @@ function handleOnHeaderMenuCommand(e) {
 
 #### Grid Service
 
-- `onItemAdded`
-- `onItemDeleted`
-- `onItemUpdated`
-- `onItemUpserted`
+- `onItemsAdded`
+- `onItemsDeleted`
+- `onItemsUpdated`
+- `onItemsUpserted`
 
 #### GridState Service
 

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/composite-editor-modal.md
@@ -474,7 +474,7 @@ function handleOnCompositeEditorChange(event) {
     @onBeforeEditCell="handleOnBeforeEditCell($event.detail.eventData, $event.detail.args)"
     @onCellChange="handleOnCellChange($event.detail.eventData, $event.detail.args)"
     @onCompositeEditorChange="handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)"
-    @onItemDeleted="handleItemDeleted($event.detail)"
+    @onItemsDeleted="handleItemsDeleted($event.detail)"
     @onGridStateChanged="handleOnGridStateChanged($event.detail)"
     @onFilterChanged="handleReRenderUnsavedStyling()"
     @onPaginationChanged="handleReRenderUnsavedStyling()"

--- a/frameworks/slickgrid-vue/src/components/slickgridVueProps.interface.ts
+++ b/frameworks/slickgrid-vue/src/components/slickgridVueProps.interface.ts
@@ -208,10 +208,10 @@ export interface SlickgridVueProps {
   onOnHeaderMenuColumnResizeByContent?: (e: CustomEvent<{ eventData: any; args: { columnId: string } }>) => void;
   onOnHeaderMenuBeforeMenuShow?: (e: CustomEvent<{ eventData: any; args: HeaderMenuCommandItemCallbackArgs }>) => void;
   onOnHeaderMenuAfterMenuShow?: (e: CustomEvent<{ eventData: any; args: HeaderMenuCommandItemCallbackArgs }>) => void;
-  onOnItemAdded?: (e: CustomEvent<any>) => void;
-  onOnItemDeleted?: (e: CustomEvent<any>) => void;
-  onOnItemUpdated?: (e: CustomEvent<any>) => void;
-  onOnItemUpserted?: (e: CustomEvent<any>) => void;
+  onOnItemsAdded?: (e: CustomEvent<any>) => void;
+  onOnItemsDeleted?: (e: CustomEvent<any>) => void;
+  onOnItemsUpdated?: (e: CustomEvent<any>) => void;
+  onOnItemsUpserted?: (e: CustomEvent<any>) => void;
   onOnFullResizeByContentRequested?: (e: CustomEvent<any>) => void;
   onOnFilterChanged?: (e: CustomEvent<any>) => void;
   onOnFilterCleared?: (e: CustomEvent<any>) => void;

--- a/packages/common/src/interfaces/gridServiceDeleteOption.interface.ts
+++ b/packages/common/src/interfaces/gridServiceDeleteOption.interface.ts
@@ -2,6 +2,6 @@ export interface GridServiceDeleteOption {
   /** Defaults to false, should we skip error thrown? */
   skipError?: boolean;
 
-  /** Defaults to true, trigger an onItemDeleted event after the delete */
+  /** Defaults to true, trigger an onItemsDeleted event after the delete */
   triggerEvent?: boolean;
 }

--- a/packages/common/src/interfaces/gridServiceInsertOption.interface.ts
+++ b/packages/common/src/interfaces/gridServiceInsertOption.interface.ts
@@ -20,6 +20,6 @@ export interface GridServiceInsertOption {
   /** Defaults to true, after insert should we scroll to the inserted row position */
   scrollRowIntoView?: boolean;
 
-  /** Defaults to true, trigger an onItemAdded event after the insert */
+  /** Defaults to true, trigger an onItemsAdded event after the insert */
   triggerEvent?: boolean;
 }

--- a/packages/common/src/interfaces/gridServiceUpdateOption.interface.ts
+++ b/packages/common/src/interfaces/gridServiceUpdateOption.interface.ts
@@ -11,6 +11,6 @@ export interface GridServiceUpdateOption {
   /** Defaults to false, should we skip error thrown? */
   skipError?: boolean;
 
-  /** Defaults to true, trigger an onItemUpdated event after the update */
+  /** Defaults to true, trigger an onItemsUpdated event after the update */
   triggerEvent?: boolean;
 }

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -216,7 +216,7 @@ describe('Grid Service', () => {
         skipError: false,
         triggerEvent: true,
       });
-      expect(pubSubSpy).toHaveBeenCalledWith(`onItemUpserted`, mockItem);
+      expect(pubSubSpy).toHaveBeenCalledWith('onItemsUpserted', [mockItem]);
     });
 
     it('should expect the service to call the DataView "addItem" when calling "upsertItem" with an item and the option "position" set to "bottom"', () => {
@@ -235,7 +235,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(mockItem);
       expect(scrollSpy).toHaveBeenCalledWith(expectationNewRowPosition);
-      expect(pubSubSpy).toHaveBeenCalledWith(`onItemUpserted`, mockItem);
+      expect(pubSubSpy).toHaveBeenCalledWith('onItemsUpserted', [mockItem]);
     });
 
     it('should expect the service to call the "updateItem" multiple times when calling "upsertItems" with the items found in the grid', () => {
@@ -283,8 +283,8 @@ describe('Grid Service', () => {
         triggerEvent: false,
       });
       expect(serviceHighlightSpy).toHaveBeenCalledWith([0, 1]);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(1, `onItemUpserted`, mockItems);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(2, `onItemUpdated`, [
+      expect(pubSubSpy).toHaveBeenNthCalledWith(1, 'onItemsUpserted', mockItems);
+      expect(pubSubSpy).toHaveBeenNthCalledWith(2, 'onItemsUpdated', [
         { added: undefined as any, updated: 0 },
         { added: undefined as any, updated: 1 },
       ]);
@@ -336,9 +336,9 @@ describe('Grid Service', () => {
         triggerEvent: false,
       });
       expect(serviceHighlightSpy).toHaveBeenCalledWith([0, 15]);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(1, `onItemUpserted`, mockItems);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(2, `onItemAdded`, [{ added: 0, updated: undefined }]);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(3, `onItemUpdated`, [{ added: undefined as any, updated: 15 }]);
+      expect(pubSubSpy).toHaveBeenNthCalledWith(1, 'onItemsUpserted', mockItems);
+      expect(pubSubSpy).toHaveBeenNthCalledWith(2, 'onItemsAdded', [{ added: 0, updated: undefined }]);
+      expect(pubSubSpy).toHaveBeenNthCalledWith(3, 'onItemsUpdated', [{ added: undefined as any, updated: 15 }]);
       expect(selectSpy).toHaveBeenCalledWith([0, 15]);
     });
 
@@ -375,7 +375,7 @@ describe('Grid Service', () => {
       });
       expect(serviceHighlightSpy).not.toHaveBeenCalled();
       expect(pubSubSpy).toHaveBeenCalledTimes(0);
-      expect(pubSubSpy).not.toHaveBeenLastCalledWith(`onItemUpserted`, mockItem);
+      expect(pubSubSpy).not.toHaveBeenLastCalledWith('onItemsUpserted', [mockItem]);
       expect(selectSpy).not.toHaveBeenCalled();
     });
 
@@ -441,7 +441,7 @@ describe('Grid Service', () => {
         triggerEvent: true,
       });
       expect(serviceHighlightSpy).toHaveBeenCalledWith(0);
-      expect(pubSubSpy).toHaveBeenCalledWith(`onItemUpserted`, mockItem);
+      expect(pubSubSpy).toHaveBeenCalledWith('onItemsUpserted', [mockItem]);
     });
 
     it('should call the "upsertItemById" method and expect it to call the "addItem" with different boolean flags provided as arguments', () => {
@@ -464,7 +464,7 @@ describe('Grid Service', () => {
         triggerEvent: false,
       });
       expect(serviceHighlightSpy).not.toHaveBeenCalled();
-      expect(pubSubSpy).not.toHaveBeenLastCalledWith(`onItemUpserted`, mockItem);
+      expect(pubSubSpy).not.toHaveBeenLastCalledWith('onItemsUpserted', [mockItem]);
     });
 
     it('should call the "upsertItemById" method and expect it to call the "updateItem" when the item already exist in the grid', () => {
@@ -522,7 +522,7 @@ describe('Grid Service', () => {
         skipError: false,
         triggerEvent: true,
       });
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockItem]);
     });
 
     it('should be able to update an item that exist in the dataview even when it is not showing in the grid (filtered from the grid) but will not highlight/selectRow since it is not in showing in the grid', () => {
@@ -541,7 +541,7 @@ describe('Grid Service', () => {
       expect(serviceHighlightSpy).not.toHaveBeenCalled();
       expect(updateRowSpy).not.toHaveBeenCalled();
       expect(selectSpy).not.toHaveBeenCalled();
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockItem]);
     });
 
     it('should expect the service to call the "updateItemById" when calling "updateItem" and setting the "selecRow" flag and the grid option "enableRowSelection" is set', () => {
@@ -556,7 +556,7 @@ describe('Grid Service', () => {
       expect(getRowIdSpy).toHaveBeenCalledWith(0);
       expect(getRowIndexSpy).toHaveBeenCalledWith(0);
       expect(serviceHighlightSpy).not.toHaveBeenCalled();
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockItem]);
     });
 
     it('should expect the service to call the "updateItem" when calling "updateItems" with a single item which is not an array', () => {
@@ -584,7 +584,7 @@ describe('Grid Service', () => {
         triggerEvent: true,
       });
       expect(serviceHighlightSpy).toHaveBeenCalledWith(0);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockItem]);
     });
 
     it('should expect the row to be selected when calling "updateItems" with an item when setting the "selecRow" flag and the grid option "enableRowSelection" is set', () => {
@@ -605,7 +605,7 @@ describe('Grid Service', () => {
       expect(updateSpy).toHaveBeenCalledWith([0], [mockItem]);
       expect(selectSpy).toHaveBeenCalledWith([0]);
       expect(serviceHighlightSpy).toHaveBeenCalledWith([0]);
-      expect(pubSubSpy).toHaveBeenCalledWith(`onItemUpdated`, [mockItem]);
+      expect(pubSubSpy).toHaveBeenCalledWith('onItemsUpdated', [mockItem]);
     });
 
     it('should call the "updateItem" method and expect it to call the "updateItemById" with different boolean flags provided as arguments', () => {
@@ -637,7 +637,7 @@ describe('Grid Service', () => {
         triggerEvent: true,
       });
       expect(serviceHighlightSpy).not.toHaveBeenCalled();
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockItem]);
     });
 
     it('should expect the service to call the DataView "updateItem" when calling "addItem" with an item that has an Id defined by the "datasetIdPropertyName" property', () => {
@@ -660,7 +660,7 @@ describe('Grid Service', () => {
         skipError: false,
         triggerEvent: true,
       });
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockItem]);
 
       delete mockGridOptions.datasetIdPropertyName;
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(mockGridOptions);
@@ -737,7 +737,7 @@ describe('Grid Service', () => {
 
       expect(updateSpy).toHaveBeenCalledTimes(1);
       expect(updateSpy).toHaveBeenCalledWith(mockUpdatedItem.id, mockUpdatedItem);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, mockUpdatedItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockUpdatedItem]);
       expect(invalidateSpy).toHaveBeenCalled();
       expect(setItemSpy).toHaveBeenCalledWith(mockFlatDataset);
     });
@@ -768,7 +768,7 @@ describe('Grid Service', () => {
 
       expect(updateSpy).toHaveBeenCalledTimes(1);
       expect(updateSpy).toHaveBeenCalledWith([mockUpdatedItem.id], [mockUpdatedItem]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemUpdated`, [mockUpdatedItem]);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsUpdated', [mockUpdatedItem]);
       expect(invalidateSpy).toHaveBeenCalled();
       expect(setItemSpy).toHaveBeenCalledWith(mockFlatDataset);
     });
@@ -852,7 +852,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledWith(0, mockItem);
       expect(selectSpy).not.toHaveBeenCalled();
       expect(scrollSpy).toHaveBeenCalledWith(0);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       delete mockGridOptions.datasetIdPropertyName;
       vi.spyOn(gridStub, 'getOptions').mockReturnValue({});
     });
@@ -870,7 +870,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledWith(0, mockItem);
       expect(selectSpy).not.toHaveBeenCalled();
       expect(scrollSpy).toHaveBeenCalledWith(0);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
     });
 
     it('should expect the row to be selected when calling "addItem" with an item when setting the "selecRow" flag and the grid option "enableRowSelection" is set', () => {
@@ -886,7 +886,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(0, mockItem);
       expect(selectSpy).toHaveBeenCalledWith([0]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
     });
 
     it('should expect the service to call the DataView "addItem" when calling "addItem" with an item and the option "position" set to "bottom"', () => {
@@ -902,7 +902,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(mockItem);
       expect(scrollSpy).toHaveBeenCalledWith(expectationNewRowPosition);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
     });
 
     it('should expect the service to call the DataView "insertItem" and go to first page when using local Pagination and calling "addItem" when the insert position is set to "top"', () => {
@@ -919,7 +919,7 @@ describe('Grid Service', () => {
 
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(0, mockItem);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       expect(firstPageSpy).toHaveBeenCalledTimes(1);
       expect(lastPageSpy).toHaveBeenCalledTimes(0);
 
@@ -944,7 +944,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(mockItem);
       expect(scrollSpy).toHaveBeenCalledWith(expectationNewRowPosition);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       expect(firstPageSpy).toHaveBeenCalledTimes(0);
       expect(lastPageSpy).toHaveBeenCalledTimes(1);
 
@@ -973,7 +973,7 @@ describe('Grid Service', () => {
       expect(insertItemsSpy).toHaveBeenCalledWith(0, [mockItems[0], mockItems[1]]);
       expect(serviceHighlightSpy).toHaveBeenCalledTimes(1);
       expect(serviceHighlightSpy).toHaveBeenCalledWith([0, 1]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItems);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', mockItems);
     });
 
     it('should expect to call the DataView "addItems" once when calling the service "addItems" with an array of items and the option "position" set to "bottom"', () => {
@@ -998,7 +998,7 @@ describe('Grid Service', () => {
       expect(addItemsSpy).toHaveBeenCalledWith([mockItems[0], mockItems[1]]);
       expect(serviceHighlightSpy).toHaveBeenCalledTimes(1);
       expect(serviceHighlightSpy).toHaveBeenCalledWith([expectationNewRowPosition1, expectationNewRowPosition2]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItems);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', mockItems);
     });
 
     it('should expect the service to call the "addItem" when calling "addItems" with a single item which is not an array', () => {
@@ -1023,7 +1023,7 @@ describe('Grid Service', () => {
         triggerEvent: true,
       });
       expect(serviceHighlightSpy).toHaveBeenCalledTimes(1);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
     });
 
     it('should add a single item by calling "addItems" method and expect to call a grid resort but without highlighting neither triggering an event', () => {
@@ -1050,7 +1050,7 @@ describe('Grid Service', () => {
         triggerEvent: false,
       });
       expect(serviceHighlightSpy).not.toHaveBeenCalled();
-      expect(pubSubSpy).not.toHaveBeenLastCalledWith(`onItemAdded`);
+      expect(pubSubSpy).not.toHaveBeenLastCalledWith('onItemsAdded');
     });
 
     it('should add a single item by calling "addItems" method and expect to call a grid resort & highlight but without triggering an event', () => {
@@ -1075,7 +1075,7 @@ describe('Grid Service', () => {
       expect(insertItemsSpy).toHaveBeenCalledWith(0, [mockItems[0], mockItems[1]]);
       expect(serviceHighlightSpy).toHaveBeenCalledTimes(1);
       expect(getRowByIdSpy).toHaveBeenCalledTimes(2);
-      expect(pubSubSpy).not.toHaveBeenLastCalledWith(`onItemAdded`);
+      expect(pubSubSpy).not.toHaveBeenLastCalledWith('onItemsAdded');
     });
 
     it('should expect the row to be selected when calling "addItems" with an item when setting the "selecRow" flag and the grid option "enableRowSelection" is set', () => {
@@ -1095,7 +1095,7 @@ describe('Grid Service', () => {
       expect(insertSpy).toHaveBeenCalledTimes(1);
       expect(insertSpy).toHaveBeenCalledWith(0, [mockItem]);
       expect(selectSpy).toHaveBeenCalledWith([0]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, [mockItem]);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
     });
 
     it('should expect the row to be selected when calling "addItems" with an item wich is not an array when setting the "selecRow" flag and the grid option "enableRowSelection" is set', () => {
@@ -1118,7 +1118,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(0, mockItem);
       expect(selectSpy).toHaveBeenCalledWith(0);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
     });
 
     it('should expect the service to call the DataView "insertItem" when calling "addItem" with an item that has an Id defined by the "datasetIdPropertyName" property', () => {
@@ -1141,7 +1141,7 @@ describe('Grid Service', () => {
       expect(addSpy).toHaveBeenCalledWith(0, mockItem);
       expect(selectSpy).not.toHaveBeenCalled();
       expect(scrollSpy).toHaveBeenCalledWith(0);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       delete mockGridOptions.datasetIdPropertyName;
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(mockGridOptions);
     });
@@ -1174,7 +1174,7 @@ describe('Grid Service', () => {
 
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(mockItem);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       expect(invalidateSpy).toHaveBeenCalled();
       expect(setItemSpy).toHaveBeenCalledWith(mockFlatDataset);
       expect(scrollSpy).toHaveBeenCalled();
@@ -1208,7 +1208,7 @@ describe('Grid Service', () => {
 
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith(mockItem);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, mockItem);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       expect(invalidateSpy).toHaveBeenCalled();
       expect(setItemSpy).toHaveBeenCalledWith(mockFlatDataset);
       expect(scrollSpy).not.toHaveBeenCalled();
@@ -1242,7 +1242,7 @@ describe('Grid Service', () => {
 
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith([mockItem]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, [mockItem]);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       expect(invalidateSpy).toHaveBeenCalled();
       expect(setItemSpy).toHaveBeenCalledWith(mockFlatDataset);
       expect(scrollSpy).toHaveBeenCalled();
@@ -1276,7 +1276,7 @@ describe('Grid Service', () => {
 
       expect(addSpy).toHaveBeenCalledTimes(1);
       expect(addSpy).toHaveBeenCalledWith([mockItem]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemAdded`, [mockItem]);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsAdded', [mockItem]);
       expect(invalidateSpy).toHaveBeenCalled();
       expect(setItemSpy).toHaveBeenCalledWith(mockFlatDataset);
       expect(scrollSpy).not.toHaveBeenCalled();
@@ -1352,7 +1352,7 @@ describe('Grid Service', () => {
       expect(output).toEqual(4);
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith(mockItem.id);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemDeleted`, mockItem.id);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsDeleted', [mockItem.id]);
     });
 
     it('should remove any row selection when the grid option "enableCheckboxSelector" is enabled', () => {
@@ -1392,7 +1392,7 @@ describe('Grid Service', () => {
       expect(output).toEqual([0, 5]);
       expect(deleteItemsSpy).toHaveBeenCalledTimes(1);
       expect(deleteItemsSpy).toHaveBeenCalledWith([0, 5]);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemDeleted`, mockItems);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsDeleted', mockItems);
     });
 
     it('should expect the service to call the "deleteItem" when calling "deleteItems" with a single item which is not an array', () => {
@@ -1409,7 +1409,7 @@ describe('Grid Service', () => {
       expect(output).toEqual([4]);
       expect(serviceDeleteSpy).toHaveBeenCalledTimes(1);
       expect(serviceDeleteSpy).toHaveBeenCalledWith(mockItem, { skipError: false, triggerEvent: true });
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemDeleted`, mockItem.id);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsDeleted', [mockItem.id]);
     });
 
     it('should delete a single item by calling "deleteItems" method without triggering an event', () => {
@@ -1426,7 +1426,7 @@ describe('Grid Service', () => {
       expect(output).toEqual([0]);
       expect(serviceDeleteSpy).toHaveBeenCalled();
       expect(serviceDeleteSpy).toHaveBeenCalledWith(mockItem, { skipError: false, triggerEvent: false });
-      expect(pubSubSpy).not.toHaveBeenLastCalledWith(`onItemDeleted`);
+      expect(pubSubSpy).not.toHaveBeenLastCalledWith('onItemsDeleted');
     });
 
     it('should delete multiple items by calling "deleteItems" method and expect to trigger a single an event', () => {
@@ -1462,7 +1462,7 @@ describe('Grid Service', () => {
       expect(output).toEqual([3]);
       expect(serviceDeleteSpy).toHaveBeenCalled();
       expect(serviceDeleteSpy).toHaveBeenCalledWith(3, { triggerEvent: false });
-      expect(pubSubSpy).not.toHaveBeenLastCalledWith(`onItemDeleted`);
+      expect(pubSubSpy).not.toHaveBeenLastCalledWith('onItemsDeleted');
     });
 
     it('should delete a single item by calling "deleteItemByIds" method and expect to trigger a single an event', () => {
@@ -1501,7 +1501,7 @@ describe('Grid Service', () => {
       expect(output).toEqual(4);
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith(mockItem.customId);
-      expect(pubSubSpy).toHaveBeenLastCalledWith(`onItemDeleted`, mockItem.customId);
+      expect(pubSubSpy).toHaveBeenLastCalledWith('onItemsDeleted', [mockItem.customId]);
       delete mockGridOptions.datasetIdPropertyName;
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(mockGridOptions);
     });

--- a/packages/common/src/services/__tests__/pagination.service.spec.ts
+++ b/packages/common/src/services/__tests__/pagination.service.spec.ts
@@ -816,7 +816,7 @@ describe('PaginationService', () => {
     });
 
     it('should call "processOnItemsAddedOrRemoved" and expect the (To) to be incremented by 1 when "onItemsAdded" is triggered with a single item', () => {
-      const mockItems = { name: 'John' };
+      const mockItems = [{ name: 'John' }];
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
@@ -871,7 +871,7 @@ describe('PaginationService', () => {
     });
 
     it('should call "processOnItemsAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemsDeleted" is triggered with a single item', () => {
-      const mockItems = { name: 'John' };
+      const mockItems = [{ name: 'John' }];
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
@@ -929,7 +929,7 @@ describe('PaginationService', () => {
     it('should call "processOnItemsAddedOrRemoved" and expect the (To) to equal the total items when it is lower than the total pageSize count', () => {
       mockGridOption.pagination!.pageNumber = 4;
       mockGridOption.pagination!.totalItems = 100;
-      const mockItems = { name: 'John' };
+      const mockItems = [{ name: 'John' }];
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       fnCallbacks['onItemsAdded'](mockItems);
@@ -942,7 +942,7 @@ describe('PaginationService', () => {
     it('should call "processOnItemsAddedOrRemoved" and expect the (To) to equal the total items when it is higher than the total pageSize count', () => {
       mockGridOption.pagination!.pageNumber = 4;
       mockGridOption.pagination!.totalItems = 99;
-      const mockItems = { name: 'John' };
+      const mockItems = [{ name: 'John' }];
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       fnCallbacks['onItemsAdded'](mockItems);

--- a/packages/common/src/services/__tests__/pagination.service.spec.ts
+++ b/packages/common/src/services/__tests__/pagination.service.spec.ts
@@ -591,7 +591,7 @@ describe('PaginationService', () => {
       service.processOnPageChanged(1);
 
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 25, pageNum: 0 });
-      expect(pubSubSpy).toHaveBeenCalledWith(`onPaginationChanged`, {
+      expect(pubSubSpy).toHaveBeenCalledWith('onPaginationChanged', {
         dataFrom: 26,
         dataTo: 50,
         pageSize: 25,
@@ -664,7 +664,7 @@ describe('PaginationService', () => {
           service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
           service.refreshPagination();
         } catch (e) {
-          expect(e.toString()).toContain(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
+          expect(e.toString()).toContain('BackendServiceApi requires the following 2 properties "process" and "service" to be defined.');
           done();
         }
       }));
@@ -806,8 +806,8 @@ describe('PaginationService', () => {
     });
   });
 
-  // processOnItemAddedOrRemoved is private but we can spy on recalculateFromToIndexes
-  describe('processOnItemAddedOrRemoved private method', () => {
+  // processOnItemsAddedOrRemoved is private but we can spy on recalculateFromToIndexes
+  describe('processOnItemsAddedOrRemoved private method', () => {
     afterEach(() => {
       mockGridOption.pagination!.pageSize = 25;
       mockGridOption.pagination!.pageNumber = 2;
@@ -815,16 +815,16 @@ describe('PaginationService', () => {
       vi.clearAllMocks();
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be incremented by 1 when "onItemAdded" is triggered with a single item', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to be incremented by 1 when "onItemsAdded" is triggered with a single item', () => {
       const mockItems = { name: 'John' };
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemAdded'](mockItems);
+      fnCallbacks['onItemsAdded'](mockItems);
 
       expect(recalculateSpy).toHaveBeenCalledTimes(2);
-      expect(pubSubSpy).toHaveBeenCalledWith(`onPaginationChanged`, {
+      expect(pubSubSpy).toHaveBeenCalledWith('onPaginationChanged', {
         dataFrom: 26,
         dataTo: 50 + 1,
         pageSize: 25,
@@ -837,16 +837,16 @@ describe('PaginationService', () => {
       expect(service.dataTo).toBe(50 + 1);
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be incremented by 2 when "onItemAdded" is triggered with an array of 2 new items', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to be incremented by 2 when "onItemsAdded" is triggered with an array of 2 new items', () => {
       const mockItems = [{ name: 'John' }, { name: 'Jane' }];
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemAdded'](mockItems);
+      fnCallbacks['onItemsAdded'](mockItems);
 
       expect(recalculateSpy).toHaveBeenCalledTimes(2);
-      expect(pubSubSpy).toHaveBeenCalledWith(`onPaginationChanged`, {
+      expect(pubSubSpy).toHaveBeenCalledWith('onPaginationChanged', {
         dataFrom: 26,
         dataTo: 50 + mockItems.length,
         pageSize: 25,
@@ -859,28 +859,28 @@ describe('PaginationService', () => {
       expect(service.dataTo).toBe(50 + mockItems.length);
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect not onPaginationChanged to be triggered and the (To) to remain the same when "onItemAdded" is triggered without any items', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect not onPaginationChanged to be triggered and the (To) to remain the same when "onItemsAdded" is triggered without any items', () => {
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemAdded'](null);
+      fnCallbacks['onItemsAdded'](null);
 
       expect(recalculateSpy).toHaveBeenCalledTimes(1);
       expect(service.dataFrom).toBe(26);
       expect(service.dataTo).toBe(50);
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemDeleted" is triggered with a single item', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemsDeleted" is triggered with a single item', () => {
       const mockItems = { name: 'John' };
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemDeleted'](mockItems);
+      fnCallbacks['onItemsDeleted'](mockItems);
 
-      // called 2x times by init() then by processOnItemAddedOrRemoved()
+      // called 2x times by init() then by processOnItemsAddedOrRemoved()
       expect(recalculateSpy).toHaveBeenCalledTimes(2);
-      expect(pubSubSpy).toHaveBeenCalledWith(`onPaginationChanged`, {
+      expect(pubSubSpy).toHaveBeenCalledWith('onPaginationChanged', {
         dataFrom: 26,
         dataTo: 50 - 1,
         pageSize: 25,
@@ -893,16 +893,16 @@ describe('PaginationService', () => {
       expect(service.dataTo).toBe(50 - 1);
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemDeleted" is triggered with an array of 2 new items', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemsDeleted" is triggered with an array of 2 new items', () => {
       const mockItems = [{ name: 'John' }, { name: 'Jane' }];
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemDeleted'](mockItems);
+      fnCallbacks['onItemsDeleted'](mockItems);
 
-      expect(recalculateSpy).toHaveBeenCalledTimes(2); // called 2x times by init() then by processOnItemAddedOrRemoved()
-      expect(pubSubSpy).toHaveBeenCalledWith(`onPaginationChanged`, {
+      expect(recalculateSpy).toHaveBeenCalledTimes(2); // called 2x times by init() then by processOnItemsAddedOrRemoved()
+      expect(pubSubSpy).toHaveBeenCalledWith('onPaginationChanged', {
         dataFrom: 26,
         dataTo: 50 - mockItems.length,
         pageSize: 25,
@@ -913,12 +913,12 @@ describe('PaginationService', () => {
       });
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to remain the same when "onItemDeleted" is triggered without any items', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to remain the same when "onItemsDeleted" is triggered without any items', () => {
       const recalculateSpy = vi.spyOn(service, 'recalculateFromToIndexes');
 
       // service.totalItems = 85;
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemDeleted'](null);
+      fnCallbacks['onItemsDeleted'](null);
 
       // called 1x time by init() only
       expect(recalculateSpy).toHaveBeenCalledTimes(1);
@@ -926,26 +926,26 @@ describe('PaginationService', () => {
       expect(service.dataTo).toBe(50);
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to equal the total items when it is lower than the total pageSize count', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to equal the total items when it is lower than the total pageSize count', () => {
       mockGridOption.pagination!.pageNumber = 4;
       mockGridOption.pagination!.totalItems = 100;
       const mockItems = { name: 'John' };
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemAdded'](mockItems);
+      fnCallbacks['onItemsAdded'](mockItems);
       service.changeItemPerPage(200);
 
       expect(service.dataFrom).toBe(1);
       expect(service.dataTo).toBe(101);
     });
 
-    it('should call "processOnItemAddedOrRemoved" and expect the (To) to equal the total items when it is higher than the total pageSize count', () => {
+    it('should call "processOnItemsAddedOrRemoved" and expect the (To) to equal the total items when it is higher than the total pageSize count', () => {
       mockGridOption.pagination!.pageNumber = 4;
       mockGridOption.pagination!.totalItems = 99;
       const mockItems = { name: 'John' };
 
       service.init(gridStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
-      fnCallbacks['onItemAdded'](mockItems);
+      fnCallbacks['onItemsAdded'](mockItems);
       service.changeItemPerPage(100);
 
       expect(service.dataFrom).toBe(1);
@@ -1025,9 +1025,9 @@ describe('PaginationService', () => {
       service.togglePaginationVisibility(false);
 
       expect(sharedService.gridOptions.enablePagination).toBe(false);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(1, `onPaginationRefreshed`, expectedPagination);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(2, `onPaginationPresetsInitialized`, expectedPagination);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(3, `onPaginationVisibilityChanged`, { visible: false });
+      expect(pubSubSpy).toHaveBeenNthCalledWith(1, 'onPaginationRefreshed', expectedPagination);
+      expect(pubSubSpy).toHaveBeenNthCalledWith(2, 'onPaginationPresetsInitialized', expectedPagination);
+      expect(pubSubSpy).toHaveBeenNthCalledWith(3, 'onPaginationVisibilityChanged', { visible: false });
       expect(setPagingSpy).not.toHaveBeenCalled();
     });
 
@@ -1040,7 +1040,7 @@ describe('PaginationService', () => {
       service.togglePaginationVisibility(false);
 
       expect(sharedService.gridOptions.enablePagination).toBe(false);
-      expect(pubSubSpy).toHaveBeenNthCalledWith(3, `onPaginationVisibilityChanged`, { visible: false });
+      expect(pubSubSpy).toHaveBeenNthCalledWith(3, 'onPaginationVisibilityChanged', { visible: false });
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 0, pageNum: 0 });
     });
 
@@ -1055,7 +1055,7 @@ describe('PaginationService', () => {
 
       expect(sharedService.gridOptions.enablePagination).toBe(true);
       expect(gotoSpy).toHaveBeenCalled();
-      expect(pubSubSpy).toHaveBeenCalledWith(`onPaginationVisibilityChanged`, { visible: true });
+      expect(pubSubSpy).toHaveBeenCalledWith('onPaginationVisibilityChanged', { visible: true });
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: mockGridOption.pagination!.pageSize, pageNum: 0 });
     });
   });

--- a/packages/common/src/services/__tests__/sort.service.spec.ts
+++ b/packages/common/src/services/__tests__/sort.service.spec.ts
@@ -439,7 +439,7 @@ describe('SortService', () => {
       expect(collectionServiceStub.parseSingleDateItem).toHaveBeenCalled();
     });
 
-    it('should enable pre-parse and expect "preParseSingleDateItem()" being called when PubSub "onItemAdded" event is called', async () => {
+    it('should enable pre-parse and expect "preParseSingleDateItem()" being called when PubSub "onItemsAdded" event is called', async () => {
       const mockColumns = [
         { id: 'firstName', field: 'firstName' },
         { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso },
@@ -455,13 +455,13 @@ describe('SortService', () => {
       gridOptionMock.preParseDateColumns = true;
 
       service.bindLocalOnSort(gridStub);
-      eventPubSubService.publish('onItemAdded', mockData[0]);
+      eventPubSubService.publish('onItemsAdded', mockData[0]);
 
       expect(parseSingleSpy).toHaveBeenCalled();
       expect(collectionServiceStub.parseSingleDateItem).toHaveBeenCalled();
     });
 
-    it('should enable pre-parse and expect "preParseSingleDateItem()" being called when PubSub "onItemUpdated" event is called', async () => {
+    it('should enable pre-parse and expect "preParseSingleDateItem()" being called when PubSub "onItemsUpdated" event is called', async () => {
       const mockColumns = [
         { id: 'firstName', field: 'firstName' },
         { id: 'updatedDate', field: 'updatedDate', type: FieldType.dateIso },
@@ -477,7 +477,7 @@ describe('SortService', () => {
       gridOptionMock.preParseDateColumns = true;
 
       service.bindLocalOnSort(gridStub);
-      eventPubSubService.publish('onItemUpdated', mockData[0]);
+      eventPubSubService.publish('onItemsUpdated', [mockData[0]]);
 
       expect(parseSingleSpy).toHaveBeenCalled();
       expect(collectionServiceStub.parseSingleDateItem).toHaveBeenCalled();

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -462,7 +462,7 @@ export class GridService {
 
     // do we want to trigger an event after adding the item
     if (insertOptions.triggerEvent) {
-      this.pubSubService.publish('onItemAdded', item);
+      this.pubSubService.publish<T[]>('onItemsAdded', [item]);
     }
 
     // when using Pagination in a local grid, we need to either go to first page or last page depending on which position user want to insert the new row
@@ -543,7 +543,7 @@ export class GridService {
 
     // do we want to trigger an event after adding the item
     if (insertOptions.triggerEvent) {
-      this.pubSubService.publish('onItemAdded', items);
+      this.pubSubService.publish<T[]>('onItemsAdded', items);
     }
 
     return rowNumbers;
@@ -599,7 +599,7 @@ export class GridService {
 
     // do we want to trigger an event after deleting the item
     if (options.triggerEvent) {
-      this.pubSubService.publish('onItemDeleted', items);
+      this.pubSubService.publish<T[]>('onItemsDeleted', items);
     }
     return itemIds;
   }
@@ -633,7 +633,7 @@ export class GridService {
 
     // do we want to trigger an event after deleting the item
     if (options.triggerEvent) {
-      this.pubSubService.publish('onItemDeleted', itemId);
+      this.pubSubService.publish<Array<string | number>>('onItemsDeleted', [itemId]);
     }
     return itemId;
   }
@@ -662,7 +662,7 @@ export class GridService {
 
       // do we want to trigger an event after deleting the item
       if (options.triggerEvent) {
-        this.pubSubService.publish('onItemDeleted', itemIds);
+        this.pubSubService.publish<Array<number | string>>('onItemsDeleted', itemIds);
       }
       return itemIds;
     }
@@ -746,7 +746,7 @@ export class GridService {
 
     // do we want to trigger an event after updating the item
     if (options.triggerEvent) {
-      this.pubSubService.publish('onItemUpdated', items);
+      this.pubSubService.publish<T[]>('onItemsUpdated', items);
     }
 
     return rowNumbers;
@@ -805,7 +805,7 @@ export class GridService {
 
       // do we want to trigger an event after updating the item
       if (options.triggerEvent) {
-        this.pubSubService.publish('onItemUpdated', item);
+        this.pubSubService.publish<T[]>('onItemsUpdated', [item]);
       }
     }
     return rowNumber;
@@ -869,14 +869,14 @@ export class GridService {
 
     // do we want to trigger an event after updating the item
     if (options.triggerEvent) {
-      this.pubSubService.publish('onItemUpserted', items);
+      this.pubSubService.publish<T[]>('onItemsUpserted', items);
       const addedItems = upsertedRows.filter((upsertRow) => upsertRow.added !== undefined);
       if (Array.isArray(addedItems) && addedItems.length > 0) {
-        this.pubSubService.publish('onItemAdded', addedItems);
+        this.pubSubService.publish<Array<{ added: number | undefined; updated: number | undefined }>>('onItemsAdded', addedItems);
       }
       const updatedItems = upsertedRows.filter((upsertRow) => upsertRow.updated !== undefined);
       if (Array.isArray(updatedItems) && updatedItems.length > 0) {
-        this.pubSubService.publish('onItemUpdated', updatedItems);
+        this.pubSubService.publish<Array<{ added: number | undefined; updated: number | undefined }>>('onItemsUpdated', updatedItems);
       }
     }
     return upsertedRows;
@@ -916,8 +916,8 @@ export class GridService {
 
     // do we want to trigger an event after updating the item
     if (options.triggerEvent) {
-      this.pubSubService.publish('onItemUpserted', item);
-      isItemAdded ? this.pubSubService.publish('onItemAdded', item) : this.pubSubService.publish('onItemUpdated', item);
+      this.pubSubService.publish<T[]>('onItemsUpserted', [item]);
+      isItemAdded ? this.pubSubService.publish<T[]>('onItemsAdded', [item]) : this.pubSubService.publish<any[]>('onItemsUpdated', [item]);
     }
     return { added: rowNumberAdded, updated: rowNumberUpdated };
   }

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -917,7 +917,7 @@ export class GridService {
     // do we want to trigger an event after updating the item
     if (options.triggerEvent) {
       this.pubSubService.publish<T[]>('onItemsUpserted', [item]);
-      isItemAdded ? this.pubSubService.publish<T[]>('onItemsAdded', [item]) : this.pubSubService.publish<any[]>('onItemsUpdated', [item]);
+      this.pubSubService.publish<T[]>(isItemAdded ? 'onItemsAdded' : 'onItemsUpdated', [item]);
     }
     return { added: rowNumberAdded, updated: rowNumberUpdated };
   }

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -614,9 +614,9 @@ export class PaginationService {
    * until user does an action which will refresh the data hence the pagination which will then become normal again
    */
   protected processOnItemsAddedOrRemoved(items: any[], isItemAdded = true): void {
-    if (items !== null) {
+    if (Array.isArray(items)) {
       const previousDataTo = this._dataTo;
-      const itemCount = Array.isArray(items) ? items.length : 1;
+      const itemCount = items.length;
       const itemCountWithDirection = isItemAdded ? +itemCount : -itemCount;
 
       // refresh the total count in the pagination and in the UI

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -614,7 +614,7 @@ export class PaginationService {
    * until user does an action which will refresh the data hence the pagination which will then become normal again
    */
   protected processOnItemsAddedOrRemoved(items: any[], isItemAdded = true): void {
-    if (Array.isArray(items)) {
+    if (Array.isArray(items) && items.length > 0) {
       const previousDataTo = this._dataTo;
       const itemCount = items.length;
       const itemCountWithDirection = isItemAdded ? +itemCount : -itemCount;

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -163,10 +163,10 @@ export class PaginationService {
     // that would trigger a refresh of the pagination numbers
     if (this.dataView) {
       this._subscriptions.push(
-        this.pubSubService.subscribe<any | any[]>('onItemAdded', (items) => this.processOnItemAddedOrRemoved(items, true))
+        this.pubSubService.subscribe<any[]>('onItemsAdded', (items) => this.processOnItemsAddedOrRemoved(items, true))
       );
       this._subscriptions.push(
-        this.pubSubService.subscribe<any | any[]>('onItemDeleted', (items) => this.processOnItemAddedOrRemoved(items, false))
+        this.pubSubService.subscribe<any[]>('onItemsDeleted', (items) => this.processOnItemsAddedOrRemoved(items, false))
       );
     }
 
@@ -613,7 +613,7 @@ export class PaginationService {
    * basically we assume that this offset is fine for the time being,
    * until user does an action which will refresh the data hence the pagination which will then become normal again
    */
-  protected processOnItemAddedOrRemoved(items: any | any[], isItemAdded = true): void {
+  protected processOnItemsAddedOrRemoved(items: any[], isItemAdded = true): void {
     if (items !== null) {
       const previousDataTo = this._dataTo;
       const itemCount = Array.isArray(items) ? items.length : 1;

--- a/packages/common/src/services/sort.service.ts
+++ b/packages/common/src/services/sort.service.ts
@@ -101,7 +101,7 @@ export class SortService {
     // we'll automatically run Date parsing for these items to keep sort in sync
     if (this._gridOptions.preParseDateColumns) {
       this._eventHandler.subscribe(grid.onCellChange, (_e, args) => this.preParseSingleDateItem(args.item));
-      this.pubSubService.subscribe(['onItemAdded', 'onItemUpdated'], (item) => this.preParseSingleDateItem(item));
+      this.pubSubService.subscribe(['onItemsAdded', 'onItemsUpdated'], (item) => this.preParseSingleDateItem(item));
     }
   }
 


### PR DESCRIPTION
Our GridService has CRUD event that was sometime returning a single item or sometime multiple items and for that reason we had to rely on code like `onItemAdded.subscribe(item => { const items = Array.isArray(item) ? item : [item] }`, but if we always return an array then we know exactly the shape of items.