### PR TITLE
feat!: Row Detail `parent` prop renamed to `parentRef`

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example19-detail-view.ts
+++ b/demos/aurelia/src/examples/slickgrid/example19-detail-view.ts
@@ -25,8 +25,8 @@ export class Example19DetailView {
   @bindable() dataView!: SlickDataView;
 
   // you can also optionally use the Parent Component reference
-  // NOTE that you MUST provide it through the "parent" property in your "rowDetail" grid options
-  @bindable() parent?: any;
+  // NOTE that you MUST provide it through the "parentRef" property in your "rowDetail" grid options
+  @bindable() parentRef?: any;
 
   alertAssignee(name: string) {
     if (typeof name === 'string') {
@@ -44,11 +44,11 @@ export class Example19DetailView {
       // then you can delete the item from the dataView
       this.dataView.deleteItem(model.rowId);
 
-      this.parent!.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+      this.parentRef!.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
     }
   }
 
   callParentMethod(model: any) {
-    this.parent!.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+    this.parentRef!.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
   }
 }

--- a/demos/aurelia/src/examples/slickgrid/example19.ts
+++ b/demos/aurelia/src/examples/slickgrid/example19.ts
@@ -189,7 +189,7 @@ export class Example19 {
         viewModel: Example19DetailView,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this,
+        parentRef: this,
 
         onBeforeRowDetailToggle: (e, args) => {
           // you coud cancel opening certain rows

--- a/demos/aurelia/src/examples/slickgrid/example45.ts
+++ b/demos/aurelia/src/examples/slickgrid/example45.ts
@@ -109,7 +109,7 @@ export class Example45 {
         // how many grid rows do we want to use for the row detail panel
         panelRows: this.detailViewRowCount,
         // optionally expose the functions that you want to use from within the row detail Child Component
-        parent: this,
+        parentRef: this,
         // Preload View Template
         preloadViewModel: Example45Preload,
 

--- a/demos/react/src/examples/slickgrid/Example19-detail-view.tsx
+++ b/demos/react/src/examples/slickgrid/Example19-detail-view.tsx
@@ -38,12 +38,12 @@ const Example19DetailView: React.FC<RowDetailViewProps<Item, any>> = forwardRef(
       // then you can delete the item from the dataView
       props.dataView.deleteItem(model.rowId);
 
-      props.parent.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+      props.parentRef.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
     }
   }
 
   function callParentMethod(model: any) {
-    props.parent.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+    props.parentRef.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
   }
 
   return (

--- a/demos/react/src/examples/slickgrid/Example19.tsx
+++ b/demos/react/src/examples/slickgrid/Example19.tsx
@@ -187,7 +187,7 @@ const Example19: React.FC = () => {
         panelRows: detailViewRowCount,
         preloadComponent: Example19Preload,
         viewComponent: Example19DetailView,
-        parent: {
+        parentRef: {
           showFlashMessage,
         },
         onBeforeRowDetailToggle: (e, args) => {

--- a/demos/vue/src/components/Example19.vue
+++ b/demos/vue/src/components/Example19.vue
@@ -161,7 +161,7 @@ function defineGrid() {
       // expandableOverride: (row: number, dataContext: any) => (dataContext.rowId % 2 === 1),
 
       // optionally expose the functions that you want to use from within the row detail Child Component
-      parent: { showFlashMessage },
+      parentRef: { showFlashMessage },
 
       // Preload View Template
       preloadComponent: Example19Preload,

--- a/demos/vue/src/components/Example19Detail.vue
+++ b/demos/vue/src/components/Example19Detail.vue
@@ -31,12 +31,12 @@ function deleteRow(model: Item) {
     // then you can delete the item from the dataView
     props.dataView?.deleteItem(model.rowId);
 
-    props.parent?.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+    props.parentRef?.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
   }
 }
 
 function callParentMethod(model: Item) {
-  props.parent?.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+  props.parentRef?.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
 }
 </script>
 <template>

--- a/demos/vue/src/components/Example45.vue
+++ b/demos/vue/src/components/Example45.vue
@@ -104,7 +104,7 @@ function defineGrid() {
       // how many grid rows do we want to use for the row detail panel
       panelRows: detailViewRowCount.value,
       // optionally expose the functions that you want to use from within the row detail Child Component
-      parent: {},
+      parentRef: {},
       // Preload View Template
       preloadComponent: Example45Preload,
       // ViewModel Template to load when row detail data is ready

--- a/docs/grid-functionalities/row-detail.md
+++ b/docs/grid-functionalities/row-detail.md
@@ -103,7 +103,7 @@ export default class Example21 {
         expandableOverride: (_row, dataContext) => dataContext.id % 2 === 1,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this
+        parentRef: this
       }
     };
   }
@@ -250,7 +250,7 @@ export class Example {
         postTemplate: this.loadView.bind(this),
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this
+        parentRef: this
       }
     };
   }

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-detail.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-detail.md
@@ -93,7 +93,7 @@ export class GridRowDetailComponent implements OnInit, OnDestroy {
         viewComponent: RowDetailViewComponent,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this
+        parentRef: this
       }
     };
   }
@@ -269,7 +269,7 @@ this.gridOptions = {
     viewComponent: RowDetailViewComponent,
 
     // Optionally pass your Parent Component reference to your Child Component (row detail component)
-    parent: this  // <-- THIS REFERENCE
+    parentRef: this  // <-- THIS REFERENCE
   },
 
   // a Parent Method that we want to access
@@ -325,8 +325,8 @@ export class RowDetailViewComponent {
   dataView: any;
 
   // you can also optionally use the Parent Component reference
-  // NOTE that you MUST provide it through the "parent" property in your "rowDetail" grid options
-  parent: GridRowDetailComponent;
+  // NOTE that you MUST provide it through the "parentRef" property in your "rowDetail" grid options
+  parentRef: GridRowDetailComponent;
 
   constructor() { }
 
@@ -347,12 +347,12 @@ export class RowDetailViewComponent {
       this.dataView.deleteItem(model.id);
 
       // and perhaps display a flash message by calling a method on the Parent Component
-      this.parent.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+      this.parentRef.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
     }
   }
 
   callParentMethod(model) {
-    this.parent.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+    this.parentRef.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
   }
 }
 ```

--- a/frameworks/angular-slickgrid/src/demos/examples/grid-rowdetail.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/grid-rowdetail.component.ts
@@ -180,7 +180,7 @@ export class GridRowDetailComponent implements OnDestroy, OnInit {
         viewComponent: RowDetailViewComponent,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this,
+        parentRef: this,
 
         onBeforeRowDetailToggle: (e, args) => {
           // you coud cancel opening certain rows

--- a/frameworks/angular-slickgrid/src/demos/examples/grid45.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/grid45.component.ts
@@ -118,7 +118,7 @@ export class Grid45Component implements OnDestroy, OnInit {
         // how many grid rows do we want to use for the row detail panel
         panelRows: this.detailViewRowCount,
         // optionally expose the functions that you want to use from within the row detail Child Component
-        parent: this,
+        parentRef: this,
         // Preload View Template
         preloadComponent: RowDetailPreloadComponent,
         // ViewModel Template to load when row detail data is ready

--- a/frameworks/angular-slickgrid/src/demos/examples/rowdetail-view.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/rowdetail-view.component.ts
@@ -25,8 +25,8 @@ export class RowDetailViewComponent {
   dataView!: SlickDataView;
 
   // you can also optionally use the Parent Component reference
-  // NOTE that you MUST provide it through the "parent" property in your "rowDetail" grid options
-  parent!: GridRowDetailComponent;
+  // NOTE that you MUST provide it through the "parentRef" property in your "rowDetail" grid options
+  parentRef!: GridRowDetailComponent;
 
   alertAssignee(name: string) {
     if (typeof name === 'string') {
@@ -44,11 +44,11 @@ export class RowDetailViewComponent {
       // then you can delete the item from the dataView
       this.dataView.deleteItem(model.rowId);
 
-      this.parent.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+      this.parentRef.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
     }
   }
 
   callParentMethod(model: any) {
-    this.parent.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+    this.parentRef.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
   }
 }

--- a/frameworks/angular-slickgrid/src/library/extensions/__tests__/slickRowDetailView.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/extensions/__tests__/slickRowDetailView.spec.ts
@@ -440,7 +440,7 @@ describe('SlickRowDetailView', () => {
                 addon: expect.anything(),
                 grid: gridStub,
                 dataView: dataViewStub,
-                parent: undefined,
+                parentRef: undefined,
               },
               { sanitizer: expect.any(Function) }
             );
@@ -477,7 +477,7 @@ describe('SlickRowDetailView', () => {
               addon: expect.anything(),
               grid: gridStub,
               dataView: dataViewStub,
-              parent: undefined,
+              parentRef: undefined,
             },
             { sanitizer: expect.any(Function) }
           );
@@ -512,7 +512,7 @@ describe('SlickRowDetailView', () => {
                 addon: expect.anything(),
                 grid: gridStub,
                 dataView: dataViewStub,
-                parent: undefined,
+                parentRef: undefined,
               },
               { sanitizer: expect.any(Function) }
             );

--- a/frameworks/angular-slickgrid/src/library/extensions/slickRowDetailView.ts
+++ b/frameworks/angular-slickgrid/src/library/extensions/slickRowDetailView.ts
@@ -2,7 +2,7 @@ import type { ApplicationRef, ComponentRef, Type, ViewContainerRef } from '@angu
 import type {
   EventSubscription,
   OnBeforeRowDetailToggleArgs,
-  OnRowBackToViewportRangeArgs,
+  OnRowBackOrOutOfViewportRangeArgs,
   RxJsFacade,
   SlickGrid,
 } from '@slickgrid-universal/common';
@@ -383,7 +383,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
   }
 
   /** When Row comes back to Viewport Range, we need to redraw the View */
-  protected handleOnRowBackToViewportRange(_e: SlickEventData<OnRowBackToViewportRangeArgs>, args: OnRowBackToViewportRangeArgs) {
+  protected handleOnRowBackToViewportRange(_e: SlickEventData<OnRowBackOrOutOfViewportRangeArgs>, args: OnRowBackOrOutOfViewportRangeArgs) {
     const viewModel = this._views.find((x) => x.id === args.rowId);
     if (viewModel && !viewModel.rendered) {
       this.redrawViewComponent(viewModel);

--- a/frameworks/angular-slickgrid/src/library/extensions/slickRowDetailView.ts
+++ b/frameworks/angular-slickgrid/src/library/extensions/slickRowDetailView.ts
@@ -276,7 +276,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
           addon: this,
           grid: this._grid,
           dataView: this.dataView,
-          parent: this.rowDetailViewOptions?.parent,
+          parentRef: this.rowDetailViewOptions?.parentRef,
         },
         {
           sanitizer: this._grid.sanitizeHtmlString,

--- a/frameworks/angular-slickgrid/src/library/models/rowDetailView.interface.ts
+++ b/frameworks/angular-slickgrid/src/library/models/rowDetailView.interface.ts
@@ -6,7 +6,7 @@ export interface RowDetailView extends UniversalRowDetailView {
    * Optionally pass your Parent Component reference to your Child Component (row detail component).
    * note:: If anyone finds a better way of passing the parent to the row detail extension, please reach out and/or create a PR
    */
-  parent?: any;
+  parentRef?: any;
 
   /** View Component of the preload template (typically a spinner) which shows after opening on the row detail but before the row detail is ready */
   preloadComponent?: Type<object>;

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-detail.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-detail.md
@@ -92,7 +92,7 @@ export class GridExample {
         viewModel: PLATFORM.moduleName('examples/detail-view'),
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this
+        parentRef: this
       }
     };
   }
@@ -257,7 +257,7 @@ this.gridOptions = {
     viewModel: PLATFORM.moduleName('examples/slickgrid/example19-detail-view'),
 
     // Optionally pass your Parent Component reference to your Child Component (row detail component)
-    parent: this  // <-- THIS REFERENCE
+    parentRef: this  // <-- THIS REFERENCE
   }
 
   // a Parent Method that we want to access
@@ -309,8 +309,8 @@ export class DetailViewCustomElement{
   dataView: any;
 
   // you can also optionally use the Parent Component reference
-  // NOTE that you MUST provide it through the "parent" property in your "rowDetail" grid options
-  parent: GridRowDetail;
+  // NOTE that you MUST provide it through the "parentRef" property in your "rowDetail" grid options
+  parentRef: GridRowDetail;
 
   constructor() { }
 
@@ -331,12 +331,12 @@ export class DetailViewCustomElement{
       this.dataView.deleteItem(model.id);
 
       // and perhaps display a flash message by calling a method on the Parent Component
-      this.parent.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+      this.parentRef.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
     }
   }
 
   callParentMethod(model) {
-    this.parent.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+    this.parentRef.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
   }
 }
 ```

--- a/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
+++ b/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
@@ -268,7 +268,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         addon: this,
         grid: this._grid,
         dataView: this.dataView,
-        parent: this.rowDetailViewOptions?.parent,
+        parentRef: this.rowDetailViewOptions?.parentRef,
       } as ViewModelBindableInputData;
       const aureliaComp = await this.aureliaUtilService.createAureliaViewModelAddToSlot(this._viewModel, bindableData, containerElement);
       const slotObj = this._slots.find((obj) => obj.id === item[this.datasetIdPropName]);

