### PR TITLE
fix(filter): input filter empty values & save GridState/Preset

### DIFF
--- a/docs/column-functionalities/filters/input-filter.md
+++ b/docs/column-functionalities/filters/input-filter.md
@@ -2,6 +2,7 @@
 - [Usage](#ui-usage)
 - [Filtering with Localization](#filtering-with-localization-i18n)
 - [Filter Complex Object](#how-to-filter-complex-objects)
+- [Filtering empty values](#filtering-empty-values)
 - [Update Filters Dynamically](#update-filters-dynamically)
 - [Query Different Field (Filter/Sort)](#query-different-field)
 - [Dynamic Query Field](#dynamic-query-field)
@@ -102,6 +103,30 @@ this.columnDefinitions = [
     // it will use the "field" property to explode (from "." notation) and find the child value
     id: 'zip', name: 'ZIP', field: 'buyer.address.zip', filterable: true
    // id: 'street',  ...
+  }
+];
+```
+
+### Filtering empty values
+You can filter empty dataset values using `=` (empty values) and `!=` (non-empty values) by default. Using this in a Grid State/Preset will also work. However in some cases you might want to disregard such behavior and for that you can assign the `emptySearchTermReturnAllValues` filter option to `false` which will ignore such filters and delete them from the final search.
+
+Note: the default is different depending on the filter type
+- input filter default is `emptySearchTermReturnAllValues: false`
+- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `emptySearchTermReturnAllValues: true`
+- any other filter type has a default of `emptySearchTermReturnAllValues: true`
+
+For example if you would want to disable this behavior, you can assign `emptySearchTermReturnAllValues: false`
+```ts
+// define you columns, in this demo Effort Driven will use a Select Filter
+this.columnDefinitions = [
+  { 
+    id: 'lastName', name: 'Last Name', field: 'lastName',
+    filterable: true,
+    filter: {
+       model: Filters.input, // default filter
+       emptySearchTermReturnAllValues: true, // True will ignore the filter and return all values (empty & non-empty)
+    }
   }
 ];
 ```

--- a/docs/column-functionalities/filters/select-filter.md
+++ b/docs/column-functionalities/filters/select-filter.md
@@ -207,7 +207,8 @@ Note: the defaults for single & multiple select filters are different
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  { 
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmark,
     type: 'boolean',
     filterable: true,
@@ -215,7 +216,8 @@ this.columnDefinitions = [
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
        emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
-   }
+    }
+  }
 ];
 ```
 

--- a/frameworks/angular-slickgrid/docs/column-functionalities/filters/input-filter.md
+++ b/frameworks/angular-slickgrid/docs/column-functionalities/filters/input-filter.md
@@ -2,6 +2,7 @@
 - [Usage](#ui-usage)
 - [Filtering with Localization](#filtering-with-localization-i18n)
 - [Filter Complex Object](#how-to-filter-complex-objects)
+- [Filtering empty values](#filtering-empty-values)
 - [Update Filters Dynamically](#update-filters-dynamically)
 - [Query Different Field (Filter/Sort)](#query-different-field)
 - [Dynamic Query Field](#dynamic-query-field)
@@ -101,6 +102,31 @@ this.columnDefinitions = [
     // it will use the "field" property to explode (from "." notation) and find the child value
     id: 'zip', name: 'ZIP', field: 'buyer.address.zip', filterable: true
    // id: 'street',  ...
+  }
+];
+```
+
+### Filtering empty values
+You can filter empty dataset values using `=` (empty values) and `!=` (non-empty values) by default. Using this in a Grid State/Preset will also work. However in some cases you might want to disregard such behavior and for that you can assign the `emptySearchTermReturnAllValues` filter option to `false` which will ignore such filters and delete them from the final search.
+
+Note: the default is different depending on the filter type
+- input filter default is `emptySearchTermReturnAllValues: false`
+- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `emptySearchTermReturnAllValues: true`
+- any other filter type has a default of `emptySearchTermReturnAllValues: true`
+
+For example if you would want to disable this behavior, you can assign `emptySearchTermReturnAllValues: false`
+```ts
+// define you columns, in this demo Effort Driven will use a Select Filter
+this.columnDefinitions = [
+  { 
+    id: 'lastName', name: 'Last Name', field: 'lastName',
+    filterable: true,
+    filter: {
+       model: Filters.input, // default filter
+       emptySearchTermReturnAllValues: true, // True will ignore the filter and return all values (empty & non-empty)
+    }
+  }
 ];
 ```
 

--- a/frameworks/angular-slickgrid/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/angular-slickgrid/docs/column-functionalities/filters/select-filter.md
@@ -207,7 +207,8 @@ Note: the defaults for single & multiple select filters are different
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  { 
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',
     filterable: true,
@@ -215,7 +216,8 @@ this.columnDefinitions = [
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
        emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
-   }
+    }
+  }
 ];
 ```
 

--- a/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/input-filter.md
+++ b/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/input-filter.md
@@ -3,6 +3,7 @@
 - [Filtering with Localization](#filtering-with-localization-i18n)
 - [Filter Complex Object](#how-to-filter-complex-objects)
 - [Update Filters Dynamically](#update-filters-dynamically)
+- [Filtering empty values](#filtering-empty-values)
 - [Query Different Field (Filter/Sort)](#query-different-field)
 - [Dynamic Query Field](#dynamic-query-field)
 - [Debounce/Throttle Text Search (wait for user to stop typing before filtering)](#debouncethrottle-text-search-wait-for-user-to-stop-typing-before-filtering)
@@ -101,6 +102,31 @@ this.columnDefinitions = [
     // it will use the "field" property to explode (from "." notation) and find the child value
     id: 'zip', name: 'ZIP', field: 'buyer.address.zip', filterable: true
    // id: 'street',  ...
+  }
+];
+```
+
+### Filtering empty values
+You can filter empty dataset values using `=` (empty values) and `!=` (non-empty values) by default. Using this in a Grid State/Preset will also work. However in some cases you might want to disregard such behavior and for that you can assign the `emptySearchTermReturnAllValues` filter option to `false` which will ignore such filters and delete them from the final search.
+
+Note: the default is different depending on the filter type
+- input filter default is `emptySearchTermReturnAllValues: false`
+- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `emptySearchTermReturnAllValues: true`
+- any other filter type has a default of `emptySearchTermReturnAllValues: true`
+
+For example if you would want to disable this behavior, you can assign `emptySearchTermReturnAllValues: false`
+```ts
+// define you columns, in this demo Effort Driven will use a Select Filter
+this.columnDefinitions = [
+  { 
+    id: 'lastName', name: 'Last Name', field: 'lastName',
+    filterable: true,
+    filter: {
+       model: Filters.input, // default filter
+       emptySearchTermReturnAllValues: true, // True will ignore the filter and return all values (empty & non-empty)
+    }
+  }
 ];
 ```
 

--- a/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/select-filter.md
@@ -210,7 +210,8 @@ Note: the defaults for single & multiple select filters are different
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
+  { 
+    id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',
     filterable: true,
@@ -218,7 +219,8 @@ this.columnDefinitions = [
        collection: [ { value: '', label: '' }, { value: true, labelKey: 'TRUE' }, { value: false, label: 'FALSE' } ],
        model: Filters.singleSelect,
        emptySearchTermReturnAllValues: false, // False when we really want to filter empty values
-   }
+    }
+  }
 ];
 ```
 

--- a/frameworks/slickgrid-react/docs/column-functionalities/filters/input-filter.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/filters/input-filter.md
@@ -3,6 +3,7 @@
 - [Filtering with Localization](#filtering-with-localization-i18n)
 - [Filter Complex Object](#how-to-filter-complex-objects)
 - [Update Filters Dynamically](#update-filters-dynamically)
+- [Filtering empty values](#filtering-empty-values)
 - [Query Different Field (Filter/Sort)](#query-different-field)
 - [Dynamic Query Field](#dynamic-query-field)
 - [Debounce/Throttle Text Search (wait for user to stop typing before filtering)](#debouncethrottle-text-search-wait-for-user-to-stop-typing-before-filtering)
@@ -101,6 +102,31 @@ const columns = [
     // it will use the "field" property to explode (from "." notation) and find the child value
     id: 'zip', name: 'ZIP', field: 'buyer.address.zip', filterable: true
    // id: 'street',  ...
+  }
+];
+```
+
+### Filtering empty values
+You can filter empty dataset values using `=` (empty values) and `!=` (non-empty values) by default. Using this in a Grid State/Preset will also work. However in some cases you might want to disregard such behavior and for that you can assign the `emptySearchTermReturnAllValues` filter option to `false` which will ignore such filters and delete them from the final search.
+
+Note: the default is different depending on the filter type
+- input filter default is `emptySearchTermReturnAllValues: false`
+- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `emptySearchTermReturnAllValues: true`
+- any other filter type has a default of `emptySearchTermReturnAllValues: true`
+
+For example if you would want to disable this behavior, you can assign `emptySearchTermReturnAllValues: false`
+```ts
+// define you columns, in this demo Effort Driven will use a Select Filter
+this.columnDefinitions = [
+  { 
+    id: 'lastName', name: 'Last Name', field: 'lastName',
+    filterable: true,
+    filter: {
+       model: Filters.input, // default filter
+       emptySearchTermReturnAllValues: true, // True will ignore the filter and return all values (empty & non-empty)
+    }
+  }
 ];
 ```
 

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/input-filter.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/input-filter.md
@@ -2,6 +2,7 @@
 - [Usage](#ui-usage)
 - [Filtering with Localization](#filtering-with-localization-i18n)
 - [Filter Complex Object](#how-to-filter-complex-objects)
+- [Filtering empty values](#filtering-empty-values)
 - [Update Filters Dynamically](#update-filters-dynamically)
 - [Query Different Field (Filter/Sort)](#query-different-field)
 - [Dynamic Query Field](#dynamic-query-field)
@@ -101,6 +102,30 @@ columnDefinitions.value = [
     // it will use the "field" property to explode (from "." notation) and find the child value
     id: 'zip', name: 'ZIP', field: 'buyer.address.zip', filterable: true
    // id: 'street',  ...
+  }
+];
+```
+
+### Filtering empty values
+You can filter empty dataset values using `=` (empty values) and `!=` (non-empty values) by default. Using this in a Grid State/Preset will also work. However in some cases you might want to disregard such behavior and for that you can assign the `emptySearchTermReturnAllValues` filter option to `false` which will ignore such filters and delete them from the final search.
+
+Note: the default is different depending on the filter type
+- input filter default is `emptySearchTermReturnAllValues: false`
+- multiple select filter default is `emptySearchTermReturnAllValues: false`
+- single select filter default is `emptySearchTermReturnAllValues: true`
+- any other filter type has a default of `emptySearchTermReturnAllValues: true`
+
+For example if you would want to disable this behavior, you can assign `emptySearchTermReturnAllValues: false`
+```ts
+// define you columns, in this demo Effort Driven will use a Select Filter
+this.columnDefinitions = [
+  { 
+    id: 'lastName', name: 'Last Name', field: 'lastName',
+    filterable: true,
+    filter: {
+       model: Filters.input, // default filter
+       emptySearchTermReturnAllValues: true, // True will ignore the filter and return all values (empty & non-empty)
+    }
   }
 ];
 ```

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -94,6 +94,12 @@ export class InputFilter implements Filter {
     // filter input can only have 1 search term, so we will use the 1st array index if it exist
     const searchTerm = Array.isArray(this.searchTerms) && this.searchTerms.length >= 0 ? this.searchTerms[0] : '';
 
+    // when we're using an input filter and we have an empty search value,
+    // we probably want this value to be a valid filter option that will ONLY return value that are empty (not everything like its default behavior)
+    // user can still override it by defining it
+    this.columnDef.filter ??= {};
+    this.columnDef.filter.emptySearchTermReturnAllValues ??= false;
+
     // step 1, create the DOM Element of the filter & initialize it if searchTerm is filled
     this.createDomFilterElement(searchTerm);
 

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -455,14 +455,12 @@ describe('FilterService', () => {
       service.init(gridStub);
       service.bindLocalOnFilter(gridStub);
       gridStub.onHeaderRowCellRendered.notify(mockArgs as any, new SlickEventData(), gridStub);
-      service
-        .getFiltersMetadata()[0]
-        .callback(new Event('input'), {
-          columnDef: { ...mockColumn, filter: { model: Filters.singleSelect } },
-          operator: 'EQ',
-          searchTerms: [''],
-          shouldTriggerQuery: true,
-        });
+      service.getFiltersMetadata()[0].callback(new Event('input'), {
+        columnDef: { ...mockColumn, filter: { model: Filters.singleSelect } },
+        operator: 'EQ',
+        searchTerms: [''],
+        shouldTriggerQuery: true,
+      });
 
       expect(service.getColumnFilters()).toEqual({});
     });

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -455,7 +455,14 @@ describe('FilterService', () => {
       service.init(gridStub);
       service.bindLocalOnFilter(gridStub);
       gridStub.onHeaderRowCellRendered.notify(mockArgs as any, new SlickEventData(), gridStub);
-      service.getFiltersMetadata()[0].callback(new Event('input'), { columnDef: mockColumn, operator: 'EQ', searchTerms: [''], shouldTriggerQuery: true });
+      service
+        .getFiltersMetadata()[0]
+        .callback(new Event('input'), {
+          columnDef: { ...mockColumn, filter: { model: Filters.singleSelect } },
+          operator: 'EQ',
+          searchTerms: [''],
+          shouldTriggerQuery: true,
+        });
 
       expect(service.getColumnFilters()).toEqual({});
     });


### PR DESCRIPTION
this PR expands the previous PR #2016 
By default, we should be able to filter empty values using the default input filter and then using Grid State/Preset should also work when reloading the grid with Grid Preset. This was even more problematic when using a Tree Data grid