### PR TITLE
feat(filter): add `collectionLazy` callback to Column Filter

### DIFF
--- a/demos/vanilla/src/examples/example16.html
+++ b/demos/vanilla/src/examples/example16.html
@@ -19,11 +19,16 @@
   </div>
 </h3>
 
-<div class="row mb-3">
-  <span>
-    <label for="server-delay">Simulated Server Delay (ms): </label>
-    <input type="number" id="server-delay" class="is-narrow input is-small" data-test="server-delay" value.bind="serverApiDelay" />
-  </span>
+<div class="columns row mb-3 no-margin">
+  <div class="column">
+    <span>
+      <label for="server-delay">Simulated Server Delay (ms): </label>
+      <input type="number" id="server-delay" class="is-narrow input is-small" data-test="server-delay" value.bind="serverApiDelay" />
+    </span>
+  </div>
+  <div class="column invisible is-4" class.bind="notificationContainerClass" data-test="alert-lazy">
+    <div class="notification is-info is-light is-narrow">Lazy loading collection...</div>
+  </div>
 </div>
 
 <div class="grid16"></div>

--- a/demos/vanilla/src/examples/example16.ts
+++ b/demos/vanilla/src/examples/example16.ts
@@ -21,6 +21,8 @@ import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanil
 import { ExampleGridOptions } from './example-grid-options.js';
 import './example16.scss';
 
