### PR TITLE
fix: followup of PR #2048 ms-select width/position/styling, fixes #2044

### DIFF
--- a/packages/common/src/services/domUtilities.ts
+++ b/packages/common/src/services/domUtilities.ts
@@ -40,7 +40,7 @@ export function buildMsSelectCollectionList(
   const optionLabel = columnFilterOrEditor?.customStructure?.optionLabel ?? 'value';
   const valueName = columnFilterOrEditor?.customStructure?.value ?? 'value';
 
-  const selectElement = createDomElement('select', { className: 'ms-filter search-filter' });
+  const selectElement = createDomElement('select', { className: 'ms-filter' });
   const extraCssClasses = type === 'filter' ? ['search-filter', `filter-${columnId}`] : ['select-editor', `editor-${columnId}`];
   selectElement.classList.add(...extraCssClasses);
   selectElement.multiple = isMultiSelect;

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -506,8 +506,7 @@ $slick-slider-editor-runnable-track-padding:                0 6px !default;
 $slick-slider-editor-number-padding:                        4px 6px !default;
 $slick-slider-editor-focus-border-color:                    $slick-input-focus-border-color !default;
 $slick-slider-editor-focus-box-shadow:                      $slick-input-focus-box-shadow !default;
-$slick-multiselect-editor-height:                           $slick-editor-input-height !default;
-$slick-multiselect-editor-transform:                        translate(0, -2px) !default;
+$slick-multiselect-editor-height:                           100% !default;
 
 /* Slick Composite Editor Modal */
 $slick-editor-modal-backdrop-transition-background:         rgba(0, 0, 0, 0.6) !default;
@@ -616,6 +615,7 @@ $slick-editor-modal-large-editor-count-margin:              0 !default;
 $slick-editor-modal-multiselect-editor-height:              $slick-editor-modal-input-editor-height !default;
 $slick-editor-modal-reset-btn-color:                        #333 !default;
 $slick-editor-modal-reset-btn-bg-color:                     #fff !default;
+$slick-editor-modal-select-editor-border:                   $slick-editor-modal-input-editor-border !default;
 $slick-editor-modal-slider-editor-value-height:             $slick-editor-modal-input-editor-height !default;
 $slick-editor-modal-slider-editor-value-min-height:         100% !default;
 $slick-editor-modal-text-color:                             #000 !default;
@@ -750,6 +750,7 @@ $slick-multiselect-input-filter-font-family:                "Helvetica Neue", He
 $slick-multiselect-input-filter-font-size:                  12px !default;
 $slick-multiselect-input-focus-border-color:                $slick-input-focus-border-color !default;
 $slick-multiselect-input-focus-box-shadow:                  $slick-input-focus-box-shadow !default;
+$slick-multiselect-input-filter-height:                     $slick-header-input-height !default;
 $slick-multiselect-dropdown-border:                         1px solid #bbb !default;
 $slick-multiselect-dropdown-bg-color:                       #fff !default;
 $slick-multiselect-dropdown-list-padding:                   4px 6px !default;
@@ -922,6 +923,7 @@ $slick-empty-data-warning-z-index:                          10 !default;
   $ms-choice-bgcolor:                                       $slick-form-control-bg-color,
   $ms-choice-border:                                        $slick-multiselect-input-filter-border,
   $ms-choice-focus-box-shadow:                              $slick-form-control-focus-box-shadow,
+  $ms-choice-height:                                        $slick-multiselect-input-filter-height,
   $ms-drop-background:                                      $slick-multiselect-dropdown-bg-color,
   $ms-drop-list-padding:                                    $slick-multiselect-dropdown-list-padding,
   $ms-drop-list-item-align-items:                           center,

--- a/packages/common/src/styles/slick-editors.scss
+++ b/packages/common/src/styles/slick-editors.scss
@@ -62,7 +62,7 @@
   }
 
   .ms-filter.select-editor {
-    transform: var(--slick-multiselect-editor-transform, v.$slick-multiselect-editor-transform);
+    width: 100%;
     height: var(--slick-multiselect-editor-height, v.$slick-multiselect-editor-height);
     button.ms-choice {
       height: var(--slick-multiselect-editor-height, v.$slick-multiselect-editor-height);
@@ -436,6 +436,7 @@
       }
       button.ms-choice {
         height: var(--slick-editor-modal-multiselect-editor-height, v.$slick-editor-modal-multiselect-editor-height);
+        border: var(--slick-editor-modal-select-editor-border, v.$slick-editor-modal-select-editor-border);
       }
       .checkbox-editor-container {
         padding: var(--slick-editor-modal-checkbox-editor-padding, v.$slick-editor-modal-checkbox-editor-padding);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^3.0.2
       version: 3.0.2
     multiple-select-vanilla:
-      specifier: ^4.3.4
-      version: 4.3.4
+      specifier: ^4.3.5
+      version: 4.3.5
     native-copyfiles:
       specifier: ^1.3.4
       version: 1.3.4
@@ -522,7 +522,7 @@ importers:
         version: 3.2.6
       multiple-select-vanilla:
         specifier: 'catalog:'
-        version: 4.3.4
+        version: 4.3.5
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -1155,7 +1155,7 @@ importers:
         version: 2.0.3
       multiple-select-vanilla:
         specifier: 'catalog:'
-        version: 4.3.4
+        version: 4.3.5
       sortablejs:
         specifier: 'catalog:'
         version: 1.15.6
@@ -8575,8 +8575,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  multiple-select-vanilla@4.3.4:
-    resolution: {integrity: sha512-PnEY9/jq/nSlfHvMa/mEgQGWgX/LlpZySNiKlcS7VKeAXNzsh1UbPVAJBQIMijumnCM/bZqSM5xY55QlmkCXSg==}
+  multiple-select-vanilla@4.3.5:
+    resolution: {integrity: sha512-UDXPIdIoENXc2DGBSsFMqb1xKwIHjTRedRUUKLenRGRLVrb+D9Fsvgk7lMdNQcKQMX+Se67XXsYTEhUtjnL5iQ==}
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -20795,7 +20795,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  multiple-select-vanilla@4.3.4:
+  multiple-select-vanilla@4.3.5:
     dependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalog:
   i18next-vue: ^5.3.0
   jsdom: ^26.1.0
   jsdom-global: ^3.0.2
-  multiple-select-vanilla: ^4.3.4
+  multiple-select-vanilla: ^4.3.5
   native-copyfiles: ^1.3.4
   npm-run-all2: ^8.0.4
   remove-glob: ^0.3.4


### PR DESCRIPTION
This PR is a follow-up of a recent PR #2048, but it now properly fixes the ms-select width and positioning via a new ms-select version but also via a few CSS fixes in here too. 

This PR fixes or improves the following:
- now correctly calculates drop width by widest text
  -  the previous code wasn't very accurate and had few issues
- better positioning of the drop 
  - the drop wasn't always correctly positioned especially in the Composite Editor modal window
- better styling 
  - some border and width styles weren't correctly following other filter/editor