### PR TITLE
feat: add Grouping to Grid State

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example18.ts
+++ b/demos/aurelia/src/examples/slickgrid/example18.ts
@@ -246,6 +246,7 @@ export class Example18 {
         sortDescIconCssClass: 'mdi mdi-arrow-down',
         onGroupChanged: (_e, args) => this.onGroupChanged(args),
         onExtensionRegistered: (extension) => (this.draggableGroupingPlugin = extension),
+        initialGroupBy: ['duration'],
       },
       darkMode: this._darkMode,
       enableTextExport: true,

--- a/demos/aurelia/test/cypress/e2e/example18.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example18.cy.ts
@@ -22,6 +22,24 @@ describe('Example 18 - Draggable Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should initially be grouped by "Duration" when loading the grid', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 1}px);"] > .slick-cell:nth(2)`).should('contain', '0');
+  });
+
+  it('should clear all groups with "Clear all Grouping" and no longer expect any grouping', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+    cy.get('#grid18').find('.slick-group-toggle-all').should('be.hidden');
+
+    cy.get('#grid18')
+      .find('.slick-draggable-dropzone-placeholder')
+      .should('be.visible')
+      .should('have.text', 'Drop a column header here to group by the column');
+  });
+
   it('should have a draggable dropzone on top of the grid in the top-header section', () => {
     cy.get('#grid18').find('.slick-topheader-panel .slick-dropzone:visible').contains('Drop a column header here to group by the column');
   });

--- a/demos/react/src/examples/slickgrid/Example18.tsx
+++ b/demos/react/src/examples/slickgrid/Example18.tsx
@@ -240,9 +240,8 @@ const Example18: React.FC = () => {
         sortAscIconCssClass: 'mdi mdi-arrow-up',
         sortDescIconCssClass: 'mdi mdi-arrow-down',
         onGroupChanged: (_e, args) => onGroupChanged(args),
-        onExtensionRegistered: (extension) => {
-          setDraggableGroupingPlugin(extension);
-        },
+        onExtensionRegistered: (extension) => setDraggableGroupingPlugin(extension),
+        initialGroupBy: ['duration'],
       },
       darkMode,
       enableTextExport: true,

--- a/demos/react/test/cypress/e2e/example18.cy.ts
+++ b/demos/react/test/cypress/e2e/example18.cy.ts
@@ -22,6 +22,24 @@ describe('Example 18 - Draggable Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should initially be grouped by "Duration" when loading the grid', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 1}px);"] > .slick-cell:nth(2)`).should('contain', '0');
+  });
+
+  it('should clear all groups with "Clear all Grouping" and no longer expect any grouping', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+    cy.get('#grid18').find('.slick-group-toggle-all').should('be.hidden');
+
+    cy.get('#grid18')
+      .find('.slick-draggable-dropzone-placeholder')
+      .should('be.visible')
+      .should('have.text', 'Drop a column header here to group by the column');
+  });
+
   it('should have a draggable dropzone on top of the grid in the top-header section', () => {
     cy.get('#grid18').find('.slick-topheader-panel .slick-dropzone:visible').contains('Drop a column header here to group by the column');
   });

--- a/demos/vanilla/src/examples/example03.ts
+++ b/demos/vanilla/src/examples/example03.ts
@@ -383,6 +383,11 @@ export default class Example03 {
         // groupIconCssClass: 'mdi mdi-drag-vertical',
         initialGroupBy: ['duration'],
       },
+      // Grouping Grid Presets only works with DraggableGrouping plugin (not regular Grouping),
+      // however, it's typically better to use `initialGroupBy: []`
+      presets: {
+        grouping: ['duration'],
+      },
       enableCheckboxSelector: true,
       enableRowSelection: true,
       checkboxSelector: {

--- a/demos/vue/src/components/Example18.vue
+++ b/demos/vue/src/components/Example18.vue
@@ -238,6 +238,7 @@ function defineGrid() {
       sortDescIconCssClass: 'mdi mdi-arrow-down',
       onGroupChanged: (_e, args) => onGroupChanged(args),
       onExtensionRegistered: (extension) => (draggableGroupingPlugin = extension),
+      initialGroupBy: ['duration'],
     },
     darkMode: darkMode.value,
     enableTextExport: true,

--- a/demos/vue/test/cypress/e2e/example18.cy.ts
+++ b/demos/vue/test/cypress/e2e/example18.cy.ts
@@ -22,6 +22,24 @@ describe('Example 18 - Draggable Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should initially be grouped by "Duration" when loading the grid', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 1}px);"] > .slick-cell:nth(2)`).should('contain', '0');
+  });
+
+  it('should clear all groups with "Clear all Grouping" and no longer expect any grouping', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+    cy.get('#grid18').find('.slick-group-toggle-all').should('be.hidden');
+
+    cy.get('#grid18')
+      .find('.slick-draggable-dropzone-placeholder')
+      .should('be.visible')
+      .should('have.text', 'Drop a column header here to group by the column');
+  });
+
   it('should have a draggable dropzone on top of the grid in the top-header section', () => {
     cy.get('#grid18').find('.slick-topheader-panel .slick-dropzone:visible').contains('Drop a column header here to group by the column');
   });