--- a/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
+++ b/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
@@ -3,7 +3,7 @@ import {
   createDomElement,
   type EventSubscription,
   type OnBeforeRowDetailToggleArgs,
-  type OnRowBackToViewportRangeArgs,
+  type OnRowBackOrOutOfViewportRangeArgs,
   SlickEventData,
   type SlickGrid,
   SlickRowSelectionModel,
@@ -326,7 +326,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
 
   /** When Row comes back to Viewport Range, we need to redraw the View */
   protected async handleOnRowBackToViewportRange(
-    _e: SlickEventData<OnRowBackToViewportRangeArgs>,
+    _e: SlickEventData<OnRowBackOrOutOfViewportRangeArgs>,
     args: {
       item: any;
       rowId: string | number;

--- a/frameworks/aurelia-slickgrid/src/models/rowDetailView.interface.ts
+++ b/frameworks/aurelia-slickgrid/src/models/rowDetailView.interface.ts
@@ -6,7 +6,7 @@ export interface RowDetailView extends UniversalRowDetailView {
    * Optionally pass your Parent Component reference to your Child Component (row detail component).
    * note:: If anyone finds a better way of passing the parent to the row detail extension, please reach out and/or create a PR
    */
-  parent?: any;
+  parentRef?: any;
 
   /** View Model of the preload template which shows after opening row detail & before row detail data shows up */
   preloadViewModel?: Constructable;

--- a/frameworks/aurelia-slickgrid/src/models/viewModelBindableData.interface.ts
+++ b/frameworks/aurelia-slickgrid/src/models/viewModelBindableData.interface.ts
@@ -6,5 +6,5 @@ export interface ViewModelBindableData {
   addon: any;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent?: any;
+  parentRef?: any;
 }

--- a/frameworks/aurelia-slickgrid/src/models/viewModelBindableInputData.interface.ts
+++ b/frameworks/aurelia-slickgrid/src/models/viewModelBindableInputData.interface.ts
@@ -5,5 +5,5 @@ export interface ViewModelBindableInputData {
   addon: any;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent?: any;
+  parentRef?: any;
 }

--- a/frameworks/aurelia-slickgrid/src/services/aureliaUtil.service.ts
+++ b/frameworks/aurelia-slickgrid/src/services/aureliaUtil.service.ts
@@ -16,7 +16,7 @@ export class AureliaUtilService {
       const addonBindable = bindableData?.addon ? 'addon.bind="bindableData.addon"' : '';
       const gridBindable = bindableData?.grid ? 'grid.bind="bindableData.grid"' : '';
       const dataViewBindable = bindableData?.dataView ? 'data-view.bind="bindableData.dataView"' : '';
-      const parentBindable = bindableData?.parent ? 'parent.bind="bindableData.parent"' : '';
+      const parentBindable = bindableData?.parentRef ? 'parent-ref.bind="bindableData.parentRef"' : '';
 
       targetElement.innerHTML =
         `<${def.name} model.bind="bindableData.model" ${addonBindable} ${gridBindable} ${dataViewBindable} ${parentBindable}></${def.name}>`.trim();

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-detail.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-detail.md
@@ -90,7 +90,7 @@ const Example: React.FC = () => {
         viewComponent: Example19DetailView,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this
+        parentRef: this
       }
     });
   }
@@ -184,7 +184,7 @@ interface Props {
   addon: SlickRowDetailView;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent: any;
+  parentRef: any;
 }
 interface State { assignee: string; }
 
@@ -285,7 +285,7 @@ const Example: React.FC = () => {
         viewComponent: Example19DetailView,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this
+        parentRef: this
       }
     });
   }
