### PR TITLE
fix: incorrect grid container box size calculation border not showing

### DIFF
--- a/demos/aurelia/test/cypress/e2e/example32.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example32.cy.ts
@@ -25,7 +25,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should make the grid readonly and expect to fit the text by content and expect column width to be the same as earlier', () => {
@@ -41,7 +41,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
@@ -57,7 +57,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.lt', 85);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.lt', 120);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.lt', 100);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should double-click on the "Complexity" column resize handle and expect the column to become wider and show all text', () => {

--- a/demos/react/test/cypress/e2e/example32.cy.ts
+++ b/demos/react/test/cypress/e2e/example32.cy.ts
@@ -25,7 +25,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should make the grid readonly and expect to fit the text by content and expect column width to be the same as earlier', () => {
@@ -41,7 +41,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
@@ -57,7 +57,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.lt', 85);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.lt', 120);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.lt', 100);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should double-click on the "Complexity" column resize handle and expect the column to become wider and show all text', () => {

--- a/demos/vue/test/cypress/e2e/example32.cy.ts
+++ b/demos/vue/test/cypress/e2e/example32.cy.ts
@@ -25,7 +25,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should make the grid readonly and expect to fit the text by content and expect column width to be the same as earlier', () => {
@@ -41,7 +41,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
@@ -57,7 +57,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.lt', 85);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.lt', 120);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.lt', 100);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should double-click on the "Complexity" column resize handle and expect the column to become wider and show all text', () => {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example32.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example32.cy.ts
@@ -25,7 +25,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should make the grid readonly and expect to fit the text by content and expect column width to be the same as earlier', () => {
@@ -41,7 +41,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
@@ -57,7 +57,7 @@ describe('Example 32 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.lt', 85);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.lt', 120);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.lt', 100);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should double-click on the "Complexity" column resize handle and expect the column to become wider and show all text', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -913,26 +913,27 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this._canvas = [this._canvasTopL, this._canvasTopR, this._canvasBottomL, this._canvasBottomR];
 
     this.scrollbarDimensions = this.scrollbarDimensions || this.measureScrollbar();
+    const canvasWithScrollbarWidth = this.getCanvasWidth() + this.scrollbarDimensions.width;
 
     // Default the active canvas to the top left
     this._activeCanvasNode = this._canvasTopL;
 
     // top-header
     if (this._topHeaderPanelSpacer) {
-      Utils.width(this._topHeaderPanelSpacer, this.getCanvasWidth() + this.scrollbarDimensions.width);
+      Utils.width(this._topHeaderPanelSpacer, canvasWithScrollbarWidth);
     }
 
     // pre-header
     if (this._preHeaderPanelSpacer) {
-      Utils.width(this._preHeaderPanelSpacer, this.getCanvasWidth() + this.scrollbarDimensions.width);
+      Utils.width(this._preHeaderPanelSpacer, canvasWithScrollbarWidth);
     }
 
     this._headers.forEach((el) => {
       Utils.width(el, this.getHeadersWidth());
     });
 
-    Utils.width(this._headerRowSpacerL, this.getCanvasWidth() + this.scrollbarDimensions.width);
-    Utils.width(this._headerRowSpacerR, this.getCanvasWidth() + this.scrollbarDimensions.width);
+    Utils.width(this._headerRowSpacerL, canvasWithScrollbarWidth);
+    Utils.width(this._headerRowSpacerR, canvasWithScrollbarWidth);
 
     // footer Row
     if (this._options.createFooterRow) {
@@ -946,13 +947,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } },
         this._footerRowScrollerL
       );
-      Utils.width(this._footerRowSpacerL, this.getCanvasWidth() + this.scrollbarDimensions.width);
+      Utils.width(this._footerRowSpacerL, canvasWithScrollbarWidth);
       this._footerRowSpacerR = createDomElement(
         'div',
         { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } },
         this._footerRowScrollerR
       );
-      Utils.width(this._footerRowSpacerR, this.getCanvasWidth() + this.scrollbarDimensions.width);
+      Utils.width(this._footerRowSpacerR, canvasWithScrollbarWidth);
 
       this._footerRowL = createDomElement(
         'div',
@@ -1379,12 +1380,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this._options.createTopHeaderPanel) {
       Utils.width(this._topHeaderPanel, this._options.topHeaderPanelWidth ?? this.canvasWidth);
     }
