### PR TITLE
feat: add second css property to RangeDecorator plugin

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellRangeDecorator.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellRangeDecorator.spec.ts
@@ -28,6 +28,10 @@ describe('CellRangeDecorator Plugin', () => {
         border: '2px dashed red',
         zIndex: '9999',
       },
+      copyToSelectionCss: {
+        border: '2px dashed blue',
+        zIndex: '9999',
+      },
       offset: { top: -1, left: -1, height: -2, width: -2 },
     });
   });
@@ -67,5 +71,12 @@ describe('CellRangeDecorator Plugin', () => {
     expect(plugin.addonElement!.style.left).toEqual('31px'); // 26 + 5px
     expect(plugin.addonElement!.style.height).toEqual('20px'); // 12 - 25 + 33px
     expect(plugin.addonElement!.style.width).toEqual('13px'); // 27 - 26 + 12px
+  });
+
+  it('should be able to set selection CSS', () => {
+    plugin = new SlickCellRangeDecorator(gridStub, { offset: { top: 20, left: 5, width: 12, height: 33 } });
+    plugin.setSelectionCss({ border: '2px solid green', zIndex: '9998' } as CSSStyleDeclaration);
+
+    expect(plugin.getSelectionCss()).toEqual({ border: '2px solid green', zIndex: '9998' } as CSSStyleDeclaration);
   });
 });

--- a/packages/common/src/interfaces/cellRange.interface.ts
+++ b/packages/common/src/interfaces/cellRange.interface.ts
@@ -3,6 +3,7 @@ import type { SlickCellRangeDecorator } from '../extensions/slickCellRangeDecora
 export interface CellRangeDecoratorOption {
   selectionCssClass: string;
   selectionCss: CSSStyleDeclaration;
+  copyToSelectionCss: CSSStyleDeclaration;
   offset: { top: number; left: number; height: number; width: number };
 }
 
@@ -24,4 +25,7 @@ export interface CellRangeSelectorOption {
 
   /** styling (for example blue background on cell) */
   selectionCss: CSSStyleDeclaration;
+
+  /** styling for drag-fill rangel marker (optional) */
+  copyToSelectionCss: CSSStyleDeclaration;
 }


### PR DESCRIPTION
Thanks to Ben for adding this new feature via SlickGrid PR: 
https://github.com/6pac/SlickGrid/pull/1140

![SlickHilight](https://github.com/user-attachments/assets/8a145fe0-163a-474a-9d35-926fd93b1627)

Note that this is used in the next PR, it's not directly used at the moment. This is the drag-fill feature, and this PR allows the drag-fill selection to look different to the initial selection.

It's very simple, but it's just logically separate to the rest, so I'm separating it.