### PR TITLE
Update slickRowDetailView.ts

### DIFF
--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -784,6 +784,11 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
 
   protected handleRemoveRow(rowIndex: number): void {
     const item = this.dataView.getItemByIdx(rowIndex);
+
+    if (!item) {
+      return;
+    }
+    
     const rowId = item[this.dataViewIdProperty];
 
     if (this._expandedRowIds.has(rowId)) {


### PR DESCRIPTION
This Pull Request adds a check to ensure `item` exists before trying to access a property in it.

In situations where rows need to be updated like changing the page, filtering, sorting, etc. the event `onBeforeRemoveCachedRow` is triggered which in turn triggers the RowDetailViewPlugin's method `handleRemoveRow`. 
Sometimes the index provided to this method can't be found in the dataset so the line 
`const item = this.dataView.getItemByIdx(rowIndex)` yields undefined.

