### PR TITLE
fix: avoid using SF unsupported `document.elementFromPoint()`

### DIFF
--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -59,7 +59,6 @@ describe('SlickCustomTooltip plugin', () => {
     plugin = new SlickCustomTooltip();
     divContainer.className = `slickgrid-container ${GRID_UID}`;
     document.body.appendChild(divContainer);
-    (document as any).elementFromPoint = vi.fn(); // document.elementFromPoint() doesn't exist in JSDOM but we can mock it
     (getOffset as Mock).mockReturnValue({ top: 0, left: 0, right: 0, bottom: 0 });
   });
 
@@ -370,26 +369,6 @@ describe('SlickCustomTooltip plugin', () => {
     expect(tooltipElm.textContent).toBe('some very extra long...');
   });
 
-  it('should NOT create a tooltip as regular tooltip with truncated text when tooltip option has "useRegularTooltip" enabled but the mouse over is not a slick-cell cell type', () => {
-    const cellNode = document.createElement('div');
-    cellNode.className = 'slick-cell l2 r2';
-    cellNode.textContent = 'some very extra long tooltip text sentence';
-    cellNode.setAttribute('title', 'tooltip text');
-    Object.defineProperty(cellNode, 'scrollWidth', { writable: true, configurable: true, value: 400 });
-    const mockColumns = [{ id: 'firstName', field: 'firstName' }] as Column[];
-    vi.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 0, row: 1 });
-    vi.spyOn(gridStub, 'getCellNode').mockReturnValue(cellNode);
-    vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
-    vi.spyOn(dataviewStub, 'getItem').mockReturnValue({ firstName: 'John', lastName: 'Doe' });
-
-    plugin.init(gridStub, container);
-    plugin.setOptions({ useRegularTooltip: true, tooltipTextMaxLength: 23 });
-    gridStub.onHeaderMouseOver.notify({ column: mockColumns[0], grid: gridStub }, { ...new SlickEventData(), target: cellNode } as any);
-
-    const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
-    expect(tooltipElm).toBeFalsy();
-  });
-
   it('should create a tooltip with only the tooltip pulled from the cell text when enabling option "useRegularTooltip" & "useRegularTooltipFromCellTextOnly" and column definition has a regular formatter with a "title" attribute filled', () => {
     const cellNode = document.createElement('div');
     cellNode.className = 'slick-cell l2 r2';
@@ -402,7 +381,6 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, useRegularTooltipFromCellTextOnly: true, maxHeight: 100 });
-    (document as any).elementFromPoint.mockReturnValue(cellNode);
 
     gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
 
@@ -436,9 +414,8 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, maxHeight: 100 });
-    (document as any).elementFromPoint.mockReturnValue(icon2Elm);
 
-    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
+    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: icon2Elm } as any);
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -470,9 +447,8 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, maxHeight: 100 });
-    (document as any).elementFromPoint.mockReturnValue(icon2Elm);
 
-    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
+    gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: icon2Elm } as any);
 
     const tooltipElm = document.body.querySelector('.slick-custom-tooltip') as HTMLDivElement;
     expect(tooltipElm).toBeTruthy();
@@ -502,7 +478,6 @@ describe('SlickCustomTooltip plugin', () => {
 
     plugin.init(gridStub, container);
     plugin.setOptions({ useRegularTooltip: true, maxHeight: 100 });
-    (document as any).elementFromPoint.mockReturnValue(icon2Elm);
 
     gridStub.onMouseEnter.notify({ grid: gridStub } as any, { ...new SlickEventData(), target: cellNode } as any);
 

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -72,7 +72,6 @@ export class SlickCustomTooltip {
   protected _sharedService?: SharedService | null = null;
   protected _tooltipBodyElm?: HTMLDivElement;
   protected _tooltipElm?: HTMLDivElement;
-  protected _mousePosition: { x: number; y: number } = { x: 0, y: 0 };
   protected _mouseTarget?: HTMLElement | null;
   protected _hasMultipleTooltips = false;
   protected _defaultOptions = {
@@ -210,8 +209,7 @@ export class SlickCustomTooltip {
   /** depending on the selector type, execute the necessary handler code */
   protected handleOnHeaderMouseOverByType(event: SlickEventData, args: any, selector: CellType): void {
     this._cellType = selector;
-    this._mousePosition = { x: event.clientX || 0, y: event.clientY || 0 };
-    this._mouseTarget = document.elementFromPoint(event.clientX || 0, event.clientY || 0)?.closest(SELECTOR_CLOSEST_TOOLTIP_ATTR);
+    this._mouseTarget = event.target?.closest(SELECTOR_CLOSEST_TOOLTIP_ATTR);
 
     // before doing anything, let's remove any previous tooltip before
     // and cancel any opened Promise/Observable when using async
@@ -256,8 +254,7 @@ export class SlickCustomTooltip {
 
   protected async handleOnMouseOver(event: SlickEventData): Promise<void> {
     this._cellType = 'slick-cell';
-    this._mousePosition = { x: event.clientX || 0, y: event.clientY || 0 };
-    this._mouseTarget = document.elementFromPoint(event.clientX || 0, event.clientY || 0)?.closest(SELECTOR_CLOSEST_TOOLTIP_ATTR);
+    this._mouseTarget = event.target?.closest(SELECTOR_CLOSEST_TOOLTIP_ATTR);
 
     // before doing anything, let's remove any previous tooltip before
     // and cancel any opened Promise/Observable when using async


### PR DESCRIPTION
another 1 of those "regular JS code fails in Salesforce LWC with locker service".... I'm not entire sure but I think `document.elementFromPoint()` isn't well supported in Salesforce and we don't actually have to use it anyway, we can simply use simply get tooltip target from input event