### PR TITLE
chore: use offsetHeight instead of clientHeight for cell menu position

### DIFF
--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -1112,7 +1112,7 @@ describe('GridMenuControl', () => {
 
           subCommands1Elm!.dispatchEvent(new Event('click'));
           const gridMenu2Elm = document.body.querySelector('.slick-grid-menu.slick-menu-level-1') as HTMLDivElement;
-          Object.defineProperty(gridMenu2Elm, 'clientHeight', { writable: true, configurable: true, value: 320 });
+          Object.defineProperty(gridMenu2Elm, 'offsetHeight', { writable: true, configurable: true, value: 320 });
 
           const divEvent = new MouseEvent('click', { bubbles: true, cancelable: true, composed: false });
           const subMenuElm = document.createElement('div');

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -822,7 +822,7 @@ describe('HeaderMenu Plugin', () => {
         subCommands1Elm!.dispatchEvent(new Event('click'));
         plugin.repositionMenu(divEvent1 as any, headerMenu1Elm, undefined, plugin.addonOptions);
         const headerMenu2Elm = document.body.querySelector('.slick-header-menu.slick-menu-level-1') as HTMLDivElement;
-        Object.defineProperty(headerMenu2Elm, 'clientHeight', { writable: true, configurable: true, value: 320 });
+        Object.defineProperty(headerMenu2Elm, 'offsetHeight', { writable: true, configurable: true, value: 320 });
 
         const divEvent = new MouseEvent('click', { bubbles: true, cancelable: true, composed: false });
         const subMenuElm = document.createElement('div');

--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -440,7 +440,7 @@ export class MenuBaseClass<M extends CellMenu | ContextMenu | GridMenu | HeaderM
       // for sub-menus only, auto-adjust drop position (up/down)
       // we first need to see what position the drop will be located (defaults to bottom)
       // since we reposition menu below slick cell, we need to take it in consideration and do our calculation from that element
-      const menuHeight = menuElm?.clientHeight || 0;
+      const menuHeight = menuElm?.offsetHeight || 0;
       if ((this.pluginName === 'GridMenu' || this.pluginName === 'HeaderMenu') && isSubMenu) {
         availableSpaceBottom = parentSpaceBottom;
         availableSpaceTop = parentSpaceTop;


### PR DESCRIPTION
- use offsetHeight for cell menu positioning to be equivalent to the same position as prior to PR #2071

<img width="1522" height="1250" alt="image" src="https://github.com/user-attachments/assets/cfe30e47-c086-4e37-b310-88dca9fd2db9" />