--- a/docs/grid-functionalities/grid-state-preset.md
+++ b/docs/grid-functionalities/grid-state-preset.md
@@ -82,6 +82,7 @@ export interface CurrentSorter {
 export interface GridState {
   columns?: CurrentColumn[] | null;
   filters?: CurrentFilter[] | null;
+  grouping?: string[] | null;
   sorters?: CurrentSorter[] | null;
   pagination?: {
     pageNumber: number;
@@ -92,6 +93,9 @@ export interface GridState {
   treeData?: Partial<TreeToggleStateChange> | null;
 }
 ```
+
+> [!NOTE]
+> You can get Grouping column Ids as Grid State but it is limited to Draggable Grouping **only** via Grid Presets and it will not work with regular Grouping.
 
 #### Example
 For example, we can set `presets` on a grid like so:
@@ -145,6 +149,7 @@ export class GridExample {
         pagination: { pageNumber: 2, pageSize: 20 }
       }
     };
+  }
 }
 ```
 
@@ -185,7 +190,7 @@ export class GridExample {
 </div>
 ```
 ## How to Load Grid with certain Columns Preset (example hide certain Column(s) on load)
-You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](Grid-State-&-Preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
+You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](grid-state-preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
 
 So let say that we want to hide the last Column on page load, we can just find the column by it's `id` that you want to hide and pass the new column definition to the `presets` (again make sure to follow the correct preset structure).
 

--- a/frameworks/angular-slickgrid/docs/TOC.md
+++ b/frameworks/angular-slickgrid/docs/TOC.md
@@ -56,7 +56,7 @@
 * [Export to Excel](grid-functionalities/Export-to-Excel.md)
 * [Export to File (csv/txt)](grid-functionalities/Export-to-Text-File.md)
 * [Grid Menu](grid-functionalities/Grid-Menu.md)
-* [Grid State & Presets](grid-functionalities/Grid-State-&-Preset.md)
+* [Grid State & Presets](grid-functionalities/grid-state-preset.md)
 * [Grouping & Aggregators](grid-functionalities/grouping-and-aggregators.md)
 * [Header & Footer Slots](grid-functionalities/header-footer-slots.md)
 * [Header Menu & Header Buttons](grid-functionalities/Header-Menu-&-Header-Buttons.md)

--- a/frameworks/angular-slickgrid/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/angular-slickgrid/docs/column-functionalities/filters/select-filter.md
@@ -91,10 +91,10 @@ If you want to load the grid with certain default filter(s), you can use the fol
 - `searchTerms` (array of values)
 
 #### Note
-Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/Grid-State-&-Preset#grid-presets) for more info.
+Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/grid-state-preset#grid-presets) for more info.
 
 **NOTE**
-If you also have `presets` in the grid options, then your `searchTerms` will be ignored completely (even if it's a different column) since `presets` have higher priority over `searchTerms`. See [Grid State & Grid Presets](../../grid-functionalities/Grid-State-&-Preset.md) from more info.
+If you also have `presets` in the grid options, then your `searchTerms` will be ignored completely (even if it's a different column) since `presets` have higher priority over `searchTerms`. See [Grid State & Grid Presets](../../grid-functionalities/grid-state-preset.md) from more info.
 
 #### Sample
 ```ts
@@ -207,7 +207,7 @@ Note: the defaults for single & multiple select filters are different
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { 
+  {
     id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/Row-Selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/Row-Selection.md
@@ -167,7 +167,7 @@ handleOnSelectedRowsChanged(args) {
   this.isMyButtonDisabled = args?.rows?.length === 0;
 }
 ```
-2. use the `onGridStateChanged` event (see [Grid State & Presets](Grid-State-&-Preset.md) Wiki)
+2. use the `onGridStateChanged` event (see [Grid State & Presets](grid-state-preset.md) Wiki)
 ```html
 <button disabled.bind="isMyButtonDisabled">My Button</button>
 <angular-slickgrid gridId="grid2"

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/grid-state-preset.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/grid-state-preset.md
@@ -97,6 +97,9 @@ export interface GridState {
 }
 ```
 
+> [!NOTE]
+> You can get Grouping column Ids as Grid State but it is limited to Draggable Grouping **only** via Grid Presets and it will not work with regular Grouping.
+
 #### Example
 For example, we can set `presets` on a grid like so:
 **Component**
@@ -202,7 +205,7 @@ export class ExampleComponent implements OnInit, OnDestroy {
 ```
 
 ## How to Load Grid with certain Columns Preset (example hide certain Column(s) on load)
-You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](Grid-State-&-Preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
+You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](grid-state-preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
 
 So let say that we want to hide the last Column on page load, we can just find the column by it's `id` that you want to hide and pass the new column definition to the `presets` (again make sure to follow the correct preset structure).
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example18.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example18.component.ts
@@ -270,6 +270,7 @@ export class Example18Component implements OnInit, OnDestroy {
         sortDescIconCssClass: 'mdi mdi-arrow-down',
         onGroupChanged: (e, args) => this.onGroupChanged(args),
         onExtensionRegistered: (extension) => (this.draggableGroupingPlugin = extension),
+        initialGroupBy: ['duration'],
       },
       darkMode: this._darkMode,
       enableTextExport: true,

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example18.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example18.cy.ts
@@ -22,6 +22,24 @@ describe('Example 18 - Draggable Grouping & Aggregators', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
+  it('should initially be grouped by "Duration" when loading the grid', () => {
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(0) .slick-group-title`).should(
+      'contain',
+      'Duration: 0'
+    );
+    cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 1}px);"] > .slick-cell:nth(2)`).should('contain', '0');
+  });
+
+  it('should clear all groups with "Clear all Grouping" and no longer expect any grouping', () => {
+    cy.get('[data-test="clear-grouping-btn"]').click();
+    cy.get('#grid18').find('.slick-group-toggle-all').should('be.hidden');
+
+    cy.get('#grid18')
+      .find('.slick-draggable-dropzone-placeholder')
+      .should('be.visible')
+      .should('have.text', 'Drop a column header here to group by the column');
+  });
+
   it('should have a draggable dropzone on top of the grid in the top-header section', () => {
     cy.get('#grid18').find('.slick-topheader-panel .slick-dropzone:visible').contains('Drop a column header here to group by the column');
   });

--- a/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/aurelia-slickgrid/docs/column-functionalities/filters/select-filter.md
@@ -94,7 +94,7 @@ If you want to load the grid with certain default filter(s), you can use the fol
 - `searchTerms` (array of values)
 
 #### Note
-Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/Grid-State-&-Preset#grid-presets) for more info.
+Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/grid-state-preset#grid-presets) for more info.
 
 **NOTE**
 If you also have `presets` in the grid options, then your `searchTerms` will be ignored completely (even if it's a different column) since `presets` have higher priority over `searchTerms`. See [Grid State & Grid Presets](../../grid-functionalities/grid-state-preset.md) from more info.
@@ -210,7 +210,7 @@ Note: the defaults for single & multiple select filters are different
 ```ts
 // define you columns, in this demo Effort Driven will use a Select Filter
 this.columnDefinitions = [
-  { 
+  {
     id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
     formatter: Formatters.checkmarkMaterial,
     type: 'boolean',

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/grid-state-preset.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/grid-state-preset.md
@@ -101,6 +101,9 @@ export interface GridState {
 }
 ```
 
+> [!NOTE]
+> You can get Grouping column Ids as Grid State but it is limited to Draggable Grouping **only** via Grid Presets and it will not work with regular Grouping.
+
 #### Example
 For example, we can set `presets` on a grid like so:
 
@@ -174,7 +177,7 @@ export class Example {
 ```
 
 ## How to Load Grid with certain Columns Preset (example hide certain Column(s) on load)
-You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](Grid-State-&-Preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
+You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](grid-state-preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
 
 So let say that we want to hide the last Column on page load, we can just find the column by it's `id` that you want to hide and pass the new column definition to the `presets` (again make sure to follow the correct preset structure).
 

--- a/frameworks/slickgrid-react/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/slickgrid-react/docs/column-functionalities/filters/select-filter.md
@@ -96,7 +96,7 @@ If you want to load the grid with certain default filter(s), you can use the fol
 - `searchTerms` (array of values)
 
 #### Note
-Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/Grid-State-&-Preset#grid-presets) for more info.
+Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/grid-state-preset#grid-presets) for more info.
 
 **NOTE**
 If you also have `presets` in the grid options, then your `searchTerms` will be ignored completely (even if it's a different column) since `presets` have higher priority over `searchTerms`. See [Grid State & Grid Presets](../../grid-functionalities/grid-state-preset.md) from more info.

--- a/frameworks/slickgrid-react/docs/grid-functionalities/grid-state-preset.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/grid-state-preset.md
@@ -112,6 +112,9 @@ export interface GridState {
 }
 ```
 
+> [!NOTE]
+> You can get Grouping column Ids as Grid State but it is limited to Draggable Grouping **only** via Grid Presets and it will not work with regular Grouping.
+
 #### Example
 For example, we can set `presets` on a grid like so:
 
@@ -197,7 +200,7 @@ const Example: React.FC = () => {
 ```
 
 ## How to Load Grid with certain Columns Preset (example hide certain Column(s) on load)
-You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](Grid-State-&-Preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
+You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](grid-state-preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
 
 So let say that we want to hide the last Column on page load, we can just find the column by it's `id` that you want to hide and pass the new column definition to the `presets` (again make sure to follow the correct preset structure).
 

--- a/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
+++ b/frameworks/slickgrid-vue/docs/column-functionalities/filters/select-filter.md
@@ -96,7 +96,7 @@ If you want to load the grid with certain default filter(s), you can use the fol
 - `searchTerms` (array of values)
 
 #### Note
-Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/Grid-State-&-Preset#grid-presets) for more info.
+Even though the option of `searchTerms` it is much better to use the more powerful `presets` grid options, please refer to the [Grid State & Presets](../../grid-functionalities/grid-state-preset#grid-presets) for more info.
 
 **NOTE**
 If you also have `presets` in the grid options, then your `searchTerms` will be ignored completely (even if it's a different column) since `presets` have higher priority over `searchTerms`. See [Grid State & Grid Presets](../../grid-functionalities/grid-state-preset.md) from more info.

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/grid-state-preset.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/grid-state-preset.md
@@ -111,6 +111,9 @@ export interface GridState {
 }
 ```
 
+> [!NOTE]
+> You can get Grouping column Ids as Grid State but it is limited to Draggable Grouping **only** via Grid Presets and it will not work with regular Grouping.
+
 #### Example
 For example, we can set `presets` on a grid like so:
 
@@ -193,7 +196,7 @@ function gridStateChanged(gridState) {
 ```
 
 ## How to Load Grid with certain Columns Preset (example hide certain Column(s) on load)
-You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](Grid-State-&-Preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
+You can show/hide or even change a column position via the `presets`, yes `presets` is that powerful. All you need to do is to pass all Columns that you want to show as part of the `columns` property of `presets`. Typically you already have the entire columns definition since you just defined it, so you can loop through it and just use `map` to list the `columns` according to the structure needed (see [preset structure](grid-state-preset#structure.md)). What you have to know is that whatever array you provide to `presets`, that will equal to what the user will see and also in which order the columns will show (the array order does matter in this case). If a Columns is omitted from that array, then it will be considered to be a hidden column (you can still show it through Grid Menu and/or Column Picker).
 
 So let say that we want to hide the last Column on page load, we can just find the column by it's `id` that you want to hide and pass the new column definition to the `presets` (again make sure to follow the correct preset structure).
 

--- a/packages/common/src/enums/gridStateType.enum.ts
+++ b/packages/common/src/enums/gridStateType.enum.ts
@@ -15,6 +15,8 @@ export type GridStateTypeString =
   | 'columns'
   /** List of Current Filters including these props (`columnId`, `operator`, `searchTerms`, `targetSelector`, `verbatimSearchTerms`) */
   | 'filter'
+  /** List of Current Grouping column IDs. NOTE: Grid Presets for Grouping is only available when using `DraggableGrouping` */
+  | 'grouping'
   /** List of Current Pagination including these props (`pageNumber`, `pageSize`) */
   | 'pagination'
   /** List of Current Pinning including these props (`frozenBottom`, `frozenColumn`, `frozenRow`) */

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -546,6 +546,19 @@ describe('Draggable Grouping Plugin', () => {
           expect(setGroupedSpy).toHaveBeenCalledWith(['duration']);
         });
 
+        it('should initialize the Draggable Grouping with initial grid option presets when provided to the plugin', () => {
+          const setGroupedSpy = vi.spyOn(plugin, 'setDroppedGroups');
+          vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({ ...gridOptionsMock, presets: { grouping: ['duration', 'active'] } });
+          plugin.init(gridStub, addonOptions);
+          plugin.isInitialized = false;
+          vi.spyOn(gridStub, 'getHeaderColumn').mockReturnValue(mockHeaderColumnDiv1);
+          plugin.setupColumnReorder(gridStub, mockHeaderLeftDiv1, {}, setColumnsSpy, setColumnResizeSpy, mockColumns, getColumnIndexSpy, GRID_UID, triggerSpy);
+
+          const preHeaderElm = document.querySelector('.slick-preheader-panel') as HTMLDivElement;
+          expect(preHeaderElm).toBeTruthy();
+          expect(setGroupedSpy).toHaveBeenCalledWith(['duration', 'active']);
+        });
+
         it('should call sortable "update" from setupColumnDropbox and expect "updateGroupBy" to be called with a sort-group', () => {
           expect(plugin.dropboxElement).toEqual(dropzoneElm);
           expect(plugin.columnsGroupBy.length).toBeGreaterThan(0);

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -399,8 +399,9 @@ export class SlickDraggableGrouping {
     );
 
     // user can optionally provide initial groupBy columns
-    if (this._addonOptions.initialGroupBy && !this._isInitialized) {
-      this.setDroppedGroups(this._addonOptions.initialGroupBy);
+    const initialGroupIds = this._addonOptions.initialGroupBy ?? this.gridOptions.presets?.grouping;
+    if (initialGroupIds && !this._isInitialized) {
+      this.setDroppedGroups(initialGroupIds);
     }
     this._isInitialized = true;
 

--- a/packages/common/src/interfaces/gridState.interface.ts
+++ b/packages/common/src/interfaces/gridState.interface.ts
@@ -15,6 +15,12 @@ export interface GridState {
   /** Filters (and their state, columnId, searchTerm(s)) that are currently applied in the grid */
   filters?: CurrentFilter[] | null;
 
+  /**
+   * List of Current Grouping column IDs (it won't work when `getter` is a function).
+   * NOTE: Grid Presets for Grouping is only available when using `DraggableGrouping`
+   */
+  grouping?: string[] | null;
+
   /** Sorters (and their state, columnId, direction) that are currently applied in the grid */
   sorters?: CurrentSorter[] | null;
 

--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -65,6 +65,7 @@ const dataViewStub = {
   getAllSelectedIds: vi.fn(),
   getAllSelectedFilteredIds: vi.fn(),
   getFilteredItems: vi.fn(),
+  getGrouping: vi.fn(),
   mapIdsToRows: vi.fn(),
   mapRowsToIds: vi.fn(),
   onBeforePagingInfoChanged: new SlickEvent(),
@@ -420,6 +421,38 @@ describe('GridStateService', () => {
         { id: 'field2', field: 'field2', width: 150, cssClass: undefined, headerCssClass: 'blue' },
         { id: 'field3', field: 'field3', width: 0, cssClass: undefined, headerCssClass: undefined },
       ]);
+    });
+  });
+
+  describe('getCurrentGrouping method', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should call "getCurrentGrouping" and return null when grouping is not enabled', () => {
+      const gridOptionsMock = { enableGrouping: false, enableDraggableGrouping: false } as GridOption;
+      vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce(gridOptionsMock);
+
+      const output = service.getCurrentGrouping();
+      expect(output).toBeNull();
+    });
+
+    it('should call "getCurrentGrouping" and return grouped column Ids when enabled and Grouping getter are defined as strings', () => {
+      const gridOptionsMock = { enableGrouping: true, enableDraggableGrouping: false } as GridOption;
+      vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValueOnce([{ getter: 'duration' }, { getter: 'active' }]);
+
+      const output = service.getCurrentGrouping();
+      expect(output).toEqual(['duration', 'active']);
+    });
+
+    it('should call "getCurrentGrouping" and return grouped column Ids when enabled and DraggableGrouping getter are defined as strings', () => {
+      const gridOptionsMock = { enableGrouping: false, enableDraggableGrouping: true } as GridOption;
+      vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValueOnce([{ getter: 'duration' }, { getter: 'active' }]);
+
+      const output = service.getCurrentGrouping();
+      expect(output).toEqual(['duration', 'active']);
     });
   });
 

--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -440,19 +440,25 @@ describe('GridStateService', () => {
     it('should call "getCurrentGrouping" and return grouped column Ids when enabled and Grouping getter are defined as strings', () => {
       const gridOptionsMock = { enableGrouping: true, enableDraggableGrouping: false } as GridOption;
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
-      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValueOnce([{ getter: 'duration' }, { getter: 'active' }]);
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([{ getter: 'duration' }, { getter: 'active' }]);
 
       const output = service.getCurrentGrouping();
+      const gridState = service.getCurrentGridState();
+
       expect(output).toEqual(['duration', 'active']);
+      expect(gridState.grouping).toEqual(['duration', 'active']);
     });
 
     it('should call "getCurrentGrouping" and return grouped column Ids when enabled and DraggableGrouping getter are defined as strings', () => {
       const gridOptionsMock = { enableGrouping: false, enableDraggableGrouping: true } as GridOption;
       vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
-      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValueOnce([{ getter: 'duration' }, { getter: 'active' }]);
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([{ getter: 'duration' }, { getter: 'active' }]);
 
       const output = service.getCurrentGrouping();
+      const gridState = service.getCurrentGridState();
+
       expect(output).toEqual(['duration', 'active']);
+      expect(gridState.grouping).toEqual(['duration', 'active']);
     });
   });
 

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -269,6 +269,10 @@ export class GridStateService {
     return null;
   }
 
+  /**
+   * Get the Grouping column IDs or null when there are no Grouping set
+   * @returns current Grouping column IDs
+   */
   getCurrentGrouping(): string[] | null {
     if (this._gridOptions?.enableGrouping || this._gridOptions.enableDraggableGrouping) {
       return this._dataView.getGrouping().map((g) => g.getter?.toString() || '');
@@ -387,8 +391,7 @@ export class GridStateService {
   resetRowSelectionWhenRequired(): void {
     if (!this.needToPreserveRowSelection() && (this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector)) {
       // this also requires the Row Selection Model to be registered as well
-      const rowSelectionExtension = this.extensionService?.getExtensionByName?.(ExtensionName.rowSelection);
-      if (rowSelectionExtension?.instance) {
+      if (this.extensionService?.getExtensionByName?.(ExtensionName.rowSelection)?.instance) {
         this._grid.setSelectedRows([]);
       }
     }

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -154,6 +154,12 @@ export class GridStateService {
       pinning: { frozenColumn, frozenRow, frozenBottom },
     };
 
+    // optional Grouping
+    const currentGrouping = this.getCurrentGrouping();
+    if (currentGrouping) {
+      gridState.grouping = currentGrouping;
+    }
+
     // optional Pagination
     const currentPagination = this.getCurrentPagination();
     if (currentPagination) {
@@ -263,6 +269,13 @@ export class GridStateService {
     return null;
   }
 
+  getCurrentGrouping(): string[] | null {
+    if (this._gridOptions?.enableGrouping || this._gridOptions.enableDraggableGrouping) {
+      return this._dataView.getGrouping().map((g) => g.getter?.toString() || '');
+    }
+    return null;
+  }
+
   /**
    * Get current Pagination (and its state, pageNumber, pageSize) that are currently applied in the grid
    * @return current pagination state
@@ -274,9 +287,8 @@ export class GridStateService {
         if (backendService?.getCurrentPagination) {
           return backendService.getCurrentPagination();
         }
-      } else {
-        return this.sharedService.currentPagination;
       }
+      return this.sharedService.currentPagination;
     }
     return null;
   }


### PR DESCRIPTION
- add Grouping to Grid State
- for Grid Presets it only works with Draggable Grouping since regular Grouping requires much more setup and only Draggable Grouping accepts an `initialGroupBy: []` value 