### PR TITLE
fix!: remove Arrow pointer from Custom Tooltip

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example33.scss
+++ b/demos/aurelia/src/examples/slickgrid/example33.scss
@@ -13,10 +13,6 @@ $button-border-color: #ababab;
 //   --slick-tooltip-border-color:             #252525;
 //   --slick-tooltip-border:                   2px solid #252525;
 //   --slick-tooltip-color:                    #ffffff;
-
-//   --slick-tooltip-arrow-color:              var(--slick-tooltip-border-color);
-//   --slick-tooltip-arrow-size:               10px;
-//   --slick-tooltip-arrow-side-margin:        15px;
 // }
 
 .editable-field {
@@ -42,7 +38,7 @@ $button-border-color: #ababab;
   font-size: 14px;
 }
 .headerrow-tooltip-title {
-  color: #AD0041;
+  color: #ad0041;
   font-style: italic;
   font-size: 13px;
   font-weight: bold;
@@ -61,24 +57,4 @@ $button-border-color: #ababab;
   color: #ffffff;
   background-color: #363636;
   border: 2px solid #252525;
-}
-.l4.slick-custom-tooltip.arrow-down::after,
-.l4.slick-custom-tooltip.arrow-up::after {
-  border-width: 10px; // arrow size
-}
-.l4.slick-custom-tooltip.arrow-down::after {
-  border-top-color: #252525; // arrow down color
-}
-.l4.slick-custom-tooltip.arrow-up::after {
-  top: -20px; // arrow size * 2
-  border-bottom-color: #252525; // arrow up color
-}
-.l4.slick-custom-tooltip.arrow-left-align::after {
-  margin-left: 15px;
-}
-.l4.slick-custom-tooltip.arrow-right-align::after {
-  margin-left: calc(100% - 20px - 15px); // 20px is (arrow size * 2), 15px is your extra side margin
-}
-.l6.slick-custom-tooltip.arrow-left-align::after {
-  margin-left: 4px;
 }

