### PR TITLE
fix: autoHeight should add preHeader height when enabled

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2171,6 +2171,37 @@ describe('SlickGrid core file', () => {
         expect(grid.getViewportHeight()).toBe(DEFAULT_COLUMN_HEIGHT * data.length);
       });
 
+      it('should return full viewport height by data size when "autoHeight" is enabled and has pre-header & frozenColumn', () => {
+        grid = new SlickGrid<any, Column>(container, data, columns, {
+          ...defaultOptions,
+          autoHeight: true,
+          frozenColumn: 1,
+          createPreHeaderPanel: true,
+          showPreHeaderPanel: true,
+          preHeaderPanelHeight: 44,
+        });
+        grid.init();
+
+        expect(grid.getViewportHeight()).toBe(DEFAULT_COLUMN_HEIGHT * data.length);
+      });
+
+      it('should return full viewport height by data size + headerRow & preHeader when they are enabled with "autoHeight"', () => {
+        grid = new SlickGrid<any, Column>(container, data, columns, {
+          ...defaultOptions,
+          autoHeight: true,
+          forceFitColumns: true,
+          showHeaderRow: true,
+          headerRowHeight: 50,
+          createPreHeaderPanel: true,
+          showPreHeaderPanel: true,
+          preHeaderPanelHeight: 44,
+        });
+        grid.init();
+
+        expect(grid.getViewportHeight()).toBe(DEFAULT_COLUMN_HEIGHT * data.length + 50 + 44);
+        expect(grid.getCanvasWidth()).toBe(800);
+      });
+
       it('should return full viewport height by data size + headerRow & footerRow when they are enabled with "autoHeight"', () => {
         grid = new SlickGrid<any, Column>(container, data, columns, {
           ...defaultOptions,

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4335,6 +4335,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (this._options.autoHeight) {
       let fullHeight = this._paneHeaderL.offsetHeight;
+      fullHeight += this._options.showPreHeaderPanel
+        ? this._options.preHeaderPanelHeight! + this.getVBoxDelta(this._preHeaderPanelScroller)
+        : 0;
       fullHeight += this._options.showHeaderRow ? this._options.headerRowHeight! + this.getVBoxDelta(this._headerRowScroller[0]) : 0;
       fullHeight += this._options.showFooterRow ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0]) : 0;
       fullHeight += this.getCanvasWidth() > this.viewportW ? this.scrollbarDimensions?.height || 0 : 0;
@@ -4420,8 +4423,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       if (this._options.autoHeight) {
         if (this.hasFrozenColumns()) {
-          const style = getComputedStyle(this._headerScrollerL);
-          Utils.height(this._container, this.paneTopH + Utils.toFloat(style.height));
+          let fullHeight = this.paneTopH + this._headerScrollerL.offsetHeight;
+          fullHeight += this.getVBoxDelta(this._container);
+          if (this._options.showPreHeaderPanel) {
+            fullHeight += this._options.preHeaderPanelHeight!;
+          }
+          Utils.height(this._container, fullHeight);
         }
 
         this._paneTopL.style.position = 'relative';


### PR DESCRIPTION
fixes an issue identified in SlickGrid, see [issue 1123](https://github.com/6pac/SlickGrid/pull/1123)

- when preHeader is enabled, it should be added to the calculation of the grid container auto-height, this wasn't the case before and the frozen scroll ended up being shown in the hidden section making it completely unusable

![image](https://github.com/user-attachments/assets/f125a02b-6a8e-4af4-9a8b-764698c70836)

