### PR TITLE
perf: build date Formatters/Sorters dynamically to decrease build size

### DIFF
--- a/packages/common/src/formatters/formatters.index.ts
+++ b/packages/common/src/formatters/formatters.index.ts
@@ -1,5 +1,7 @@
-import { FieldType } from '../enums/index.js';
+import { FieldType } from '../enums/fieldType.enum.js';
+import type { Formatter, IFormatters } from '../interfaces/formatter.interface.js';
 import { getAssociatedDateFormatter, getBaseDateFormatter } from './formatterUtilities.js';
+import { getAllDateFieldTypes } from '../services/utilities.js';
 import { arrayObjectToCsvFormatter } from './arrayObjectToCsvFormatter.js';
 import { arrayToCsvFormatter } from './arrayToCsvFormatter.js';
 import { checkmarkMaterialFormatter } from './checkmarkMaterialFormatter.js';
@@ -27,232 +29,56 @@ import { treeExportFormatter } from './treeExportFormatter.js';
 import { treeFormatter } from './treeFormatter.js';
 import { treeParseTotalsFormatter } from './treeParseTotalsFormatter.js';
 import { translateBooleanFormatter } from './translateBooleanFormatter.js';
-import type { Formatter } from '../interfaces/formatter.interface.js';
 
 /** Provides a list of different Formatters that will change the cell value displayed in the UI */
