### PR TITLE
fix: `initiallyCollapsed` should work with hierarchical tree dataset

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example28.ts
+++ b/demos/aurelia/src/examples/slickgrid/example28.ts
@@ -145,6 +145,7 @@ export class Example28 {
         columnId: 'file',
         childrenPropName: 'files',
         excludeChildrenWhenFilteringTree: this.isExcludingChildWhenFiltering, // defaults to false
+        // initiallyCollapsed: true,
 
         // skip any other filter criteria(s) if the column holding the Tree (file) passes its own filter criteria
         // (e.g. filtering with "Files = music AND Size > 7", the row "Music" and children will only show up when this flag is enabled

--- a/demos/react/src/examples/slickgrid/Example28.tsx
+++ b/demos/react/src/examples/slickgrid/Example28.tsx
@@ -146,6 +146,7 @@ const Example28: React.FC = () => {
         columnId: 'file',
         childrenPropName: 'files',
         excludeChildrenWhenFilteringTree: isExcludingChildWhenFilteringRef.current, // defaults to false
+        // initiallyCollapsed: true,
 
         // skip any other filter criteria(s) if the column holding the Tree (file) passes its own filter criteria
         // (e.g. filtering with "Files = music AND Size > 7", the row "Music" and children will only show up when this flag is enabled

--- a/demos/vanilla/src/examples/example06.ts
+++ b/demos/vanilla/src/examples/example06.ts
@@ -46,6 +46,7 @@ export default class Example06 {
       undefined,
       this.datasetHierarchical
     );
+    // this.sgb.datasetHierarchical = this.datasetHierarchical;
     document.body.classList.add('salesforce-theme');
   }
 
@@ -166,6 +167,7 @@ export default class Example06 {
         columnId: 'file',
         childrenPropName: 'files',
         excludeChildrenWhenFilteringTree: this.isExcludingChildWhenFiltering, // defaults to false
+        // initiallyCollapsed: true,
 
         // skip any other filter criteria(s) if the column holding the Tree (file) passes its own filter criteria
         // (e.g. filtering with "Files = music AND Size > 7", the row "Music" and children will only show up when this flag is enabled

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -171,6 +171,7 @@ function defineGrid() {
       columnId: 'file',
       childrenPropName: 'files',
       excludeChildrenWhenFilteringTree: isExcludingChildWhenFiltering.value, // defaults to false
+      // initiallyCollapsed: true,
 
       // skip any other filter criteria(s) if the column holding the Tree (file) passes its own filter criteria
       // (e.g. filtering with "Files = music AND Size > 7", the row "Music" and children will only show up when this flag is enabled

--- a/frameworks/angular-slickgrid/src/demos/examples/example28.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example28.component.ts
@@ -150,6 +150,7 @@ export class Example28Component implements OnInit {
         columnId: 'file',
         childrenPropName: 'files',
         excludeChildrenWhenFilteringTree: this.isExcludingChildWhenFiltering, // defaults to false
+        // initiallyCollapsed: true,
 
         // skip any other filter criteria(s) if the column holding the Tree (file) passes its own filter criteria
         // (e.g. filtering with "Files = music AND Size > 7", the row "Music" and children will only show up when this flag is enabled

--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -206,6 +206,7 @@ const treeDataServiceStub = {
   convertFlatParentChildToTreeDatasetAndSort: vi.fn(),
   dispose: vi.fn(),
   handleOnCellClick: vi.fn(),
+  initHierarchicalTree: vi.fn(),
   sortHierarchicalDataset: vi.fn(),
   toggleTreeDataCollapse: vi.fn(),
 } as unknown as TreeDataService;

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -237,6 +237,7 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     // when a hierarchical dataset is set afterward, we can reset the flat dataset and call a tree data sort that will overwrite the flat dataset
     if (newHierarchicalDataset && this.slickGrid && this.sortService?.processTreeDataInitialSort) {
       this.sortService.processTreeDataInitialSort();
+      this.treeDataService.initHierarchicalTree();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
       // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -678,6 +678,7 @@ export class AureliaSlickgridCustomElement {
     // when a hierarchical dataset is set afterward, we can reset the flat dataset and call a tree data sort that will overwrite the flat dataset
     if (newHierarchicalDataset && this.grid && this.sortService?.processTreeDataInitialSort) {
       this.sortService.processTreeDataInitialSort();
+      this.treeDataService.initHierarchicalTree();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
       // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -231,6 +231,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
     if (this.dataView && newHierarchicalDataset && this.grid && this.sortService?.processTreeDataInitialSort) {
       this.dataView.setItems([], this._options?.datasetIdPropertyName ?? 'id');
       this.sortService.processTreeDataInitialSort();
+      this.treeDataService.initHierarchicalTree();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
       // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -257,6 +257,7 @@ watch(
     if (dataview && newHierarchicalDataset && grid && sortService?.processTreeDataInitialSort) {
       dataview.setItems([], _gridOptions.value?.datasetIdPropertyName ?? 'id');
       sortService.processTreeDataInitialSort();
+      treeDataService.initHierarchicalTree();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
       // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -827,4 +827,56 @@ describe('TreeData Service', () => {
       expect(sortHierarchySpy).toHaveBeenCalledWith(mockHierarchical, [mockColumnSort]);
     });
   });
+
+  describe('hierarchical dataset', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      gridOptionsMock.treeDataOptions = { columnId: 'file', parentPropName: 'parentId', childrenPropName: 'files', initiallyCollapsed: false };
+      vi.clearAllMocks();
+    });
+
+    it('should initially collapse all hierarchical items when "initiallyCollapsed" is enabled', async () => {
+      const mockHierarchical = [
+        {
+          id: 0,
+          file: 'documents',
+          files: [
+            { id: 2, file: 'todo.txt', size: 2.3 },
+            {
+              id: 1,
+              file: 'vacations',
+              files: [
+                { id: 2, file: 'todo.txt', size: 2.3 },
+                { id: 1, file: 'vacation.txt', size: 1.2 },
+              ],
+            },
+          ],
+        },
+      ];
+      gridOptionsMock.treeDataOptions!.initiallyCollapsed = true;
+      vi.spyOn(SharedService.prototype, 'hierarchicalDataset', 'get').mockReturnValueOnce(mockHierarchical).mockReturnValueOnce(mockHierarchical);
+
+      service.init(gridStub);
+
+      expect(service.datasetHierarchical).toEqual([
+        {
+          __collapsed: true,
+          id: 0,
+          file: 'documents',
+          files: [
+            { id: 2, file: 'todo.txt', size: 2.3 },
+            {
+              __collapsed: true,
+              id: 1,
+              file: 'vacations',
+              files: [
+                { id: 2, file: 'todo.txt', size: 2.3 },
+                { id: 1, file: 'vacation.txt', size: 1.2 },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+  });
 });

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -194,6 +194,7 @@ const treeDataServiceStub = {
   convertFlatParentChildToTreeDatasetAndSort: vi.fn(),
   dispose: vi.fn(),
   handleOnCellClick: vi.fn(),
+  initHierarchicalTree: vi.fn(),
   sortHierarchicalDataset: vi.fn(),
   toggleTreeDataCollapse: vi.fn(),
 } as unknown as TreeDataService;

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -193,6 +193,7 @@ export class SlickVanillaGridBundle<TData = any> {
     // when a hierarchical dataset is set afterward, we can reset the flat dataset and call a tree data sort that will overwrite the flat dataset
     if (this.dataView && newHierarchicalDataset && this.slickGrid && this.sortService?.processTreeDataInitialSort) {
       this.sortService.processTreeDataInitialSort();
+      this.treeDataService.initHierarchicalTree();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
       // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready


### PR DESCRIPTION
The `initiallyCollapsed` option for Tree Data was working fine for a parent/child dataset but it wasn't working at all for a hierarchical (tree) dataset. This fixes it and it now works for both types