### PR TITLE
feat!: remove deprecated `colspanCallback` grid option

### DIFF
--- a/frameworks/angular-slickgrid/src/demos/examples/grid-colspan.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/grid-colspan.component.ts
@@ -60,7 +60,11 @@ export class GridColspanComponent implements OnInit {
       showPreHeaderPanel: true,
       preHeaderPanelHeight: 28,
       explicitInitialization: true,
-      colspanCallback: this.renderDifferentColspan,
+      dataView: {
+        globalItemMetadataProvider: {
+          getRowMetadata: (item: any) => this.renderDifferentColspan(item),
+        },
+      },
       gridMenu: {
         iconButtonContainer: 'preheader', // we can display the grid menu icon in either the preheader or in the column header (default)
       },

--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -1944,29 +1944,6 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         expect(populateSpy).toHaveBeenCalledWith(mockPresetFilters);
       });
 
-      it('should return null when "getItemMetadata" is called without a colspan callback defined', () => {
-        const itemSpy = vi.spyOn(mockDataView, 'getItem');
-
-        component.options = { colspanCallback: undefined } as unknown as GridOption;
-        component.initialization(slickEventHandler);
-        mockDataView.getItemMetadata(2);
-
-        expect(itemSpy).not.toHaveBeenCalled();
-      });
-
-      it('should execute colspan callback when defined in the grid options and "getItemMetadata" is called', () => {
-        const mockCallback = vi.fn();
-        const mockItem = { firstName: 'John', lastName: 'Doe' };
-        const itemSpy = vi.spyOn(mockDataView, 'getItem').mockReturnValue(mockItem);
-
-        component.options = { colspanCallback: mockCallback } as unknown as GridOption;
-        component.initialization(slickEventHandler);
-        mockDataView.getItemMetadata(2);
-
-        expect(itemSpy).toHaveBeenCalledWith(2);
-        expect(mockCallback).toHaveBeenCalledWith(mockItem);
-      });
-
       it('should update each row and re-render the grid when filtering and DataView "onRowsChanged" event is triggered', () => {
         const renderSpy = vi.spyOn(mockGrid, 'render');
         const updateRowSpy = vi.spyOn(mockGrid, 'updateRow');

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -24,7 +24,6 @@ import {
   EventSubscription,
   ExternalResource,
   isColumnDateType,
-  ItemMetadata,
   Locale,
   Metrics,
   Pagination,
@@ -1051,18 +1050,6 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
           }
         });
       }
-    }
-
-    // @deprecated @user `dataview.globalItemMetadataProvider.getRowMetadata`
-    // did the user add a colspan callback? If so, hook it into the DataView getItemMetadata
-    if (gridOptions?.colspanCallback && dataView && dataView.getItem && dataView.getItemMetadata) {
-      dataView.getItemMetadata = (rowNumber: number) => {
-        let callbackResult: ItemMetadata | null = null;
-        if (gridOptions.colspanCallback) {
-          callbackResult = gridOptions.colspanCallback(dataView.getItem(rowNumber));
-        }
-        return callbackResult;
-      };
     }
   }
 

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -840,18 +840,6 @@ export class AureliaSlickgridCustomElement {
         }
       }
     }
-
-    // @deprecated @user `dataview.globalItemMetadataProvider.getRowMetadata`
-    // did the user add a colspan callback? If so, hook it into the DataView getItemMetadata
-    if (gridOptions?.colspanCallback && dataView?.getItem && dataView?.getItemMetadata) {
-      dataView.getItemMetadata = (rowNumber: number) => {
-        let callbackResult = null;
-        if (gridOptions.colspanCallback) {
-          callbackResult = gridOptions.colspanCallback(dataView.getItem(rowNumber));
-        }
-        return callbackResult;
-      };
-    }
   }
 
   bindBackendCallbackFunctions(gridOptions: GridOption) {

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -944,18 +944,6 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
         }
       }
     }