@@ -333,7 +333,7 @@ const Example: React.FC = () => {
         viewComponent: CustomDetailView,
 
         // Optionally pass your Parent Component reference to your Child Component (row detail component)
-        parent: this  // <-- THIS REFERENCE
+        parentRef: this  // <-- THIS REFERENCE
       }
     });
   }
@@ -410,12 +410,12 @@ const Example: React.FC = (props: Props) => {
       // then you can delete the item from the dataView
       props.dataView.deleteItem(model.rowId);
 
-      props.parent!.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+      props.parentRef!.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
     }
   }
 
   function callParentMethod(model: any) {
-    props.parent!.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+    props.parentRef!.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
   }
 
   render() {

--- a/frameworks/slickgrid-react/src/extensions/slickRowDetailView.ts
+++ b/frameworks/slickgrid-react/src/extensions/slickRowDetailView.ts
@@ -3,7 +3,7 @@ import {
   createDomElement,
   type EventSubscription,
   type OnBeforeRowDetailToggleArgs,
-  type OnRowBackToViewportRangeArgs,
+  type OnRowBackOrOutOfViewportRangeArgs,
   SlickEventData,
   type SlickGrid,
   SlickRowSelectionModel,
@@ -355,7 +355,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
 
   /** When Row comes back to Viewport Range, we need to redraw the View */
   protected async handleOnRowBackToViewportRange(
-    _e: SlickEventData<OnRowBackToViewportRangeArgs>,
+    _e: SlickEventData<OnRowBackOrOutOfViewportRangeArgs>,
     args: {
       item: any;
       rowId: string | number;

--- a/frameworks/slickgrid-react/src/extensions/slickRowDetailView.ts
+++ b/frameworks/slickgrid-react/src/extensions/slickRowDetailView.ts
@@ -256,7 +256,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         addon: this,
         grid: this._grid,
         dataView: this.dataView,
-        parent: this.rowDetailViewOptions?.parent,
+        parentRef: this.rowDetailViewOptions?.parentRef,
       } as ViewModelBindableInputData;
       const detailContainer = document.createElement('section');
       containerElement.appendChild(detailContainer);
@@ -277,7 +277,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         addon: this,
         grid: this._grid,
         dataView: this.dataView,
-        parent: this.rowDetailViewOptions?.parent,
+        parentRef: this.rowDetailViewOptions?.parentRef,
       } as ViewModelBindableInputData;
 
       // load our Row Detail React Component dynamically, typically we would want to use `root.render()` after the preload component (last argument below)

--- a/frameworks/slickgrid-react/src/models/rowDetailView.interface.ts
+++ b/frameworks/slickgrid-react/src/models/rowDetailView.interface.ts
@@ -5,7 +5,7 @@ export interface RowDetailView extends UniversalRowDetailView {
    * Optionally pass your Parent Component reference to your Child Component (row detail component).
    * note:: If anyone finds a better way of passing the parent to the row detail extension, please reach out and/or create a PR
    */
-  parent?: any;
+  parentRef?: any;
 
   /** View Model of the preload template which shows after opening row detail & before row detail data shows up */
   preloadComponent?: any;

--- a/frameworks/slickgrid-react/src/models/viewModelBindableData.interface.ts
+++ b/frameworks/slickgrid-react/src/models/viewModelBindableData.interface.ts
@@ -6,5 +6,5 @@ export interface ViewModelBindableData {
   addon: any;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent?: any;
+  parentRef?: any;
 }

--- a/frameworks/slickgrid-react/src/models/viewModelBindableInputData.interface.ts
+++ b/frameworks/slickgrid-react/src/models/viewModelBindableInputData.interface.ts
@@ -5,5 +5,5 @@ export interface ViewModelBindableInputData {
   addon: any;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent?: any;
+  parentRef?: any;
 }

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-detail.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-detail.md
@@ -85,7 +85,7 @@ function defineGrid() {
       viewComponent: Example19DetailView,
 
       // Optionally pass your Parent Component reference to your Child Component (row detail component)
-      parent: this
+      parentRef: this
     }
   };
 }
@@ -199,12 +199,12 @@ function deleteRow(model: Item) {
     // then you can delete the item from the dataView
     props.dataView?.deleteItem(model.rowId);
 
-    props.parent?.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+    props.parentRef?.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
   }
 }
 
 function callParentMethod(model: Item) {
-  props.parent?.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+  props.parentRef?.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
 }
 </script>
 <template>
