### PR TITLE
fix: use custom clipboard override when native API unsupported in SF

### DIFF
--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -491,7 +491,8 @@ export class SlickCellExternalCopyManager {
               clipText += clipTextRows.join('\r\n') + '\r\n';
             }
 
-            await navigator.clipboard.writeText(clipText);
+            const copyFn = this._grid.getOptions().clipboardWriteOverride ?? navigator.clipboard.writeText;
+            await copyFn(clipText);
 
             if (typeof this._onCopySuccess === 'function') {
               // If it's cell selection, use the toRow/fromRow fields

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -83,7 +83,8 @@ export async function copyCellToClipboard(args: {
         .trim();
     }
 
-    await navigator.clipboard.writeText(finalTextToCopy);
+    const copyFn = gridOptions.clipboardWriteOverride ?? navigator.clipboard.writeText;
+    await copyFn(finalTextToCopy);
   } catch (err) {
     console.error(`Unable to read/write to clipboard. Please check your browser settings or permissions. Error: ${err}`);
   }

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -179,6 +179,12 @@ export interface GridOption<C extends Column = Column> {
   /** Checkbox Select Plugin options (columnId, cssClass, toolTip, width) */
   checkboxSelector?: CheckboxSelectorOption;
 
+  /**
+   * Optionally override the default copy (write) to clipboard behavior.
+   * The default is to use the native Clipboard API but it isn't guaranteed to work in all environments (i.e.: Salesforce LWC).
+   */
+  clipboardWriteOverride?: (text: string) => void;
+
   /** Defaults to " - ", separator between the column group label and the column label. */
   columnGroupSeparator?: string;
 

--- a/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
+++ b/packages/vanilla-force-bundle/src/salesforce-global-grid-options.ts
@@ -6,6 +6,23 @@ const emptyWarningElm = document.createElement('div');
 emptyWarningElm.appendChild(createDomElement('span', { className: 'mdi mdi-alert text-color-warning' }));
 emptyWarningElm.appendChild(createDomElement('span', { textContent: 'No data to display.' }));
 
+// copy to clipboard override since the default clipboard API isn't supported in Salesforce
+function copyToClipboard(textInput: string) {
+  const scrollPos = document.documentElement.scrollTop || document.body.scrollTop;
+  const tmpElem = document.createElement('textarea');
+  if (tmpElem && document.body) {
+    tmpElem.style.position = 'absolute';
+    tmpElem.style.opacity = '0';
+    tmpElem.style.top = `${scrollPos}px`;
+    tmpElem.value = textInput;
+    document.body.appendChild(tmpElem);
+    tmpElem.select();
+    if (document.execCommand('copy', false, textInput)) {
+      tmpElem.remove();
+    }
+  }
+}
+
 /** Global Grid Options Defaults for Salesforce */
 export const SalesforceGlobalGridOptions = {
   autoEdit: true, // true single click (false for double-click)
@@ -14,6 +31,7 @@ export const SalesforceGlobalGridOptions = {
   autoFixResizeRequiredGoodCount: 5 * 60 * 60, // make it the same as the interval timeout, this is equivalent to say don't stop until the timeout is over
   autoFixResizeWhenBrokenStyleDetected: true,
   cellValueCouldBeUndefined: true,
+  clipboardWriteOverride: copyToClipboard,
   contextMenu: {
     hideCloseButton: false,
   },


### PR DESCRIPTION
- default browser clipboard API doesn't seem to work in Salesforce LWC, so let's add an override but only in the Salesforce global grid options.