### PR TITLE
perf: reconcile multiple `repositionMenu()` into single fn for all menus

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellMenu.plugin.spec.ts
@@ -156,6 +156,7 @@ const columnsMock: Column[] = [
 describe('CellMenu Plugin', () => {
   let backendUtilityService: BackendUtilityService;
   let extensionUtility: ExtensionUtility;
+  let parentContainer: HTMLDivElement;
   let translateService: TranslateServiceStub;
   let plugin: SlickCellMenu;
   let sharedService: SharedService;
@@ -166,6 +167,9 @@ describe('CellMenu Plugin', () => {
     translateService = new TranslateServiceStub();
     extensionUtility = new ExtensionUtility(sharedService, backendUtilityService, translateService);
     sharedService.slickGrid = gridStub;
+    parentContainer = document.createElement('div');
+    sharedService.gridContainerElement = parentContainer;
+    vi.spyOn(gridStub, 'getGridPosition').mockReturnValue({ top: 10, bottom: 5, left: 15, right: 22, width: 225 } as ElementPosition);
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
     vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -173,6 +173,7 @@ const treeDataServiceStub = {
 describe('ContextMenu Plugin', () => {
   let backendUtilityService: BackendUtilityService;
   let extensionUtility: ExtensionUtility;
+  let parentContainer: HTMLDivElement;
   let translateService: TranslateServiceStub;
   let plugin: SlickContextMenu;
   let sharedService: SharedService;
@@ -190,6 +191,9 @@ describe('ContextMenu Plugin', () => {
       readText: vi.fn(() => Promise.resolve('')),
       writeText: vi.fn(() => Promise.resolve()),
     };
+    parentContainer = document.createElement('div');
+    sharedService.gridContainerElement = parentContainer;
+    vi.spyOn(gridStub, 'getGridPosition').mockReturnValue({ top: 10, bottom: 5, left: 15, right: 22, width: 225 } as ElementPosition);
     vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     vi.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
     vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -154,6 +154,7 @@ describe('GridMenuControl', () => {
 
   describe('with I18N Service', () => {
     const consoleErrorSpy = vi.spyOn(global.console, 'error').mockReturnValue();
+    let parentContainer: HTMLDivElement;
 
     beforeEach(() => {
       div = document.createElement('div');
@@ -166,6 +167,8 @@ describe('GridMenuControl', () => {
       sharedService.dataView = dataViewStub;
       sharedService.slickGrid = gridStub;
 
+      parentContainer = document.createElement('div');
+      sharedService.gridContainerElement = parentContainer;
       vi.spyOn(gridStub, 'getContainerNode').mockReturnValue(document.body as HTMLDivElement);
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
@@ -1101,7 +1104,7 @@ describe('GridMenuControl', () => {
           control.columns = columnsMock;
           control.init();
 
-          const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+          const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLButtonElement;
           buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
           const gridMenu1Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-0') as HTMLDivElement;
           const commandList1Elm = gridMenu1Elm.querySelector('.slick-menu-command-list') as HTMLDivElement;
@@ -1122,7 +1125,7 @@ describe('GridMenuControl', () => {
           Object.defineProperty(divEvent, 'target', { writable: true, configurable: true, value: subMenuElm });
           menuItem.appendChild(subMenuElm);
 
-          control.repositionMenu(divEvent, gridMenu2Elm);
+          control.repositionMenu(divEvent as any, gridMenu2Elm, buttonElm);
           const gridMenu2Elm2 = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
 
           expect(gridMenu2Elm2.classList.contains('dropup')).toBeTruthy();

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -794,12 +794,12 @@ describe('HeaderMenu Plugin', () => {
         expect(disposeSubMenuSpy).toHaveBeenCalled();
       });
 
-      it('should create a Grid Menu item with commands sub-menu commandItems and expect sub-menu to be positioned on top (dropup)', () => {
+      it('should create a Header Menu item with commands sub-menu commandItems and expect sub-menu to be positioned on top (dropup)', () => {
         const hideMenuSpy = vi.spyOn(plugin, 'hideMenu');
         const onCommandMock = vi.fn();
         Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 50 });
         vi.spyOn(gridStub, 'getColumns').mockReturnValueOnce(columnsMock);
-        vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValueOnce({
+        vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           darkMode: true,
         });
@@ -820,7 +820,7 @@ describe('HeaderMenu Plugin', () => {
         Object.defineProperty(divEvent1, 'target', { writable: true, configurable: true, value: headerButtonElm });
 
         subCommands1Elm!.dispatchEvent(new Event('click'));
-        plugin.repositionMenu(divEvent1 as any, headerMenu1Elm);
+        plugin.repositionMenu(divEvent1 as any, headerMenu1Elm, undefined, plugin.addonOptions);
         const headerMenu2Elm = document.body.querySelector('.slick-header-menu.slick-menu-level-1') as HTMLDivElement;
         Object.defineProperty(headerMenu2Elm, 'clientHeight', { writable: true, configurable: true, value: 320 });
 
@@ -836,7 +836,7 @@ describe('HeaderMenu Plugin', () => {
         menuItem.appendChild(subMenuElm);
 
         parentContainer.classList.add('slickgrid-container');
-        plugin.repositionMenu(divEvent as any, headerMenu2Elm);
+        plugin.repositionMenu(divEvent as any, headerMenu2Elm, undefined, plugin.addonOptions);
         const headerMenu2Elm2 = document.body.querySelector('.slick-header-menu.slick-menu-level-1') as HTMLDivElement;
 
         expect(headerMenu2Elm2.classList.contains('dropup')).toBeTruthy();

--- a/packages/common/src/extensions/slickCellMenu.ts
+++ b/packages/common/src/extensions/slickCellMenu.ts
@@ -136,7 +136,7 @@ export class SlickCellMenu extends MenuFromCellBaseClass<CellMenu> {
 
       // reposition the menu to where the user clicked
       if (this._menuElm) {
-        this.repositionMenu(event, this._menuElm);
+        this.repositionMenu(event, this._menuElm, undefined, this._addonOptions);
         this._menuElm.ariaExpanded = 'true';
         this._menuElm.style.display = 'block';
         if (this.gridOptions.darkMode) {

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -158,7 +158,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
 
       // reposition the menu to where the user clicked
       if (this._menuElm) {
-        this.repositionMenu(event, this._menuElm);
+        this.repositionMenu(event, this._menuElm, undefined, this._addonOptions);
         this._menuElm.ariaExpanded = 'true';
         this._menuElm.style.display = 'block';
       }

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -9,6 +9,9 @@ import type {
 } from './index.js';
 
 export interface GridMenuOption {
+  /** Defaults to true, Auto-align drop menu to the left or right depending on grid viewport available space */
+  autoAlignSide?: boolean;
+
   /**
    * All the commands text labels
    * NOTE: some of the text have other properties outside of this option (like 'clearAllFiltersCommand', 'exportExcelCommand', ...) and that is because they were created prior to this refactoring of labels


### PR DESCRIPTION
Reconciling all Menu plugins `repositionMenu()` functions into a single location for all these menu plugins:
- Cell Menu
- Context Menu
- Grid Menu
- Header Menu

This saves about 100 lines of code (even though codecov is only showing 36 lines)