### PR TITLE
fix(core): rollback slickgrid width UI change & drop `::ms` styling

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2969,7 +2969,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             continue;
           }
           const absMinWidth = Math.max(c.minWidth!, this.absoluteColumnMinWidth);
-          let shrinkSize = Math.fround(shrinkProportion * (width - absMinWidth)) || 1;
+          let shrinkSize = Math.floor(shrinkProportion * (width - absMinWidth)) || 1;
           shrinkSize = Math.min(shrinkSize, width - absMinWidth);
           total -= shrinkSize;
           shrinkLeeway -= shrinkSize;
@@ -2996,7 +2996,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           if (!c.resizable || c.maxWidth! <= currentWidth) {
             growSize = 0;
           } else {
-            growSize = Math.min(Math.fround(growProportion * currentWidth) - currentWidth, c.maxWidth! - currentWidth || 1000000) || 1;
+            growSize = Math.min(Math.floor(growProportion * currentWidth) - currentWidth, c.maxWidth! - currentWidth || 1000000) || 1;
           }
           total += growSize;
           widths[i] += total <= availWidth ? growSize : 0;

--- a/packages/common/src/styles/extra-styling.scss
+++ b/packages/common/src/styles/extra-styling.scss
@@ -1,17 +1,20 @@
 @use './variables' as v;
 
-$slick-font-size-count: 50;
-$slick-margin-max-count: 50;
+$slick-margin-max-count: 30;
 $slick-padding-max-count: 30;
 
-.pointer { cursor: pointer; }
-.bold { font-weight: bold; }
+.pointer {
+  cursor: pointer;
+}
+.bold {
+  font-weight: bold;
+}
 
 .fake-hyperlink {
   cursor: pointer;
   color: v.$slick-link-color;
   &:hover {
-      text-decoration: underline;
+    text-decoration: underline;
   }
 }
 
@@ -27,30 +30,32 @@ $slick-padding-max-count: 30;
   }
 }
 
-.delete-icon {
-  &:hover {
-    color: #b14c4a;
-  }
+.delete-icon :hover {
+  color: #b14c4a;
 }
-.edit-icon,
-.info-icon {
-  &:hover {
-    color: rgb(0, 153, 255);
-  }
+.edit-icon:hover,
+.info-icon:hover {
+  color: #0099ff;
 }
 
 @for $percent from 1 through 10 {
-  .height-#{$percent * 10} { height: #{$percent * 10%} !important; }
+  .height-#{$percent * 10} {
+    height: #{$percent * 10%} !important;
+  }
 }
 
 // margin-0px up to margin-30px
 @for $i from 0 through $slick-margin-max-count {
-  .margin-#{$i}px { margin: #{$i}px; }
+  .margin-#{$i}px {
+    margin: #{$i}px;
+  }
 }
 
 // padding-0px up to padding-30px
 @for $i from 0 through $slick-padding-max-count {
-  .padding-#{$i}px { padding: #{$i}px; }
+  .padding-#{$i}px {
+    padding: #{$i}px;
+  }
 }
 
 .margin-auto {
@@ -58,14 +63,30 @@ $slick-padding-max-count: 30;
 }
 
 /* Text and Alignment Utilities */
-.text-bold { font-weight: bold !important; }
-.text-italic { font-style: italic !important; }
-.text-center { text-align: center !important; }
-.text-left   { text-align: left !important; }
-.text-right  { text-align: right !important; }
-.text-lowercase { text-transform: lowercase !important; }
-.text-uppercase { text-transform: uppercase !important; }
-.text-underline { text-decoration: underline !important; }
+.text-bold {
+  font-weight: bold !important;
+}
+.text-italic {
+  font-style: italic !important;
+}
+.text-center {
+  text-align: center !important;
+}
+.text-left {
+  text-align: left !important;
+}
+.text-right {
+  text-align: right !important;
+}
+.text-lowercase {
+  text-transform: lowercase !important;
+}
+.text-uppercase {
+  text-transform: uppercase !important;
+}
+.text-underline {
+  text-decoration: underline !important;
+}
 
 .vertical-align-bottom,
 .vertical-align-middle,

--- a/packages/common/src/styles/slick-editors.scss
+++ b/packages/common/src/styles/slick-editors.scss
@@ -2,7 +2,7 @@
 @use './slick.layout' as sl;
 @use './svg-utilities' as svg;
 
