### PR TITLE
fix(core): small UI regression causing column width to be smaller

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2017,9 +2017,11 @@ describe('SlickGrid core file', () => {
       expect(grid.getVisibleColumns().length).toBe(3);
       expect(result).toBe(1012);
       expect(columns[0].width).toBe(0);
-      expect(columns[1].width).toBe(455);
+      expect(columns[1].width).toBeGreaterThanOrEqual(454);
+      expect(columns[1].width).toBeLessThanOrEqual(456);
       expect(columns[2].width).toBe(192);
-      expect(columns[3].width).toBe(153);
+      expect(columns[3].width).toBeGreaterThanOrEqual(152);
+      expect(columns[3].width).toBeLessThan(154);
       expect(columns[4].width).toBe(0); // hidden
     });
 
@@ -2199,7 +2201,8 @@ describe('SlickGrid core file', () => {
         grid.init();
 
         expect(grid.getViewportHeight()).toBe(DEFAULT_COLUMN_HEIGHT * data.length + 50 + 44);
-        expect(grid.getCanvasWidth()).toBe(800);
+        expect(grid.getCanvasWidth()).toBeGreaterThanOrEqual(799);
+        expect(grid.getCanvasWidth()).toBeLessThanOrEqual(801);
       });
 
       it('should return full viewport height by data size + headerRow & footerRow when they are enabled with "autoHeight"', () => {
@@ -2216,7 +2219,8 @@ describe('SlickGrid core file', () => {
         grid.init();
 
         expect(grid.getViewportHeight()).toBe(DEFAULT_COLUMN_HEIGHT * data.length + 50 + 40);
-        expect(grid.getCanvasWidth()).toBe(800);
+        expect(grid.getCanvasWidth()).toBeGreaterThanOrEqual(799);
+        expect(grid.getCanvasWidth()).toBeLessThanOrEqual(801);
       });
 
       it('should return original grid height when calling method', () => {
@@ -3454,7 +3458,8 @@ describe('SlickGrid core file', () => {
       expect(columns[1].width).toBe(0);
       expect(columns[2].width).toBe(74);
       expect(columns[3].width).toBe(88);
-      expect(columns[4].width).toBe(551);
+      expect(columns[4].width).toBeGreaterThanOrEqual(550);
+      expect(columns[4].width).toBeLessThanOrEqual(552);
     });
 
     it('should resize 2nd column with forceFitColumns option enabled', () => {
@@ -3614,7 +3619,7 @@ describe('SlickGrid core file', () => {
       expect(columns[1].width).toBe(0);
       expect(columns[2].width).toBe(74);
       expect(columns[3].width).toBe(132);
-      expect(columns[4].width).toBe(552);
+      expect(columns[4].width).toBeGreaterThanOrEqual(550);
     });
 
     it('should resize 4th column with forceFitColumns option enabled and a column with maxWidth and a frozen column', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1384,8 +1384,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.canvasWidth !== oldCanvasWidth || this.canvasWidthL !== oldCanvasWidthL || this.canvasWidthR !== oldCanvasWidthR;
 
     if (widthChanged || this.hasFrozenColumns() || this.hasFrozenRows) {
-      // in some browsers horizontal is showing when it shouldn't and removing 0.1px patches this issue (or even 0.0001 would be enough)
-      Utils.width(this._canvasTopL, this.canvasWidthL - 0.1);
+      Utils.width(this._canvasTopL, this.canvasWidthL);
 
       this.getHeadersWidth();
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2969,7 +2969,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             continue;
           }
           const absMinWidth = Math.max(c.minWidth!, this.absoluteColumnMinWidth);
-          let shrinkSize = Math.floor(shrinkProportion * (width - absMinWidth)) || 1;
+          let shrinkSize = Math.fround(shrinkProportion * (width - absMinWidth)) || 1;
           shrinkSize = Math.min(shrinkSize, width - absMinWidth);
           total -= shrinkSize;
           shrinkLeeway -= shrinkSize;
@@ -2996,7 +2996,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           if (!c.resizable || c.maxWidth! <= currentWidth) {
             growSize = 0;
           } else {
-            growSize = Math.min(Math.floor(growProportion * currentWidth) - currentWidth, c.maxWidth! - currentWidth || 1000000) || 1;
+            growSize = Math.min(Math.fround(growProportion * currentWidth) - currentWidth, c.maxWidth! - currentWidth || 1000000) || 1;
           }
           total += growSize;
           widths[i] += total <= availWidth ? growSize : 0;

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -376,9 +376,9 @@ export class ResizerService {
       if (!this.gridOptions.autoHeight) {
         this._gridDomElm.style.height = `${newHeight}px`;
       }
-      this._gridDomElm.style.width = `${newWidth}px`;
+      this._gridDomElm.style.width = typeof newWidth === 'string' ? newWidth : `${newWidth || 1}px`;
       if (this._gridContainerElm) {
-        this._gridContainerElm.style.width = `${newWidth}px`;
+        this._gridContainerElm.style.width = typeof newWidth === 'string' ? newWidth : `${newWidth}px`;
       }
 
       // resize the slickgrid canvas on all browser

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -63,7 +63,7 @@ $slick-container-border-left:                               0 none !default;
 $slick-canvas-bg-color:                                     #fff !default;
 
 /* grid */
-$slick-grid-border-color:                                   none !default;
+$slick-grid-border-color:                                   transparent !default;
 $slick-grid-border-style:                                   solid !default;
 $slick-grid-header-background:                              rgba(255, 255, 255, .6) !default;
 $slick-grid-header-unorderable-bg-color:                    $slick-grid-header-background !default;


### PR DESCRIPTION
- partially rolling back a small change made in PR https://github.com/ghiscoding/slickgrid-universal/pull/1961
- use `Math.fround` (float) instead of `Math.floor` (int) for column width calculations, it helps with some grids but not all of them

trying again to fix the issue shown below, this issue is only happening in some Chromium browsers, it's rare but it does show then it shows consistently and it never happens in Firefox. I'm assuming this issue is caused by Chrome miscalculating the width (possibly because of float precision) and when that happens the scrollbar shows too early. In the case below, our grid container is 800px, we remove 15px for scrollbar and so we have 785px left for the columns and it's supposed to fit perfectly... but for some reasons, some browsers show the scrollbar when it shouldn't

![image](https://github.com/user-attachments/assets/3543956c-4a8b-4baf-9c55-c49383a8c57f)