-
-    // @deprecated @user `dataview.globalItemMetadataProvider.getRowMetadata`
-    // did the user add a colspan callback? If so, hook it into the DataView getItemMetadata
-    if (gridOptions?.colspanCallback && dataView?.getItem && dataView?.getItemMetadata) {
-      dataView.getItemMetadata = (rowNumber: number) => {
-        let callbackResult: ItemMetadata | null = null;
-        if (gridOptions.colspanCallback) {
-          callbackResult = gridOptions.colspanCallback(dataView.getItem(rowNumber));
-        }
-        return callbackResult;
-      };
-    }
   }
 
   bindBackendCallbackFunctions(gridOptions: GridOption) {

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -11,7 +11,6 @@ import {
   type ExtensionList,
   type ExternalResource,
   GridStateType,
-  type ItemMetadata,
   type Metrics,
   type Pagination,
   type PaginationMetadata,

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -842,18 +842,6 @@ function bindDifferentHooks(grid: SlickGrid, gridOptions: GridOption, dataView: 
       }
     }
   }
-
-  // @deprecated @user `dataview.globalItemMetadataProvider.getRowMetadata`
-  // did the user add a colspan callback? If so, hook it into the DataView getItemMetadata
-  if (gridOptions?.colspanCallback && dataView?.getItem && dataView?.getItemMetadata) {
-    dataView.getItemMetadata = (rowNumber: number) => {
-      let callbackResult = null;
-      if (gridOptions.colspanCallback) {
-        callbackResult = gridOptions.colspanCallback(dataView.getItem(rowNumber));
-      }
-      return callbackResult;
-    };
-  }
 }
 
 function bindBackendCallbackFunctions(gridOptions: GridOption) {

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -179,12 +179,6 @@ export interface GridOption<C extends Column = Column> {
   /** Checkbox Select Plugin options (columnId, cssClass, toolTip, width) */
   checkboxSelector?: CheckboxSelectorOption;
 
-  /**
-   * @deprecated @use `gridOptions = { dataView: { globalItemMetadataProvider: { getRowMetadata: (item, row) => any }}}` instead
-   * A callback function that will be used to define row spanning accross multiple columns
-   */
-  colspanCallback?: (item: any) => ItemMetadata;
-
   /** Defaults to " - ", separator between the column group label and the column label. */
   columnGroupSeparator?: string;
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1899,29 +1899,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(populateSpy).toHaveBeenCalledWith(mockPresetFilters);
       });
 
-      it('should return null when "getItemMetadata" is called without a colspan callback defined', () => {
-        const itemSpy = vi.spyOn(mockDataView, 'getItem');
-
-        component.gridOptions = { colspanCallback: undefined } as unknown as GridOption;
-        component.initialization(divContainer, slickEventHandler);
-        mockDataView.getItemMetadata(2);
-
-        expect(itemSpy).not.toHaveBeenCalled();
-      });
-
-      it('should execute colspan callback when defined in the grid options and "getItemMetadata" is called', () => {
-        const mockCallback = vi.fn();
-        const mockItem = { firstName: 'John', lastName: 'Doe' };
-        const itemSpy = vi.spyOn(mockDataView, 'getItem').mockReturnValue(mockItem);
-
-        component.gridOptions = { colspanCallback: mockCallback } as unknown as GridOption;
-        component.initialization(divContainer, slickEventHandler);
-        mockDataView.getItemMetadata(2);
-
-        expect(itemSpy).toHaveBeenCalledWith(2);
-        expect(mockCallback).toHaveBeenCalledWith(mockItem);
-      });
-
       it('should update each row and re-render the grid when filtering and DataView "onRowsChanged" event is triggered', () => {
         const renderSpy = vi.spyOn(mockGrid, 'render');
         const updateRowSpy = vi.spyOn(mockGrid, 'updateRow');

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -930,18 +930,6 @@ export class SlickVanillaGridBundle<TData = any> {
       this.loadColumnPresetsWhenDatasetInitialized();
       this.loadFilterPresetsWhenDatasetInitialized();
     }
-
-    // @deprecated @use `dataview.globalItemMetadataProvider.getRowMetadata`
-    // did the user add a colspan callback? If so, hook it into the DataView getItemMetadata
-    if (gridOptions?.colspanCallback && dataView?.getItem && dataView?.getItemMetadata) {
-      dataView.getItemMetadata = (rowNumber: number) => {
-        let callbackResult = null;
-        if (gridOptions.colspanCallback) {
-          callbackResult = gridOptions.colspanCallback(dataView.getItem(rowNumber));
-        }
-        return callbackResult;
-      };
-    }
   }
 
   bindBackendCallbackFunctions(gridOptions: GridOption): void {


### PR DESCRIPTION
This option was deprecated when `globalItemMetadataProvider` was added with the new recent RowSpan feature, just use `gridOptions = { dataView: { globalItemMetadataProvider: { getRowMetadata: (item, row) => any }}}` instead