### PR TITLE
Support cell selection

### DIFF
--- a/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
@@ -104,6 +104,12 @@ export interface CompositeEditorOpenDetailOption {
    */
   onClose?: () => Promise<boolean>;
 
+  /**
+   * onDispose callback allows user to execute something when the modal is disposed (closed and removed from the DOM).
+   * This will be called regardless of whether there are changes done in the form or not.
+   */
+  onDispose?: () => void;
+
   /** onError callback allows user to override what the system does when an error (error message & type) is thrown, defaults to console.log */
   onError?: (error: OnErrorOption) => void;
 

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -130,6 +130,9 @@ export class SlickCompositeEditorComponent implements ExternalResource {
     this._eventHandler.unsubscribeAll();
     this._bindEventService.unbindAll();
     this._formValues = null;
+    if (typeof this._options.onDispose === 'function') {
+      this._options.onDispose();
+    }
     this.disposeComponent();
   }
 


### PR DESCRIPTION
As discussed in #1987:
- Allow either the CellSelectionModel or the RowSelectionModel;
- Don't beak the selected cell ranges when using the CellSelectionModel;
- Provide an extra callback onDestroy, that always gets called when the editor is removed.
