### PR TITLE
chore: always load Grouping grids with a Group by Duration

### DIFF
--- a/.github/workflows/test-aurelia.yml
+++ b/.github/workflows/test-aurelia.yml
@@ -92,7 +92,7 @@ jobs:
           install: false
           working-directory: demos/aurelia
           # start: pnpm aurelia:serve
-          wait-on: 'http://localhost:9000'
+          wait-on: 'http://localhost:7900'
           config-file: test/cypress.config.ts
           browser: chrome
           record: false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
       "type": "chrome",
       "request": "launch",
       "name": "Aurelia - Chrome Debugger",
-      "url": "http://localhost:9000",
+      "url": "http://localhost:7900",
       "webRoot": "${workspaceFolder}/demos/aurelia",
       "pathMapping": {
         "/@fs/": ""

--- a/demos/aurelia/src/examples/slickgrid/example13.ts
+++ b/demos/aurelia/src/examples/slickgrid/example13.ts
@@ -41,6 +41,7 @@ export class Example13 {
     this.aureliaGrid = aureliaGrid;
     this.dataviewObj = aureliaGrid.dataView;
     this.gridObj = aureliaGrid.slickGrid;
+    this.groupByDuration(); // group by duration on page load
   }
 
   /* Define grid Options and Columns */

--- a/demos/aurelia/test/cypress.config.ts
+++ b/demos/aurelia/test/cypress.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     runMode: true, // run in CI
   },
   e2e: {
-    baseUrl: 'http://localhost:9000/#',
+    baseUrl: 'http://localhost:7900/#',
     experimentalRunAllSpecs: true,
     supportFile: 'test/cypress/support/index.ts',
     specPattern: 'test/cypress/e2e/**/*.cy.ts',

--- a/demos/aurelia/test/cypress/e2e/example13.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example13.cy.ts
@@ -14,6 +14,29 @@ describe('Example 13 - Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should expect grid to be Grouped by "Duration" when loaded', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should(
+      'have.length',
+      1
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+
+    // 2nd row should be a regular row
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l2').contains('0');
+  });
+
+  it('should clear all Groupings', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+
+    // 1st and 2nd row should now be a regular row
+    cy.get('[data-row="0"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+  });
+
   describe('Grouping Tests', () => {
     it('should "Group by Duration & sort groups by value" then Collapse All and expect only group titles', () => {
       cy.get('[data-test="add-50k-rows-btn"]').click();

--- a/demos/aurelia/vite.config.mts
+++ b/demos/aurelia/vite.config.mts
@@ -20,14 +20,14 @@ export default defineConfig({
     }) as PluginOption,
   ],
   preview: {
-    port: 9000,
+    port: 7900,
   },
   server: {
-    port: 9000,
+    port: 7900,
     cors: true,
     host: 'localhost',
     hmr: {
-      clientPort: 9000,
+      clientPort: 7900,
     },
   },
   build: {

--- a/demos/react/src/examples/slickgrid/Example13.tsx
+++ b/demos/react/src/examples/slickgrid/Example13.tsx
@@ -32,6 +32,7 @@ const Example13: React.FC = () => {
 
   function reactGridReady(reactGrid: SlickgridReactInstance) {
     reactGridRef.current = reactGrid;
+    groupByDuration(); // group by duration on page load
   }
 
   /* Define grid Options and Columns */

--- a/demos/react/test/cypress/e2e/example13.cy.ts
+++ b/demos/react/test/cypress/e2e/example13.cy.ts
@@ -14,6 +14,29 @@ describe('Example 13 - Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should expect grid to be Grouped by "Duration" when loaded', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should(
+      'have.length',
+      1
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+
+    // 2nd row should be a regular row
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l2').contains('0');
+  });
+
+  it('should clear all Groupings', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+
+    // 1st and 2nd row should now be a regular row
+    cy.get('[data-row="0"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+  });
+
   describe('Grouping Tests', () => {
     it('should "Group by Duration & sort groups by value" then Collapse All and expect only group titles', () => {
       cy.get('[data-test="add-50k-rows-btn"]').click();

--- a/demos/vanilla/src/examples/example02.ts
+++ b/demos/vanilla/src/examples/example02.ts
@@ -70,7 +70,7 @@ export default class Example02 {
     );
 
     // you could group by duration on page load (must be AFTER the DataView is created, so after GridBundle)
-    // this.groupByDuration();
+    this.groupByDuration();
 
     // override CSS template to be Material Design
     // await import('@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-material.scss');

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -360,6 +360,7 @@ function toggleSubTitle() {
 
 function vueGridReady(grid: SlickgridVueInstance) {
   vueGrid = grid;
+  groupByDuration(); // group by duration on page load
 }
 </script>
 

--- a/demos/vue/test/cypress/e2e/example13.cy.ts
+++ b/demos/vue/test/cypress/e2e/example13.cy.ts
@@ -14,6 +14,29 @@ describe('Example 13 - Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should expect grid to be Grouped by "Duration" when loaded', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should(
+      'have.length',
+      1
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+
+    // 2nd row should be a regular row
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l2').contains('0');
+  });
+
+  it('should clear all Groupings', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+
+    // 1st and 2nd row should now be a regular row
+    cy.get('[data-row="0"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+  });
+
   describe('Grouping Tests', () => {
     it('should "Group by Duration & sort groups by value" then Collapse All and expect only group titles', () => {
       cy.get('[data-test="add-50k-rows-btn"]').click();

--- a/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
@@ -225,6 +225,7 @@ export class Example13Component implements OnInit {
     this.angularGrid = angularGrid;
     this.gridObj = angularGrid.slickGrid;
     this.dataviewObj = angularGrid.dataView;
+    this.groupByDuration(); // group by duration on page load
   }
 
   loadData(rowCount: number) {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example13.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example13.cy.ts
@@ -14,6 +14,29 @@ describe('Example 13 - Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should expect grid to be Grouped by "Duration" when loaded', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should(
+      'have.length',
+      1
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+
+    // 2nd row should be a regular row
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l2').contains('0');
+  });
+
+  it('should clear all Groupings', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+
+    // 1st and 2nd row should now be a regular row
+    cy.get('[data-row="0"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+  });
+
   describe('Grouping Tests', () => {
     it('should "Group by Duration & sort groups by value" then Collapse All and expect only group titles', () => {
       cy.get('[data-test="add-50k-rows-btn"]').click();

--- a/test/cypress/e2e/example02.cy.ts
+++ b/test/cypress/e2e/example02.cy.ts
@@ -42,6 +42,29 @@ describe('Example 02 - Grouping & Aggregators', () => {
     cy.get('.grid2').find('.slick-custom-footer').find('.left-footer').contains('created with Slickgrid-Universal');
   });
 
+  it('should expect grid to be Grouped by "Duration" when loaded', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-toggle.expanded`).should(
+      'have.length',
+      1
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+
+    // 2nd row should be a regular row
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l2').contains('0');
+  });
+
+  it('should clear all Groupings', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+
+    // 1st and 2nd row should now be a regular row
+    cy.get('[data-row="0"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+  });
+
   it('should copy "Task 2" cell text to clipboard and paste it and expect 111 items shown in the footer', () => {
     cy.get('.search-filter.filter-title').clear();
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 2}px);"] > .slick-cell:nth(1)`).should('contain', 'Task 2');
@@ -376,7 +399,7 @@ describe('Example 02 - Grouping & Aggregators', () => {
 
       cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(4)`).should('contain', '01/05/2010');
       cy.window().then((win) => {
-        expect(win.console.log).to.be.calledWithMatch(/sort: [0-9]{4}.?[0-9]* ms/);
+        expect(win.console.log).to.be.calledWithMatch(/sort: [0-9]{3,4}.?[0-9]* ms/);
       });
     });
 


### PR DESCRIPTION
- I think it's better to load the Grouping grids with a default Group by Duration, to highlight grouping from the "get go"
- also change Aurelia demo port from 9000 to 7900 since 9000 is restricted in some domains