@@ -278,7 +278,7 @@ function defineGrid() {
       viewComponent: Example19DetailView,
 
       // Optionally pass your Parent Component reference to your Child Component (row detail component)
-      parent: this
+      parentRef: this
     }
   };
 }
@@ -315,7 +315,7 @@ function defineGrid() {
       viewComponent: CustomDetailView,
 
       // Optionally pass your Parent Component reference to your Child Component (row detail component)
-      parent: this  // <-- THIS REFERENCE
+      parentRef: this  // <-- THIS REFERENCE
     }
   }
 }
@@ -389,12 +389,12 @@ function deleteRow(model: any) {
     // then you can delete the item from the dataView
     props.dataView.deleteItem(model.rowId);
 
-    props.parent!.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
+    props.parentRef!.showFlashMessage(`Deleted row with ${model.title}`, 'danger');
   }
 }
 
 function callParentMethod(model: any) {
-  props.parent!.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
+  props.parentRef!.showFlashMessage(`We just called Parent Method from the Row Detail Child Component on ${model.title}`);
 }
 </script>
 

--- a/frameworks/slickgrid-vue/src/extensions/slickRowDetailView.ts
+++ b/frameworks/slickgrid-vue/src/extensions/slickRowDetailView.ts
@@ -266,15 +266,13 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         addon: this,
         grid: this._grid,
         dataView: this.dataView,