-export const Formatters: Record<string, Formatter> = {
-  /**
-   * Takes an array of complex objects converts it to a comma delimited string.
-   * Requires to pass an array of "propertyNames" in the column definition the generic "params" property
-   * For example, if we have an array of user objects that have the property of firstName & lastName then we need to pass in your column definition::
-   * params: { propertyNames: ['firtName', 'lastName'] } => 'John Doe, Jane Doe'
-   */
+const allFormatters: Record<string, Formatter> = {
   arrayObjectToCsv: arrayObjectToCsvFormatter,
-
-  /** Takes an array of string and converts it to a comma delimited string */
   arrayToCsv: arrayToCsvFormatter,
-
-  /**
-   * When value is filled, or if the value is a number and is bigger than 0, it will display a Material Design check icon (mdi-check).
-   * The icon will NOT be displayed when the value is any of the following ("false", false, "0", 0, -0.5, null, undefined)
-   * Anything else than the condition specified will display the icon, so a text with "00123" will display the icon but "0" will not.
-   * Also note that a string ("null", "undefined") will display the icon but (null, undefined) will not, so the typeof is also important
-   */
   checkmarkMaterial: checkmarkMaterialFormatter,
-
-  /**
-   * Takes a complex data object and return the data under that property (for example: "user.firstName" will return the first name "John")
-   * You can pass the complex structure in the "field" (field: "user.firstName") or in the "params" (labelKey: "firstName", params: { complexField: "user" }) properties.
-   * For example::
-   * this.columnDefs = [{ id: 'username', field: 'user.firstName', ... }]
-   * OR this.columnDefs = [{ id: 'username', field: 'user', labelKey: 'firstName', params: { complexField: 'user' }, ... }]
-   * OR this.columnDefs = [{ id: 'username', field: 'user', params: { complexField: 'user.firstName' }, ... }]
-   */
   complex: complexObjectFormatter,
   complexObject: complexObjectFormatter,
-
-  /**
-   * Looks up values from the columnDefinition.params.collection property and displays the label in CSV or string format
-   * @example
-   * // the grid will display 'foo' and 'bar' and not 1 and 2 from your dataset
-   * { params: { collection: [{ value: 1, label: 'foo'}, {value: 2, label: 'bar' }] }}
-   * const dataset = [1, 2];
-   */
   collection: collectionFormatter,
-
-  /**
-   * Roughly the same as the "collectionFormatter" except that it
-   * looks up values from the columnDefinition.editor.collection (instead of params) property and displays the label in CSV or string format
-   * @example
-   * // the grid will display 'foo' and 'bar' and not 1 and 2 from your dataset
-   * { editor: { collection: [{ value: 1, label: 'foo'}, {value: 2, label: 'bar' }] }}
-   * const dataset = [1, 2];
-   */
   collectionEditor: collectionEditorFormatter,
-
-  /**
-   * Similar to "Formatters.decimal", but it allows you to provide prefixes and suffixes (currencyPrefix, currencySuffix, numberPrefix, numberSuffix)
-   * So with this, it allows the user to provide dual prefixes/suffixes via the following params
-   * You can pass "minDecimal", "maxDecimal", "decimalSeparator", "thousandSeparator", "numberPrefix", "currencyPrefix", "currencySuffix", and "numberSuffix" to the "params" property.
-   * For example:: `{ formatter: Formatters.decimal, params: { minDecimal: 2, maxDecimal: 4, prefix: 'Price ', currencyPrefix: '€', currencySuffix: ' EUR' }}`
-   * with value of 33.45 would result into: "Price €33.45 EUR"
-   */
   currency: currencyFormatter,
-
-  /** Base Date formatter which requires the user to provide a Date Format via column `params.dateFormat` */
   date: getBaseDateFormatter(),
 
-  /** Takes a Date object and displays it as an ISO Date format (YYYY-MM-DD) */
-  dateIso: getAssociatedDateFormatter(FieldType.dateIso, '-'),
+  // --
+  // add all the date Formatters dynamically below
 
-  /** Takes a Date object and displays it as an ISO Date+Time format (YYYY-MM-DD HH:mm:ss) */
-  dateTimeIso: getAssociatedDateFormatter(FieldType.dateTimeIso, '-'),
-
-  /** Takes a Date object and displays it as an ISO Date+Time (without seconds) format (YYYY-MM-DD HH:mm) */
-  dateTimeShortIso: getAssociatedDateFormatter(FieldType.dateTimeShortIso, '-'),
-
-  /** Takes a Date object and displays it as an ISO Date+Time+(am/pm) format (YYYY-MM-DD h:mm:ss a) */
-  dateTimeIsoAmPm: getAssociatedDateFormatter(FieldType.dateTimeIsoAmPm, '-'),
-
-  /** Takes a Date object and displays it as an ISO Date+Time+(AM/PM) format (YYYY-MM-DD hh:mm:ss A) */
-  dateTimeIsoAM_PM: getAssociatedDateFormatter(FieldType.dateTimeIsoAM_PM, '-'),
-
-  /** Takes a Date object and displays it as an Euro Date format (DD/MM/YYYY) */
-  dateEuro: getAssociatedDateFormatter(FieldType.dateEuro, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date format (D/M/YY) */
-  dateEuroShort: getAssociatedDateFormatter(FieldType.dateEuroShort, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time format (DD/MM/YYYY HH:mm:ss) */
-  dateTimeEuro: getAssociatedDateFormatter(FieldType.dateTimeEuro, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time format (D/M/YY H:m:s) */
-  dateTimeEuroShort: getAssociatedDateFormatter(FieldType.dateTimeEuroShort, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time (without seconds) format (DD/MM/YYYY HH:mm) */
-  dateTimeShortEuro: getAssociatedDateFormatter(FieldType.dateTimeShortEuro, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (DD/MM/YYYY hh:mm:ss a) */
-  dateTimeEuroAmPm: getAssociatedDateFormatter(FieldType.dateTimeEuroAmPm, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time+(AM/PM) format (DD/MM/YYYY hh:mm:ss A) */
-  dateTimeEuroAM_PM: getAssociatedDateFormatter(FieldType.dateTimeEuroAM_PM, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (D/M/YY h:m:s a) */
-  dateTimeEuroShortAmPm: getAssociatedDateFormatter(FieldType.dateTimeEuroShortAmPm, '/'),
-
-  /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (D/M/YY h:m:s A) */
-  dateTimeEuroShortAM_PM: getAssociatedDateFormatter(FieldType.dateTimeEuroShortAM_PM, '/'),
-
-  /** Takes a Date object and displays it as an US Date format (MM/DD/YYYY) */
-  dateUs: getAssociatedDateFormatter(FieldType.dateUs, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time format (MM/DD/YYYY HH:mm:ss) */
-  dateTimeUs: getAssociatedDateFormatter(FieldType.dateTimeUs, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time (without seconds) format (MM/DD/YYYY HH:mm:ss) */
-  dateTimeShortUs: getAssociatedDateFormatter(FieldType.dateTimeShortUs, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time+(am/pm) format (MM/DD/YYYY hh:mm:ss a) */
-  dateTimeUsAmPm: getAssociatedDateFormatter(FieldType.dateTimeUsAmPm, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time+(AM/PM) format (MM/DD/YYYY hh:mm:ss A) */
-  dateTimeUsAM_PM: getAssociatedDateFormatter(FieldType.dateTimeUsAM_PM, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time format (M/D/YY H:m:s) */
-  dateTimeUsShort: getAssociatedDateFormatter(FieldType.dateTimeUsShort, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time+(am/pm) format (M/D/YY h:m:s a) */
-  dateTimeUsShortAmPm: getAssociatedDateFormatter(FieldType.dateTimeUsShortAmPm, '/'),
-
-  /** Takes a Date object and displays it as an US Date+Time+(AM/PM) format (M/D/YY h:m:s A) */
-  dateTimeUsShortAM_PM: getAssociatedDateFormatter(FieldType.dateTimeUsShortAM_PM, '/'),
-
-  /** Takes a Date object and displays it as an US Date format (M/D/YY) */
-  dateUsShort: getAssociatedDateFormatter(FieldType.dateUsShort, '/'),
-
-  /** Takes a Date object and displays it as a regular TZ timestamp format (YYYY-MM-DDTHH:mm:ss.SSSZ) */
-  dateUtc: getAssociatedDateFormatter(FieldType.dateUtc, '-'),
-
-  /**
-   * Display the value as x decimals formatted, defaults to 2 decimals.
-   * You can pass "minDecimal" and/or "maxDecimal" to the "params" property.
-   * For example:: `{ formatter: Formatters.decimal, params: { minDecimal: 2, maxDecimal: 4 }}`
-   */
   decimal: decimalFormatter,
-
-  /** Display the value as 2 decimals formatted with dollar sign '$' at the end of of the value */
   dollar: dollarFormatter,
-
-  /** Display the value as 2 decimals formatted with dollar sign '$' at the end of of the value, change color of text to red/green on negative/positive value */
   dollarColored: dollarColoredFormatter,
-
-  /** Display the value as 2 decimals formatted with dollar sign '$' at the end of of the value, change color of text to red/green on negative/positive value, show it in bold font weight as well */
   dollarColoredBold: dollarColoredBoldFormatter,
-
-  /**
-   * Takes an hyperlink cell value and transforms it into a real hyperlink, given that the value starts with 1 of these (http|ftp|https).
-   * The structure will be "<a href="hyperlink">hyperlink</a>"
-   *
-   * You can optionally change the hyperlink text displayed by using the generic params "hyperlinkText" in the column definition
-   * For example: { id: 'link', field: 'link', params: { hyperlinkText: 'Company Website' } } will display "<a href="link">Company Website</a>"
-   *
-   * You can also optionally provide the hyperlink URL by using the generic params "hyperlinkUrl" in the column definition
-   * For example: { id: 'link', field: 'link', params: {  hyperlinkText: 'Company Website', hyperlinkUrl: 'http://www.somewhere.com' } } will display "<a href="http://www.somewhere.com">Company Website</a>"
-   */
   hyperlink: hyperlinkFormatter,
-
-  /** Display whichever icon you want (library agnostic, it could be Font-Awesome, Material or any other icons set) */
   icon: iconFormatter,
-
-  /**
-   * Display whichever icon but only for boolean truthy values (library agnostic, it could be Font-Awesome, Material or any other icons set)
-   * Note: a value of "false", null, undefined, "1" or any number below 0 are all considered falsy and will not display the icon
-   */
   iconBoolean: iconBooleanFormatter,
-
-  /**
-   * Takes a value display it according to a mask provided
-   * e.: 1234567890 with mask "(000) 000-0000" will display "(123) 456-7890"
-   */
   mask: maskFormatter,
-
-  /**
-   * You can pipe multiple formatters (executed in sequence), use params to pass the list of formatters.
-   * Requires to pass an array of "formatters" in the column definition the generic "params" property
-   * For example::
-   * { field: 'title', formatter: Formatters.multiple, params: { formatters: [ Formatters.dollar, myCustomFormatter ] }
-   */
   multiple: multipleFormatter,
-
-  /** Takes a cell value number (between 0.0-1.0) and displays a red (<50) or green (>=50) bar */
   percent: percentFormatter,
-
-  /** Takes a cell value number (between 0.0-100) and displays a red (<50) or green (>=50) bar */
   percentComplete: percentCompleteFormatter,
-
-  /** Takes a cell value number (between 0-100) and displays a SlickGrid custom "percent-complete-bar" a red (<30), silver (>30 & <70) or green (>=70) bar */
   percentCompleteBar: percentCompleteBarFormatter,
-
-  /** Takes a cell value number (between 0-100) and displays SlickGrid custom "percent-complete-bar" with Text a red (<30), silver (>30 & <70) or green (>=70) bar */
   percentCompleteBarWithText: percentCompleteBarWithTextFormatter,
-
-  /** Takes a cell value number (between 0-100) and add the "%" after the number */
   percentSymbol: percentSymbolFormatter,
-
-  /** Takes a cell value number (between 0-100) and displays Bootstrap "progress-bar" a red (<30), silver (>30 & <70) or green (>=70) bar */
   progressBar: progressBarFormatter,
-
-  /** Takes a cell value and translates it. Requires an instance of the Translate Service:: `translater: this.translate */
   translate: translateFormatter,
-
-  /** Takes a translation key string and tries to translate it. Requires an instance of the Translate Service:: `translater: this.translate */
   translateBoolean: translateBooleanFormatter,
-
-  /** Formatter that must be used with a Tree Data column */
   tree: treeFormatter,
-
-  /**
-   * Formatter that can be use to parse Tree Data totals and display totals using GroupTotalFormatters.
-   * This formatter works with both regular `Formatters` or `GroupTotalFormatters`,
-   * it will auto-detect if the current data context has a `__treeTotals` prop,
-   * then it will use the `GroupTotalFormatters`, if not then it will try to use regular `Formatters`.
-   *
-   * This mean that you can provide an array of `Formatters` & `GroupTotalFormatters` and it will use the correct formatter
-   * by detecting if the current data context has a `__treeTotals` prop (`GroupTotalFormatters`) or not (regular `Formatter`)
-   */
   treeParseTotals: treeParseTotalsFormatter,
-
-  /** Formatter that must be use with a Tree Data column for Exporting the data */
   treeExport: treeExportFormatter,
 };
+
+// add date Formatters dynamically but exclude "dateTime" because that is a native JS Date object
+getAllDateFieldTypes().forEach((dateType) => {
+  const fieldType = FieldType[dateType as keyof typeof FieldType];
+  if (fieldType && fieldType !== FieldType.dateTime) {
+    allFormatters[dateType] = getAssociatedDateFormatter(fieldType, dateType);
+  }
+});
+
+/**
+ * All available Formatters, including static and dynamically added date formatters.
+ *
+ * - Static: see IFormatters interface
+ * - Dynamic: all date field types (see {@link getAllDateFieldTypes})
+ */
+export const Formatters: IFormatters = allFormatters as unknown as IFormatters;

--- a/packages/common/src/formatters/formatters.index.ts
+++ b/packages/common/src/formatters/formatters.index.ts
@@ -67,10 +67,11 @@ const allFormatters: Record<string, Formatter> = {
   treeExport: treeExportFormatter,
 };
 
-// add date Formatters dynamically but exclude "dateTime" because that is a native JS Date object
+// add date Formatters dynamically but exclude "FieldType.date" since that one was created above
+// and it has a different implementation
 getAllDateFieldTypes().forEach((dateType) => {
   const fieldType = FieldType[dateType as keyof typeof FieldType];
-  if (fieldType && fieldType !== FieldType.dateTime) {
+  if (fieldType && fieldType !== FieldType.date) {
     allFormatters[dateType] = getAssociatedDateFormatter(fieldType, dateType);
   }
 });

--- a/packages/common/src/interfaces/formatter.interface.ts
+++ b/packages/common/src/interfaces/formatter.interface.ts
@@ -9,3 +9,228 @@ export declare type Formatter<T = any> = (
   dataContext: T,
   grid: SlickGrid
 ) => string | HTMLElement | DocumentFragment | FormatterResultWithHtml | FormatterResultWithText;
+
+/**
+ * All built-in Formatters, including static and date formatters.
+ */
+export interface IFormatters {
+  /**
+   * Takes an array of complex objects converts it to a comma delimited string.
+   * Requires to pass an array of "propertyNames" in the column definition the generic "params" property
+   * For example, if we have an array of user objects that have the property of firstName & lastName then we need to pass in your column definition::
+   * params: { propertyNames: ['firtName', 'lastName'] } => 'John Doe, Jane Doe'
+   */
+  arrayObjectToCsv: Formatter;
+
+  /** Takes an array of string and converts it to a comma delimited string */
+  arrayToCsv: Formatter;
+
+  /** Displays a Material Design check icon for truthy values */
+  checkmarkMaterial: Formatter;
+
+  /**
+   * Takes a complex data object and return the data under that property (for example: "user.firstName" will return the first name "John")
+   * You can pass the complex structure in the "field" (field: "user.firstName") or in the "params" (labelKey: "firstName", params: { complexField: "user" }) properties.
+   * For example::
+   * this.columnDefs = [{ id: 'username', field: 'user.firstName', ... }]
+   * OR this.columnDefs = [{ id: 'username', field: 'user', labelKey: 'firstName', params: { complexField: 'user' }, ... }]
+   * OR this.columnDefs = [{ id: 'username', field: 'user', params: { complexField: 'user.firstName' }, ... }]
+   */
+  complex: Formatter;
+  complexObject: Formatter;
+
+  /**
+   * Looks up values from the columnDefinition.params.collection property and displays the label in CSV or string format
+   * @example
+   * // the grid will display 'foo' and 'bar' and not 1 and 2 from your dataset
+   * { params: { collection: [{ value: 1, label: 'foo'}, {value: 2, label: 'bar' }] }}
+   * const dataset = [1, 2];
+   */
+  collection: Formatter;
+
+  /**
+   * Roughly the same as the "collectionFormatter" except that it
+   * looks up values from the columnDefinition.editor.collection (instead of params) property and displays the label in CSV or string format
+   * @example
+   * // the grid will display 'foo' and 'bar' and not 1 and 2 from your dataset
+   * { editor: { collection: [{ value: 1, label: 'foo'}, {value: 2, label: 'bar' }] }}
+   * const dataset = [1, 2];
+   */
+  collectionEditor: Formatter;
+
+  /**
+   * Similar to "Formatters.decimal", but it allows you to provide prefixes and suffixes (currencyPrefix, currencySuffix, numberPrefix, numberSuffix)
+   * So with this, it allows the user to provide dual prefixes/suffixes via the following params
+   * You can pass "minDecimal", "maxDecimal", "decimalSeparator", "thousandSeparator", "numberPrefix", "currencyPrefix", "currencySuffix", and "numberSuffix" to the "params" property.
+   * For example:: `{ formatter: Formatters.decimal, params: { minDecimal: 2, maxDecimal: 4, prefix: 'Price ', currencyPrefix: '€', currencySuffix: ' EUR' }}`
+   * with value of 33.45 would result into: "Price €33.45 EUR"
+   */
+  currency: Formatter;
+
+  /** Base Date formatter which requires the user to provide a Date Format via column `params.dateFormat` */
+  date: Formatter;
+
+  /** Takes a Date object and displays it as an ISO Date format (YYYY-MM-DD) */
+  dateIso: Formatter;
+
+  /** Takes a Date object and displays it as an ISO Date+Time format (YYYY-MM-DD HH:mm:ss) */
+  dateTimeIso: Formatter;
+
+  /** Takes a Date object and displays it as an ISO Date+Time (without seconds) format (YYYY-MM-DD HH:mm) */
+  dateTimeShortIso: Formatter;
+
+  /** Takes a Date object and displays it as an ISO Date+Time+(am/pm) format (YYYY-MM-DD h:mm:ss a) */
+  dateTimeIsoAmPm: Formatter;
+
+  /** Takes a Date object and displays it as an ISO Date+Time+(AM/PM) format (YYYY-MM-DD hh:mm:ss A) */
+  dateTimeIsoAM_PM: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date format (DD/MM/YYYY) */
+  dateEuro: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date format (D/M/YY) */
+  dateEuroShort: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time format (DD/MM/YYYY HH:mm:ss) */
+  dateTimeEuro: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time format (D/M/YY H:m:s) */
+  dateTimeEuroShort: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time (without seconds) format (DD/MM/YYYY HH:mm) */
+  dateTimeShortEuro: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (DD/MM/YYYY hh:mm:ss a) */
+  dateTimeEuroAmPm: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time+(AM/PM) format (DD/MM/YYYY hh:mm:ss A) */
+  dateTimeEuroAM_PM: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (D/M/YY h:m:s a) */
+  dateTimeEuroShortAmPm: Formatter;
+
+  /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (D/M/YY h:m:s A) */
+  dateTimeEuroShortAM_PM: Formatter;
+
+  /** Takes a Date object and displays it as an US Date format (MM/DD/YYYY) */
+  dateUs: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time format (MM/DD/YYYY HH:mm:ss) */
+  dateTimeUs: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time (without seconds) format (MM/DD/YYYY HH:mm:ss) */
+  dateTimeShortUs: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time+(am/pm) format (MM/DD/YYYY hh:mm:ss a) */
+  dateTimeUsAmPm: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time+(AM/PM) format (MM/DD/YYYY hh:mm:ss A) */
+  dateTimeUsAM_PM: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time format (M/D/YY H:m:s) */
+  dateTimeUsShort: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time+(am/pm) format (M/D/YY h:m:s a) */
+  dateTimeUsShortAmPm: Formatter;
+
+  /** Takes a Date object and displays it as an US Date+Time+(AM/PM) format (M/D/YY h:m:s A) */
+  dateTimeUsShortAM_PM: Formatter;
+
+  /** Takes a Date object and displays it as an US Date format (M/D/YY) */
+  dateUsShort: Formatter;
+
+  /** Takes a Date object and displays it as a regular TZ timestamp format (YYYY-MM-DDTHH:mm:ss.SSSZ) */
+  dateUtc: Formatter;
+
+  /**
+   * Display the value as x decimals formatted, defaults to 2 decimals.
+   * You can pass "minDecimal" and/or "maxDecimal" to the "params" property.
+   * For example:: `{ formatter: Formatters.decimal, params: { minDecimal: 2, maxDecimal: 4 }}`
+   */
+  decimal: Formatter;
+
+  /** Display the value as 2 decimals formatted with dollar sign '$' at the end of of the value */
+  dollar: Formatter;
+
+  /** Display the value as 2 decimals formatted with dollar sign '$' at the end of of the value, change color of text to red/green on negative/positive value */
+  dollarColored: Formatter;
+
+  /** Display the value as 2 decimals formatted with dollar sign '$' at the end of of the value, change color of text to red/green on negative/positive value, show it in bold font weight as well */
+  dollarColoredBold: Formatter;
+
+  /**
+   * Takes an hyperlink cell value and transforms it into a real hyperlink, given that the value starts with 1 of these (http|ftp|https).
+   * The structure will be "<a href="hyperlink">hyperlink</a>"
+   *
+   * You can optionally change the hyperlink text displayed by using the generic params "hyperlinkText" in the column definition
+   * For example: { id: 'link', field: 'link', params: { hyperlinkText: 'Company Website' } } will display "<a href="link">Company Website</a>"
+   *
+   * You can also optionally provide the hyperlink URL by using the generic params "hyperlinkUrl" in the column definition
+   * For example: { id: 'link', field: 'link', params: {  hyperlinkText: 'Company Website', hyperlinkUrl: 'http://www.somewhere.com' } } will display "<a href="http://www.somewhere.com">Company Website</a>"
+   */
+  hyperlink: Formatter;
+
+  /** Display whichever icon you want (library agnostic, it could be Font-Awesome, Material or any other icons set) */
+  icon: Formatter;
+
+  /**
+   * Display whichever icon but only for boolean truthy values (library agnostic, it could be Font-Awesome, Material or any other icons set)
+   * Note: a value of "false", null, undefined, "1" or any number below 0 are all considered falsy and will not display the icon
+   */
+  iconBoolean: Formatter;
+
+  /**
+   * Takes a value display it according to a mask provided
+   * e.: 1234567890 with mask "(000) 000-0000" will display "(123) 456-7890"
+   */
+  mask: Formatter;
+
+  /**
+   * You can pipe multiple formatters (executed in sequence), use params to pass the list of formatters.
+   * Requires to pass an array of "formatters" in the column definition the generic "params" property
+   * For example::
+   * { field: 'title', formatter: Formatters.multiple, params: { formatters: [ Formatters.dollar, myCustomFormatter ] }
+   */
+  multiple: Formatter;
+
+  /** Takes a cell value number (between 0.0-1.0) and displays a red (<50) or green (>=50) bar */
+  percent: Formatter;
+
+  /** Takes a cell value number (between 0.0-100) and displays a red (<50) or green (>=50) bar */
+  percentComplete: Formatter;
+
+  /** Takes a cell value number (between 0-100) and displays a SlickGrid custom "percent-complete-bar" a red (<30), silver (>30 & <70) or green (>=70) bar */
+  percentCompleteBar: Formatter;
+
+  /** Takes a cell value number (between 0-100) and displays SlickGrid custom "percent-complete-bar" with Text a red (<30), silver (>30 & <70) or green (>=70) bar */
+  percentCompleteBarWithText: Formatter;
+
+  /** Takes a cell value number (between 0-100) and add the "%" after the number */
+  percentSymbol: Formatter;
+
+  /** Takes a cell value number (between 0-100) and displays Bootstrap "progress-bar" a red (<30), silver (>30 & <70) or green (>=70) bar */
+  progressBar: Formatter;
+
+  /** Takes a cell value and translates it. Requires an instance of the Translate Service:: `translater: this.translate */
+  translate: Formatter;
+
+  /** Takes a translation key string and tries to translate it. Requires an instance of the Translate Service:: `translater: this.translate */
+  translateBoolean: Formatter;
+
+  /** Formatter that must be used with a Tree Data column */
+  tree: Formatter;
+
+  /**
+   * Formatter that can be use to parse Tree Data totals and display totals using GroupTotalFormatters.
+   * This formatter works with both regular `Formatters` or `GroupTotalFormatters`,
+   * it will auto-detect if the current data context has a `__treeTotals` prop,
+   * then it will use the `GroupTotalFormatters`, if not then it will try to use regular `Formatters`.
+   *
+   * This mean that you can provide an array of `Formatters` & `GroupTotalFormatters` and it will use the correct formatter
+   * by detecting if the current data context has a `__treeTotals` prop (`GroupTotalFormatters`) or not (regular `Formatter`)
+   */
+  treeParseTotals: Formatter;
+
+  /** Formatter that must be use with a Tree Data column for Exporting the data */
+  treeExport: Formatter;
+}

--- a/packages/common/src/interfaces/sorter.interface.ts
+++ b/packages/common/src/interfaces/sorter.interface.ts
@@ -9,3 +9,103 @@ export type SortComparer = (
   sortColumn?: Column,
   gridOptions?: GridOption
 ) => number;
+
+/**
+ * All built-in SortComparers.
+ */
+export interface ISortComparers {
+  /** SortComparer method to sort boolean values as regular strings */
+  boolean: SortComparer;
+
+  /** SortComparer method to sort values by Date object type (uses Tempo ISO_8601 standard format, optionally include time) */
+  date: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD HH:mm:ss) */
+  dateIso: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DDTHH:mm:ss.SSSZ) */
+  dateUtc: SortComparer;
+
+  /** SortComparer method to sort values by Date and Time (native Date object) */
+  dateTime: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD HH:mm:ss) */
+  dateTimeIso: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD h:mm:ss a) */
+  dateTimeIsoAmPm: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD h:mm:ss A) */
+  dateTimeIsoAM_PM: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD HH:mm) */
+  dateTimeShortIso: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as Euro date (DD/MM/YYYY) */
+  dateEuro: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as Euro short date (D/M/YY) */
+  dateEuroShort: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY HH:mm) */
+  dateTimeShortEuro: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY HH:mm:ss) */
+  dateTimeEuro: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY hh:mm:ss a) */
+  dateTimeEuroAmPm: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY hh:mm:ss A) */
+  dateTimeEuroAM_PM: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (D/M/YY H:m:s) */
+  dateTimeEuroShort: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (D/M/YY h:m:s a) */
+  dateTimeEuroShortAmPm: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (D/M/YY h:m:s A) */
+  dateTimeEuroShortAM_PM: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as US date (MM/DD/YYYY) */
+  dateUs: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as US short date (M/D/YY) */
+  dateUsShort: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY HH:mm) */
+  dateTimeShortUs: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY HH:mm:s) */
+  dateTimeUs: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY hh:mm:ss a) */
+  dateTimeUsAmPm: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY hh:mm:ss A) */
+  dateTimeUsAM_PM: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (M/D/YY H:m:s) */
+  dateTimeUsShort: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (M/D/YY h:m:s a) */
+  dateTimeUsShortAmPm: SortComparer;
+
+  /** SortComparer method to sort values by Date formatted as (M/D/YY h:m:s A) */
+  dateTimeUsShortAM_PM: SortComparer;
+
+  /** SortComparer method to sort values as numeric fields */
+  numeric: SortComparer;
+
+  /**
+   * SortComparer method to sort object values with a "dataKey" provided in your column definition, it's data content must be of type string
+   * Example:
+   * columnDef = { id='user', field: 'user', ..., dataKey: 'firstName', SortComparer: SortComparers.objectString }
+   * collection = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Bob', lastName: 'Cash' }]
+   */
+  objectString: SortComparer;
+
+  /** SortComparer method to sort values as regular strings */
+  string: SortComparer;
+}

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -436,39 +436,44 @@ export function getColumnFieldType(columnDef: Column): (typeof FieldType)[keyof 
   return columnDef.outputType || columnDef.type || FieldType.string;
 }
 
+/** Return all Date field types that exists in the library */
+export function getAllDateFieldTypes(): (typeof FieldType)[keyof typeof FieldType][] {
+  return [
+    FieldType.date,
+    FieldType.dateTime,
+    FieldType.dateIso,
+    FieldType.dateTimeIso,
+    FieldType.dateTimeShortIso,
+    FieldType.dateTimeIsoAmPm,
+    FieldType.dateTimeIsoAM_PM,
+    FieldType.dateEuro,
+    FieldType.dateEuroShort,
+    FieldType.dateTimeEuro,
+    FieldType.dateTimeShortEuro,
+    FieldType.dateTimeEuroAmPm,
+    FieldType.dateTimeEuroAM_PM,
+    FieldType.dateTimeEuroShort,
+    FieldType.dateTimeEuroShortAmPm,
+    FieldType.dateTimeEuroShortAM_PM,
+    FieldType.dateUs,
+    FieldType.dateUsShort,
+    FieldType.dateTimeUs,
+    FieldType.dateTimeShortUs,
+    FieldType.dateTimeUsAmPm,
+    FieldType.dateTimeUsAM_PM,
+    FieldType.dateTimeUsShort,
+    FieldType.dateTimeUsShortAmPm,
+    FieldType.dateTimeUsShortAM_PM,
+    FieldType.dateUtc,
+  ];
+}
+
 /** Verify if the identified column is of type Date */
 export function isColumnDateType(fieldType?: (typeof FieldType)[keyof typeof FieldType]): boolean {
-  switch (fieldType) {
-    case FieldType.date:
-    case FieldType.dateTime:
-    case FieldType.dateIso:
-    case FieldType.dateTimeIso:
-    case FieldType.dateTimeShortIso:
-    case FieldType.dateTimeIsoAmPm:
-    case FieldType.dateTimeIsoAM_PM:
-    case FieldType.dateEuro:
-    case FieldType.dateEuroShort:
-    case FieldType.dateTimeEuro:
-    case FieldType.dateTimeShortEuro:
-    case FieldType.dateTimeEuroAmPm:
-    case FieldType.dateTimeEuroAM_PM:
-    case FieldType.dateTimeEuroShort:
-    case FieldType.dateTimeEuroShortAmPm:
-    case FieldType.dateTimeEuroShortAM_PM:
-    case FieldType.dateUs:
-    case FieldType.dateUsShort:
-    case FieldType.dateTimeUs:
-    case FieldType.dateTimeShortUs:
-    case FieldType.dateTimeUsAmPm:
-    case FieldType.dateTimeUsAM_PM:
-    case FieldType.dateTimeUsShort:
-    case FieldType.dateTimeUsShortAmPm:
-    case FieldType.dateTimeUsShortAM_PM:
-    case FieldType.dateUtc:
-      return true;
-    default:
-      return false;
+  if (getAllDateFieldTypes().includes(fieldType as (typeof FieldType)[keyof typeof FieldType])) {
+    return true;
   }
+  return false;
 }
 
 /**

--- a/packages/common/src/sortComparers/sortComparers.index.ts
+++ b/packages/common/src/sortComparers/sortComparers.index.ts
@@ -1,110 +1,41 @@
+import { FieldType } from '../enums/fieldType.enum.js';
+import type { ISortComparers, SortComparer } from '../interfaces/sorter.interface.js';
+import { getAssociatedDateSortComparer } from './dateUtilities.js';
+import { getAllDateFieldTypes } from '../services/utilities.js';
 import { booleanSortComparer } from './booleanSortComparer.js';
 import { numericSortComparer } from './numericSortComparer.js';
 import { objectStringSortComparer } from './objectStringSortComparer.js';
 import { stringSortComparer } from './stringSortComparer.js';
-import { getAssociatedDateSortComparer } from './dateUtilities.js';
-import { FieldType } from '../enums/fieldType.enum.js';
-import type { SortComparer } from '../interfaces/sorter.interface.js';
 
 // export the Sort Utilities so they could be used by others
 export * from './sortUtilities.js';
 
-export const SortComparers: Record<string, SortComparer> = {
-  /** SortComparer method to sort values as regular strings */
-  boolean: booleanSortComparer satisfies SortComparer as SortComparer,
+/**
+ * Builds a map of all available SortComparers, including date comparers.
+ * @returns {ISortComparers} All sort comparers, keyed by type.
+ */
+function buildAllSortComparers(): ISortComparers {
+  const comparers: Record<string, SortComparer> = {
+    boolean: booleanSortComparer,
+    numeric: numericSortComparer,
+    objectString: objectStringSortComparer,
+    string: stringSortComparer,
+  };
 
-  /** SortComparer method to sort values by Date object type (uses Tempo ISO_8601 standard format, optionally include time) */
-  date: getAssociatedDateSortComparer(FieldType.date),
+  // Dynamically add date comparers based on available FieldTypes, doing it this way to keep smaller bundle size
+  getAllDateFieldTypes().forEach((dateType) => {
+    const fieldType = FieldType[dateType as keyof typeof FieldType];
+    if (fieldType) {
+      comparers[dateType] = getAssociatedDateSortComparer(fieldType);
+    }
+  });
+  return comparers as unknown as ISortComparers;
+}
 
-  /**
-   * SortComparer method to sort values by Date formatted as ISO date (excluding time),
-   * If you wish to optionally include time simply use the "SortComparers.date" which work with/without time
-   */
-  dateIso: getAssociatedDateSortComparer(FieldType.dateIso),
-
-  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DDTHH:mm:ss.SSSZ) */
-  dateUtc: getAssociatedDateSortComparer(FieldType.dateUtc),
-
-  /** SortComparer method to sort values by Date and Time (native Date object) */
-  dateTime: getAssociatedDateSortComparer(FieldType.dateTime),
-
-  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD HH:mm:ss) */
-  dateTimeIso: getAssociatedDateSortComparer(FieldType.dateTimeIso),
-
-  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD h:mm:ss a) */
-  dateTimeIsoAmPm: getAssociatedDateSortComparer(FieldType.dateTimeIsoAmPm),
-
-  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD h:mm:ss A) */
-  dateTimeIsoAM_PM: getAssociatedDateSortComparer(FieldType.dateTimeIsoAM_PM),
-
-  /** SortComparer method to sort values by Date formatted as (YYYY-MM-DD HH:mm) */
-  dateTimeShortIso: getAssociatedDateSortComparer(FieldType.dateTimeShortIso),
-
-  /** SortComparer method to sort values by Date formatted as Euro date (DD/MM/YYYY) */
-  dateEuro: getAssociatedDateSortComparer(FieldType.dateEuro),
-
-  /** SortComparer method to sort values by Date formatted as Euro short date (D/M/YY) */
-  dateEuroShort: getAssociatedDateSortComparer(FieldType.dateEuroShort),
-
-  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY HH:mm) */
-  dateTimeShortEuro: getAssociatedDateSortComparer(FieldType.dateTimeShortEuro),
-
-  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY HH:mm:ss) */
-  dateTimeEuro: getAssociatedDateSortComparer(FieldType.dateTimeEuro),
-
-  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY hh:mm:ss a) */
-  dateTimeEuroAmPm: getAssociatedDateSortComparer(FieldType.dateTimeEuroAmPm),
-
-  /** SortComparer method to sort values by Date formatted as (DD/MM/YYYY hh:mm:ss A) */
-  dateTimeEuroAM_PM: getAssociatedDateSortComparer(FieldType.dateTimeEuroAM_PM),
-
-  /** SortComparer method to sort values by Date formatted as (D/M/YY H:m:s) */
-  dateTimeEuroShort: getAssociatedDateSortComparer(FieldType.dateTimeEuroShort),
-
-  /** SortComparer method to sort values by Date formatted as (D/M/YY h:m:s a) */
-  dateTimeEuroShortAmPm: getAssociatedDateSortComparer(FieldType.dateTimeEuroShortAmPm),
-
-  /** SortComparer method to sort values by Date formatted as (D/M/YY h:m:s A) */
-  dateTimeEuroShortAM_PM: getAssociatedDateSortComparer(FieldType.dateTimeEuroShortAM_PM),
-
-  /** SortComparer method to sort values by Date formatted as US date (MM/DD/YYYY) */
-  dateUs: getAssociatedDateSortComparer(FieldType.dateUs),
-
-  /** SortComparer method to sort values by Date formatted as US short date (M/D/YY) */
-  dateUsShort: getAssociatedDateSortComparer(FieldType.dateUsShort),
-
-  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY HH:mm) */
-  dateTimeShortUs: getAssociatedDateSortComparer(FieldType.dateTimeShortUs),
-
-  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY HH:mm:s) */
-  dateTimeUs: getAssociatedDateSortComparer(FieldType.dateTimeUs),
-
-  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY hh:mm:ss a) */
-  dateTimeUsAmPm: getAssociatedDateSortComparer(FieldType.dateTimeUsAmPm),
-
-  /** SortComparer method to sort values by Date formatted as (MM/DD/YYYY hh:mm:ss A) */
-  dateTimeUsAM_PM: getAssociatedDateSortComparer(FieldType.dateTimeUsAM_PM),
-
-  /** SortComparer method to sort values by Date formatted as (M/D/YY H:m:s) */
-  dateTimeUsShort: getAssociatedDateSortComparer(FieldType.dateTimeUsShort),
-
-  /** SortComparer method to sort values by Date formatted as (M/D/YY h:m:s a) */
-  dateTimeUsShortAmPm: getAssociatedDateSortComparer(FieldType.dateTimeUsShortAmPm),
-
-  /** SortComparer method to sort values by Date formatted as (M/D/YY h:m:s A) */
-  dateTimeUsShortAM_PM: getAssociatedDateSortComparer(FieldType.dateTimeUsShortAM_PM),
-
-  /** SortComparer method to sort values as numeric fields */
-  numeric: numericSortComparer satisfies SortComparer as SortComparer,
-
-  /**
-   * SortComparer method to sort object values with a "dataKey" provided in your column definition, it's data content must be of type string
-   * Example:
-   * columnDef = { id='user', field: 'user', ..., dataKey: 'firstName', SortComparer: SortComparers.objectString }
-   * collection = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Bob', lastName: 'Cash' }]
-   */
-  objectString: objectStringSortComparer satisfies SortComparer as SortComparer,
-
-  /** SortComparer method to sort values as regular strings */
-  string: stringSortComparer satisfies SortComparer as SortComparer,
-};
+/**
+ * All available SortComparers, including static and dynamically added date comparers.
+ *
+ * - Static: boolean, numeric, objectString, string
+ * - Dynamic: all date field types (see {@link getAllDateFieldTypes})
+ */
+export const SortComparers: ISortComparers = buildAllSortComparers();


### PR DESCRIPTION
while working on a base Date Formatters, I saw an opportunity to decrease lib build size by creating all date Formatters & SortComparers dynamically and remove duplicative code (duplicate lines of code for all date types).