### PR TITLE
fix: Chromium patch to avoid showing scrollbar too early

### DIFF
--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -404,6 +404,11 @@ export class ResizerService {
         this.resizeColumnsByCellContent(false);
       }
 
+      // patch for Chromium browsers to avoid scrollbar from showing way too early when using `overflow:auto`
+      // the canvas size equals exactly the size of its container and for some users (not all) it will show the horizontal scrollbar too early.
+      // not exactly sure but, this might be caused by a floating precision on some computers
+      this._gridDomElm.style.width = typeof newWidth === 'string' ? newWidth : `${(newWidth || 1) + 0.2}px`;
+
       // keep last resized dimensions & resolve them to the Promise
       this._lastDimensions = {
         height: newHeight || 0,


### PR DESCRIPTION
- another trial at fixing or I should patching the issue I first tried to fix in #1961, this new patch seems to work a lot better though and is much more safe which is just to add `0.2px` to the grid container but only after the grid columns autosize is called.
- this is just a patch because in the end, I'm pretty sure that it's a Chromium bug because this issue never shows in Firefox and I would guess that it's caused by a floating precision which could differ on different computers. There are some open Chromium bugs for similar things but it could take a very long time before any fix comes in, so let's patch it since we can


![image](https://github.com/user-attachments/assets/3543956c-4a8b-4baf-9c55-c49383a8c57f)