-        // @deprecated @use `parentRef`
-        parent: this.rowDetailViewOptions?.parent,
-        parentRef: this.rowDetailViewOptions?.parent,
+        parentRef: this.rowDetailViewOptions?.parentRef,
       } as AppData & ViewModelBindableInputData;
 
       const tmpDiv = document.createElement('div');
       this._preloadApp = createApp(this._preloadComponent, bindableData);
       const instance = this._preloadApp.mount(tmpDiv) as ComponentPublicInstance;
-      bindableData.parent = instance;
+      bindableData.parentRef = instance;
       containerElement.appendChild(instance.$el);
 
       if (viewObj) {
@@ -293,9 +291,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         addon: this,
         grid: this._grid,
         dataView: this.dataView,
-        // @deprecated @use `parentRef`
-        parent: this.rowDetailViewOptions?.parent,
-        parentRef: this.rowDetailViewOptions?.parent,
+        parentRef: this.rowDetailViewOptions?.parentRef,
       } as AppData & ViewModelBindableInputData;
 
       this.unmountViewWhenExists(item[this.datasetIdPropName]);
@@ -304,7 +300,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
       const tmpDiv = document.createElement('div');
       const app = createApp(this._component, bindableData);
       const instance = app.mount(tmpDiv) as ComponentPublicInstance;
