### PR TITLE
fix: only toggle title and data-slick-tooltip if value is defined

### DIFF
--- a/frameworks/angular-slickgrid/src/demos/examples/custom-angularComponentFilter.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/custom-angularComponentFilter.ts
@@ -14,13 +14,14 @@ import {
   type SlickGrid,
   unsubscribeAllObservables,
 } from '../../library';
+import { FilterNgSelectComponent } from './filter-ng-select.component';
 
 export class CustomAngularComponentFilter implements Filter {
   private _shouldTriggerQuery = true;
   private _subscriptions: Subscription[] = [];
 
   /** Angular Component Reference */
-  componentRef!: ComponentRef<any>;
+  componentRef!: ComponentRef<FilterNgSelectComponent>;
 
   grid!: SlickGrid;
   searchTerms: SearchTerm[] = [];
@@ -79,11 +80,11 @@ export class CustomAngularComponentFilter implements Filter {
         this.componentRef = componentOuput.componentRef;
 
         this._subscriptions.push(
-          componentOuput.componentRef.instance.onItemChanged.subscribe((item: any) => {
+          componentOuput.componentRef.instance.onItemChanged.subscribe((items: any[]) => {
             this.callback(undefined, {
               columnDef: this.columnDef,
               operator: this.operator,
-              searchTerms: [item.id],
+              searchTerms: items.map((item) => item.id),
               shouldTriggerQuery: this._shouldTriggerQuery,
             });
             // reset flag for next use
@@ -99,8 +100,8 @@ export class CustomAngularComponentFilter implements Filter {
    */
   clear(shouldTriggerQuery = true) {
     this._shouldTriggerQuery = shouldTriggerQuery;
-    if (this.componentRef?.instance && 'selectedId' in this.componentRef.instance) {
-      this.componentRef.instance.selectedId = 0;
+    if (this.componentRef?.instance) {
+      this.componentRef.instance.selectedIds.set([]);
     }
   }
 
@@ -116,8 +117,9 @@ export class CustomAngularComponentFilter implements Filter {
 
   /** Set value(s) on the DOM element */
   setValues(values: SearchTerm[] | SearchTerm) {
-    if (this.componentRef?.instance && 'selectedId' in this.componentRef.instance) {
-      this.componentRef.instance.selectedId = values;
+    if (this.componentRef?.instance) {
+      const value = values instanceof Array ? values : [values];
+      this.componentRef.instance.selectedIds.set(value);
     }
   }
 }

--- a/frameworks/angular-slickgrid/src/demos/examples/example26.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example26.component.ts
@@ -20,6 +20,7 @@ import { CustomAngularComponentFilter } from './custom-angularComponentFilter';
 import { CustomTitleFormatterComponent } from './custom-titleFormatter.component';
 import { FilterNgSelectComponent } from './filter-ng-select.component';
 import { CustomButtonFormatterComponent } from './custom-buttonFormatter.component';
+import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 
 const NB_ITEMS = 100;
 
@@ -278,6 +279,7 @@ export class Example26Component implements OnInit {
         this._commandQueue.push(editCommand);
         editCommand.execute();
       },
+      externalResources: [new SlickCustomTooltip()],
       i18n: this.translate,
       params: {
         angularUtilService: this.angularUtilService, // provide the service to all at once (Editor, Filter, AsyncPostRender)

--- a/frameworks/angular-slickgrid/src/demos/examples/filter-ng-select.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/filter-ng-select.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
+import { SearchTerm } from '@slickgrid-universal/common';
 import { Subject } from 'rxjs';
 
 // the appendTo="body" (necessary for SlickGrid filter) requires the body to be position relative like so
@@ -12,22 +13,23 @@ import { Subject } from 'rxjs';
     appendTo="body"
     [clearable]="false"
     (change)="onChange($event)"
-    [(ngModel)]="selectedId"
+    [(ngModel)]="selectedIds"
+    [multiple]="true"
   >
     <ng-template ng-label-tmp ng-option-tmp let-item="item">
-      {{ item?.name }}
+      <span [title]="item?.name">{{ item?.name }}</span>
     </ng-template>
   </ng-select>`,
   standalone: false,
 })
-export class FilterNgSelectComponent {
-  selectedId = '';
-  selectedItem: any;
+export class FilterNgSelectComponent<T = any> {
+  selectedIds = signal<SearchTerm[]>([]);
+  selectedItems = signal<T[]>([]);
   collection?: any[]; // this will be filled by the collection of your column definition
   onItemChanged = new Subject<any>(); // object
 
-  onChange(item: any) {
-    this.selectedItem = item;
-    this.onItemChanged.next(item);
+  onChange(items: any) {
+    this.selectedItems.set(items);
+    this.onItemChanged.next(items);
   }
 }

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example26.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example26.cy.ts
@@ -103,6 +103,30 @@ describe('Example 26 - Use of Angular Components', () => {
       });
   });
 
+  it('should render the Custom Tooltip on top of the ng-select multi value component', () => {
+    cy.get('.slick-headerrow-column:nth(2)').find('ng-select').click();
+    cy.get('.ng-option:nth(1)').click();
+
+    cy.get('.slick-headerrow-column:nth(2)').find('ng-select').click();
+    cy.get('.ng-option:nth(2)').click();
+
+    cy.wait(1000);
+
+    cy.get('.ng-value:nth(1)')
+      .realHover()
+      .then(() => {
+        cy.get('.slick-custom-tooltip').should('exist');
+        cy.get('.slick-custom-tooltip').should('contain', 'Pierre');
+      });
+
+    cy.get('.ng-value:nth(0)')
+      .realHover()
+      .then(() => {
+        cy.get('.slick-custom-tooltip').should('exist');
+        cy.get('.slick-custom-tooltip').should('contain', 'John');
+      });
+  });
+
   it('should remove Angular Component rendered for AsyncPostRender once content is copied', () => {
     cy.visit(`${Cypress.config('baseUrl')}/angular-components`);
 

--- a/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
+++ b/packages/custom-tooltip-plugin/src/slickCustomTooltip.ts
@@ -576,7 +576,7 @@ export class SlickCustomTooltip {
     const titleElm = inputTitleElm || (this._cellNodeElm && ((this._cellNodeElm.hasAttribute('title') && this._cellNodeElm.getAttribute('title')) ? this._cellNodeElm : this._cellNodeElm?.querySelector('[title]')));
 
     // flip tooltip text from `title` to `data-slick-tooltip`
-    if (titleElm) {
+    if (titleElm && tooltipText) {
       titleElm.setAttribute('data-slick-tooltip', tooltipText || '');
       if (titleElm.hasAttribute('title')) {
         titleElm.setAttribute('title', '');


### PR DESCRIPTION
this PR makes sure that the toggling of the title and data-slick-tooltip attributes of the customTooltip plugin only happens if there is a value to set.

closes https://github.com/ghiscoding/slickgrid-universal/issues/2028