### PR TITLE
feat: add `onInstantiated` on all Editor/Filter with 3rd party lib

### DIFF
--- a/docs/column-functionalities/editors/Autocomplete-Editor-(Kraaden-lib).md
+++ b/docs/column-functionalities/editors/Autocomplete-Editor-(Kraaden-lib).md
@@ -30,7 +30,7 @@ export class GridBasicComponent {
   dataset: any[];
 
   attached(): void {
-      // your columns definition
+    // your columns definition
     this.columnDefinitions = [
       {
         id: 'countryOfOrigin', name: 'Country of Origin', field: 'countryOfOrigin',
@@ -46,11 +46,13 @@ export class GridBasicComponent {
           model: Editors.autocompleter,
           customStructure: { label: 'name', value: 'code' },
           collectionAsync: this.http.get('assets/data/countries.json'), // this demo will load the JSON file asynchronously
+          onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
         },
         filter: {
           model: Editors.autocompleter,
           customStructure: { label: 'name', value: 'code' },
           collectionAsync: this.http.get('assets/data/countries.json'),
+          onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
         }
       }
     ];
@@ -131,7 +133,7 @@ export class GridBasicComponent {
   dataset: any[];
 
   initializeGrid() {
-      // your columns definition
+    // your columns definition
     this.columnDefinitions = [
       {
         id: 'product', name: 'Product', field: 'product',
@@ -146,12 +148,12 @@ export class GridBasicComponent {
             fetch: (searchText, updateCallback) => {
               // assuming your API call returns a label/value pair
               yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
-                 .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]); })
-                 .catch(error => console.log('Error:', error);
+                 .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
+                 .catch(error => console.log('Error:', error));
             },
           } as AutocompleterOption,
         },
-      }
+      },
     ];
 
     this.gridOptions = {
@@ -175,17 +177,18 @@ this.columnDefinitions = [
       type: 'object',
       sortComparer: SortComparers.objectString,
       editorOptions: {
-        showOnFocus: true,
-        minLength: 1,
-        fetch: (searchText, updateCallback) => {
-          // assuming your API call returns a label/value pair
-          yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
-            .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]); })
-            .catch(error => console.log('Error:', error);
-          },
-        } as AutocompleterOption,
-      }
-    ];
+      showOnFocus: true,
+      minLength: 1,
+      fetch: (searchText, updateCallback) => {
+        // assuming your API call returns a label/value pair
+        yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
+          .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
+          .catch(error => console.log('Error:', error));
+        },
+      } as AutocompleterOption,
+    }
+  },
+];
 ```
 
 ### Remote API with `renderItem` + custom layout (`twoRows` or `fourCorners`)
@@ -218,8 +221,8 @@ export class GridBasicComponent {
             minLength: 1,
             fetch: (searchText, updateCallback) => {
               yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
-                 .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]); })
-                 .catch(error => console.log('Error:', error);
+                .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
+                .catch(error => console.log('Error:', error));
             },
             renderItem: {
               layout: 'twoRows',
@@ -280,8 +283,8 @@ export class GridBasicComponent {
             minLength: 1,
             fetch: (searchText, updateCallback) => {
               yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
-                 .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]); })
-                 .catch(error => console.log('Error:', error);
+                .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
+                .catch(error => console.log('Error:', error));
             },
             renderItem: {
               layout: 'twoRows',
@@ -302,27 +305,28 @@ export class GridBasicComponent {
             },
           } as AutocompleterOption,
           callbacks: {
-             // callback on the AutoComplete on the instance
-             renderItem: {
-                templateCallback: (item: any) => {
-                  return `<div class="autocomplete-container-list">
-                    <div class="autocomplete-left">
-                      <!--<img src="http://i.stack.imgur.com/pC1Tv.jpg" width="50" />-->
-                      <span class="mdi ${item.icon} mdi-26px"></span>
-                    </div>
-                    <div>
-                      <span class="autocomplete-top-left">
-                        <span class="mdi ${item.itemTypeName === 'I' ? 'mdi-information-outline' : 'mdi-content-copy'} mdi-14px"></span>
-                        ${item.itemName}
-                      </span>
-                      <span class="autocomplete-top-right">${formatNumber(item.listPrice, 2, 2, false, '$')}</span>
-                    <div>
+            // callback on the AutoComplete on the instance
+            renderItem: {
+              templateCallback: (item: any) => {
+                return `<div class="autocomplete-container-list">
+                  <div class="autocomplete-left">
+                    <!--<img src="http://i.stack.imgur.com/pC1Tv.jpg" width="50" />-->
+                    <span class="mdi ${item.icon} mdi-26px"></span>
                   </div>
                   <div>
-                    <div class="autocomplete-bottom-left">${item.itemNameTranslated}</div>
-                    <span class="autocomplete-bottom-right">Type: <b>${item.itemTypeName === 'I' ? 'Item' : item.itemTypeName === 'C' ? 'PdCat' : 'Cat'}</b></span>
-                  </div>`;
+                    <span class="autocomplete-top-left">
+                      <span class="mdi ${item.itemTypeName === 'I' ? 'mdi-information-outline' : 'mdi-content-copy'} mdi-14px"></span>
+                      ${item.itemName}
+                    </span>
+                    <span class="autocomplete-top-right">${formatNumber(item.listPrice, 2, 2, false, '$')}</span>
+                  <div>
+                </div>
+                <div>
+                  <div class="autocomplete-bottom-left">${item.itemNameTranslated}</div>
+                  <span class="autocomplete-bottom-right">Type: <b>${item.itemTypeName === 'I' ? 'Item' : item.itemTypeName === 'C' ? 'PdCat' : 'Cat'}</b></span>
+                </div>`;
               }
+            },
           },
         },
       }
@@ -408,22 +412,23 @@ export class GridBasicComponent {
 If you want to add the autocomplete functionality but want the user to be able to input a new option, then follow the example below:
 
 ```ts
-this.columnDefinitions = [{
-  id: 'area',
-  name: 'Area',
-  field: 'area',
-  type: FieldType.string,
-  editor: {
-    model: Editors.autocompleter,
-    editorOptions: {
-      minLength: 0,
-      forceUserInput: true,
-      fetch: (searchText, updateCallback) => {
-        updateCallback(this.areas); // add here the array
-      },
+this.columnDefinitions = [
+  {
+    id: 'area',
+    name: 'Area',
+    field: 'area',
+    type: FieldType.string,
+    editor: {
+      model: Editors.autocompleter,
+      editorOptions: {
+        minLength: 0,
+        forceUserInput: true,
+        fetch: (searchText, updateCallback) => {
+          updateCallback(this.areas); // add here the array
+        },
+      }
     }
-  }
-},
+  },
 ];
 ```
 You can also use the `minLength` to limit the autocomplete text to `0` characters or more, the default number is `3`.

--- a/docs/column-functionalities/editors/Select-Dropdown-Editor-(single,multiple).md
+++ b/docs/column-functionalities/editors/Select-Dropdown-Editor-(single,multiple).md
@@ -193,7 +193,8 @@ this.columnDefinitions = [
       // watch for any changes in the collection and re-render when that happens
       enableCollectionWatch: true,
       collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }],
-      model: Editors.singleSelect
+      model: Editors.singleSelect,
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
     }
   }
 ];

--- a/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
+++ b/docs/column-functionalities/editors/date-editor-(vanilla-calendar).md
@@ -27,6 +27,7 @@ prepareGrid() {
       type: 'dateIso', // if your type has hours/minutes, then the date picker will include date+time
       editor: {
         model: Editors.date,
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
         editorOptions: {
           range: {
             max: 'today',
@@ -64,6 +65,7 @@ initializeGrid() {
       id: 'title', name: 'Title', field: 'title',
       editor: {
         model: Editors.date,
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
         required: true,
         validator: (value, args) => {
           const dataContext = args && args.item;

--- a/docs/column-functionalities/filters/select-filter.md
+++ b/docs/column-functionalities/filters/select-filter.md
@@ -493,7 +493,7 @@ this.columnDefinitions = [
     filterable: true,
     filter: {
       model: Filters.multipleSelect,
-
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       // this async call will return the collection inside the response object in this format
       // { data: { myCollection: [ /*...*/ ] } }
       collectionAsync: this.http.fetch('api/data/pre-requisites'),
@@ -550,6 +550,7 @@ this.columnDefinitions = [
     filter: {
       collectionLazy: (col: Column) => this.http.fetch('api/data/pre-requisites'),
       model: Filters.multipleSelect,
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
     }
   }
 ];

--- a/frameworks/slickgrid-vue/docs/column-functionalities/editors/autocomplete-editor-kraaden.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/editors/autocomplete-editor-kraaden.md
@@ -52,11 +52,13 @@ function defineGrid() {
         model: Editors.autocompleter,
         customStructure: { label: 'name', value: 'code' },
         collectionAsync: fetch('assets/data/countries.json'), // this demo will load the JSON file asynchronously
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       },
       filter: {
         model: Filters.autocompleter,
         customStructure: { label: 'name', value: 'code' },
         collectionAsync: fetch('assets/data/countries.json'),
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       }
     }
   ];
@@ -191,11 +193,12 @@ columnDefinitions.value = [
         fetch: (searchText, updateCallback) => {
           // assuming your API call returns a label/value pair
           yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
-            .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]); })
-            .catch(error => console.log('Error:', error);
-      },
-    } as AutocompleterOption,
-  }
+            .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
+            .catch(error => console.log('Error:', error));
+        },
+      } as AutocompleterOption,
+    }
+  },
 ];
 ```
 
@@ -237,7 +240,7 @@ function defineGrid() {
           fetch: (searchText, updateCallback) => {
             yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
                 .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
-                .catch(error => console.log('Error:', error);
+                .catch(error => console.log('Error:', error));
           },
           renderItem: {
             layout: 'twoRows',
@@ -308,8 +311,8 @@ function defineGrid() {
           },
           fetch: (searchText, updateCallback) => {
             yourAsyncApiCall(searchText) // typically you'll want to return no more than 10 results
-                .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]); })
-                .catch(error => console.log('Error:', error);
+                .then(result => updateCallback((results.length > 0) ? results : [{ label: 'No match found.', value: '' }]))
+                .catch(error => console.log('Error:', error));
           },
           renderItem: {
             layout: 'twoRows',
@@ -428,6 +431,7 @@ columnDefinitions.value = [{
   type: FieldType.string,
   editor: {
     model: Editors.autocompleter,
+    onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
     editorOptions: {
       minLength: 0,
       forceUserInput: true,

--- a/frameworks/slickgrid-vue/docs/column-functionalities/editors/date-editor-vanilla-calendar.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/editors/date-editor-vanilla-calendar.md
@@ -36,6 +36,7 @@ function defineGrid() {
       type: 'dateIso', // if your type has hours/minutes, then the date picker will include date+time
       editor: {
         model: Editors.date,
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
         editorOptions: {
           range: {
             max: 'today',
@@ -68,6 +69,7 @@ function initializeGrid() {
       id: 'title', name: 'Title', field: 'title',
       editor: {
         model: Editors.date,
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
         required: true,
         validator: (value, args) => {
           const dataContext = args && args.item;

--- a/frameworks/slickgrid-vue/docs/column-functionalities/editors/select-dropdown-editor.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/editors/select-dropdown-editor.md
@@ -23,6 +23,7 @@ columnDefinitions.value = [
     type: FieldType.string,
     editor: {
       model: Editors.multipleSelect,
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       collection: Array.from(Array(12).keys()).map(k => ({ value: `Task ${k}`, label: `Task ${k}` })),
       collectionSortBy: {
         property: 'label',
@@ -86,6 +87,7 @@ columnDefinitions.value = [{
   formatter: Formatters.complexObject, // the complex formatter is necessary, unless you provide a custom formatter
   editor: {
     model: Editors.SingleSelect,
+    onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
     complexObjectPath: 'user.middleName',
     serializeComplexValueFormat: 'flat' // (flat) will return 'Bob', (object) will return { label: 'Bob', value: 'Bob' }
   }
@@ -104,6 +106,7 @@ columnDefinitions.value = [
     type: FieldType.string,
     editor: {
       model: Editors.multipleSelect,
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       collection: Array.from(Array(12).keys()).map(k => ({ value: `Task ${k}`, label: `Task ${k}` })),
       collectionOverride: (updatedCollection, args) => {
         console.log(args);
@@ -143,11 +146,12 @@ editor: {
     label: 'currency',
     labelPrefix: 'symbol',
     labelSuffix: 'country',
-  collectionOptions: {
-    separatorBetweenTextLabels: ' ', // add white space between each text
-    includePrefixSuffixToSelectedValues: true // should the selected value include the prefix/suffix in the output format
-  },
-  model: Editors.multipleSelect
+    collectionOptions: {
+      separatorBetweenTextLabels: ' ', // add white space between each text
+      includePrefixSuffixToSelectedValues: true // should the selected value include the prefix/suffix in the output format
+    },
+    model: Editors.multipleSelect
+  }
 }
 ```
 

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/autocomplete-filter-kraaden.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/autocomplete-filter-kraaden.md
@@ -47,11 +47,13 @@ function defineGrid() {
         model: Editors.autoComplete,
         customStructure: { label: 'name', value: 'code' },
         collectionAsync: fetch('assets/data/countries.json'), // this demo will load the JSON file asynchronously
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       },
       filter: {
         model: Filters.autoComplete,
         customStructure: { label: 'name', value: 'code' },
         collectionAsync: fetch('assets/data/countries.json'),
+        onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
       }
     }
   ];
@@ -159,6 +161,7 @@ columnDefinitions.value = [{
   type: FieldType.string,
   editor: {
     model: Editors.autocompleter,
+    onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
     editorOptions: {
       minLength: 0,
       forceUserInput: true,

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
@@ -68,17 +68,18 @@ columnDefinitions.value = [
     type: FieldType.boolean,
     filterable: true,
     filter: {
-       collection: [ { value: '', label: '' }, { value: true, label: 'true' }, { value: false, label: 'false' } ],
-       model: Filters.multipleSelect,
+      collection: [ { value: '', label: '' }, { value: true, label: 'true' }, { value: false, label: 'false' } ],
+      model: Filters.multipleSelect,
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
 
-       // you can add "multiple-select" plugin options like styling the first row
-       filterOptions: {
-          offsetLeft: 14,
-          width: 100
-       } as MultipleSelectOption,
+      // you can add "multiple-select" plugin options like styling the first row
+      filterOptions: {
+        offsetLeft: 14,
+        width: 100
+      } as MultipleSelectOption,
 
-       // you can also add an optional placeholder
-       placeholder: 'choose an option'
+      // you can also add an optional placeholder
+      placeholder: 'choose an option'
    }
   }
 ];
@@ -113,6 +114,7 @@ columnDefinitions.value = [
        model: Filters.multipleSelect,
        searchTerms: [true],
     }
+  },
 ];
 ```
 
@@ -129,7 +131,8 @@ columnDefinitions.value = [
     filter: {
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
-   }
+    }
+  },
 ];
 ```
 
@@ -562,6 +565,7 @@ columnDefinitions.value = [
     filter: {
       collectionLazy: (col: Column) => this.http.fetch('api/data/pre-requisites'),
       model: Filters.multipleSelect,
+      onInstantiated: (instance) => console.log('instance', instance), // get instance from 3rd party lib
     }
   }
 ];

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -714,6 +714,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     }
 
     this.args.container.appendChild(this._editorInputGroupElm);
+    this.columnEditor.onInstantiated?.(this._instance);
 
     if (!this.args.compositeEditorOptions) {
       window.setTimeout(() => this.focus(), 50);

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -232,6 +232,7 @@ export class DateEditor implements Editor {
             updatePickerUI: true,
           });
         }
+        this.columnEditor.onInstantiated?.(this.calendarInstance);
       });
     }
   }

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -189,8 +189,8 @@ export class SelectEditor implements Editor {
   }
 
   /** Get Column Editor object */
-  get columnEditor(): ColumnEditor | undefined {
-    return this.columnDef?.editor ?? ({} as ColumnEditor);
+  get columnEditor(): ColumnEditor {
+    return (this.columnDef?.editor ?? {}) as ColumnEditor;
   }
 
   /** Getter for item data context object */
@@ -803,6 +803,8 @@ export class SelectEditor implements Editor {
     this.editorElmOptions = { ...this.defaultOptions, ...this.editorOptions, data: dataCollection };
     this._msInstance = multipleSelect(selectElement, this.editorElmOptions) as MultipleSelectInstance;
     this.editorElm = this._msInstance.getParentElement();
+    this.columnEditor.onInstantiated?.(this._msInstance);
+
     if (!this.isCompositeEditor) {
       this.show(this.delayOpening);
     }

--- a/packages/common/src/filters/autocompleterFilter.ts
+++ b/packages/common/src/filters/autocompleterFilter.ts
@@ -507,6 +507,7 @@ export class AutocompleterFilter<T extends AutocompleteItem = any> implements Fi
     // append the new DOM element to the header row & an empty span
     this.filterContainerElm.appendChild(filterDivContainerElm);
     this.filterContainerElm.appendChild(document.createElement('span'));
+    this.columnFilter.onInstantiated?.(this._instance);
 
     return this._filterElm;
   }

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -414,6 +414,7 @@ export class DateFilter implements Filter {
         updatePickerUI: false,
       });
     }
+    this.columnFilter.onInstantiated?.(this.calendarInstance);
   }
 
   /** Get the available operator option values to populate the operator select dropdown list */

--- a/packages/common/src/interfaces/columnEditor.interface.ts
+++ b/packages/common/src/interfaces/columnEditor.interface.ts
@@ -107,6 +107,9 @@ export interface ColumnEditor {
   /** SlickGrid Editor class or EditorConstructor function that implements Editor for the cell inline editing */
   model?: EditorConstructor;
 
+  /** When the Filter is an external library, it could be useful to get its instance so that we could call any of the external library functions. */
+  onInstantiated?: <T = any>(instance: T) => void;
+
   /**
    * Placeholder text that can be used by some Editors.
    * Note that this will override the default placeholder configured in the global config

--- a/packages/common/src/interfaces/columnFilter.interface.ts
+++ b/packages/common/src/interfaces/columnFilter.interface.ts
@@ -120,6 +120,9 @@ export interface ColumnFilter {
     }
   >;
 
+  /** When the Filter is an external library, it could be useful to get its instance so that we could call any of the external library functions. */
+  onInstantiated?: <T = any>(instance: T) => void;
+
   /**
    * Use "params" to pass any type of arguments to your Custom Filter
    * for example, to pass a second collection to a select Filter we can type this:
@@ -149,9 +152,6 @@ export interface ColumnFilter {
    * In any case, the user can overrides it this flag.
    */
   emptySearchTermReturnAllValues?: boolean;
-
-  /** When the Filter is an external library, it could be useful to get its instance so that we could call any of the external library functions. */
-  onInstantiated?: <T = any>(instance: T) => void;
 
   /**
    * Should we skip filtering when the Operator is changed before the Compound Filter input.


### PR DESCRIPTION
sometime we would like to control or call a function from the external library directly, the user will now be able to do this via the `onInstantiated` callback which will return the 3rd party lib instance when ready

```ts
this.columns = [
{
    id: 'prerequisites', name: 'Prerequisites', field: 'prerequisites', filterable: true,
    filter: {
      model: Filters.multipleSelect,
      collection: [/*...*/],
      onInstantiated: (msSelect) => console.log('ms-select instance', msSelect),
    },
  },
];
```