-      bindableData.parent = app.component;
+      bindableData.parentRef = app.component;
       containerElement.appendChild(instance.$el);
       this.upsertViewRefs(item, { app, instance, rendered: true });
     }

--- a/frameworks/slickgrid-vue/src/extensions/slickRowDetailView.ts
+++ b/frameworks/slickgrid-vue/src/extensions/slickRowDetailView.ts
@@ -2,7 +2,7 @@ import {
   createDomElement,
   type EventSubscription,
   type OnBeforeRowDetailToggleArgs,
-  type OnRowBackToViewportRangeArgs,
+  type OnRowBackOrOutOfViewportRangeArgs,
   SlickEventData,
   type SlickGrid,
   SlickRowSelectionModel,
@@ -367,7 +367,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
 
   /** When Row comes back to Viewport Range, we need to redraw the View */
   protected handleOnRowBackToViewportRange(
-    _e: SlickEventData<OnRowBackToViewportRangeArgs>,
+    _e: SlickEventData<OnRowBackOrOutOfViewportRangeArgs>,
     args: {
       item: any;
       rowId: string | number;

--- a/frameworks/slickgrid-vue/src/models/rowDetailView.interface.ts
+++ b/frameworks/slickgrid-vue/src/models/rowDetailView.interface.ts
@@ -6,7 +6,7 @@ export interface RowDetailView extends UniversalRowDetailView {
    * Optionally pass your Parent Component reference to your Child Component (row detail component).
    * note:: If anyone finds a better way of passing the parent to the row detail extension, please reach out and/or create a PR
    */
-  parent?: any;
+  parentRef?: any;
 
   /** View Model of the preload template which shows after opening row detail & before row detail data shows up */
   preloadComponent?: DefineComponent<any, any, any>;

--- a/frameworks/slickgrid-vue/src/models/viewModelBindableData.interface.ts
+++ b/frameworks/slickgrid-vue/src/models/viewModelBindableData.interface.ts
@@ -6,5 +6,5 @@ export interface ViewModelBindableData {
   addon: any;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent?: any;
+  parentRef?: any;
 }

--- a/frameworks/slickgrid-vue/src/models/viewModelBindableInputData.interface.ts
+++ b/frameworks/slickgrid-vue/src/models/viewModelBindableInputData.interface.ts
@@ -5,5 +5,5 @@ export interface ViewModelBindableInputData {
   addon: any;
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent?: any;
+  parentRef?: any;
 }

--- a/packages/common/src/interfaces/rowDetailView.interface.ts
+++ b/packages/common/src/interfaces/rowDetailView.interface.ts
@@ -21,13 +21,13 @@ export interface RowDetailView extends RowDetailViewOption {
   onBeforeRowDetailToggle?: (e: SlickEventData, args: OnBeforeRowDetailToggleArgs) => void;
 
   /** Fired just before a row becomes out of viewport range (you can use this event to save inner Grid State before it gets destroyed) */
-  onBeforeRowOutOfViewportRange?: (e: SlickEventData, args: OnRowOutOfViewportRangeArgs) => void;
+  onBeforeRowOutOfViewportRange?: (e: SlickEventData, args: OnRowBackOrOutOfViewportRangeArgs) => void;
 
   /** Fired after the row detail gets toggled */
-  onRowBackToViewportRange?: (e: SlickEventData, args: OnRowBackToViewportRangeArgs) => void;
+  onRowBackToViewportRange?: (e: SlickEventData, args: OnRowBackOrOutOfViewportRangeArgs) => void;
 
   /** Fired after a row becomes out of viewport range (user can't see the row anymore) */
-  onRowOutOfViewportRange?: (e: SlickEventData, args: OnRowOutOfViewportRangeArgs) => void;
+  onRowOutOfViewportRange?: (e: SlickEventData, args: OnRowBackOrOutOfViewportRangeArgs) => void;
 }
 
 /** This event must be used with the "notify" by the end user once the Asynchronous Server call returns the item detail */
@@ -85,34 +85,7 @@ export interface OnBeforeRowDetailToggleArgs {
 }
 
 /** Fired after the row detail gets toggled */
-export interface OnRowBackToViewportRangeArgs {
-  /** Item data context object */
-  item: any;
-
-  /** Id of the Row object (datacontext) in the Grid */
-  rowId: string | number;
-
-  /** Index of the Row in the Grid */
-  rowIndex: number;
-
-  /** Array of the Expanded Row Ids */
-  expandedRows: Array<number | string>;
-
-  /** Array of the Out of viewport Range Rows */
-  rowIdsOutOfViewport: Array<number | string>;
-
-  /** Reference to the Slick grid object */
-  grid: SlickGrid;
-
-  /** provide any generic params */
-  params?: any;
-}
-
-/**
- * @deprecated We should eventually merge out/back to viewport into a single interface.
- * Fired after a row becomes out of viewport range (user can't see the row anymore)
- */
-export interface OnRowOutOfViewportRangeArgs {
+export interface OnRowBackOrOutOfViewportRangeArgs {
   /** Item data context object */
   item: any;
 

--- a/packages/common/src/interfaces/rowDetailViewOption.interface.ts
+++ b/packages/common/src/interfaces/rowDetailViewOption.interface.ts
@@ -7,7 +7,7 @@ export interface RowDetailViewProps<T = any, C = any> {
   expandedRows?: (string | number)[];
   grid: SlickGrid;
   dataView: SlickDataView;
-  parent: C;
+  parentRef: C;
   rowId?: string | number;
   rowIndex?: number;
   rowIdsOutOfViewport?: (string | number)[];
@@ -56,7 +56,7 @@ export interface RowDetailViewOption {
   panelRows: number;
 
   /** Optionally pass your Parent Component reference or exposed functions to your Child Component (row detail component). */
-  parent?: any;
+  parentRef?: any;
 
   /** Defaults to false, makes the column reorderable to another position in the grid. */
   reorderable?: boolean;

--- a/packages/common/src/interfaces/slickRowDetailView.interface.ts
+++ b/packages/common/src/interfaces/slickRowDetailView.interface.ts
@@ -3,10 +3,9 @@ import type {
   GridOption,
   OnAfterRowDetailToggleArgs,
   OnBeforeRowDetailToggleArgs,
-  OnRowBackToViewportRangeArgs,
+  OnRowBackOrOutOfViewportRangeArgs,
   OnRowDetailAsyncEndUpdateArgs,
   OnRowDetailAsyncResponseArgs,
-  OnRowOutOfViewportRangeArgs,
   RowDetailViewOption,
 } from './index.js';
 import type { ContainerService } from '../services/container.service.js';
@@ -81,11 +80,11 @@ export interface SlickRowDetailView {
   onBeforeRowDetailToggle?: SlickEvent<OnBeforeRowDetailToggleArgs>;
 
   /** Fired just before a row becomes out of viewport range (you can use this event to save inner Grid State before it gets destroyed) */
-  onBeforeRowOutOfViewportRange: SlickEvent<OnRowOutOfViewportRangeArgs>;
+  onBeforeRowOutOfViewportRange: SlickEvent<OnRowBackOrOutOfViewportRangeArgs>;
 
   /** Fired after the row detail gets toggled */
-  onRowBackToViewportRange?: SlickEvent<OnRowBackToViewportRangeArgs>;
+  onRowBackToViewportRange?: SlickEvent<OnRowBackOrOutOfViewportRangeArgs>;
 
   /** Fired after a row becomes out of viewport range (user can't see the row anymore) */
-  onRowOutOfViewportRange?: SlickEvent<OnRowOutOfViewportRangeArgs>;
+  onRowOutOfViewportRange?: SlickEvent<OnRowBackOrOutOfViewportRangeArgs>;
 }

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -6,10 +6,9 @@ import type {
   GridOption,
   OnAfterRowDetailToggleArgs,
   OnBeforeRowDetailToggleArgs,
-  OnRowBackToViewportRangeArgs,
+  OnRowBackOrOutOfViewportRangeArgs,
   OnRowDetailAsyncEndUpdateArgs,
   OnRowDetailAsyncResponseArgs,
-  OnRowOutOfViewportRangeArgs,
   PubSubService,
   RowDetailView,
   RowDetailViewOption,
@@ -45,13 +44,13 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   onBeforeRowDetailToggle: SlickEvent<OnBeforeRowDetailToggleArgs>;
 
   /** Fired just before a row becomes out of viewport range (you can use this event to save inner Grid State before it gets destroyed) */
-  onBeforeRowOutOfViewportRange: SlickEvent<OnRowOutOfViewportRangeArgs>;
+  onBeforeRowOutOfViewportRange: SlickEvent<OnRowBackOrOutOfViewportRangeArgs>;
 
   /** Fired after the row detail gets toggled */
-  onRowBackToViewportRange: SlickEvent<OnRowBackToViewportRangeArgs>;
+  onRowBackToViewportRange: SlickEvent<OnRowBackOrOutOfViewportRangeArgs>;
 
   /** Fired after a row becomes out of viewport range (when user can't see the row anymore) */
-  onRowOutOfViewportRange: SlickEvent<OnRowOutOfViewportRangeArgs>;
+  onRowOutOfViewportRange: SlickEvent<OnRowBackOrOutOfViewportRangeArgs>;
 
   // --
   // protected props
@@ -95,9 +94,9 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     this.onAsyncResponse = new SlickEvent<OnRowDetailAsyncResponseArgs>('onAsyncResponse');
     this.onAfterRowDetailToggle = new SlickEvent<OnAfterRowDetailToggleArgs>('onAfterRowDetailToggle');
     this.onBeforeRowDetailToggle = new SlickEvent<OnBeforeRowDetailToggleArgs>('onBeforeRowDetailToggle');
-    this.onBeforeRowOutOfViewportRange = new SlickEvent<OnRowOutOfViewportRangeArgs>('onBeforeRowOutOfViewportRange');
-    this.onRowBackToViewportRange = new SlickEvent<OnRowBackToViewportRangeArgs>('onRowBackToViewportRange');
-    this.onRowOutOfViewportRange = new SlickEvent<OnRowOutOfViewportRangeArgs>('onRowOutOfViewportRange');
+    this.onBeforeRowOutOfViewportRange = new SlickEvent<OnRowBackOrOutOfViewportRangeArgs>('onBeforeRowOutOfViewportRange');
+    this.onRowBackToViewportRange = new SlickEvent<OnRowBackOrOutOfViewportRangeArgs>('onRowBackToViewportRange');
+    this.onRowOutOfViewportRange = new SlickEvent<OnRowBackOrOutOfViewportRangeArgs>('onRowOutOfViewportRange');
   }
 
   get addonOptions(): RowDetailView {


### PR DESCRIPTION
- Row Detail `parent` prop renamed to `parentRef`
- merge `OnRowBackToViewportRangeArgs` and `OnRowOutOfViewportRangeArgs` both have the same props, so let's merge them into a new single `OnRowBackOrOutOfViewportRangeArgs` interface