### PR TITLE
fix(editor): ms-select drop, full width in composite editor, fixes #2044

### DIFF
--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -753,7 +753,6 @@ $slick-multiselect-input-focus-box-shadow:                  $slick-input-focus-b
 $slick-multiselect-dropdown-border:                         1px solid #bbb !default;
 $slick-multiselect-dropdown-bg-color:                       #fff !default;
 $slick-multiselect-dropdown-list-padding:                   4px 6px !default;
-$slick-multiselect-dropdown-max-width:                      250px !default;
 $slick-multiselect-dropdown-z-index:                        9999 !default;
 $slick-multiselect-checkbox-margin-left:                    0px !default;
 $slick-multiselect-checkbox-hover-bg-color:                 #fafafa !default;

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -667,7 +667,6 @@ li.hidden {
   box-shadow: var(--slick-multiselect-input-focus-box-shadow, v.$slick-multiselect-input-focus-box-shadow);
 }
 .ms-drop {
-  max-width: var(--slick-multiselect-dropdown-max-width, v.$slick-multiselect-dropdown-max-width);
   border: var(--slick-multiselect-dropdown-border, v.$slick-multiselect-dropdown-border);
   z-index: var(--slick-multiselect-dropdown-z-index, v.$slick-multiselect-dropdown-z-index);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^3.0.2
       version: 3.0.2
     multiple-select-vanilla:
-      specifier: ^4.3.3
-      version: 4.3.3
+      specifier: ^4.3.4
+      version: 4.3.4
     native-copyfiles:
       specifier: ^1.3.3
       version: 1.3.3
@@ -527,7 +527,7 @@ importers:
         version: 3.2.6
       multiple-select-vanilla:
         specifier: 'catalog:'
-        version: 4.3.3
+        version: 4.3.4
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -1160,7 +1160,7 @@ importers:
         version: 2.0.3
       multiple-select-vanilla:
         specifier: 'catalog:'
-        version: 4.3.3
+        version: 4.3.4
       sortablejs:
         specifier: 'catalog:'
         version: 1.15.6
@@ -8587,8 +8587,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  multiple-select-vanilla@4.3.3:
-    resolution: {integrity: sha512-3gGYWHfDyUa6+bA+5VVesPej09PfhWSkVwgeXJ3aIomnILnZr0bpaOQVbZnrP9rKAzGpoqNTCM63rWmZZoObKQ==}
+  multiple-select-vanilla@4.3.4:
+    resolution: {integrity: sha512-PnEY9/jq/nSlfHvMa/mEgQGWgX/LlpZySNiKlcS7VKeAXNzsh1UbPVAJBQIMijumnCM/bZqSM5xY55QlmkCXSg==}
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -20816,7 +20816,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  multiple-select-vanilla@4.3.3:
+  multiple-select-vanilla@4.3.4:
     dependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalog:
   i18next-vue: ^5.3.0
   jsdom: ^26.1.0
   jsdom-global: ^3.0.2
-  multiple-select-vanilla: ^4.3.3
+  multiple-select-vanilla: ^4.3.4
   native-copyfiles: ^1.3.3
   npm-run-all2: ^8.0.4
   remove-glob: ^0.3.2


### PR DESCRIPTION
fixes #2044

- remove `$slick-multiselect-dropdown-max-width` SASS variable, also removing the drop `max-width` styling, since that was causing issues that could be all avoided by simply just not using any max-width on the ms-select drop. 
- also push a fix in ms-select library to assign any of the ms-select width options (`width`, `minWidth`, `maxWidth`, `dropWidth`) and assign them as CSS style on the drop element (via this [PR](https://github.com/ghiscoding/multiple-select-vanilla/pull/402)) and released ms-select [v4.3.4](https://github.com/ghiscoding/multiple-select-vanilla/releases/tag/v4.3.4) that includes this fix. 