### PR TITLE
feat(filter): allow processing empty search term via flag

### DIFF
--- a/docs/column-functionalities/filters/select-filter.md
+++ b/docs/column-functionalities/filters/select-filter.md
@@ -198,24 +198,26 @@ this.columnDefinitions = [
 ```
 
 ### How to filter empty values?
-By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `emptySearchTermReturnAllValues` set to `false` to add the ability to really search only empty values.
+By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `processEmptySearchTerms` set to `true` (or the previously `@deprecated` flag `emptySearchTermReturnAllValues` to `false`) to add the ability to really search only empty values.
 
 Note: the defaults for single & multiple select filters are different
-- single select filter default is `emptySearchTermReturnAllValues: true`
-- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `processEmptySearchTerms: false` (or deprecated `emptySearchTermReturnAllValues: true`)
+- multiple select filter default is `processEmptySearchTerms: true` (or deprecated `emptySearchTermReturnAllValues: false`)
 
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  {
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmark,
     type: 'boolean',
     filterable: true,
     filter: {
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
-       emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
-   }
+       processEmptySearchTerms: true, // enable it when we really want to filter empty values
+    }
+  }
 ];
 ```
 

--- a/frameworks/angular-slickgrid/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/angular-slickgrid/docs/column-functionalities/filters/select-filter.md
@@ -198,24 +198,26 @@ this.columnDefinitions = [
 ```
 
 ### How to filter empty values?
-By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `emptySearchTermReturnAllValues` set to `false` to add the ability to really search only empty values.
+By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `processEmptySearchTerms` set to `true` (or the previously `@deprecated` flag `emptySearchTermReturnAllValues` to `false`) to add the ability to really search only empty values.
 
 Note: the defaults for single & multiple select filters are different
-- single select filter default is `emptySearchTermReturnAllValues: true`
-- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `processEmptySearchTerms: false` (or deprecated `emptySearchTermReturnAllValues: true`)
+- multiple select filter default is `processEmptySearchTerms: true` (or deprecated `emptySearchTermReturnAllValues: false`)
 
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  {
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',
     filterable: true,
     filter: {
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
-       emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
-   }
+       processEmptySearchTerms: true, // enable it when we really want to filter empty values
+    }
+  }
 ];
 ```
 

--- a/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/select-filter.md
@@ -201,24 +201,26 @@ this.columnDefinitions = [
 ```
 
 ### How to filter empty values?
-By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `emptySearchTermReturnAllValues` set to `false` to add the ability to really search only empty values.
+By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `processEmptySearchTerms` set to `true` (or the previously `@deprecated` flag `emptySearchTermReturnAllValues` to `false`) to add the ability to really search only empty values.
 
 Note: the defaults for single & multiple select filters are different
-- single select filter default is `emptySearchTermReturnAllValues: true`
-- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `processEmptySearchTerms: false` (or deprecated `emptySearchTermReturnAllValues: true`)
+- multiple select filter default is `processEmptySearchTerms: true` (or deprecated `emptySearchTermReturnAllValues: false`)
 
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  {
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',
     filterable: true,
     filter: {
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
-       emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
-   }
+       processEmptySearchTerms: true, // enable it when we really want to filter empty values
+    }
+  }
 ];
 ```
 

--- a/frameworks/slickgrid-react/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/filters/select-filter.md
@@ -213,11 +213,11 @@ const columnDefinitions = [
 ```
 
 ### How to filter empty values?
-By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `emptySearchTermReturnAllValues` set to `false` to add the ability to really search only empty values.
+By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `processEmptySearchTerms` set to `true` (or the previously `@deprecated` flag `emptySearchTermReturnAllValues` to `false`) to add the ability to really search only empty values.
 
 Note: the defaults for single & multiple select filters are different
-- single select filter default is `emptySearchTermReturnAllValues: true`
-- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `processEmptySearchTerms: false` (or deprecated `emptySearchTermReturnAllValues: true`)
+- multiple select filter default is `processEmptySearchTerms: true` (or deprecated `emptySearchTermReturnAllValues: false`)
 
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
@@ -230,7 +230,7 @@ const columnDefinitions = [
     filter: {
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
-       emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
+       processEmptySearchTerms: true, // enable it when we really want to filter empty values
     }
   }
 ];

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
@@ -208,23 +208,24 @@ columnDefinitions.value = [
 ```
 
 ### How to filter empty values?
-By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `emptySearchTermReturnAllValues` set to `false` to add the ability to really search only empty values.
+By default you cannot filter empty dataset values (unless you use a `multipleSelect` Filter). You might be wondering, why though? By default an empty value in a `singleSelect` Filter is equal to returning **all values**. You could however use this option `processEmptySearchTerms` set to `true` (or the previously `@deprecated` flag `emptySearchTermReturnAllValues` to `false`) to add the ability to really search only empty values.
 
 Note: the defaults for single & multiple select filters are different
-- single select filter default is `emptySearchTermReturnAllValues: true`
-- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `processEmptySearchTerms: false` (or deprecated `emptySearchTermReturnAllValues: true`)
+- multiple select filter default is `processEmptySearchTerms: true` (or deprecated `emptySearchTermReturnAllValues: false`)
 
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 columnDefinitions.value = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  {
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',
     filterable: true,
     filter: {
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
-       emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
+       processEmptySearchTerms: true, // enable it when we really want to filter empty values
     }
   }
 ];

--- a/packages/common/src/filters/__tests__/inputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputFilter.spec.ts
@@ -170,6 +170,23 @@ describe('InputFilter', () => {
       expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: '>', searchTerms: ['>9'], shouldTriggerQuery: true });
     });
 
+    it('should call "setValues" with an operator that equals to the input value and use it with `processEmptySearchTerms`', () => {
+      mockColumn.filter!.processEmptySearchTerms = true;
+      gridOptionMock.enableFilterTrimWhiteSpace = true;
+      const spyCallback = vi.spyOn(filterArguments, 'callback');
+
+      filter.init(filterArguments);
+      filter.setValues('!=', '!=');
+      const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
+
+      filterElm.focus();
+      filterElm.dispatchEvent(new (window.window as any).Event('keyup', { key: 'a', keyCode: 97, bubbles: true, cancelable: true }));
+      const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
+
+      expect(filterFilledElms.length).toBe(1);
+      expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '!=', searchTerms: ['!='], shouldTriggerQuery: true });
+    });
+
     it('should call "setValues" and include an operator and expect the operator to show up in the output search string shown in the filter input text value', () => {
       filter.init(filterArguments);
 

--- a/packages/common/src/filters/selectFilter.ts
+++ b/packages/common/src/filters/selectFilter.ts
@@ -260,12 +260,14 @@ export class SelectFilter implements Filter {
 
   /** Set value(s) on the DOM element */
   setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false): void {
-    if (values !== undefined && this._msInstance) {
+    const processEmptySearchTerms =
+      this.columnDef.filter?.processEmptySearchTerms ?? !(this.columnDef.filter?.emptySearchTermReturnAllValues ?? true);
+    if (this._msInstance && (values !== undefined || !processEmptySearchTerms)) {
       values = Array.isArray(values) ? (values.every((x) => isPrimitiveValue(x)) ? values.map(String) : values) : [values];
       this._msInstance.setSelects(values);
     }
 
-    // set the operator when defined
+    // update the CSS filter style when operator is defined
     this.updateFilterStyle(this.getValues().length > 0);
 
     // set the operator when defined

--- a/packages/common/src/interfaces/columnFilter.interface.ts
+++ b/packages/common/src/interfaces/columnFilter.interface.ts
@@ -149,15 +149,17 @@ export interface ColumnFilter {
   queryField?: string;
 
   /**
-   * Defaults to true, should an empty search term have the effect of returning all results?
-   * Typically that would be True except for a dropdown Select Filter,
-   * we might really want to filter an empty string and/or `undefined` and for these special cases we can set this flag to `false`.
-   *
-   * NOTE: for a dropdown Select Filter, we will assume that on a multipleSelect Filter it should default to `false`
-   * however for a singleSelect Filter (and any other type of Filters) it should default to `true`.
-   * In any case, the user can overrides it this flag.
+   * @deprecated @use `processEmptySearchTerms` (just a rename with a shorter, better and clearer flag name)
+   * NOTE: `processEmptySearchTerms` is the inverse of `emptySearchTermReturnAllValues` (if you had it set to `false` then use the new `processEmptySearchTerms: true`)
    */
   emptySearchTermReturnAllValues?: boolean;
+
+  /**
+   * Defaults to `false`, when set to `true` an empty string search term would be applied and stored as Grid State/Presets.
+   * But when set to `false` (default), an empty search terms has the default behavior of returning all values.
+   * For example, typically an empty value would be skipped and not saved as Grid State/Presets
+   */
+  processEmptySearchTerms?: boolean;
 
   /**
    * Should we skip filtering when the Operator is changed before the Compound Filter input.


### PR DESCRIPTION
- an empty filter search term will return everything and that is not being processed or saved by Grid State/Presets. So to deal with that I added `processEmptySearchTerms` as a flag that can be enabled as a `filter` option and with that enabled, 
- also note that we previously had a flag named `emptySearchTermReturnAllValues` but it was a bit lengthy and not exactly clear what it was meant to do, it was also working only on an ms-select filter, the new flag works for both ms-select and text filter. 
- Also note that the new `processEmptySearchTerms` flag is the complete inverse of `emptySearchTermReturnAllValues` and the latter is now a `@deprecated` flag (to be removed in next major)