### PR TITLE
fix: htmlDecode should work with number entities `é` is `&#233;`

### DIFF
--- a/packages/utils/src/__tests__/domUtils.spec.ts
+++ b/packages/utils/src/__tests__/domUtils.spec.ts
@@ -291,13 +291,13 @@ describe('Service/domUtilies', () => {
     });
 
     it('should return a decoded HTML string with single quotes decoded as well', () => {
-      const result = htmlDecode(`&lt;div class=&#39;color: blue&#39;&gt;Something&lt;/div&gt;`);
-      expect(result).toBe(`<div class='color: blue'>Something</div>`);
+      const result = htmlDecode(`&lt;div class=&#39;color: blue&#39;&gt;Hablar espa&#241;ol?&lt;/div&gt;`);
+      expect(result).toBe(`<div class='color: blue'>Hablar español?</div>`);
     });
 
     it('should return a decoded HTML map even when prefixed with invalid map like the "&" char and still decode what it can', () => {
-      const result = htmlDecode(`&lt;div class=&quot;color: blue&quot;&gt;Bob &&amp; John&lt;/div&gt;`);
-      expect(result).toBe(`<div class="color: blue">Bob && John</div>`);
+      const result = htmlDecode(`&lt;div class=&quot;color: blue&quot;&gt;Bob &&amp; John, hablar espa&#241;ol&lt;/div&gt;`);
+      expect(result).toBe(`<div class="color: blue">Bob && John, hablar español</div>`);
     });
 
     it('should return same HTML string when encode value is not a valid entity map', () => {

--- a/packages/utils/src/domUtils.ts
+++ b/packages/utils/src/domUtils.ts
@@ -219,20 +219,16 @@ export function htmlEncode(inputValue: string): string {
 }
 
 /**
- * Simple function to decode the 5 most common HTML entities (`<`, `>`, `"`, `'`, `&`).
- * For example: "&lt;div&gt;Hello&lt;/div&gt;" => "<div>Hello</div>"
+ * Simple function to decode the most common HTML entities.
+ * For example: "&lt;div&gt;Hablar espa&#241;ol?&lt;/div&gt;" => "<div>Hablar español?</div>"
  * @param {String} inputValue - input value to be decoded
  * @return {String}
  */
 export function htmlDecode(input?: string): string {
   if (isDefined(input)) {
-    const val = typeof input === 'string' ? input : String(input);
-    return val
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+    const txt = document.createElement('textarea');
+    txt.innerHTML = input;
+    return txt.value;
   }
   return '';
 }

--- a/test/vitest.config.mts
+++ b/test/vitest.config.mts
@@ -30,7 +30,6 @@ export default defineConfig({
     fakeTimers: {
       toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'queueMicrotask'],
     },
-    pool: 'threads',
     globalSetup: './test/vitest-global-setup.ts',
     setupFiles: ['./test/vitest-pretest.ts', './test/vitest-global-mocks.ts'],
     testTimeout: 60000,


### PR DESCRIPTION
The previous html decode wasn't decoding entities with numbers (e.g. `&#233;`). The new code uses the browser to decode without executing any JS code, so it's still XSS safe and will decode everything a browser can decode