--- a/demos/aurelia/src/examples/slickgrid/example33.ts
+++ b/demos/aurelia/src/examples/slickgrid/example33.ts
@@ -415,7 +415,6 @@ export class Example33 {
         headerFormatter: this.headerFormatter,
         headerRowFormatter: this.headerRowFormatter,
         usabilityOverride: (args) => args.cell !== 0 && args?.column?.id !== 'action', // don't show on first/last columns
-        // hideArrow: true, // defaults to False
       },
       presets: {
         filters: [{ columnId: 'prerequisites', searchTerms: [1, 3, 5, 7, 9, 12, 15, 18, 21, 25, 28, 29, 30, 32, 34] }],

--- a/demos/react/src/examples/slickgrid/Example33.tsx
+++ b/demos/react/src/examples/slickgrid/Example33.tsx
@@ -405,7 +405,6 @@ const Example33: React.FC = () => {
         headerFormatter,
         headerRowFormatter,
         usabilityOverride: (args) => args.cell !== 0 && args?.column?.id !== 'action', // don't show on first/last columns
-        // hideArrow: true, // defaults to False
       },
       presets: {
         filters: [{ columnId: 'prerequisites', searchTerms: [1, 3, 5, 7, 9, 12, 15, 18, 21, 25, 28, 29, 30, 32, 34] }],

--- a/demos/react/src/examples/slickgrid/example33.scss
+++ b/demos/react/src/examples/slickgrid/example33.scss
@@ -13,10 +13,6 @@ $button-border-color: #ababab;
 //   --slick-tooltip-border-color:             #252525;
 //   --slick-tooltip-border:                   2px solid #252525;
 //   --slick-tooltip-color:                    #ffffff;
-
-//   --slick-tooltip-arrow-color:              var(--slick-tooltip-border-color);
-//   --slick-tooltip-arrow-size:               10px;
-//   --slick-tooltip-arrow-side-margin:        15px;
 // }
 
 .editable-field {
@@ -42,7 +38,7 @@ $button-border-color: #ababab;
   font-size: 14px;
 }
 .headerrow-tooltip-title {
-  color: #AD0041;
+  color: #ad0041;
   font-style: italic;
   font-size: 13px;
   font-weight: bold;
@@ -61,24 +57,4 @@ $button-border-color: #ababab;
   color: #ffffff;
   background-color: #363636;
   border: 2px solid #252525;
-}
-.l4.slick-custom-tooltip.arrow-down::after,
-.l4.slick-custom-tooltip.arrow-up::after {
-  border-width: 10px; // arrow size
-}
-.l4.slick-custom-tooltip.arrow-down::after {
-  border-top-color: #252525; // arrow down color
-}
-.l4.slick-custom-tooltip.arrow-up::after {
-  top: -20px; // arrow size * 2
-  border-bottom-color: #252525; // arrow up color
-}
-.l4.slick-custom-tooltip.arrow-left-align::after {
-  margin-left: 15px;
-}
-.l4.slick-custom-tooltip.arrow-right-align::after {
-  margin-left: calc(100% - 20px - 15px); // 20px is (arrow size * 2), 15px is your extra side margin
-}
-.l6.slick-custom-tooltip.arrow-left-align::after {
-  margin-left: 4px;
 }

--- a/demos/vanilla/src/examples/example16.scss
+++ b/demos/vanilla/src/examples/example16.scss
@@ -8,10 +8,6 @@
 //   --slick-tooltip-border-color:             #252525;
 //   --slick-tooltip-border:                   2px solid #252525;
 //   --slick-tooltip-color:                    #ffffff;
-
-//   --slick-tooltip-arrow-color:              var(--slick-tooltip-border-color);
-//   --slick-tooltip-arrow-size:               10px;
-//   --slick-tooltip-arrow-side-margin:        15px;
 // }
 
 .header-tooltip-title {
@@ -19,7 +15,7 @@
   font-size: 14px;
 }
 .headerrow-tooltip-title {
-  color: #AD0041;
+  color: #ad0041;
   font-style: italic;
   font-size: 13px;
   font-weight: bold;
@@ -40,33 +36,12 @@
     background-color: #696969;
     border: 2px solid #545454;
   }
-  &.l4.arrow-down::after,
-  &.l4.arrow-up::after {
-    border-width: 10px; // arrow size
-  }
-  &.l4.arrow-down::after {
-    border-top-color: #464646; // arrow down color
-  }
-  &.l4.arrow-up::after {
-    top: -20px; // arrow size * 2
-    border-bottom-color: #464646; // arrow up color
-  }
-  &.l4.arrow-left-align::after {
-    margin-left: 15px;
-  }
-  &.l4.arrow-right-align::after {
-    margin-left: calc(100% - 20px - 15px); // 20px is (arrow size * 2), 15px is your extra side margin
-  }
-  &.l6.arrow-left-align::after {
-    margin-left: 4px;
-  }
 }
 
-[data-theme=dark] .grid16-tooltip {
+[data-theme='dark'] .grid16-tooltip {
   --slick-tooltip-color: #dadada;
   --slick-tooltip-border: 1px solid #5a5a5a;
   --slick-tooltip-background-color: #414141;
-  --slick-tooltip-arrow-color: #707070;
 
   &.l4 {
     --slick-tooltip-color: #dadada;

--- a/demos/vanilla/src/examples/example16.ts
+++ b/demos/vanilla/src/examples/example16.ts
@@ -451,7 +451,6 @@ export default class Example16 {
         headerFormatter: this.headerFormatter,
         headerRowFormatter: this.headerRowFormatter,
         usabilityOverride: (args) => args.cell !== 0 && args?.column?.id !== 'action', // don't show on first/last columns
-        // hideArrow: true, // defaults to False
       },
       presets: {
         filters: [{ columnId: 'prerequisites', searchTerms: [1, 3, 5, 7, 9, 12, 15, 18, 21, 25, 28, 29, 30, 32, 34] }],

--- a/demos/vue/src/components/Example33.vue
+++ b/demos/vue/src/components/Example33.vue
@@ -440,7 +440,6 @@ function defineGrid() {
       headerFormatter,
       headerRowFormatter,
       usabilityOverride: (args) => args.cell !== 0 && args?.column?.id !== 'action', // don't show on first/last columns
-      // hideArrow: true, // defaults to False
     },
     presets: {
       filters: [{ columnId: 'prerequisites', searchTerms: [1, 3, 5, 7, 9, 12, 15, 18, 21, 25, 28, 29, 30, 32, 34] }],

--- a/docs/migrations/migration-to-9.x.md
+++ b/docs/migrations/migration-to-9.x.md
@@ -14,7 +14,7 @@ The other great thing about having everything under the same roof/project is tha
 - upgrade Vanilla-Calendar-Pro to v3 with [flat config](#date-editorfilter-flat-config)
 - skipping v6-8 and going straight to v9.0
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
-- removing Arrow pointer from Custom Tooltip addon
+- removing Arrow pointer from Custom Tooltip addon (because it was often offset with the cell text)
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/docs/migrations/migration-to-9.x.md
+++ b/docs/migrations/migration-to-9.x.md
@@ -14,6 +14,7 @@ The other great thing about having everything under the same roof/project is tha
 - upgrade Vanilla-Calendar-Pro to v3 with [flat config](#date-editorfilter-flat-config)
 - skipping v6-8 and going straight to v9.0
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
+- removing Arrow pointer from Custom Tooltip addon
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/angular-slickgrid/docs/migrations/migration-to-9.x.md
+++ b/frameworks/angular-slickgrid/docs/migrations/migration-to-9.x.md
@@ -13,7 +13,7 @@ I also decided to align all SlickGrid examples in all frameworks and Angular-Sli
 - upgrade Vanilla-Calendar-Pro to v3 with [flat config](#date-editorfilter-flat-config)
 - [shorter attribute names](#shorter-attribute-names)
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
-- removing Arrow pointer from Custom Tooltip addon
+- removing Arrow pointer from Custom Tooltip addon (because it was often offset with the cell text)
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/angular-slickgrid/docs/migrations/migration-to-9.x.md
+++ b/frameworks/angular-slickgrid/docs/migrations/migration-to-9.x.md
@@ -13,6 +13,7 @@ I also decided to align all SlickGrid examples in all frameworks and Angular-Sli
 - upgrade Vanilla-Calendar-Pro to v3 with [flat config](#date-editorfilter-flat-config)
 - [shorter attribute names](#shorter-attribute-names)
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
+- removing Arrow pointer from Custom Tooltip addon
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example33.component.scss
+++ b/frameworks/angular-slickgrid/src/demos/examples/example33.component.scss
@@ -10,10 +10,6 @@
 //   --slick-tooltip-border-color:             #252525;
 //   --slick-tooltip-border:                   2px solid #252525;
 //   --slick-tooltip-color:                    #ffffff;
-
-//   --slick-tooltip-arrow-color:              var(--slick-tooltip-border-color);
-//   --slick-tooltip-arrow-size:               10px;
-//   --slick-tooltip-arrow-side-margin:        15px;
 // }
 
 .editable-field {
@@ -28,7 +24,7 @@
   font-size: 14px;
 }
 .headerrow-tooltip-title {
-  color: #AD0041;
+  color: #ad0041;
   font-style: italic;
   font-size: 13px;
   font-weight: bold;
@@ -47,24 +43,4 @@
   color: #ffffff;
   background-color: #363636;
   border: 2px solid #252525;
-}
-.l4.slick-custom-tooltip.arrow-down::after,
-.l4.slick-custom-tooltip.arrow-up::after {
-  border-width: 10px; // arrow size
-}
-.l4.slick-custom-tooltip.arrow-down::after {
-  border-top-color: #252525; // arrow down color
-}
-.l4.slick-custom-tooltip.arrow-up::after {
-  top: -20px; // arrow size * 2
-  border-bottom-color: #252525; // arrow up color
-}
-.l4.slick-custom-tooltip.arrow-left-align::after {
-  margin-left: 15px;
-}
-.l4.slick-custom-tooltip.arrow-right-align::after {
-  margin-left: calc(100% - 20px - 15px); // 20px is (arrow size * 2), 15px is your extra side margin
-}
-.l6.slick-custom-tooltip.arrow-left-align::after {
-  margin-left: 4px;
 }

--- a/frameworks/angular-slickgrid/src/demos/examples/example33.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example33.component.ts
@@ -406,7 +406,6 @@ export class Example33Component implements OnInit {
         headerFormatter: this.headerFormatter,
         headerRowFormatter: this.headerRowFormatter,
         usabilityOverride: (args) => args.cell !== 0 && args?.column?.id !== 'action', // don't show on first/last columns
-        // hideArrow: true, // defaults to False
       },
       presets: {
         filters: [{ columnId: 'prerequisites', searchTerms: [1, 3, 5, 7, 9, 12, 15, 18, 21, 25, 28, 29, 30, 32, 34] }],

--- a/frameworks/aurelia-slickgrid/docs/migrations/migration-to-9.x.md
+++ b/frameworks/aurelia-slickgrid/docs/migrations/migration-to-9.x.md
@@ -12,7 +12,7 @@ The other great thing about having everything under the same roof/project is tha
 - upgrade Vanilla-Calendar-Pro to v3 with [flat config](#date-editorfilter-flat-config)
 - [shorter attribute names](#shorter-attribute-names)
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
-- removing Arrow pointer from Custom Tooltip addon
+- removing Arrow pointer from Custom Tooltip addon (because it was often offset with the cell text)
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/aurelia-slickgrid/docs/migrations/migration-to-9.x.md
+++ b/frameworks/aurelia-slickgrid/docs/migrations/migration-to-9.x.md
@@ -12,6 +12,7 @@ The other great thing about having everything under the same roof/project is tha
 - upgrade Vanilla-Calendar-Pro to v3 with [flat config](#date-editorfilter-flat-config)
 - [shorter attribute names](#shorter-attribute-names)
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
+- removing Arrow pointer from Custom Tooltip addon
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/slickgrid-react/docs/migrations/migration-to-9.x.md
+++ b/frameworks/slickgrid-react/docs/migrations/migration-to-9.x.md
@@ -18,7 +18,7 @@ The other great thing about having everything under the same roof/project is tha
 - [shorter attribute names](#shorter-attribute-names)
 - skipping v6-8 and going straight to v9.0
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
-- removing Arrow pointer from Custom Tooltip addon
+- removing Arrow pointer from Custom Tooltip addon (because it was often offset with the cell text)
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/slickgrid-react/docs/migrations/migration-to-9.x.md
+++ b/frameworks/slickgrid-react/docs/migrations/migration-to-9.x.md
@@ -18,6 +18,7 @@ The other great thing about having everything under the same roof/project is tha
 - [shorter attribute names](#shorter-attribute-names)
 - skipping v6-8 and going straight to v9.0
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
+- removing Arrow pointer from Custom Tooltip addon
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/slickgrid-vue/docs/migrations/migration-to-9.x.md
+++ b/frameworks/slickgrid-vue/docs/migrations/migration-to-9.x.md
@@ -17,6 +17,7 @@ The other great thing about having everything under the same roof/project is tha
   - requires i18next v25+ (when installed)
 - skipping v6-8 and going straight to v9.0
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
+- removing Arrow pointer from Custom Tooltip addon
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/frameworks/slickgrid-vue/docs/migrations/migration-to-9.x.md
+++ b/frameworks/slickgrid-vue/docs/migrations/migration-to-9.x.md
@@ -17,7 +17,7 @@ The other great thing about having everything under the same roof/project is tha
   - requires i18next v25+ (when installed)
 - skipping v6-8 and going straight to v9.0
 - now using `clipboard` API, used in ExcelCopyBuffer/ContextMenu/CellCopy, which might requires end user permissions
-- removing Arrow pointer from Custom Tooltip addon
+- removing Arrow pointer from Custom Tooltip addon (because it was often offset with the cell text)
 
 > **Note:** if you come from an earlier version, please make sure to follow each migrations in their respected order (review previous migration guides)
 

--- a/packages/common/src/interfaces/customTooltipOption.interface.ts
+++ b/packages/common/src/interfaces/customTooltipOption.interface.ts
@@ -31,9 +31,6 @@ export interface CustomTooltipOption<T = any> {
   /** Formatter to execute when custom tooltip is over a heade row column (e.g. filter) */
   headerRowFormatter?: Formatter;
 
-  /** defaults to False, should we hide the tooltip pointer arrow? */
-  hideArrow?: boolean;
-
   /** defaults to "tooltip-body" class name */
   bodyClassName?: string;
 
@@ -52,9 +49,6 @@ export interface CustomTooltipOption<T = any> {
 
   /** optional maximum width number (in pixel) of the tooltip container */
   maxWidth?: number;
-
-  /** defaults to 3, arrow position offset that is also used in CSS (see `$slick-tooltip-arrow-side-margin` variable) */
-  offsetArrow?: number;
 
   /** defaults to 0, optional left offset, it must be a positive/negative number (in pixel) that will be added to the offset position calculation of the tooltip container. */
   offsetLeft?: number;

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -903,14 +903,6 @@ $slick-tooltip-overflow:                                    hidden !default;
 $slick-tooltip-text-overflow:                               ellipsis !default;
 $slick-tooltip-white-space:                                 normal !default;
 $slick-tooltip-z-index:                                     9999 !default;
-// tooltip arrow
-$slick-tooltip-arrow-color:                                 color.adjust($slick-tooltip-border-color, $lightness: -5%) !default;
-$slick-tooltip-arrow-size:                                  8px !default;
-$slick-tooltip-down-arrow-top-margin:                       100% !default;
-$slick-tooltip-up-arrow-top-margin:                         -($slick-tooltip-arrow-size * 2) !default;
-$slick-tooltip-arrow-side-margin:                           3px !default;
-$slick-tooltip-arrow-center-margin:                         calc(50% - #{$slick-tooltip-arrow-size}) !default;
-$slick-tooltip-right-arrow-side-margin:                     calc(100% - #{($slick-tooltip-arrow-size * 2)} - #{$slick-tooltip-arrow-side-margin}) !default;
 
 /** Empty Data Warning element */
 $slick-empty-data-warning-color:                            $slick-cell-text-color !default;

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -455,32 +455,6 @@ li.hidden {
     text-overflow: var(--slick-tooltip-text-overflow, v.$slick-tooltip-text-overflow);
     white-space: var(--slick-tooltip-white-space, v.$slick-tooltip-white-space);
   }
-
-  &.tooltip-arrow::after {
-    content: '';
-    left: 0px;
-    position: absolute;
-    border: transparent;
-    border-style: solid;
-    border-width: var(--slick-tooltip-arrow-size, v.$slick-tooltip-arrow-size);
-  }
-  &.tooltip-arrow.arrow-up::after {
-    top: var(--slick-tooltip-up-arrow-top-margin, v.$slick-tooltip-up-arrow-top-margin);
-    border-bottom-color: var(--slick-tooltip-arrow-color, v.$slick-tooltip-arrow-color);
-  }
-  &.tooltip-arrow.arrow-down::after {
-    top: var(--slick-tooltip-down-arrow-top-margin, v.$slick-tooltip-down-arrow-top-margin);
-    border-top-color: var(--slick-tooltip-arrow-color, v.$slick-tooltip-arrow-color);
-  }
-  &.tooltip-arrow.arrow-left-align::after {
-    margin-left: var(--slick-tooltip-arrow-side-margin, v.$slick-tooltip-arrow-side-margin);
-  }
-  &.tooltip-arrow.arrow-right-align::after {
-    margin-left: var(--slick-tooltip-right-arrow-side-margin, v.$slick-tooltip-right-arrow-side-margin);
-  }
-  &.tooltip-arrow.arrow-center-align::after {
-    margin-left: var(--slick-tooltip-arrow-center-margin, v.$slick-tooltip-arrow-center-margin);
-  }
 }
 
 // ---------------------------------------------------------

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -77,11 +77,9 @@ describe('SlickCustomTooltip plugin', () => {
     const mockOptions = {
       bodyClassName: 'tooltip-body',
       className: 'some-class',
-      offsetArrow: 3,
       offsetLeft: 5,
       offsetRight: 7,
       offsetTopBottom: 8,
-      hideArrow: true,
       regularTooltipWhiteSpace: 'pre-wrap',
       whiteSpace: 'normal',
     };
@@ -195,8 +193,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('editing input tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip from the editor [title] attribute and a formatter instead of the cell [title] when currently editing (editor lock) and a formatter is provided', () => {
@@ -219,8 +215,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('EDITING FORMATTER');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip, with default positioning (down & leftAlign), when tooltip option has "useRegularTooltip" enabled', () => {
@@ -240,8 +234,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip align on the right, when position is set to "right-align"', () => {
@@ -261,10 +253,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-center-align')).toBeFalsy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeFalsy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 
   it('should create a centered tooltip, when position is set to "center"', () => {
@@ -284,10 +272,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-center-align')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeFalsy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeFalsy();
   });
 
   it('should create a tooltip with truncated text when tooltip option has "useRegularTooltip" enabled and the tooltip text is longer than that of "tooltipTextMaxLength"', () => {
@@ -307,8 +291,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('some very extra long...');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip as regular tooltip with coming from text content when it is filled & also expect "hideTooltip" to be called after leaving the cell when "onMouseLeave" event is triggered', () => {
@@ -334,8 +316,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(plugin.addonOptions).toBeTruthy();
     expect(tooltipElm.style.maxWidth).toBe('85px');
     expect(tooltipElm.textContent).toBe('some text content');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
 
     gridStub.onMouseLeave.notify({ grid: gridStub } as any);
     expect(hideColumnSpy).toHaveBeenCalled();
@@ -364,8 +344,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(plugin.addonOptions).toBeTruthy();
     expect(tooltipElm.style.maxWidth).toBe('85px');
     expect(tooltipElm.textContent).toBe('some text content');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
 
     gridStub.onHeaderRowMouseLeave.notify({ grid: gridStub } as any);
     expect(hideColumnSpy).toHaveBeenCalled();
@@ -390,8 +368,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('some very extra long...');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should NOT create a tooltip as regular tooltip with truncated text when tooltip option has "useRegularTooltip" enabled but the mouse over is not a slick-cell cell type', () => {
@@ -434,8 +410,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('tooltip text');
     expect(tooltipElm.style.maxHeight).toBe('100px');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip aligned left from a cell with multiple span and title attributes', () => {
@@ -470,8 +444,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('Click here to cancel the action');
     expect(tooltipElm.style.maxHeight).toBe('100px');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip aligned right from a cell with multiple span and title attributes', () => {
@@ -506,8 +478,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('Click here to cancel the action');
     expect(tooltipElm.style.maxHeight).toBe('100px');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-right-align')).toBeTruthy();
   });
 
   it('should NOT create a tooltip from a cell with multiple span and title attributes but it is actually hidden', () => {
@@ -558,8 +528,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('formatter tooltip text');
     expect(tooltipElm.style.maxHeight).toBe('100px');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should throw an error when trying to create an async tooltip without "asyncPostFormatter" defined', () => {
@@ -613,7 +581,6 @@ describe('SlickCustomTooltip plugin', () => {
 
     tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm.textContent).toBe('async post text with ratio: 1.2');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
   });
 
   it('should create an Observable async tooltip and throw an error when the Observable is throwing', () => {
@@ -678,8 +645,6 @@ describe('SlickCustomTooltip plugin', () => {
 
     tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm.textContent).toBe('async post text with ratio: 1.2');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a Promise async tooltip even on regular tooltip with "asyncProcess" and "useRegularTooltip" flags', async () => {
@@ -711,7 +676,6 @@ describe('SlickCustomTooltip plugin', () => {
 
     tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm.textContent).toBe('tooltip title text with ratio: 1.2');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
   });
 
   it('should create a Promise async tooltip and throw an error when the Promise is not completing (rejected)', () =>
@@ -766,8 +730,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('name title tooltip');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderMouseOver" is triggered', () => {
@@ -795,8 +757,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseEnter" is triggered', () => {
@@ -824,8 +784,6 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header row tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 
   it('should create a tooltip on the header column when "useRegularTooltip" enabled and "onHeaderRowMouseOver" is triggered', () => {
@@ -853,7 +811,5 @@ describe('SlickCustomTooltip plugin', () => {
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
     expect(tooltipElm.textContent).toBe('header row tooltip text');
-    expect(tooltipElm.classList.contains('arrow-down')).toBeTruthy();
-    expect(tooltipElm.classList.contains('arrow-left-align')).toBeTruthy();
   });
 });

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -78,11 +78,9 @@ export class SlickCustomTooltip {
   protected _defaultOptions = {
     bodyClassName: 'tooltip-body',
     className: '',
-    offsetArrow: 3, // same as `$slick-tooltip-arrow-side-margin` CSS/SASS variable
     offsetLeft: 0,
     offsetRight: 0,
     offsetTopBottom: 4,
-    hideArrow: false,
     regularTooltipWhiteSpace: 'pre-line',
     whiteSpace: 'normal',
   } as CustomTooltipOption;
@@ -493,11 +491,6 @@ export class SlickCustomTooltip {
       // reposition the tooltip on top of the cell that triggered the mouse over event
       this.reposition(cell);
 
-      // user could optionally hide the tooltip arrow (we can simply update the CSS variables, that's the only way we have to update CSS pseudo)
-      if (!this._cellAddonOptions?.hideArrow) {
-        this._tooltipElm.classList.add('tooltip-arrow');
-      }
-
       // also clear any "title" attribute to avoid showing a 2nd browser tooltip
       this.swapAndClearTitleAttribute(inputTitleElm, outputText);
     }
@@ -523,54 +516,41 @@ export class SlickCustomTooltip {
       let newPositionTop = (cellPosition.top || 0) - this._tooltipElm.offsetHeight - (this._cellAddonOptions?.offsetTopBottom ?? 0);
       let newPositionLeft = (cellPosition.left || 0) - (this._cellAddonOptions?.offsetRight ?? 0);
 
-      // user could explicitely use a "left-align" arrow position, (when user knows his column is completely on the right in the grid)
+      // user could explicitely use a "left-align" position, (when user knows his column is completely on the right in the grid)
       // or when using "auto" and we detect not enough available space then we'll position to the "left" of the cell
-      // NOTE the class name is for the arrow and is inverse compare to the tooltip itself, so if user ask for "left-align", then the arrow will in fact be "arrow-right-align"
       const position = this._cellAddonOptions?.position ?? 'auto';
       let finalTooltipPosition = '';
       if (position === 'center') {
         newPositionLeft += cellContainerWidth / 2 - calculatedTooltipWidth / 2 + (this._cellAddonOptions?.offsetRight ?? 0);
         finalTooltipPosition = 'top-center';
-        this._tooltipElm.classList.remove('arrow-left-align', 'arrow-right-align');
-        this._tooltipElm.classList.add('arrow-center-align');
       } else if (
         position === 'right-align' ||
         ((position === 'auto' || position !== 'left-align') && newPositionLeft + calculatedTooltipWidth > calculatedBodyWidth)
       ) {
         finalTooltipPosition = 'right';
         newPositionLeft -= calculatedTooltipWidth - cellContainerWidth - (this._cellAddonOptions?.offsetLeft ?? 0);
-        this._tooltipElm.classList.remove('arrow-center-align', 'arrow-left-align');
-        this._tooltipElm.classList.add('arrow-right-align');
       } else {
         finalTooltipPosition = 'left';
-        this._tooltipElm.classList.remove('arrow-center-align', 'arrow-right-align');
-        this._tooltipElm.classList.add('arrow-left-align');
       }
 
       // do the same calculation/reposition with top/bottom (default is top of the cell or in other word starting from the cell going down)
-      // NOTE the class name is for the arrow and is inverse compare to the tooltip itself, so if user ask for "bottom", then the arrow will in fact be "arrow-top"
       if (
         position === 'bottom' ||
         ((position === 'auto' || position !== 'top') && calculatedTooltipHeight > calculateAvailableSpace(this._cellNodeElm).top)
       ) {
         newPositionTop = (cellPosition.top || 0) + (this.gridOptions.rowHeight ?? 0) + (this._cellAddonOptions?.offsetTopBottom ?? 0);
         finalTooltipPosition = `bottom-${finalTooltipPosition}`;
-        this._tooltipElm.classList.remove('arrow-down');
-        this._tooltipElm.classList.add('arrow-up');
       } else {
         finalTooltipPosition = `top-${finalTooltipPosition}`;
-        this._tooltipElm.classList.remove('arrow-up');
-        this._tooltipElm.classList.add('arrow-down');
       }
 
       // when having multiple tooltips, we'll try to reposition tooltip to mouse position
       if (this._tooltipElm && (this._hasMultipleTooltips || this.cellAddonOptions?.repositionByMouseOverTarget)) {
         const mouseElmOffset = getOffset(this._mouseTarget);
         if (finalTooltipPosition.includes('left') || finalTooltipPosition === 'top-center') {
-          newPositionLeft = mouseElmOffset.left - (this._addonOptions?.offsetArrow ?? 3);
+          newPositionLeft = mouseElmOffset.left - 3;
         } else if (finalTooltipPosition.includes('right')) {
-          newPositionLeft =
-            mouseElmOffset.left - calculatedTooltipWidth + (this._mouseTarget?.offsetWidth ?? 0) + (this._addonOptions?.offsetArrow ?? 3);
+          newPositionLeft = mouseElmOffset.left - calculatedTooltipWidth + (this._mouseTarget?.offsetWidth ?? 0) + 3;
         }
       }
 


### PR DESCRIPTION
- removing the Arrow pointer from the Custom Tooltip because it was often showing at the wrong place because of its fixed position, so I think it's better to just remove it completely and just keep tooltip auto-positioning and that should be more than sufficient.
- this also helps decreasing the build size by about 2kb (less code but also less CSS)

![brave_TE0rYOIahi](https://github.com/user-attachments/assets/97262f90-14fc-46cb-921e-e5f85220412f)
