### PR TITLE
feat: Ctrl+C to copy active cell to clipboard

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -9,7 +9,10 @@ import { SlickEventData, SlickGlobalEditorLock } from '../slickCore.js';
 import { SlickDataView } from '../slickDataview.js';
 import { SlickGrid } from '../slickGrid.js';
 
+vi.mock('../../formatters/formatterUtilities.js');
 vi.useFakeTimers();
+
+import { copyCellToClipboard } from '../../formatters/formatterUtilities.js';
 
 const pubSubServiceStub = {
   publish: vi.fn(),
@@ -6715,6 +6718,27 @@ describe('SlickGrid core file', () => {
     });
 
     describe('Keydown Events', () => {
+      it('should copy cell value to clipboard when triggering Ctrl+C key', () => {
+        const columns = [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age', editorClass: InputEditor },
+        ] as Column[];
+        grid = new SlickGrid<any, Column>(container, items, columns, {
+          ...defaultOptions,
+          enableCellNavigation: true,
+          enableExcelCopyBuffer: false,
+          editable: true,
+        });
+        const onKeyDownSpy = vi.spyOn(grid.onKeyDown, 'notify');
+        const event = new CustomEvent('keydown');
+        Object.defineProperty(event, 'key', { writable: true, value: 'C' });
+        Object.defineProperty(event, 'ctrlKey', { writable: true, value: true });
+        container.querySelector('.grid-canvas-left')!.dispatchEvent(event);
+
+        expect(onKeyDownSpy).toHaveBeenCalled();
+        expect(copyCellToClipboard).toHaveBeenCalled();
+      });
+
       it('should call navigateRowStart() when triggering Home key', () => {
         const columns = [
           { id: 'name', field: 'name', name: 'Name' },

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -96,6 +96,7 @@ import type {
   ElementPosition,
 } from '../interfaces/index.js';
 import type { SlickDataView } from './slickDataview.js';
+import { copyCellToClipboard } from '../formatters/formatterUtilities.js';
 
 /**
  * @license
@@ -5543,7 +5544,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     let handled: boolean | undefined | void = retval.isImmediatePropagationStopped();
 
     if (!handled) {
-      if (!e.shiftKey && !e.altKey) {
+      if (this._options.enableCellNavigation && e.ctrlKey && e.key.toLowerCase() === 'c' && !this._options.enableExcelCopyBuffer) {
+        // Ctrl+C (copy cell to clipboard, unless Excel Copy Buffer is enabled)
+        copyCellToClipboard({
+          grid: this as unknown as SlickGrid,
+          cell: this.activeCell,
+          row: this.activeRow,
+          column: this.columns[this.activeCell],
+          dataContext: this.getDataItem(this.activeRow),
+        });
+      } else if (!e.shiftKey && !e.altKey) {
         // editor may specify an array of keys to bubble
         if (this._options.editable && this.currentEditor?.keyCaptureList) {
           if (this.currentEditor.keyCaptureList.indexOf(e.which) > -1) {
@@ -5565,6 +5575,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         }
       }
     }
+
     if (!handled) {
       if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
         if (e.key === 'Escape') {

--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -126,12 +126,10 @@ describe('CellExternalCopyManager', () => {
   describe('registered addon', () => {
     beforeEach(() => {
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
-      const clipboard = {
+      (navigator as any).clipboard = {
         readText: vi.fn(() => Promise.resolve('')),
         writeText: vi.fn(() => Promise.resolve()),
       };
-
-      (navigator as any).clipboard = clipboard;
     });
 
     afterEach(() => {

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -186,6 +186,10 @@ describe('ContextMenu Plugin', () => {
     sharedService.dataView = dataViewStub;
     sharedService.slickGrid = gridStub;
 
+    (navigator as any).clipboard = {
+      readText: vi.fn(() => Promise.resolve('')),
+      writeText: vi.fn(() => Promise.resolve()),
+    };
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
     vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
@@ -194,6 +198,7 @@ describe('ContextMenu Plugin', () => {
 
   afterEach(() => {
     plugin?.dispose();
+    delete (navigator as any).clipboard;
   });
 
   it('should create the plugin', () => {
@@ -827,8 +832,6 @@ describe('ContextMenu Plugin', () => {
               commonAncestorContainer: { nodeName: 'BODY', ownerDocument: document },
             }) as any;
 
-          window.document.execCommand = () => true;
-
           window.getSelection = () =>
             ({
               removeAllRanges: () => {},
@@ -844,7 +847,7 @@ describe('ContextMenu Plugin', () => {
 
       // -- Copy to Clipboard -- //
       it('should populate menuCommandItems with Copy cell action when "hideCopyCellValueCommand" is disabled', () => {
-        const execSpy = vi.spyOn(window.document, 'execCommand');
+        const writeSpy = navigator.clipboard.writeText;
         gridOptionsMock.contextMenu!.hideCopyCellValueCommand = false;
         plugin.dispose();
         plugin.init({ commandItems: [], hideCopyCellValueCommand: false });
@@ -866,7 +869,7 @@ describe('ContextMenu Plugin', () => {
 
         commandItemElm1.dispatchEvent(new CustomEvent('click'));
 
-        expect(execSpy).toHaveBeenCalledWith('copy', false, 'Doe');
+        expect(writeSpy).toHaveBeenCalledWith('Doe');
       });
 
       it('should call "copyToClipboard", WITH export formatter, when the command triggered is "copy"', () => {
@@ -879,7 +882,8 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName', formatter: myUppercaseFormatter } as Column;
         const dataContextMock = { id: 123, firstName: 'John', lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const execSpy = vi.spyOn(window.document, 'execCommand');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        const writeSpy = navigator.clipboard.writeText;
         plugin.dispose();
         plugin.init({ commandItems: [] });
         plugin.init({ commandItems: [] });
@@ -898,7 +902,7 @@ describe('ContextMenu Plugin', () => {
           value: 'John',
         });
 
-        expect(execSpy).toHaveBeenCalledWith('copy', false, 'JOHN');
+        expect(writeSpy).toHaveBeenCalledWith('JOHN');
       });
 
       it('should call "copyToClipboard", with a number when the command triggered is "copy" and expect it to be copied without transformation', () => {
@@ -911,7 +915,8 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'age', name: 'Age', field: 'age' } as Column;
         const dataContextMock = { id: 123, firstName: 'John', lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const execSpy = vi.spyOn(window.document, 'execCommand');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        const writeSpy = navigator.clipboard.writeText;
         plugin.dispose();
         plugin.init({ commandItems: [] });
         plugin.init({ commandItems: [] });
@@ -930,7 +935,7 @@ describe('ContextMenu Plugin', () => {
           value: 50,
         });
 
-        expect(execSpy).toHaveBeenCalledWith('copy', false, 50);
+        expect(writeSpy).toHaveBeenCalledWith(50);
       });
 
       it('should call "copyToClipboard" and get the value even when there is a "queryFieldNameGetterFn" callback defined when the command triggered is "copy"', () => {
@@ -944,7 +949,8 @@ describe('ContextMenu Plugin', () => {
         columnsMock[firstNameColIdx] = { id: 'firstName', name: 'First Name', field: 'firstName', queryFieldNameGetterFn: () => 'lastName' } as Column;
         vi.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: firstNameColIdx, row: 1 });
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const execSpy = vi.spyOn(window.document, 'execCommand');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        const writeSpy = navigator.clipboard.writeText;
         plugin.dispose();
         plugin.init({ commandItems: [], hideCopyCellValueCommand: false });
         gridStub.onContextMenu.notify({ grid: gridStub }, eventData, gridStub);
@@ -960,7 +966,7 @@ describe('ContextMenu Plugin', () => {
         expect(commandItemElm1.classList.contains('slick-menu-item-disabled')).toBeFalsy();
 
         commandItemElm1.dispatchEvent(new CustomEvent('click'));
-        expect(execSpy).toHaveBeenCalledWith('copy', false, 'Doe');
+        expect(writeSpy).toHaveBeenCalledWith('Doe');
       });
 
       it('should call "copyToClipboard" and get the value even when there is a "queryFieldNameGetterFn" callback defined when the command triggered is "copy"', () => {
@@ -973,7 +979,8 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName', queryFieldNameGetterFn: () => 'lastName' } as Column;
         const dataContextMock = { id: 123, firstName: 'John', lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const execSpy = vi.spyOn(window.document, 'execCommand');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        const writeSpy = navigator.clipboard.writeText;
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -991,7 +998,7 @@ describe('ContextMenu Plugin', () => {
           value: 'John',
         });
 
-        expect(execSpy).toHaveBeenCalledWith('copy', false, 'Doe');
+        expect(writeSpy).toHaveBeenCalledWith('Doe');
       });
 
       it('should call "copyToClipboard" and get the value even when there is a "queryFieldNameGetterFn" callback defined with dot notation the command triggered is "copy"', () => {
@@ -1004,7 +1011,8 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName', queryFieldNameGetterFn: () => 'user.lastName' } as Column;
         const dataContextMock = { id: 123, user: { firstName: '\u034f\u034fJohn', lastName: '\u034f\u034f Doe', age: 50 } };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const execSpy = vi.spyOn(window.document, 'execCommand');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        const writeSpy = navigator.clipboard.writeText;
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1022,7 +1030,7 @@ describe('ContextMenu Plugin', () => {
           value: 'John',
         });
 
-        expect(execSpy).toHaveBeenCalledWith('copy', false, 'Doe');
+        expect(writeSpy).toHaveBeenCalledWith('Doe');
       });
 
       it('should expect "itemUsabilityOverride" callback from the "copy" command to return True when a value to copy is found in the dataContext object', () => {
@@ -1035,6 +1043,7 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName' } as Column;
         const dataContextMock = { id: 123, firstName: 'John', lastName: '·\u034f ⮞   Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1062,6 +1071,7 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName' } as Column;
         const dataContextMock = { id: 123, firstName: '', lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1089,6 +1099,7 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName' } as Column;
         const dataContextMock = { id: 123, firstName: null, lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1116,6 +1127,7 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName' } as Column;
         const dataContextMock = { id: 123, lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1143,6 +1155,7 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName', queryFieldNameGetterFn: () => 'lastName' } as Column;
         const dataContextMock = { id: 123, firstName: null, lastName: 'Doe', age: 50 };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1170,6 +1183,7 @@ describe('ContextMenu Plugin', () => {
         const columnMock = { id: 'firstName', name: 'First Name', field: 'user.firstName', queryFieldNameGetterFn: () => 'user.lastName' } as Column;
         const dataContextMock = { id: 123, user: { firstName: null, lastName: 'Doe', age: 50 } };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1196,6 +1210,7 @@ describe('ContextMenu Plugin', () => {
           contextMenu: { hideCopyCellValueCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: false },
         } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         vi.spyOn(SharedService.prototype, 'externalRegisteredResources', 'get').mockReturnValue([]);
         plugin.dispose();
         plugin.init({ commandItems: [] });
@@ -1216,6 +1231,7 @@ describe('ContextMenu Plugin', () => {
           contextMenu: { hideCopyCellValueCommand: true, hideExportCsvCommand: false, hideExportExcelCommand: true },
         } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         vi.spyOn(SharedService.prototype, 'externalRegisteredResources', 'get').mockReturnValue([]);
         plugin.dispose();
         plugin.init({ commandItems: [] });
@@ -1236,6 +1252,7 @@ describe('ContextMenu Plugin', () => {
           contextMenu: { hideCopyCellValueCommand: true, hideExportCsvCommand: false, hideExportExcelCommand: true },
         } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1256,6 +1273,7 @@ describe('ContextMenu Plugin', () => {
           contextMenu: { hideCopyCellValueCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: false },
         } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         vi.spyOn(SharedService.prototype, 'externalRegisteredResources', 'get').mockReturnValue([excelExportServiceStub]);
         plugin.dispose();
         plugin.init({ commandItems: [{ command: 'export-excel' }] }); // add fake command to test with .some()
@@ -1278,6 +1296,7 @@ describe('ContextMenu Plugin', () => {
           contextMenu: { hideCopyCellValueCommand: true, hideExportCsvCommand: false, hideExportExcelCommand: true },
         } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         vi.spyOn(SharedService.prototype, 'externalRegisteredResources', 'get').mockReturnValue([exportServiceStub]);
         plugin.dispose();
         plugin.init({ commandItems: [{ command: 'export-csv' }], hideExportCsvCommand: false }); // add fake command to test with .some()
@@ -1303,6 +1322,7 @@ describe('ContextMenu Plugin', () => {
           contextMenu: { hideCopyCellValueCommand: true, hideExportCsvCommand: false, hideExportExcelCommand: true },
         } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         vi.spyOn(SharedService.prototype, 'externalRegisteredResources', 'get').mockReturnValue([exportServiceStub]);
         plugin.init({ commandItems: [{ command: 'export-text-delimited' }] }); // add fake command to test with .some()
         plugin.init(); // calling init the 2nd time will replace the previous line init+command
@@ -1321,6 +1341,7 @@ describe('ContextMenu Plugin', () => {
       it('should call "setGrouping" from the DataView when Grouping is enabled and the command triggered is "clear-grouping"', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
         plugin.dispose();
         plugin.init({ commandItems: [{ command: 'clear-grouping' }] }); // add fake command to test with .some()
@@ -1338,6 +1359,7 @@ describe('ContextMenu Plugin', () => {
       it('should call "collapseAllGroups" from the DataView when Grouping is enabled and the command triggered is "collapse-all-groups"', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideCollapseAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
 
         plugin.dispose();
@@ -1358,6 +1380,7 @@ describe('ContextMenu Plugin', () => {
         const treeDataSpy = vi.spyOn(treeDataServiceStub, 'toggleTreeDataCollapse');
         const copyGridOptionsMock = { ...gridOptionsMock, enableTreeData: true, contextMenu: { hideCollapseAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
         plugin.init();
@@ -1373,6 +1396,7 @@ describe('ContextMenu Plugin', () => {
       it('should call "expandAllGroups" from the DataView when Grouping is enabled and the command triggered is "expand-all-groups"', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideExpandAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
 
         plugin.dispose();
@@ -1393,6 +1417,7 @@ describe('ContextMenu Plugin', () => {
         vi.spyOn(sharedService.dataView, 'getItems').mockReturnValueOnce(columnsMock);
         const copyGridOptionsMock = { ...gridOptionsMock, enableTreeData: true, contextMenu: { hideExpandAllGroups: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1407,6 +1432,7 @@ describe('ContextMenu Plugin', () => {
       it('should expect "itemUsabilityOverride" callback on all the Grouping command to return False when there are NO Groups in the grid', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         const dataviewSpy = vi.spyOn(sharedService.dataView, 'getGrouping').mockReturnValue([]);
         plugin.dispose();
         plugin.init({ commandItems: [] });
@@ -1433,6 +1459,7 @@ describe('ContextMenu Plugin', () => {
       it('should expect "itemUsabilityOverride" callback on all the Grouping command to return True when there are Groups defined in the grid', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableGrouping: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         const dataviewSpy = vi.spyOn(sharedService.dataView, 'getGrouping').mockReturnValue([{ collapsed: true }]);
         plugin.dispose();
         plugin.init({ commandItems: [] });
@@ -1459,6 +1486,7 @@ describe('ContextMenu Plugin', () => {
       it('should expect "itemUsabilityOverride" callback on all the Tree Data Grouping command to return Tree (collapse, expand) at all time even when there are NO Groups in the grid', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableTreeData: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 
@@ -1478,6 +1506,7 @@ describe('ContextMenu Plugin', () => {
       it('should expect "itemUsabilityOverride" callback on all the Tree Data Grouping command to return True (collapse, expand) when there are Groups defined in the grid', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableTreeData: true, contextMenu: { hideClearAllGrouping: false } } as GridOption;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();
         plugin.init({ commandItems: [] });
 

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -16,7 +16,7 @@ import {
   getTranslationPrefix,
   type TextExportService,
 } from '../services/index.js';
-import { exportWithFormatterWhenDefined } from '../formatters/formatterUtilities.js';
+import { copyCellToClipboard } from '../formatters/formatterUtilities.js';
 import type { ExtensionUtility } from '../extensions/extensionUtility.js';
 import type { SharedService } from '../services/shared.service.js';
 import type { TreeDataService } from '../services/treeData.service.js';
@@ -183,9 +183,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
           disabled: false,
           command: commandName,
           positionOrder: 50,
-          action: (_e, args) => {
-            this.copyToClipboard(args as MenuCommandItemCallbackArgs);
-          },
+          action: (_e, args) => copyCellToClipboard(args as MenuCommandItemCallbackArgs),
           itemUsabilityOverride: (args: MenuCallbackArgs) => {
             // make sure there's an item to copy before enabling this command
             const columnDef = args?.column as Column;
@@ -380,56 +378,6 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
 
     this.extensionUtility.translateMenuItemsFromTitleKey(menuCommandItems);
     return menuCommandItems;
-  }
-
-  /**
-   * First get the value, if "exportWithFormatter" is set then we'll use the formatter output
-   * Then we create the DOM trick to copy a text value by creating a fake <div> that is not shown to the user
-   * and from there we can call the execCommand 'copy' command and expect the value to be in clipboard
-   * @param args
-   */
-  protected copyToClipboard(args: MenuCommandItemCallbackArgs): void {
-    try {
-      if (args && args.grid && args.command) {
-        // get the value, if "exportWithFormatter" is set then we'll use the formatter output
-        const gridOptions = this.sharedService?.gridOptions ?? {};
-        const cell = args?.cell ?? 0;
-        const row = args?.row ?? 0;
-        const columnDef = args?.column;
-        const dataContext = args?.dataContext;
-        const grid = this.sharedService?.slickGrid;
-        const exportOptions = gridOptions && (gridOptions.excelExportOptions || gridOptions.textExportOptions);
-        let textToCopy = exportWithFormatterWhenDefined(row, cell, columnDef, dataContext, grid, exportOptions);
-        if (typeof columnDef.queryFieldNameGetterFn === 'function') {
-          textToCopy = getCellValueFromQueryFieldGetter(columnDef, dataContext, '');
-        }
-        let finalTextToCopy = textToCopy;
-
-        // when it's a string, we'll remove any unwanted Tree Data/Grouping symbols from the beginning (if exist) from the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
-        if (typeof textToCopy === 'string') {
-          finalTextToCopy = textToCopy
-            .replace(/^([·|⮞|⮟]\s*)|([·|⮞|⮟])\s*/gi, '')
-            // eslint-disable-next-line
-            .replace(/[\u00b7|\u034f]/gi, '')
-            .trim();
-        }
-
-        // create fake <textarea> (positioned outside of the screen) to copy into clipboard & delete it from the DOM once we're done
-        const tmpElem = document.createElement('textarea');
-        if (tmpElem && document.body) {
-          tmpElem.style.position = 'absolute';
-          tmpElem.style.opacity = '0';
-          tmpElem.value = finalTextToCopy;
-          document.body.appendChild(tmpElem);
-          tmpElem.select();
-          if (document.execCommand('copy', false, finalTextToCopy)) {
-            tmpElem.remove();
-          }
-        }
-      }
-    } catch (e) {
-      /* v8 ignore next - do nothing */
-    }
   }
 
   /** sort all menu items by their position order when defined */


### PR DESCRIPTION
- when using Ctrl+C on an active cell, it should copy its content but only when the grid options `enableCellNavigation` is enabled but `enableExcelCopyBuffer` is disabled. We simply shouldn't use it when Excel Copy Buffer is enabled because it could conflict with each others. 
- also remove `navigator.clipboard` API instead of using a temp `textarea` to copy the value