### PR TITLE
chore: add Angular-Slickgrid codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          flags: universal
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: test/vitest-coverage
           verbose: true

--- a/.github/workflows/test-angular.yml
+++ b/.github/workflows/test-angular.yml
@@ -70,6 +70,16 @@ jobs:
         if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
         run: pnpm angular:test:coverage
 
+      - name: Upload Angular Vitest coverage to Codecov
+        if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: frameworks/angular-slickgrid/coverage
+          verbose: true
+
       - name: Angular-Slickgrid Framework Build
         run: pnpm angular:build:framework
 

--- a/.github/workflows/test-angular.yml
+++ b/.github/workflows/test-angular.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          flags: angular
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: frameworks/angular-slickgrid/coverage
           verbose: true


### PR DESCRIPTION
Add codecov flags to show coverage and separation for both Angular & Vanilla folders which are the only 2 that have unit tests

![image](https://github.com/user-attachments/assets/b8b7b51a-1af9-443e-8600-ad338e9374bb)