+const NB_ITEMS = 1000;
+
 export default class Example16 {
   private _bindingEventService: BindingEventService;
   private _darkMode = false;
@@ -28,7 +30,8 @@ export default class Example16 {
   gridOptions: GridOption;
   dataset: any[];
   editCommandQueue: EditCommand[] = [];
-  serverApiDelay = 500;
+  serverApiDelay = 1000;
+  notificationContainerClass = 'column invisible is-4';
   sgb: SlickVanillaGridBundle;
   loadingClass = '';
 
@@ -38,7 +41,7 @@ export default class Example16 {
 
   attached() {
     this.initializeGrid();
-    this.dataset = this.loadData(500);
+    this.dataset = this.loadData(NB_ITEMS);
     const gridContainerElm = document.querySelector<HTMLDivElement>(`.grid16`) as HTMLDivElement;
 
     this._bindingEventService.bind(
@@ -327,11 +330,17 @@ export default class Example16 {
         },
         filter: {
           // collectionAsync: fetch(SAMPLE_COLLECTION_DATA_URL),
-          collectionAsync: new Promise((resolve) => {
-            window.setTimeout(() => {
-              resolve(Array.from(Array((this.dataset || []).length).keys()).map((k) => ({ value: k, label: `Task ${k}` })));
+          collectionLazy: () => {
+            this.notificationContainerClass = 'column is-4';
+
+            return new Promise((resolve) => {
+              window.setTimeout(() => {
+                this.notificationContainerClass = 'column invisible is-4';
+                resolve(Array.from(Array((this.dataset || []).length).keys()).map((k) => ({ value: k, label: `Task ${k}` })));
+              }, this.serverApiDelay);
             });
-          }),
+          },
+          // onInstantiated: (msSelect) => console.log('ms-select instance', msSelect),
           customStructure: {
             label: 'label',
             value: 'value',
@@ -339,6 +348,9 @@ export default class Example16 {
           },
           collectionOptions: {
             separatorBetweenTextLabels: ' ',
+          },
+          filterOptions: {
+            minHeight: 70,
           },
           model: Filters.multipleSelect,
           operator: OperatorType.inContains,

--- a/demos/vanilla/src/styles.scss
+++ b/demos/vanilla/src/styles.scss
@@ -68,6 +68,10 @@ body {
   color: #ccc;
 }
 
+.invisible {
+  opacity: 0;
+}
+
 .github-button-container {
   position: relative;
   top: 18px;
@@ -84,7 +88,7 @@ body {
   margin-top: -15px;
 }
 .notification.is-narrow {
-  padding: 0.75rem 1rem;
+  padding: 0.6rem 1rem;
 }
 input.is-narrow {
   width: 60px;

--- a/demos/vue/src/styles.scss
+++ b/demos/vue/src/styles.scss
@@ -42,6 +42,9 @@ $primary-color: #0e6cfa;
 .hidden {
   display: none;
 }
+.invisible {
+  opacity: 0;
+}
 
 .btn-icon {
   display: inline-flex;

--- a/demos/vue/test/cypress/e2e/example33.cy.ts
+++ b/demos/vue/test/cypress/e2e/example33.cy.ts
@@ -28,7 +28,7 @@ describe('Example 33 - Regular & Custom Tooltips', () => {
   });
 
   it('should change server delay to 10ms for faster testing', () => {
-    cy.get('[data-test="server-delay"]').type('{backspace}{backspace}{backspace}10');
+    cy.get('[data-test="server-delay"]').clear().type('50');
   });
 
   it('should mouse over 1st row checkbox column and NOT expect any tooltip to show since it is disabled on that column', () => {
@@ -208,11 +208,20 @@ describe('Example 33 - Regular & Custom Tooltips', () => {
     cy.get('@finish-filter').trigger('mouseout');
   });
 
+  it('should open PreRequisite dropdown and expect it be lazily loaded', () => {
+    cy.get('.slick-headerrow-columns .slick-headerrow-column:nth(10)').as('checkbox10-header');
+    cy.get('@checkbox10-header').click();
+    cy.get('[data-test="alert-lazy"]').should('be.visible');
+    cy.wait(50);
+    cy.get('@checkbox10-header').click();
+    cy.get('[data-test="alert-lazy"]').should('not.be.visible');
+  });
+
   it('should mouse over header-row (filter) Prerequisite column and expect to see tooltip of selected filter options', () => {
-    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(10)`).as('checkbox10-header');
+    cy.get('.slick-headerrow-columns .slick-headerrow-column:nth(10)').as('checkbox10-header');
     cy.get('@checkbox10-header').trigger('mouseover');
 
-    cy.get('.filter-prerequisites .ms-choice span').contains('15 of 500 selected');
+    cy.get('.filter-prerequisites .ms-choice span').contains('15 of 1000 selected');
     cy.get('.slick-custom-tooltip').should('be.visible');
     cy.get('.slick-custom-tooltip').contains(
       'Task 1, Task 3, Task 5, Task 7, Task 9, Task 12, Task 15, Task 18, Task 21, Task 25, Task 28, Task 29, Task 30, Task 32, Task 34'
@@ -222,7 +231,7 @@ describe('Example 33 - Regular & Custom Tooltips', () => {
   });
 
   it('should mouse over header title on 1st column with checkbox and NOT expect any tooltip to show since it is disabled on that column', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(0)`).as('checkbox-header');
+    cy.get('.slick-header-columns .slick-header-column:nth(0)').as('checkbox-header');
     cy.get('@checkbox-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');
@@ -230,7 +239,7 @@ describe('Example 33 - Regular & Custom Tooltips', () => {
   });
 
   it('should mouse over header title on 2nd column with Title name and expect a tooltip to show rendered from an headerFormatter', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(1)`).as('checkbox0-header');
+    cy.get('.slick-header-columns .slick-header-column:nth(1)').as('checkbox0-header');
     cy.get('@checkbox0-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('be.visible');
@@ -243,7 +252,7 @@ describe('Example 33 - Regular & Custom Tooltips', () => {
   });
 
   it('should mouse over header title on 2nd column with Finish name and NOT expect any tooltip to show since it is disabled on that column', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(8)`).as('finish-header');
+    cy.get('.slick-header-columns .slick-header-column:nth(8)').as('finish-header');
     cy.get('@finish-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');

--- a/docs/column-functionalities/editors/Select-Dropdown-Editor-(single,multiple).md
+++ b/docs/column-functionalities/editors/Select-Dropdown-Editor-(single,multiple).md
@@ -181,7 +181,7 @@ this.columnDefinitions = [
 ```
 
 ### Collection Watch
-Sometime you wish that whenever you change your filter collection, you'd like the filter to be updated, it won't do that by default but you could use `enableCollectionWatch` for that purpose to add collection observers and re-render the Filter DOM element whenever the collection changes. Also note that using `collectionAsync` will automatically watch for changes, so there's no need to enable this flag for that particular use case.
+Sometime you wish that whenever you make a change in your filter collection, you'd like the filter to be updated but it won't do that by default. You could use `enableCollectionWatch` for that purpose which will add a collection observers and re-render the Filter DOM element whenever the collection changes. Also note that using `collectionAsync` will automatically watch for changes, so there's no need to enable this flag for that particular use case.
 
 ```typescript
 this.columnDefinitions = [

--- a/docs/column-functionalities/filters/select-filter.md
+++ b/docs/column-functionalities/filters/select-filter.md
@@ -6,15 +6,16 @@
 - [How to add Translation](#how-to-add-translation)
 - [How to filter empty values](#how-to-filter-empty-values)
 - Collection Options
-   - [Add Blank Entry](#collection-add-blank-entry)
-   - [Add Custom Entry at Beginning/End of Collection](#collection-add-custom-entry-at-the-beginningend-of-the-collection)
-   - [Custom Structure](#custom-structure-keylabel-pair)
-   - [Custom Structure with Translation](#custom-structure-with-translation)
-   - [Collection filterBy/sortBy](#collection-filterbysortby)
-   - [Collection Label Prefix/Suffix](#collection-label-prefixsuffix)
-   - [Collection Label Render HTML](#collection-label-render-html)
-   - [Collection Async Load](#collection-async-load)
-   - [Collection Watch](#collection-watch)
+  - [Add Blank Entry](#collection-add-blank-entry)
+  - [Add Custom Entry at Beginning/End of Collection](#collection-add-custom-entry-at-the-beginningend-of-the-collection)
+  - [Custom Structure](#custom-structure-keylabel-pair)
+  - [Custom Structure with Translation](#custom-structure-with-translation)
+  - [Collection filterBy/sortBy](#collection-filterbysortby)
+  - [Collection Label Prefix/Suffix](#collection-label-prefixsuffix)
+  - [Collection Label Render HTML](#collection-label-render-html)
+  - [Collection Async Load](#collection-async-load)
+  - [Collection Lazy Load](#collection-lazy-load)
+  - [Collection Watch](#collection-watch)
 - [`multiple-select.js` Options](#multiple-selectjs-options)
   - [Filter Options (`MultipleSelectOption` interface)](#filter-options-multipleselectoption-interface)
   - [Display shorter selected label text](#display-shorter-selected-label-text)
@@ -534,6 +535,24 @@ For example
       }
     }, 250);
   }
+```
+
+### Collection Lazy Load
+In some cases, you might have a grid with a lot of columns and loading the collection only after opening the select dropdown (or never in some cases) might help speeding up the initial grid loading. So for that use case, defining a `collectionLazy` callback can help.
+
+#### Load the collection through an Http callback
+
+```ts
+this.columnDefinitions = [
+    {
+    id: 'prerequisites', name: 'Prerequisites', field: 'prerequisites',
+    filterable: true,
+    filter: {
+      collectionLazy: (col: Column) => this.http.fetch('api/data/pre-requisites'),
+      model: Filters.multipleSelect,
+    }
+  }
+];
 ```
 
 ### Collection Watch

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
@@ -6,15 +6,16 @@
 - [How to add Translation](#how-to-add-translation)
 - [How to filter empty values](#how-to-filter-empty-values)
 - Collection Options
-   - [Add Blank Entry](#collection-add-blank-entry)
-   - [Add Custom Entry at Beginning/End of Collection](#collection-add-custom-entry-at-the-beginningend-of-the-collection)
-   - [Custom Structure](#custom-structure-keylabel-pair)
-   - [Custom Structure with Translation](#custom-structure-with-translation)
-   - [Collection filterBy/sortBy](#collection-filterbysortby)
-   - [Collection Label Prefix/Suffix](#collection-label-prefixsuffix)
-   - [Collection Label Render HTML](#collection-label-render-html)
-   - [Collection Async Load](#collection-async-load)
-   - [Collection Watch](#collection-watch)
+  - [Add Blank Entry](#collection-add-blank-entry)
+  - [Add Custom Entry at Beginning/End of Collection](#collection-add-custom-entry-at-the-beginningend-of-the-collection)
+  - [Custom Structure](#custom-structure-keylabel-pair)
+  - [Custom Structure with Translation](#custom-structure-with-translation)
+  - [Collection filterBy/sortBy](#collection-filterbysortby)
+  - [Collection Label Prefix/Suffix](#collection-label-prefixsuffix)
+  - [Collection Label Render HTML](#collection-label-render-html)
+  - [Collection Async Load](#collection-async-load)
+  - [Collection Lazy Load](#collection-lazy-load)
+  - [Collection Watch](#collection-watch)
 - [`multiple-select.js` Options](#multiple-selectjs-options)
   - [Filter Options (`MultipleSelectOption` interface)](#filter-options-multipleselectoption-interface)
   - [Display shorter selected label text](#display-shorter-selected-label-text)
@@ -546,6 +547,24 @@ function addItem() {
     }
   }, 250);
 }
+```
+
+### Collection Lazy Load
+In some cases, you might have a grid with a lot of columns and loading the collection only after opening the select dropdown (or never in some cases) might help speeding up the initial grid loading. So for that use case, defining a `collectionLazy` callback can help.
+
+#### Load the collection through an Http callback
+
+```ts
+columnDefinitions.value = [
+    {
+    id: 'prerequisites', name: 'Prerequisites', field: 'prerequisites',
+    filterable: true,
+    filter: {
+      collectionLazy: (col: Column) => this.http.fetch('api/data/pre-requisites'),
+      model: Filters.multipleSelect,
+    }
+  }
+];
 ```
 
 ### Collection Watch

--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -7,6 +7,8 @@ import type { IOptions, ISelected, FormatDateString } from 'vanilla-calendar-pro
 import { FieldType } from '../enums/fieldType.enum.js';
 import type { AutocompleterOption, Column, ColumnEditor, ColumnFilter } from '../interfaces/index.js';
 import { formatDateByFieldType, mapTempoDateFormatWithFieldType, tryParseDate } from '../services/dateUtils.js';
+import { getDescendantProperty } from '../services/utilities.js';
+import { isObject } from '@slickgrid-universal/utils';
 
 /**
  * add loading class ".slick-autocomplete-loading" to the Kraaden Autocomplete input element
@@ -36,6 +38,21 @@ export function addAutocompleteLoadingByOverridingFetch<T extends AutocompleteIt
       previousFetch!(searchTerm, newUpdateCallback, trigger, cursorPos);
     };
   }
+}
+
+/**
+ * When enabled, get the collection from an object when `collectionInsideObjectProperty` is enabled
+ * @param {*} collection
+ * @param {ColumnFilter} columnFilterOrEditor
+ * @returns {Array}
+ */
+export function getCollectionFromObjectWhenEnabled<T = any>(collection: T, columnFilterOrEditor?: ColumnEditor | ColumnFilter): T {
+  const collectionOptions = columnFilterOrEditor?.collectionOptions ?? {};
+  if (!Array.isArray(collection) && collectionOptions?.collectionInsideObjectProperty && isObject(collection)) {
+    const collectionInsideObjectProperty = collectionOptions.collectionInsideObjectProperty;
+    collection = getDescendantProperty(collection, collectionInsideObjectProperty || '');
+  }
+  return collection;
 }
 
 export function resetDatePicker(pickerInstance: VanillaCalendar): void {

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -19,6 +19,7 @@ import type {
   Locale,
   SelectOption,
 } from './../interfaces/index.js';
+import { getCollectionFromObjectWhenEnabled } from '../commonEditorFilter/commonEditorFilterUtils.js';
 import { buildMsSelectCollectionList, CollectionService, findOrDefault, type TranslaterService } from '../services/index.js';
 import { getDescendantProperty, getTranslationPrefix } from '../services/utilities.js';
 import { SlickEventData, type SlickGrid } from '../core/index.js';
@@ -687,10 +688,7 @@ export class SelectEditor implements Editor {
   }
 
   renderDomElement(inputCollection?: any[]): void {
-    if (!Array.isArray(inputCollection) && this.collectionOptions?.collectionInsideObjectProperty) {
-      const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty;
-      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
-    }
+    inputCollection = getCollectionFromObjectWhenEnabled(inputCollection, this.columnEditor);
     if (!Array.isArray(inputCollection)) {
       throw new Error('The "collection" passed to the Select Editor is not a valid array.');
     }

--- a/packages/common/src/filters/__tests__/selectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/selectFilter.spec.ts
@@ -12,8 +12,6 @@ import { HttpStub } from '../../../../../test/httpClientStub.js';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub.js';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub.js';
 
-vi.useFakeTimers();
-
 const containerId = 'demo-container';
 
 // define a <div> container to simulate the grid container
@@ -729,92 +727,101 @@ describe('SelectFilter', () => {
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, clearFilterTriggered: true, shouldTriggerQuery: false });
   });
 
-  it('should work with English locale when locale is changed', () => {
-    translateService.use('en');
-    gridOptionMock.enableTranslate = true;
-    mockColumn.filter = {
-      enableTranslateLabel: true,
-      collection: [
-        { value: 'other', labelKey: 'OTHER' },
-        { value: 'male', labelKey: 'MALE' },
-        { value: 'female', labelKey: 'FEMALE' },
-      ],
-      filterOptions: { minimumCountSelected: 1 },
-    };
+  it('should work with English locale when locale is changed', () =>
+    new Promise(async (done: any) => {
+      translateService.use('en');
+      gridOptionMock.enableTranslate = true;
+      mockColumn.filter = {
+        enableTranslateLabel: true,
+        collection: [
+          { value: 'other', labelKey: 'OTHER' },
+          { value: 'male', labelKey: 'MALE' },
+          { value: 'female', labelKey: 'FEMALE' },
+        ],
+        filterOptions: { minimumCountSelected: 1 },
+      };
 
-    filterArguments.searchTerms = ['male', 'female'];
-    filter.init(filterArguments);
-    vi.runAllTimers(); // fast-forward timer
+      filterArguments.searchTerms = ['male', 'female'];
+      filter.init(filterArguments);
 
-    const filterSelectAllElm = divContainer.querySelector('.filter-gender .ms-select-all label span') as HTMLSpanElement;
-    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
-    const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
-    const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
-    const filterParentElm = divContainer.querySelector(`.ms-parent.ms-filter.search-filter.filter-gender button`) as HTMLButtonElement;
-    filterBtnElm.click();
+      setTimeout(() => {
+        const filterSelectAllElm = divContainer.querySelector('.filter-gender .ms-select-all label span') as HTMLSpanElement;
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
+        const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+        const filterParentElm = divContainer.querySelector(`.ms-parent.ms-filter.search-filter.filter-gender button`) as HTMLButtonElement;
+        filterBtnElm.click();
 
-    expect(filterListElm.length).toBe(3);
-    expect(filterListElm[0].textContent).toBe('Other');
-    expect(filterListElm[1].textContent).toBe('Male');
-    expect(filterListElm[2].textContent).toBe('Female');
-    expect(filterOkElm.textContent).toBe('OK');
-    expect(filterSelectAllElm.textContent).toBe('Select All');
-    expect(filterParentElm.textContent).toBe('2 of 3 selected');
-  });
+        expect(filterListElm.length).toBe(3);
+        expect(filterListElm[0].textContent).toBe('Other');
+        expect(filterListElm[1].textContent).toBe('Male');
+        expect(filterListElm[2].textContent).toBe('Female');
+        expect(filterOkElm.textContent).toBe('OK');
+        expect(filterSelectAllElm.textContent).toBe('Select All');
+        expect(filterParentElm.textContent).toBe('2 of 3 selected');
+        done();
+      });
+    }));
 
-  it('should work with French locale when locale is changed', () => {
-    translateService.use('fr');
-    gridOptionMock.enableTranslate = true;
-    mockColumn.filter = {
-      enableTranslateLabel: true,
-      collection: [
-        { value: 'other', labelKey: 'OTHER' },
-        { value: 'male', labelKey: 'MALE' },
-        { value: 'female', labelKey: 'FEMALE' },
-      ],
-      filterOptions: { minimumCountSelected: 1 },
-    };
+  it('should work with French locale when locale is changed', () =>
+    new Promise(async (done: any) => {
+      translateService.use('fr');
+      gridOptionMock.enableTranslate = true;
+      mockColumn.filter = {
+        enableTranslateLabel: true,
+        collection: [
+          { value: 'other', labelKey: 'OTHER' },
+          { value: 'male', labelKey: 'MALE' },
+          { value: 'female', labelKey: 'FEMALE' },
+        ],
+        filterOptions: { minimumCountSelected: 1 },
+      };
 
-    filterArguments.searchTerms = ['male', 'female'];
-    filter.init(filterArguments);
-    vi.runAllTimers(); // fast-forward timer
+      filterArguments.searchTerms = ['male', 'female'];
+      filter.init(filterArguments);
 
-    const filterSelectAllElm = divContainer.querySelector('.filter-gender .ms-select-all label span') as HTMLSpanElement;
-    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
-    const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
-    const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
-    const filterParentElm = divContainer.querySelector(`.ms-parent.ms-filter.search-filter.filter-gender button`) as HTMLButtonElement;
-    filterBtnElm.click();
+      setTimeout(() => {
+        const filterSelectAllElm = divContainer.querySelector('.filter-gender .ms-select-all label span') as HTMLSpanElement;
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
+        const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+        const filterParentElm = divContainer.querySelector(`.ms-parent.ms-filter.search-filter.filter-gender button`) as HTMLButtonElement;
+        filterBtnElm.click();
 
-    expect(filterListElm.length).toBe(3);
-    expect(filterListElm[0].textContent).toBe('Autre');
-    expect(filterListElm[1].textContent).toBe('Mâle');
-    expect(filterListElm[2].textContent).toBe('Femme');
-    expect(filterOkElm.textContent).toBe('Terminé');
-    expect(filterSelectAllElm.textContent).toBe('Sélectionner tout');
-    expect(filterParentElm.textContent).toBe('2 de 3 sélectionnés');
-  });
+        expect(filterListElm.length).toBe(3);
+        expect(filterListElm[0].textContent).toBe('Autre');
+        expect(filterListElm[1].textContent).toBe('Mâle');
+        expect(filterListElm[2].textContent).toBe('Femme');
+        expect(filterOkElm.textContent).toBe('Terminé');
+        expect(filterSelectAllElm.textContent).toBe('Sélectionner tout');
+        expect(filterParentElm.textContent).toBe('2 de 3 sélectionnés');
+        done();
+      });
+    }));
 
-  it('should enable Dark Mode and expect ".ms-dark-mode" CSS class to be found on parent element', () => {
-    gridOptionMock.darkMode = true;
-    mockColumn.filter = {
-      enableTranslateLabel: true,
-      collection: [
-        { value: 'other', label: 'Other' },
-        { value: 'male', label: 'Male' },
-        { value: 'female', label: 'Female' },
-      ],
-      filterOptions: { minimumCountSelected: 1 },
-    };
+  it('should enable Dark Mode and expect ".ms-dark-mode" CSS class to be found on parent element', () =>
+    new Promise(async (done: any) => {
+      gridOptionMock.darkMode = true;
+      mockColumn.filter = {
+        enableTranslateLabel: true,
+        collection: [
+          { value: 'other', label: 'Other' },
+          { value: 'male', label: 'Male' },
+          { value: 'female', label: 'Female' },
+        ],
+        filterOptions: { minimumCountSelected: 1 },
+      };
 
-    filterArguments.searchTerms = ['male', 'female'];
-    filter.init(filterArguments);
-    vi.runAllTimers(); // fast-forward timer
+      filterArguments.searchTerms = ['male', 'female'];
+      filter.init(filterArguments);
 
-    const filterElm = divContainer.querySelector('.ms-parent') as HTMLButtonElement;
+      setTimeout(() => {
+        const filterElm = divContainer.querySelector('.ms-parent') as HTMLButtonElement;
 
-    expect(filterElm.classList.contains('ms-dark-mode')).toBeTruthy();
-  });
+        expect(filterElm.classList.contains('ms-dark-mode')).toBeTruthy();
+        done();
+      });
+    }));
 
   it('should create the multi-select filter with a default search term when using "collectionAsync" as a Promise', async () => {
     const spyCallback = vi.spyOn(filterArguments, 'callback');
@@ -918,83 +925,205 @@ describe('SelectFilter', () => {
     expect(filterListElm[2].textContent).toBe('female');
   });
 
-  it('should trigger a re-render of the DOM element when collection is replaced by new collection', async () => {
-    const renderSpy = vi.spyOn(filter, 'renderDomElement');
-    const newCollection = [
-      { value: 'val1', label: 'label1' },
-      { value: 'val2', label: 'label2' },
-    ];
-    const mockDataResponse = [
-      { value: 'female', label: 'Female' },
-      { value: 'male', label: 'Male' },
-    ];
-
-    mockColumn.filter = {
-      collection: [],
-      collectionAsync: Promise.resolve(mockDataResponse),
-      enableCollectionWatch: true,
-    };
-
-    await filter.init(filterArguments);
-    mockColumn.filter!.collection = newCollection;
-    mockColumn.filter!.collection!.push({ value: 'val3', label: 'label3' });
-
-    vi.runAllTimers(); // fast-forward timer
-
-    expect(renderSpy).toHaveBeenCalledTimes(3);
-    expect(renderSpy).toHaveBeenCalledWith(newCollection);
-
-    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
-    const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
-    filterBtnElm.click();
-
-    expect(filterListElm.length).toBe(3);
-    expect(filterListElm[0].textContent).toBe('label1');
-    expect(filterListElm[1].textContent).toBe('label2');
-    expect(filterListElm[2].textContent).toBe('label3');
-  });
-
-  it('should trigger a re-render of the DOM element when collection changes', async () => {
-    const renderSpy = vi.spyOn(filter, 'renderDomElement');
-
-    mockColumn.filter = {
-      collection: [
+  it('should trigger a re-render of the DOM element when collection is replaced by new collection', () =>
+    new Promise(async (done: any) => {
+      const renderSpy = vi.spyOn(filter, 'renderDomElement');
+      const newCollection = [
+        { value: 'val1', label: 'label1' },
+        { value: 'val2', label: 'label2' },
+      ];
+      const mockDataResponse = [
         { value: 'female', label: 'Female' },
         { value: 'male', label: 'Male' },
-      ],
-      enableCollectionWatch: true,
-    };
+      ];
 
-    await filter.init(filterArguments);
-    mockColumn.filter!.collection!.push({ value: 'other', label: 'Other' });
+      mockColumn.filter = {
+        collection: [],
+        collectionAsync: Promise.resolve(mockDataResponse),
+        enableCollectionWatch: true,
+      };
 
-    vi.runAllTimers(); // fast-forward timer
-
-    expect(renderSpy).toHaveBeenCalledTimes(2);
-    expect(renderSpy).toHaveBeenCalledWith(mockColumn.filter!.collection);
-
-    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
-    const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
-    filterBtnElm.click();
-
-    expect(filterListElm.length).toBe(3);
-    expect(filterListElm[0].textContent).toBe('Female');
-    expect(filterListElm[1].textContent).toBe('Male');
-    expect(filterListElm[2].textContent).toBe('Other');
-  });
-
-  it('should throw an error when "collectionAsync" Promise does not return a valid array', async () => {
-    const promise = Promise.resolve({ hello: 'world' });
-    mockColumn.filter!.collectionAsync = promise;
-
-    try {
       await filter.init(filterArguments);
-    } catch (e) {
-      expect(e.toString()).toContain(
-        `Something went wrong while trying to pull the collection from the "collectionAsync" call in the Filter, the collection is not a valid array.`
-      );
-    }
-  });
+      mockColumn.filter!.collection = newCollection;
+      mockColumn.filter!.collection!.push({ value: 'val3', label: 'label3' });
+
+      setTimeout(() => {
+        expect(renderSpy).toHaveBeenCalledTimes(3);
+        expect(renderSpy).toHaveBeenCalledWith(newCollection);
+
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
+        filterBtnElm.click();
+
+        expect(filterListElm.length).toBe(3);
+        expect(filterListElm[0].textContent).toBe('label1');
+        expect(filterListElm[1].textContent).toBe('label2');
+        expect(filterListElm[2].textContent).toBe('label3');
+        done();
+      });
+    }));
+
+  it('should trigger a re-render of the DOM element when collection changes', () =>
+    new Promise(async (done: any) => {
+      const renderSpy = vi.spyOn(filter, 'renderDomElement');
+
+      mockColumn.filter = {
+        collection: [
+          { value: 'female', label: 'Female' },
+          { value: 'male', label: 'Male' },
+        ],
+        enableCollectionWatch: true,
+      };
+
+      await filter.init(filterArguments);
+      mockColumn.filter!.collection!.push({ value: 'other', label: 'Other' });
+
+      setTimeout(() => {
+        expect(renderSpy).toHaveBeenCalledTimes(2);
+        expect(renderSpy).toHaveBeenCalledWith(mockColumn.filter!.collection);
+
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
+        filterBtnElm.click();
+
+        expect(filterListElm.length).toBe(3);
+        expect(filterListElm[0].textContent).toBe('Female');
+        expect(filterListElm[1].textContent).toBe('Male');
+        expect(filterListElm[2].textContent).toBe('Other');
+        done();
+      });
+    }));
+
+  it('should create the multi-select filter with a default search term when using "collectionLazy" as a Promise', () =>
+    new Promise(async (done: any) => {
+      const spyCallback = vi.spyOn(filterArguments, 'callback');
+      const mockCollection = ['male', 'female'];
+      mockColumn.filter!.collection = undefined;
+      mockColumn.filter!.collectionLazy = () => Promise.resolve(mockCollection);
+
+      filterArguments.searchTerms = ['female'];
+      await filter.init(filterArguments);
+      await filter.msInstance?.open(null);
+
+      setTimeout(() => {
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[data-name=filter-gender].ms-drop ul>li input[type=checkbox]`);
+        const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+        filterBtnElm.click();
+        filterOkElm.click();
+        expect(filterListElm.length).toBe(2);
+        expect(filterListElm[1].checked).toBe(true);
+        expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: 'IN', searchTerms: ['female'], shouldTriggerQuery: true });
+        filter.msInstance?.close();
+        done();
+      }, 0);
+    }));
+
+  it('should create the multi-select filter with a default search term when using "collectionLazy" as a Promise with content to simulate http-client', () =>
+    new Promise(async (done: any) => {
+      const spyCallback = vi.spyOn(filterArguments, 'callback');
+      const mockCollection = ['male', 'female'];
+      mockColumn.filter!.collection = undefined;
+      mockColumn.filter!.collectionLazy = () => Promise.resolve({ content: mockCollection });
+
+      filterArguments.searchTerms = ['female'];
+      await filter.init(filterArguments);
+      await filter.msInstance?.open(null);
+
+      setTimeout(() => {
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[data-name=filter-gender].ms-drop ul>li input[type=checkbox]`);
+        const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+        filterBtnElm.click();
+        filterOkElm.click();
+        filter.msInstance?.close();
+
+        expect(filterListElm.length).toBe(2);
+        expect(filterListElm[1].checked).toBe(true);
+        expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: 'IN', searchTerms: ['female'], shouldTriggerQuery: true });
+        done();
+      });
+    }));
+
+  it('should create the multi-select filter with a default search term when using "collectionLazy" is a Fetch Promise', () =>
+    new Promise(async (done: any) => {
+      const spyCallback = vi.spyOn(filterArguments, 'callback');
+      const mockCollection = ['male', 'female'];
+
+      http.status = 200;
+      http.object = mockCollection;
+      http.returnKey = 'date';
+      http.returnValue = '6/24/1984';
+      http.responseHeaders = { accept: 'json' };
+      mockColumn.filter!.collectionLazy = () => http.fetch('http://locahost/api', { method: 'GET' });
+
+      filterArguments.searchTerms = ['female'];
+      await filter.init(filterArguments);
+      await filter.msInstance?.open(null);
+
+      setTimeout(() => {
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[data-name=filter-gender].ms-drop ul>li input[type=checkbox]`);
+        // const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
+        const filterOkElm = divContainer.querySelector(`[data-name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+        filterBtnElm.click();
+        filterOkElm.click();
+        filter.msInstance?.close();
+
+        expect(filterListElm.length).toBe(2);
+        // expect(filterFilledElms.length).toBe(1);
+        expect(filterListElm[1].checked).toBe(true);
+        expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: 'IN', searchTerms: ['female'], shouldTriggerQuery: true });
+        done();
+      });
+    }));
+
+  it('should create the multi-select filter with a value/label pair collectionLazy that is inside an object when "collectionInsideObjectProperty" is defined with a dot notation', () =>
+    new Promise(async (done: any) => {
+      const mockDataResponse = {
+        deep: {
+          myCollection: [
+            { value: 'other', description: 'other' },
+            { value: 'male', description: 'male' },
+            { value: 'female', description: 'female' },
+          ],
+        },
+      };
+      mockColumn.filter = {
+        collectionLazy: () => Promise.resolve(mockDataResponse),
+        collectionOptions: { collectionInsideObjectProperty: 'deep.myCollection' },
+        customStructure: { value: 'value', label: 'description' },
+      };
+
+      await filter.init(filterArguments);
+      await filter.msInstance?.open(null);
+
+      setTimeout(() => {
+        const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
+        const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[data-name=filter-gender].ms-drop ul>li span`);
+        filterBtnElm.click();
+        filter.msInstance?.close();
+
+        expect(filterListElm.length).toBe(3);
+        expect(filterListElm[0].textContent).toBe('other');
+        expect(filterListElm[1].textContent).toBe('male');
+        expect(filterListElm[2].textContent).toBe('female');
+        done();
+      });
+    }));
+
+  it('should throw an error when "collectionAsync" Promise does not return a valid array', () =>
+    new Promise((done: any) => {
+      const promise = Promise.resolve({ hello: 'world' });
+      mockColumn.filter!.collectionAsync = promise;
+
+      filter.init(filterArguments).catch((e) => {
+        expect(e.toString()).toContain(
+          `Something went wrong while trying to pull the collection from the "collectionAsync" call in the Filter, the collection is not a valid array.`
+        );
+        done();
+      });
+    }));
 
   it('should throw an error when "collectionAsync" Promise does not return a valid array', () =>
     new Promise((done: any) => {

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -8,7 +8,6 @@ import type {
   AutocompleterOption,
   AutocompleteSearchItem,
   CollectionCustomStructure,
-  CollectionOption,
   Column,
   ColumnFilter,
   DOMEvent,
@@ -19,10 +18,13 @@ import type {
   GridOption,
   Locale,
 } from '../interfaces/index.js';
-import { addAutocompleteLoadingByOverridingFetch } from '../commonEditorFilter/commonEditorFilterUtils.js';
+import {
+  addAutocompleteLoadingByOverridingFetch,
+  getCollectionFromObjectWhenEnabled,
+} from '../commonEditorFilter/commonEditorFilterUtils.js';
 import type { CollectionService } from '../services/collection.service.js';
 import { collectionObserver, propertyObserver } from '../services/observers.js';
-import { getDescendantProperty, unsubscribeAll } from '../services/utilities.js';
+import { unsubscribeAll } from '../services/utilities.js';
 import type { TranslaterService } from '../services/translater.service.js';
 import { renderCollectionOptionsAsync } from './filterUtilities.js';
 import type { RxJsFacade, Subscription } from '../services/rxjsFacade.js';
@@ -83,11 +85,6 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
   /** Getter for the Autocomplete Option */
   get autocompleterOptions(): any {
     return this._autocompleterOptions || {};
-  }
-
-  /** Getter for the Collection Options */
-  protected get collectionOptions(): CollectionOption {
-    return this.columnDef?.filter?.collectionOptions ?? {};
   }
 
   /** Getter for the Collection Used by the Filter */
@@ -354,13 +351,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
   }
 
   renderDomElement(collection?: any[]): void {
-    if (!Array.isArray(collection) && this.collectionOptions?.collectionInsideObjectProperty) {
-      const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty;
-      collection = getDescendantProperty(collection, collectionInsideObjectProperty || '');
-    }
-    // if (!Array.isArray(collection)) {
-    //   throw new Error('The "collection" passed to the Autocomplete Filter is not a valid array.');
-    // }
+    collection = getCollectionFromObjectWhenEnabled(collection, this.columnFilter);
 
     // assign the collection to a temp variable before filtering/sorting the collection
     let newCollection = collection;

--- a/packages/common/src/interfaces/columnFilter.interface.ts
+++ b/packages/common/src/interfaces/columnFilter.interface.ts
@@ -51,6 +51,12 @@ export interface ColumnFilter {
   collectionAsync?: Promise<any> | Observable<any> | Subject<any>;
 
   /**
+   * A lazy callback to will only load your collection whenever your filter is being rendered (i.e.: when opening the select dropdown)
+   * Note: for the ms-select library, we use the `onOpen` callback, so please make sure to NOT override the callback otherwise it would cancel the feature.
+   */
+  collectionLazy?: (col: Column) => Promise<any> | Observable<any> | Subject<any>;
+
+  /**
    * A collection of items/options (commonly used with a Select/Multi-Select Filter)
    * It can be a collection of string or label/value pair (the pair can be customized via the "customStructure" option)
    */
@@ -143,6 +149,9 @@ export interface ColumnFilter {
    * In any case, the user can overrides it this flag.
    */
   emptySearchTermReturnAllValues?: boolean;
+
+  /** When the Filter is an external library, it could be useful to get its instance so that we could call any of the external library functions. */
+  onInstantiated?: <T = any>(instance: T) => void;
 
   /**
    * Should we skip filtering when the Operator is changed before the Compound Filter input.

--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -43,12 +43,11 @@ export function buildMsSelectCollectionList(
   const selectElement = createDomElement('select', { className: 'ms-filter search-filter' });
   const extraCssClasses = type === 'filter' ? ['search-filter', `filter-${columnId}`] : ['select-editor', `editor-${columnId}`];
   selectElement.classList.add(...extraCssClasses);
-
   selectElement.multiple = isMultiSelect;
-  const dataCollection: OptionRowData[] = [];
-  let hasFoundSearchTerm = false;
 
   // collection could be an Array of Strings OR Objects
+  const dataCollection: OptionRowData[] = [];
+  let hasFoundSearchTerm = false;
   if (Array.isArray(collection)) {
     if (collection.every((x: any) => typeof x === 'number' || typeof x === 'string')) {
       collection.forEach((option) => {

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -907,7 +907,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         expect(component.columnDefinitions[0].editor!.model).toEqual(Editors.text);
       });
 
-      it('should be able to load async editors with an Observable', () => {
+      it('should be able to load async editors with an Observable', async () => {
         const mockCollection = ['male', 'female'];
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: of(mockCollection) } }] as Column[];
 
@@ -918,6 +918,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         component.initialization(divContainer, slickEventHandler);
 
         vi.advanceTimersByTime(5);
+        await new Promise(process.nextTick);
+
         expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
         expect(component.columnDefinitions[0].editor!.model).toEqual(Editors.text);
         expect(component.columnDefinitions[0].editorClass).toEqual(Editors.text);
@@ -940,7 +942,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         vi.advanceTimersByTime(5);
         await new Promise(process.nextTick);
 
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid-Universal] The response body passed to collectionAsync was already read.'));
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid-Universal] The response body passed to Fetch was already read.'));
       });
     });
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -47,6 +47,7 @@ import {
 
   // utilities
   emptyElement,
+  fetchAsPromise,
   isColumnDateType,
   SlickEventHandler,
   SlickDataView,
@@ -1390,37 +1391,11 @@ export class SlickVanillaGridBundle<TData = any> {
   /** Load the Editor Collection asynchronously and replace the "collection" property when Promise resolves */
   protected loadEditorCollectionAsync(column: Column<TData>): void {
     if (column?.editor) {
-      const collectionAsync = column.editor.collectionAsync;
       column.editor.disabled = true; // disable the Editor DOM element, we'll re-enable it after receiving the collection with "updateEditorCollection()"
 
-      if (collectionAsync instanceof Promise) {
-        // wait for the "collectionAsync", once resolved we will save it into the "collection"
-        // the collectionAsync can be of 3 types HttpClient, HttpFetch or a Promise
-        collectionAsync.then((response: any | any[]) => {
-          if (Array.isArray(response)) {
-            this.updateEditorCollection(column, response); // from Promise
-          } else if (response?.status >= 200 && response.status < 300 && typeof response.json === 'function') {
-            if (response.bodyUsed) {
-              console.warn(
-                `[SlickGrid-Universal] The response body passed to collectionAsync was already read.` +
-                  `Either pass the dataset from the Response or clone the response first using response.clone()`
-              );
-            } else {
-              // from Fetch
-              (response as Response).json().then((data) => this.updateEditorCollection(column, data));
-            }
-          } else if (response?.content) {
-            this.updateEditorCollection(column, response['content']); // from http-client
-          }
-        });
-      } else if (this.rxjs?.isObservable(collectionAsync)) {
-        // wrap this inside a microtask at the end of the task to avoid timing issue since updateEditorCollection requires to call SlickGrid getColumns() method after columns are available
-        queueMicrotask(() => {
-          this.subscriptions.push(
-            (collectionAsync as Observable<any>).subscribe((resolvedCollection) => this.updateEditorCollection(column, resolvedCollection))
-          );
-        });
-      }
+      fetchAsPromise(column.editor.collectionAsync, this.rxjs).then((resolvedCollection) => {
+        this.updateEditorCollection(column, resolvedCollection);
+      });
     }
   }
 

--- a/test/cypress/e2e/example16.cy.ts
+++ b/test/cypress/e2e/example16.cy.ts
@@ -29,7 +29,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
   });
 
   it('should change server delay to 10ms for faster testing', () => {
-    cy.get('[data-test="server-delay"]').type('{backspace}{backspace}{backspace}10');
+    cy.get('[data-test="server-delay"]').clear().type('50');
   });
 
   it('should mouse over 1st row checkbox column and NOT expect any tooltip to show since it is disabled on that column', () => {
@@ -209,11 +209,20 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
     cy.get('@finish-filter').trigger('mouseout');
   });
 
+  it('should open PreRequisite dropdown and expect it be lazily loaded', () => {
+    cy.get('.slick-headerrow-columns .slick-headerrow-column:nth(10)').as('checkbox10-header');
+    cy.get('@checkbox10-header').click();
+    cy.get('[data-test="alert-lazy"]').should('be.visible');
+    cy.wait(50);
+    cy.get('@checkbox10-header').click();
+    cy.get('[data-test="alert-lazy"]').should('not.be.visible');
+  });
+
   it('should mouse over header-row (filter) Prerequisite column and expect to see tooltip of selected filter options', () => {
-    cy.get(`.slick-headerrow-columns .slick-headerrow-column:nth(10)`).as('checkbox10-header');
+    cy.get('.slick-headerrow-columns .slick-headerrow-column:nth(10)').as('checkbox10-header');
     cy.get('@checkbox10-header').trigger('mouseover');
 
-    cy.get('.filter-prerequisites .ms-choice span').contains('15 of 500 selected');
+    cy.get('.filter-prerequisites .ms-choice span').contains('15 of 1000 selected');
     cy.get('.slick-custom-tooltip').should('be.visible');
     cy.get('.slick-custom-tooltip').contains(
       'Task 1, Task 3, Task 5, Task 7, Task 9, Task 12, Task 15, Task 18, Task 21, Task 25, Task 28, Task 29, Task 30, Task 32, Task 34'
@@ -223,7 +232,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
   });
 
   it('should mouse over header title on 1st column with checkbox and NOT expect any tooltip to show since it is disabled on that column', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(0)`).as('checkbox-header');
+    cy.get('.slick-header-columns .slick-header-column:nth(0)').as('checkbox-header');
     cy.get('@checkbox-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');
@@ -231,7 +240,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
   });
 
   it('should mouse over header title on 2nd column with Title name and expect a tooltip to show rendered from an headerFormatter', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(1)`).as('checkbox0-header');
+    cy.get('.slick-header-columns .slick-header-column:nth(1)').as('checkbox0-header');
     cy.get('@checkbox0-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('be.visible');
@@ -244,7 +253,7 @@ describe('Example 16 - Regular & Custom Tooltips', () => {
   });
 
   it('should mouse over header title on 2nd column with Finish name and NOT expect any tooltip to show since it is disabled on that column', () => {
-    cy.get(`.slick-header-columns .slick-header-column:nth(8)`).as('finish-header');
+    cy.get('.slick-header-columns .slick-header-column:nth(8)').as('finish-header');
     cy.get('@finish-header').trigger('mouseover');
 
     cy.get('.slick-custom-tooltip').should('not.exist');


### PR DESCRIPTION
as discussed in #1922

- when user has lots of columns, it could be useful to load the ms-select collection only when opening the select dropdown via a new `collectionLazy` callback
- this new `collectionLazy` option is only available and implemented for Single/MultipleSelect Filter
- a loading/spinner might be implemented in ms-select library in a future release

![brave_uUG4UqHHKt](https://github.com/user-attachments/assets/4f1876fe-be6b-4876-ab4a-467c953bd98f)
