### PR TITLE
perf: improve expand/collapse all tree data items

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example27.html
+++ b/demos/aurelia/src/examples/slickgrid/example27.html
@@ -39,7 +39,7 @@
 <div class="row" style="margin-bottom: 4px">
   <div class="col-md-12">
     <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-500-rows-btn" click.trigger="loadData(500)">500 rows</button>
-    <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-50k-rows-btn" click.trigger="loadData(25000)">25k rows</button>
+    <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-75k-rows-btn" click.trigger="loadData(75000)">75k rows</button>
     <button
       click.trigger="dynamicallyChangeFilter()"
       class="btn btn-outline-secondary btn-xs btn-icon"

--- a/demos/react/src/examples/slickgrid/Example27.tsx
+++ b/demos/react/src/examples/slickgrid/Example27.tsx
@@ -407,8 +407,8 @@ const Example27: React.FC = () => {
           <button className="btn btn-outline-secondary btn-xs btn-icon" data-test="add-500-rows-btn" onClick={() => setData(500)}>
             500 rows
           </button>
-          <button className="btn btn-outline-secondary btn-xs btn-icon mx-1" data-test="add-50k-rows-btn" onClick={() => setData(25000)}>
-            25k rows
+          <button className="btn btn-outline-secondary btn-xs btn-icon mx-1" data-test="add-75k-rows-btn" onClick={() => setData(75000)}>
+            75k rows
           </button>
           <button
             onClick={() => dynamicallyChangeFilter()}

--- a/demos/vanilla/src/examples/example05.html
+++ b/demos/vanilla/src/examples/example05.html
@@ -22,7 +22,7 @@
   <div class="column is-narrow">
     <div class="row mb-1">
       <button class="button is-small" data-test="add-500-rows-btn" onclick.trigger="loadData(500)">500 rows</button>
-      <button class="button is-small" data-test="add-50k-rows-btn" onclick.trigger="loadData(25000)">25k rows</button>
+      <button class="button is-small" data-test="add-75k-rows-btn" onclick.trigger="loadData(75000)">75k rows</button>
       <button onclick.trigger="dynamicallyChangeFilter()" class="button is-small" data-test="change-filter-dynamically">
         <span class="mdi mdi-filter-outline"></span>
         <span>Dynamically Change Filter (% complete &lt; 40)</span>

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -423,7 +423,7 @@ function vueGridReady(grid: SlickgridVueInstance) {
   <div class="row" style="margin-bottom: 4px">
     <div class="col-md-12">
       <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-500-rows-btn" @click="loadData(500)">500 rows</button>
-      <button class="btn btn-outline-secondary btn-xs btn-icon mx-1" data-test="add-50k-rows-btn" @click="loadData(25000)">25k rows</button>
+      <button class="btn btn-outline-secondary btn-xs btn-icon mx-1" data-test="add-75k-rows-btn" @click="loadData(75000)">75k rows</button>
       <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="change-filter-dynamically" @click="dynamicallyChangeFilter()">
         <span class="mdi mdi-filter-outline"></span>
         <span>Dynamically Change Filter (% complete &lt; 40)</span>

--- a/frameworks/angular-slickgrid/src/demos/examples/example27.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example27.component.html
@@ -38,7 +38,7 @@
   <div class="row" style="margin-bottom: 4px">
     <div class="col-md-12">
       <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-500-rows-btn" (click)="loadData(500)">500 rows</button>
-      <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-50k-rows-btn" (click)="loadData(25000)">25k rows</button>
+      <button class="btn btn-outline-secondary btn-xs btn-icon" data-test="add-75k-rows-btn" (click)="loadData(75000)">75k rows</button>
       <button (click)="dynamicallyChangeFilter()" class="btn btn-outline-secondary btn-xs btn-icon" data-test="change-filter-dynamically">
         <span class="mdi mdi-filter-outline"></span>
         <span>Dynamically Change Filter (% complete &lt; 40)</span>

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -602,6 +602,7 @@ describe('TreeData Service', () => {
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
 
       service.init(gridStub);
+      sharedService.hierarchicalDataset = service.convertFlatParentChildToTreeDataset(mockFlatDataset, gridOptionsMock);
       await service.toggleTreeDataCollapse(true);
 
       expect(pubSubSpy).toHaveBeenCalledWith(`onTreeFullToggleStart`, { collapsing: true });
@@ -667,6 +668,7 @@ describe('TreeData Service', () => {
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
 
       service.init(gridStub);
+      sharedService.hierarchicalDataset = service.convertFlatParentChildToTreeDataset(mockFlatDataset, gridOptionsMock);
       await service.toggleTreeDataCollapse(true);
 
       expect(pubSubSpy).toHaveBeenCalledWith(`onTreeFullToggleStart`, { collapsing: true });
@@ -706,6 +708,7 @@ describe('TreeData Service', () => {
       const pubSubSpy = vi.spyOn(mockPubSub, 'publish');
 
       service.init(gridStub);
+      sharedService.hierarchicalDataset = service.convertFlatParentChildToTreeDataset(mockFlatDataset, gridOptionsMock);
       await service.toggleTreeDataCollapse(false);
 
       expect(pubSubSpy).toHaveBeenCalledWith(`onTreeFullToggleStart`, { collapsing: false });
@@ -951,8 +954,7 @@ describe('TreeData Service', () => {
       await service.toggleTreeDataCollapse(true);
       const result2 = service.convertFlatParentChildToTreeDatasetAndSort(mockFlatDataset, mockColumns, gridOptionsMock);
       expect(result2).toEqual({ flat: mockFlatDataset as any[], hierarchical: mockHierarchical as any[] });
-      expect(unflattenParentChildArrayToTree).toHaveBeenNthCalledWith(3, mockFlatDataset, {
-        // 3rd call because toggleTreeDataCollapse() made the 2nd call
+      expect(unflattenParentChildArrayToTree).toHaveBeenNthCalledWith(2, mockFlatDataset, {
         columnId: 'file',
         identifierPropName: 'id',
         initiallyCollapsed: true, // changed to True

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -180,25 +180,25 @@ export function getTreeDataOptionPropName(
   let propName = '';
   switch (optionName) {
     case 'childrenPropName':
-      propName = treeDataOptions?.childrenPropName ?? Constants.treeDataProperties.CHILDREN_PROP;
+      propName = treeDataOptions?.[optionName] ?? Constants.treeDataProperties.CHILDREN_PROP;
       break;
     case 'collapsedPropName':
-      propName = treeDataOptions?.collapsedPropName ?? Constants.treeDataProperties.COLLAPSED_PROP;
+      propName = treeDataOptions?.[optionName] ?? Constants.treeDataProperties.COLLAPSED_PROP;
       break;
     case 'hasChildrenPropName':
-      propName = treeDataOptions?.hasChildrenPropName ?? Constants.treeDataProperties.HAS_CHILDREN_PROP;
+      propName = treeDataOptions?.[optionName] ?? Constants.treeDataProperties.HAS_CHILDREN_PROP;
       break;
     case 'identifierPropName':
-      propName = treeDataOptions?.identifierPropName ?? defaultDataIdPropName;
+      propName = treeDataOptions?.[optionName] ?? defaultDataIdPropName;
       break;
     case 'lazyLoadingPropName':
-      propName = treeDataOptions?.lazyLoadingPropName ?? Constants.treeDataProperties.LAZY_LOADING_PROP;
+      propName = treeDataOptions?.[optionName] ?? Constants.treeDataProperties.LAZY_LOADING_PROP;
       break;
     case 'levelPropName':
-      propName = treeDataOptions?.levelPropName ?? Constants.treeDataProperties.TREE_LEVEL_PROP;
+      propName = treeDataOptions?.[optionName] ?? Constants.treeDataProperties.TREE_LEVEL_PROP;
       break;
     case 'parentPropName':
-      propName = treeDataOptions?.parentPropName ?? Constants.treeDataProperties.PARENT_PROP;
+      propName = treeDataOptions?.[optionName] ?? Constants.treeDataProperties.PARENT_PROP;
       break;
   }
   return propName;


### PR DESCRIPTION
improve perf toggle of expand/collapse all tree data items by toggling all props on both hierarchical/flat datasets. The previous code was toggling all flat but then re-converting the flat to hierarchical dataset, that was however less performant compare to simply toggling the collapsed prop in both datasets.

##### Stats of 5 calls for a dataset of 75K rows
before: ~96ms
after: ~64ms
smaller: ~33% faster 

It was still pretty fast before, but hey why not go even faster :)