-
     const widthChanged =
       this.canvasWidth !== oldCanvasWidth || this.canvasWidthL !== oldCanvasWidthL || this.canvasWidthR !== oldCanvasWidthR;
 
     if (widthChanged || this.hasFrozenColumns() || this.hasFrozenRows) {
-      Utils.width(this._canvasTopL, this.canvasWidthL);
+      // in some browsers horizontal is showing when it shouldn't and removing 0.1px patches this issue (or even 0.0001 would be enough)
+      Utils.width(this._canvasTopL, this.canvasWidthL - 0.1);
 
       this.getHeadersWidth();
 
@@ -2478,6 +2479,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
   }
 
+  /**
+   * Calculates the vertical box sizes (the sum of top/bottom borders and paddings)
+   * for a given element by reading its computed style.
+   * @param el
+   * @returns number
+   */
   protected getVBoxDelta(el: HTMLElement): number {
     const p = ['borderTopWidth', 'borderBottomWidth', 'paddingTop', 'paddingBottom'];
     const styles = getComputedStyle(el);
@@ -4345,29 +4352,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.viewportH =
         this._options.rowHeight! * this.getDataLengthIncludingAddNew() + (this._options.frozenColumn === -1 ? fullHeight : 0);
     } else {
-      const columnNamesH = this._options.showColumnHeader
-        ? Utils.toFloat(Utils.height(this._headerScroller[0]) as number) + this.getVBoxDelta(this._headerScroller[0])
-        : 0;
-      const preHeaderH =
-        this._options.createPreHeaderPanel && this._options.showPreHeaderPanel
-          ? this._options.preHeaderPanelHeight! + this.getVBoxDelta(this._preHeaderPanelScroller)
-          : 0;
+      const style = getComputedStyle(this._container);
+      const containerBoxH = style.boxSizing !== 'content-box' ? this.getVBoxDelta(this._container) : 0;
       const topHeaderH =
         this._options.createTopHeaderPanel && this._options.showTopHeaderPanel
           ? this._options.topHeaderPanelHeight! + this.getVBoxDelta(this._topHeaderPanelScroller)
           : 0;
-
-      const style = getComputedStyle(this._container);
+      const preHeaderH =
+        this._options.createPreHeaderPanel && this._options.showPreHeaderPanel
+          ? this._options.preHeaderPanelHeight! + this.getVBoxDelta(this._preHeaderPanelScroller)
+          : 0;
+      const columnNamesH = this._options.showColumnHeader ? Utils.toFloat(Utils.height(this._headerScroller[0]) as number) : 0;
       this.viewportH =
         Utils.toFloat(style.height) -
         Utils.toFloat(style.paddingTop) -
         Utils.toFloat(style.paddingBottom) -
-        columnNamesH -
         this.topPanelH -
-        this.headerRowH -
-        this.footerRowH -
+        topHeaderH -
         preHeaderH -
-        topHeaderH;
+        this.headerRowH -
+        columnNamesH -
+        this.footerRowH -
+        containerBoxH;
     }
 
     this.numVisibleRows = Math.ceil(this.viewportH / this._options.rowHeight!);

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -227,7 +227,7 @@ export class ResizerService {
 
   /**
    * Calculate the datagrid new height/width from the available space, also consider that a % factor might be applied to calculation
-   * object gridOptions
+   * @param {GridOption} gridOptions
    */
   calculateGridNewDimensions(gridOptions: GridOption): GridSize | null {
     const autoResizeOptions = gridOptions?.autoResize ?? {};
@@ -239,7 +239,7 @@ export class ResizerService {
 
     // calculate bottom padding
     // if using pagination, we need to add the pagination height to this bottom padding
-    let bottomPadding = autoResizeOptions?.bottomPadding !== undefined ? autoResizeOptions.bottomPadding : DATAGRID_BOTTOM_PADDING;
+    let bottomPadding = autoResizeOptions?.bottomPadding ?? DATAGRID_BOTTOM_PADDING;
     if (bottomPadding && gridOptions.enablePagination) {
       bottomPadding += DATAGRID_PAGINATION_HEIGHT;
     }
@@ -389,11 +389,14 @@ export class ResizerService {
       // also call the grid auto-size columns so that it takes available space when going bigger
       if (this._grid && this.gridOptions?.enableAutoSizeColumns) {
         // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree) to avoid SlickGrid error "missing stylesheet"
-        if (this.gridUid && document.querySelector(this.gridUidSelector)) {
-          // don't call autosize unless dimension really changed
-          if (!this._lastDimensions || this._lastDimensions.height !== newHeight || this._lastDimensions.width !== newWidth) {
-            this._grid.autosizeColumns();
-          }
+        // don't call autosize unless dimension really changed
+        if (
+          (this.gridUid && document.querySelector(this.gridUidSelector)) ||
+          !this._lastDimensions ||
+          this._lastDimensions.height !== newHeight ||
+          this._lastDimensions.width !== newWidth
+        ) {
+          this._grid.autosizeColumns();
         }
       } else if (
         this.gridOptions.enableAutoResizeColumnsByCellContent &&

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -389,14 +389,11 @@ export class ResizerService {
       // also call the grid auto-size columns so that it takes available space when going bigger
       if (this._grid && this.gridOptions?.enableAutoSizeColumns) {
         // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree) to avoid SlickGrid error "missing stylesheet"
-        // don't call autosize unless dimension really changed
-        if (
-          (this.gridUid && document.querySelector(this.gridUidSelector)) ||
-          !this._lastDimensions ||
-          this._lastDimensions.height !== newHeight ||
-          this._lastDimensions.width !== newWidth
-        ) {
-          this._grid.autosizeColumns();
+        if (this.gridUid && document.querySelector(this.gridUidSelector)) {
+          // don't call autosize unless dimension really changed
+          if (!this._lastDimensions || this._lastDimensions.height !== newHeight || this._lastDimensions.width !== newWidth) {
+            this._grid.autosizeColumns();
+          }
         }
       } else if (
         this.gridOptions.enableAutoResizeColumnsByCellContent &&

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -27,33 +27,33 @@ describe('Example 14 - Columns Resize by Content', () => {
     });
 
     it('should have cell that fit the text content', () => {
-      cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('equal', 79);
-      cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('equal', 98);
-      cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('equal', 67);
-      cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('equal', 160);
-      cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('equal', 106);
-      cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('equal', 88);
-      cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('equal', 68);
-      cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('equal', 88);
-      cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('equal', 173);
-      cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('equal', 100);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('be.approximately', 79, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('be.approximately', 98, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('be.approximately', 67, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('be.approximately', 160, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('be.approximately', 106, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('be.approximately', 88, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('be.approximately', 68, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.approximately', 88, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.approximately', 173, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.approximately', 100, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should make the grid readonly and expect to fit the text by content and expect column width to be the same as earlier', () => {
       cy.get('[data-test="toggle-readonly-btn"]').click();
 
-      cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('equal', 71);
-      cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('equal', 98);
-      cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('equal', 67);
-      cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('equal', 152);
-      cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('equal', 98);
-      cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('equal', 80);
-      cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('equal', 68);
-      cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('equal', 80);
-      cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('equal', 165);
-      cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('equal', 92);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('be.approximately', 71, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('be.approximately', 98, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('be.approximately', 67, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('be.approximately', 152, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('be.approximately', 98, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('be.approximately', 80, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('be.approximately', 68, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.approximately', 80, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.approximately', 165, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.approximately', 92, 1);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
@@ -69,7 +69,7 @@ describe('Example 14 - Columns Resize by Content', () => {
       cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.lt', 85);
       cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.lt', 120);
       cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.lt', 100);
-      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+      cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('be.approximately', 58, 1);
     });
 
     it('should double-click on the "Complexity" column resize handle and expect the column to become wider and show all text', () => {


### PR DESCRIPTION
- depending on which `border-sizing` style the user has defined on its grid container element, the border was sometime not showing at bottom of the grid (ie: the grid below should have a border all around, but its bottom border wasn't showing)
- this wasn't an issue if the container has `border-sizing: 'content-box'` but most users have it set to `'border-box'` which is the default.
- also fix a problem that was in some rare occasion showing horizontal scroll for no reason, it seemed that the canvas width with slightly too wide and just removing `0.1px` out of the equation is enough to fix the problem

![image](https://github.com/user-attachments/assets/6825f96f-6fa3-4fdf-bd28-c75cacfdb614)

![image](https://github.com/user-attachments/assets/3543956c-4a8b-4baf-9c55-c49383a8c57f)