-.slick-cell  {
+.slick-cell {
   input.dual-editor-text,
   input.editor-text {
     border: var(--slick-text-editor-border, v.$slick-text-editor-border);
@@ -115,11 +115,14 @@
 }
 
 /* Long Text Editor */
+.slick-large-editor-text,
+.slick-large-editor-text textarea {
+  background: var(--slick-large-editor-background-color, v.$slick-large-editor-background-color);
+  color: var(--slick-large-editor-text-color, v.$slick-large-editor-text-color);
+}
 .slick-large-editor-text {
   z-index: 10000;
   position: absolute;
-  background: var(--slick-large-editor-background-color, v.$slick-large-editor-background-color);
-  color: var(--slick-large-editor-text-color, v.$slick-large-editor-text-color);
   padding: var(--slick-large-editor-text-padding, v.$slick-large-editor-text-padding);
   border: var(--slick-large-editor-border, v.$slick-large-editor-border);
   border-radius: var(--slick-large-editor-border-radius, v.$slick-large-editor-border-radius);
@@ -133,8 +136,6 @@
   }
 
   textarea {
-    background: var(--slick-large-editor-background-color, v.$slick-large-editor-background-color);
-    color: var(--slick-large-editor-text-color, v.$slick-large-editor-text-color);
     border: 0;
     outline: 0;
   }
@@ -181,9 +182,9 @@
     left: var(--slick-editor-modal-container-left, v.$slick-editor-modal-container-left);
     transform: var(--slick-editor-modal-container-transform, v.$slick-editor-modal-container-transform);
     transition: var(--slick-editor-modal-backdrop-transition-end, v.$slick-editor-modal-backdrop-transition-end);
-    transition-property: opacity,transform;
+    transition-property: opacity, transform;
 
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width: 768px) {
       &.split-view {
         width: calc(#{v.$slick-editor-modal-container-width} * 2);
       }
@@ -193,7 +194,7 @@
     }
 
     /** we'll triple the width only a large screen */
-    @media only screen and (max-width : 1200px) {
+    @media only screen and (max-width: 1200px) {
       &.triple-split-view {
         width: calc(#{v.$slick-editor-modal-container-width} * 2);
       }
@@ -349,7 +350,10 @@
           height: var(--slick-editor-modal-footer-btn-saving-icon-height, v.$slick-editor-modal-footer-btn-saving-icon-height);
           width: var(--slick-editor-modal-footer-btn-saving-icon-width, v.$slick-editor-modal-footer-btn-saving-icon-width);
           display: var(--slick-editor-modal-footer-btn-saving-icon-display, v.$slick-editor-modal-footer-btn-saving-icon-display);
-          vertical-align: var(--slick-editor-modal-footer-btn-saving-icon-vertical-align, v.$slick-editor-modal-footer-btn-saving-icon-vertical-align);
+          vertical-align: var(
+            --slick-editor-modal-footer-btn-saving-icon-vertical-align,
+            v.$slick-editor-modal-footer-btn-saving-icon-vertical-align
+          );
           margin: var(--slick-editor-modal-footer-btn-saving-icon-margin, v.$slick-editor-modal-footer-btn-saving-icon-margin);
           animation: var(--slick-editor-modal-footer-btn-saving-icon-animation, v.$slick-editor-modal-footer-btn-saving-icon-animation);
           content: var(--slick-editor-modal-footer-btn-saving-icon-content, v.$slick-editor-modal-footer-btn-saving-icon-content);
@@ -385,9 +389,13 @@
       margin: var(--slick-editor-modal-detail-container-margin, v.$slick-editor-modal-detail-container-margin);
       padding: var(--slick-editor-modal-detail-container-padding, v.$slick-editor-modal-detail-container-padding);
 
+      input,
+      .input-group,
+      .input-group input {
+        height: var(--slick-editor-modal-input-editor-height, v.$slick-editor-modal-input-editor-height);
+      }
       input {
         color: var(--slick-editor-modal-text-color, v.$slick-editor-modal-text-color);
-        height: var(--slick-editor-modal-input-editor-height, v.$slick-editor-modal-input-editor-height);
         margin: var(--slick-editor-modal-input-editor-margin, v.$slick-editor-modal-input-editor-margin);
         border: var(--slick-editor-modal-input-editor-border, v.$slick-editor-modal-input-editor-border);
         padding: var(--slick-editor-modal-input-editor-padding, v.$slick-editor-modal-input-editor-padding);
@@ -395,17 +403,10 @@
           border-color: var(--slick-text-editor-focus-border-color, v.$slick-text-editor-focus-border-color);
           box-shadow: var(--slick-text-editor-focus-box-shadow, v.$slick-text-editor-focus-box-shadow);
         }
-        &:disabled {
-          background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
-        }
       }
       .input-group {
         display: flex;
         position: relative;
-        height: var(--slick-editor-modal-input-editor-height, v.$slick-editor-modal-input-editor-height);
-        input {
-          height: var(--slick-editor-modal-input-editor-height, v.$slick-editor-modal-input-editor-height);
-        }
       }
       .slick-large-editor-text {
         border: var(--slick-editor-modal-large-editor-border, v.$slick-editor-modal-large-editor-border);
@@ -418,9 +419,6 @@
         textarea {
           width: 100%;
           height: 100%;
-          &:disabled {
-            background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
-          }
         }
         .editor-footer {
           height: var(--slick-editor-modal-large-editor-footer-height, v.$slick-editor-modal-large-editor-footer-height);
@@ -435,15 +433,9 @@
         &.invalid {
           border: var(--slick-editor-modal-detail-container-border-invalid, v.$slick-editor-modal-detail-container-border-invalid);
         }
-        &:disabled, &.disabled {
-          background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
-        }
       }
       button.ms-choice {
         height: var(--slick-editor-modal-multiselect-editor-height, v.$slick-editor-modal-multiselect-editor-height);
-        &:disabled {
-          background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
-        }
       }
       .checkbox-editor-container {
         padding: var(--slick-editor-modal-checkbox-editor-padding, v.$slick-editor-modal-checkbox-editor-padding);
@@ -452,9 +444,6 @@
         height: var(--slick-editor-modal-input-editor-height, v.$slick-editor-modal-input-editor-height);
         input {
           height: inherit;
-        }
-        &.disabled {
-          background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
         }
       }
 
@@ -478,7 +467,6 @@
         cursor: pointer;
         background-color: var(--slick-date-picker-bg-color, v.$slick-date-picker-bg-color);
         &:disabled {
-          background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
           cursor: initial;
         }
       }
@@ -495,16 +483,28 @@
       }
 
       &.modified {
-        input, .slick-large-editor-text, .ms-choice, .checkbox-editor-container {
+        input,
+        .slick-large-editor-text,
+        .ms-choice,
+        .checkbox-editor-container {
           border: var(--slick-editor-modal-detail-container-border-modified, v.$slick-editor-modal-detail-container-border-modified);
-          border-width: var(--slick-editor-modal-detail-container-border-width-modified, v.$slick-editor-modal-detail-container-border-width-modified);
+          border-width: var(
+            --slick-editor-modal-detail-container-border-width-modified,
+            v.$slick-editor-modal-detail-container-border-width-modified
+          );
         }
       }
       &.invalid {
-        input, .slick-large-editor-text {
+        input,
+        .slick-large-editor-text {
           border: var(--slick-editor-modal-detail-container-border-invalid, v.$slick-editor-modal-detail-container-border-invalid);
         }
       }
+    }
+
+    .item-details-editor-container,
+    .item-details-editor-container .form-control {
+      &:disabled,
       &.disabled {
         background-color: var(--slick-editor-input-disabled-color, v.$slick-editor-input-disabled-color);
       }

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -668,8 +668,8 @@
         /* like TH  */
         & {
           background: var(--slick-header-background-color, v.$slick-header-background-color);
-          font-family: var(--slick-font-family, v.$slick-font-family);
           color: var(--slick-header-text-color, v.$slick-header-text-color);
+          font-family: var(--slick-font-family, v.$slick-font-family);
           font-size: var(--slick-header-font-size, v.$slick-header-font-size);
           font-weight: var(--slick-header-font-weight, v.$slick-header-font-weight);
         }

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -11,6 +11,14 @@ li.hidden {
   display: none !important;
 }
 
+.slick-grid-menu,
+.slick-column-picker {
+  li {
+    list-style: none;
+    background: none;
+  }
+}
+
 .slick-column-picker {
   cursor: default;
   list-style-type: none;
@@ -55,9 +63,6 @@ li.hidden {
   }
 
   li {
-    list-style: none;
-    background: none;
-
     a {
       display: block;
       padding: 4px;
@@ -204,8 +209,6 @@ li.hidden {
   }
 
   li {
-    list-style: none;
-    background: none;
     overflow: hidden;
     text-overflow: ellipsis;
     @-moz-document url-prefix() {
@@ -1092,43 +1095,6 @@ li.hidden {
       outline: 1px solid #fff;
       outline-offset: -1px;
     }
-
-    /* Microsoft IE specific */
-    &::-ms-track {
-      height: var(--slick-slider-filter-runnable-track-height, v.$slick-slider-filter-runnable-track-height);
-
-      /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
-      background: transparent;
-
-      /*leave room for the larger thumb to overflow with a transparent border */
-      border-color: transparent;
-      border-width: 6px 0;
-
-      /*remove default tick marks*/
-      color: transparent;
-      appearance: none;
-    }
-    &::-ms-fill-lower {
-      background: var(--slick-slider-filter-fill-lower-color, v.$slick-slider-filter-fill-lower-color);
-      border-radius: 10px;
-    }
-    &::-ms-fill-upper {
-      background: var(--slick-slider-filter-bgcolor, v.$slick-slider-filter-bgcolor);
-      border-radius: 10px;
-    }
-    &::-ms-thumb {
-      cursor: var(--slick-slider-filter-thumb-cursor, v.$slick-slider-filter-thumb-cursor);
-      height: var(--slick-slider-filter-thumb-height, v.$slick-slider-filter-thumb-height);
-      width: var(--slick-slider-filter-thumb-width, v.$slick-slider-filter-thumb-width);
-      border-radius: var(--slick-slider-filter-thumb-border-radius, v.$slick-slider-filter-thumb-border-radius);
-      border: var(--slick-slider-filter-thumb-border, v.$slick-slider-filter-thumb-border);
-      background: var(--slick-slider-filter-thumb-color, v.$slick-slider-filter-thumb-color);
-      margin-top: 1px;
-      pointer-events: auto;
-    }
-    &::-ms-tooltip {
-      display: none;
-    }
     &:active::-webkit-slider-thumb {
       background-color: var(--slick-slider-filter-thumb-active-bg-color, v.$slick-slider-filter-thumb-active-bg-color);
       border: var(--slick-slider-filter-thumb-active-border, v.$slick-slider-filter-thumb-active-border);
@@ -1252,16 +1218,6 @@ li.hidden {
       border-color: var(--slick-slider-filter-focus-border-color, v.$slick-slider-filter-focus-border-color);
       box-shadow: var(--slick-slider-filter-focus-box-shadow, v.$slick-slider-filter-focus-box-shadow);
     }
-  }
-
-  input[type='range']::-webkit-slider-thumb {
-    pointer-events: auto;
-  }
-  input[type='range']::-moz-range-thumb {
-    pointer-events: auto;
-  }
-  input[type='range']::-ms-thumb {
-    pointer-events: auto;
   }
 }
 

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -388,8 +388,8 @@ li.hidden {
     &.slick-menu-item-disabled {
       border-color: transparent !important;
       background: inherit !important;
-      color: var(--slick-menu-item-disabled-color, v.$slick-menu-item-disabled-color);
       cursor: inherit;
+      color: var(--slick-menu-item-disabled-color, v.$slick-menu-item-disabled-color);
       .slick-menu-icon,
       .slick-menu-content {
         color: var(--slick-menu-item-disabled-color, v.$slick-menu-item-disabled-color);
@@ -785,9 +785,6 @@ li.hidden {
       &.form-control {
         cursor: pointer;
         appearance: none;
-        &:-ms-expand {
-          display: none;
-        }
         .empty {
           color: #c0c0c0;
         }
@@ -798,12 +795,12 @@ li.hidden {
     min-width: 30px;
   }
 
-  input.search-filter {
+  input.search-filter,
+  .search-filter input {
     font-family: var(--slick-filter-placeholder-font-family, v.$slick-filter-placeholder-font-family);
   }
   .search-filter {
     input {
-      font-family: var(--slick-filter-placeholder-font-family, v.$slick-filter-placeholder-font-family);
       &.compound-input {
         border-radius: var(--slick-compound-filter-border-radius, v.$slick-compound-filter-border-radius) !important;
         border-left: none;
@@ -820,9 +817,7 @@ li.hidden {
   .slick-headerrow {
     .slick-headerrow-columns {
       .slick-headerrow-column {
-        input.form-control.search-filter {
-          background-color: var(--slick-form-control-bg-color, v.$slick-form-control-bg-color);
-        }
+        input.form-control.search-filter,
         .form-group.search-filter {
           input,
           button,
@@ -1158,7 +1153,6 @@ li.hidden {
       border-radius: var(--slick-slider-filter-border-radius, v.$slick-slider-filter-border-radius);
     }
   }
-  &.input-group > :first-child:not(.input-group-addon),
   &.input-group > :first-child:not(.input-group-addon),
   &.input-group > :first-child:not(.input-group-addon) .slider-filter-input,
   &.input-group > :first-child:not(.input-group-addon) .slider-editor-input {

--- a/packages/common/src/styles/slick-without-bootstrap-min-styling.scss
+++ b/packages/common/src/styles/slick-without-bootstrap-min-styling.scss
@@ -4,7 +4,8 @@
 // $input-focus-box-shadow: 0 0 0 0.25rem #0d6efd40 !default;
 
 /** Bootstrap buttons styling copied and changed slightly for Material Design */
-.slick-editor-modal, .slick-large-editor-text {
+.slick-editor-modal,
+.slick-large-editor-text {
   .btn {
     cursor: pointer;
     font-family: var(--slick-font-family, v.$slick-font-family);
@@ -29,21 +30,24 @@
   }
 
   .btn-xs,
-  .btn-group-xs>.btn {
-    padding: 1px 5px;
+  .btn-group-xs > .btn,
+  .btn-sm {
     font-size: 12px;
     line-height: 1.5;
     border-radius: 3px;
+  }
+  .btn-xs,
+  .btn-group-xs > .btn {
+    padding: 1px 5px;
   }
   .btn-sm {
     padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
-    border-radius: 3px;
   }
 }
 
-.gridPane, .grid-pane, .slick-editor-modal {
+.gridPane,
+.grid-pane,
+.slick-editor-modal {
   font-family: var(--slick-font-family, v.$slick-font-family);
 
   .form-control {
@@ -56,8 +60,10 @@
     background-color: var(--slick-form-control-bg-color, v.$slick-form-control-bg-color);
     border: var(--slick-form-control-border, v.$slick-form-control-border);
     color: var(--slick-font-color, v.$slick-font-color);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    transition:
+      border-color ease-in-out 0.15s,
+      box-shadow ease-in-out 0.15s;
   }
 
   .input-group .form-control {
@@ -85,12 +91,15 @@
     background-color: var(--slick-input-group-addon-bg-color, v.$slick-input-group-addon-bg-color);
     border-radius: 4px;
   }
-  .input-group-addon, .input-group-btn {
+  .input-group-addon,
+  .input-group-btn {
     width: 1%;
     white-space: nowrap;
     vertical-align: middle;
   }
-  .input-group .form-control, .input-group-addon, .input-group-btn {
+  .input-group .form-control,
+  .input-group-addon,
+  .input-group-btn {
     display: table-cell;
   }
   .input-group-addon:first-child {
@@ -101,11 +110,11 @@
   }
   .input-group .form-control:last-child,
   .input-group-addon:last-child,
-  .input-group-btn:first-child>.btn-group:not(:first-child)>.btn,
-  .input-group-btn:first-child>.btn:not(:first-child),
-  .input-group-btn:last-child>.btn,
-  .input-group-btn:last-child>.btn-group>.btn,
-  .input-group-btn:last-child>.dropdown-toggle {
+  .input-group-btn:first-child > .btn-group:not(:first-child) > .btn,
+  .input-group-btn:first-child > .btn:not(:first-child),
+  .input-group-btn:last-child > .btn,
+  .input-group-btn:last-child > .btn-group > .btn,
+  .input-group-btn:last-child > .dropdown-toggle {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
@@ -119,7 +128,8 @@
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-group {
+  .input-group-btn:last-child > .btn,
+  .input-group-btn:last-child > .btn-group {
     z-index: 2;
     margin-left: -1px;
   }
@@ -134,7 +144,9 @@
     border-bottom-left-radius: 0px;
   }
 
-  *, :after, :before {
+  *,
+  :after,
+  :before {
     box-sizing: border-box;
   }
 
@@ -147,7 +159,8 @@
   .slick-pagination {
     .slick-pagination-nav {
       .pagination > li {
-        a, span {
+        a,
+        span {
           position: relative;
           float: left;
           margin-left: -1px;


### PR DESCRIPTION
- rollback again #1973 because it still causes UI issues, so we're pretty much back to the original code (before v9)
- also cleanup SASS files and also remove unnecessary `::ms-*` styling since we're no longer supporting any MS IE browsers