### PR TITLE
fix: validate allowed frozen column only when setting grid options

### DIFF
--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -275,7 +275,7 @@ const mockGrid = {
   setHeaderRowVisibility: vi.fn(),
   setOptions: vi.fn(),
   setSelectedRows: vi.fn(),
-  validateColumnFreezeAllowed: vi.fn(),
+  validateColumnFreeze: vi.fn(),
   onClick: new MockSlickEvent(),
   onClicked: new MockSlickEvent(),
   onColumnsReordered: new MockSlickEvent(),
@@ -478,7 +478,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     }));
 
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {
-    vi.spyOn(mockGrid, 'validateColumnFreezeAllowed').mockReturnValue(true);
+    vi.spyOn(mockGrid, 'validateColumnFreeze').mockReturnValue(true);
     component.columns = columnDefinitions;
     component.options = gridOptions;
     component.options.frozenColumn = 0;

--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -275,6 +275,7 @@ const mockGrid = {
   setHeaderRowVisibility: vi.fn(),
   setOptions: vi.fn(),
   setSelectedRows: vi.fn(),
+  validateColumnFreezeAllowed: vi.fn(),
   onClick: new MockSlickEvent(),
   onClicked: new MockSlickEvent(),
   onColumnsReordered: new MockSlickEvent(),
@@ -477,6 +478,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     }));
 
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {
+    vi.spyOn(mockGrid, 'validateColumnFreezeAllowed').mockReturnValue(true);
     component.columns = columnDefinitions;
     component.options = gridOptions;
     component.options.frozenColumn = 0;
@@ -491,12 +493,12 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     const sharedVisibleColumnsSpy = vi.spyOn(SharedService.prototype, 'visibleColumns', 'set');
     const newVisibleColumns = [
       { id: 'lastName', field: 'lastName' },
-      { id: 'fristName', field: 'fristName' },
+      { id: 'firstName', field: 'firstName' },
     ];
 
     component.options = { enableFiltering: true };
     component.initialization(slickEventHandler);
-    mockGrid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns, grid: mockGrid });
+    mockGrid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns, grid: mockGrid, previousColumnOrder: ['firstName', 'lastName'] });
 
     expect(component.eventHandler).toEqual(slickEventHandler);
     expect(sharedService.hasColumnsReordered).toBe(true);

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -629,7 +629,10 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     // when it's a frozen grid, we need to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward
     const frozenColumnIndex = this.options.frozenColumn !== undefined ? this.options.frozenColumn : -1;
     if (frozenColumnIndex >= 0 && frozenColumnIndex <= this.sharedService.visibleColumns.length) {
-      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex].id || '';
+      const isFreezeAllowed = this.slickGrid.validateColumnFreezeAllowed(frozenColumnIndex);
+      if (isFreezeAllowed) {
+        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex].id || '';
+      }
     }
 
     // get any possible Services that user want to register

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -628,11 +628,12 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
 
     // when it's a frozen grid, we need to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward
     const frozenColumnIndex = this.options.frozenColumn !== undefined ? this.options.frozenColumn : -1;
-    if (frozenColumnIndex >= 0 && frozenColumnIndex <= this.sharedService.visibleColumns.length) {
-      const isFreezeAllowed = this.slickGrid.validateColumnFreezeAllowed(frozenColumnIndex);
-      if (isFreezeAllowed) {
-        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex].id || '';
-      }
+    if (
+      frozenColumnIndex >= 0 &&
+      frozenColumnIndex <= this.sharedService.visibleColumns.length &&
+      this.slickGrid.validateColumnFreeze(frozenColumnIndex)
+    ) {
+      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex].id || '';
     }
 
     // get any possible Services that user want to register

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -412,7 +412,10 @@ export class AureliaSlickgridCustomElement {
       frozenColumnIndex <= this.sharedService.visibleColumns.length &&
       this.sharedService.visibleColumns.length > 0
     ) {
-      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+      const isFreezeAllowed = this.grid.validateColumnFreezeAllowed(frozenColumnIndex);
+      if (isFreezeAllowed) {
+        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+      }
     }
 
     // get any possible Services that user want to register

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -410,12 +410,10 @@ export class AureliaSlickgridCustomElement {
     if (
       frozenColumnIndex >= 0 &&
       frozenColumnIndex <= this.sharedService.visibleColumns.length &&
-      this.sharedService.visibleColumns.length > 0
+      this.sharedService.visibleColumns.length > 0 &&
+      this.grid.validateColumnFreeze(frozenColumnIndex)
     ) {
-      const isFreezeAllowed = this.grid.validateColumnFreezeAllowed(frozenColumnIndex);
-      if (isFreezeAllowed) {
-        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
-      }
+      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
     }
 
     // get any possible Services that user want to register

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -549,12 +549,10 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
     if (
       frozenColumnIndex >= 0 &&
       frozenColumnIndex <= this.sharedService.visibleColumns.length &&
-      this.sharedService.visibleColumns.length > 0
+      this.sharedService.visibleColumns.length > 0 &&
+      this.grid.validateColumnFreeze(frozenColumnIndex)
     ) {
-      const isFreezeAllowed = this.grid.validateColumnFreezeAllowed(frozenColumnIndex);
-      if (isFreezeAllowed) {
-        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
-      }
+      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
     }
 
     // get any possible Services that user want to register

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -551,7 +551,10 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
       frozenColumnIndex <= this.sharedService.visibleColumns.length &&
       this.sharedService.visibleColumns.length > 0
     ) {
-      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+      const isFreezeAllowed = this.grid.validateColumnFreezeAllowed(frozenColumnIndex);
+      if (isFreezeAllowed) {
+        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+      }
     }
 
     // get any possible Services that user want to register

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -483,7 +483,10 @@ function initialization() {
   // when it's a frozen grid, we need to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward
   const frozenColumnIndex = _gridOptions.value?.frozenColumn ?? -1;
   if (frozenColumnIndex >= 0 && frozenColumnIndex <= sharedService.visibleColumns.length && sharedService.visibleColumns.length > 0) {
-    sharedService.frozenVisibleColumnId = sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+    const isFreezeAllowed = grid.validateColumnFreezeAllowed(frozenColumnIndex);
+    if (isFreezeAllowed) {
+      sharedService.frozenVisibleColumnId = sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+    }
   }
 
   // get any possible Services that user want to register

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -482,11 +482,13 @@ function initialization() {
 
   // when it's a frozen grid, we need to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward
   const frozenColumnIndex = _gridOptions.value?.frozenColumn ?? -1;
-  if (frozenColumnIndex >= 0 && frozenColumnIndex <= sharedService.visibleColumns.length && sharedService.visibleColumns.length > 0) {
-    const isFreezeAllowed = grid.validateColumnFreezeAllowed(frozenColumnIndex);
-    if (isFreezeAllowed) {
-      sharedService.frozenVisibleColumnId = sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
-    }
+  if (
+    frozenColumnIndex >= 0 &&
+    frozenColumnIndex <= sharedService.visibleColumns.length &&
+    sharedService.visibleColumns.length > 0 &&
+    grid.validateColumnFreeze(frozenColumnIndex)
+  ) {
+    sharedService.frozenVisibleColumnId = sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
   }
 
   // get any possible Services that user want to register

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -686,7 +686,7 @@ describe('SlickGrid core file', () => {
 
       skipGridDestroy = true;
       grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
-      grid.validateColumnFreezeAllowed(gridOptions.frozenColumn);
+      grid.validateColumnFreeze(gridOptions.frozenColumn);
       expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
     });

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -660,33 +660,6 @@ describe('SlickGrid core file', () => {
       );
     });
 
-    it('should show an alert when frozen column is wider than actual grid width and alertWhenFrozenNotAllViewable is enabled', () => {
-      const alertSpy = vi.spyOn(global, 'alert').mockReturnValue();
-      const consoleSpy = vi.spyOn(global.console, 'error').mockReturnValue();
-      const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
-      const gridOptions = {
-        ...defaultOptions,
-        enableColumnReorder: false,
-        enableCellNavigation: true,
-        preHeaderPanelHeight: 30,
-        showPreHeaderPanel: true,
-        frozenColumn: 0,
-        createPreHeaderPanel: true,
-        alertWhenFrozenNotAllViewable: true,
-      } as GridOption;
-      const data = [
-        { id: 0, firstName: 'John', lastName: 'Doe', age: 30 },
-        { id: 1, firstName: 'Jane', lastName: 'Doe', age: 28 },
-      ];
-      Object.defineProperty(container, 'clientWidth', { writable: true, value: 40 });
-      vi.spyOn(container, 'getBoundingClientRect').mockReturnValueOnce({ left: 25, top: 10, right: 0, bottom: 0, width: 40 } as DOMRect);
-
-      skipGridDestroy = true;
-      grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
-      expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
-    });
-
     it('should hide column headers div when "showPreHeaderPanel" is disabled', () => {
       const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
       const gridOptions = {

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -652,12 +652,73 @@ describe('SlickGrid core file', () => {
         { id: 1, firstName: 'Jane', lastName: 'Doe', age: 28 },
       ];
       Object.defineProperty(container, 'clientWidth', { writable: true, value: 40 });
-      vi.spyOn(container, 'getBoundingClientRect').mockReturnValueOnce({ left: 25, top: 10, right: 0, bottom: 0, width: 40 } as DOMRect);
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0, width: 40 } as DOMRect);
 
       skipGridDestroy = true;
       expect(() => new SlickGrid<any, Column>(container, data, columns, gridOptions)).toThrow(
         '[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'
       );
+    });
+
+    it('should show an alert when frozen column is wider than actual grid width and alertWhenFrozenNotAllViewable is enabled', () => {
+      const alertSpy = vi.spyOn(global, 'alert').mockReturnValue();
+      const consoleSpy = vi.spyOn(global.console, 'error').mockReturnValue();
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name' },
+        { id: 'lastName', field: 'lastName', name: 'Last Name' },
+      ] as Column[];
+      const gridOptions = {
+        ...defaultOptions,
+        enableColumnReorder: false,
+        enableCellNavigation: true,
+        preHeaderPanelHeight: 30,
+        showPreHeaderPanel: true,
+        frozenColumn: 0,
+        createPreHeaderPanel: true,
+        alertWhenFrozenNotAllViewable: true,
+      } as GridOption;
+      const data = [
+        { id: 0, firstName: 'John', lastName: 'Doe', age: 30 },
+        { id: 1, firstName: 'Jane', lastName: 'Doe', age: 28 },
+      ];
+      Object.defineProperty(container, 'clientWidth', { writable: true, value: 40 });
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValueOnce({ left: 25, top: 10, right: 0, bottom: 0, width: 40 } as DOMRect);
+
+      skipGridDestroy = true;
+      grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
+      grid.validateColumnFreezeAllowed(gridOptions.frozenColumn);
+      expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
+    });
+
+    it('should show an alert when trying to use setOptions with frozen column that is wider than actual grid width and alertWhenFrozenNotAllViewable is enabled', () => {
+      const alertSpy = vi.spyOn(global, 'alert').mockReturnValue();
+      const consoleSpy = vi.spyOn(global.console, 'error').mockReturnValue();
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name' },
+        { id: 'lastName', field: 'lastName', name: 'Last Name' },
+      ] as Column[];
+      const gridOptions = {
+        ...defaultOptions,
+        enableColumnReorder: false,
+        enableCellNavigation: true,
+        preHeaderPanelHeight: 30,
+        showPreHeaderPanel: true,
+        createPreHeaderPanel: true,
+        alertWhenFrozenNotAllViewable: true,
+      } as GridOption;
+      const data = [
+        { id: 0, firstName: 'John', lastName: 'Doe', age: 30 },
+        { id: 1, firstName: 'Jane', lastName: 'Doe', age: 28 },
+      ];
+      Object.defineProperty(container, 'clientWidth', { writable: true, value: 40 });
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0, width: 40 } as DOMRect);
+
+      skipGridDestroy = true;
+      grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
+      grid.setOptions({ frozenColumn: 0 });
+      expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
     });
 
     it('should hide column headers div when "showPreHeaderPanel" is disabled', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -205,7 +205,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // settings
   protected _options!: O;
   protected _defaults: BaseGridOption = {
-    alertWhenFrozenNotAllViewable: true,
     alwaysShowVerticalScroll: false,
     alwaysAllowHorizontalScroll: false,
     explicitInitialization: false,
@@ -1362,24 +1361,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       if (this.hasFrozenColumns()) {
         const cWidth = Utils.width(this._container) || 0;
-        if (cWidth > 0 && (this.canvasWidthL > cWidth || this._options.frozenColumn! >= this.columns.length)) {
-          // in any case, we need to revert to previous frozen column setting
-          this.setOptions({ frozenColumn: this._prevFrozenColumn } as O);
-
-          // then warn the user when enabled or show console error and abort the operation
-          const errorMsg =
+        if (cWidth > 0 && this.canvasWidthL > cWidth && this._options.throwWhenFrozenNotAllViewable) {
+          throw new Error(
             '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
-            'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
-            'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.';
-
-          if (this._options.throwWhenFrozenNotAllViewable) {
-            throw new Error(errorMsg);
-          }
-          if (this._options.alertWhenFrozenNotAllViewable) {
-            alert(errorMsg);
-          }
-          console.error(errorMsg);
-          return;
+              'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
+              'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.'
+          );
         }
         Utils.width(this._canvasTopR, this.canvasWidthR);
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1345,7 +1345,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} frozenColumn the column index to freeze at
    * @param {Boolean} displayAlert optional flag to indicate if an alert should be displayed when not valid (default to True)
    */
-  validateColumnFreezeAllowed(frozenColumn = -1): boolean {
+  validateColumnFreeze(frozenColumn = -1): boolean {
     if (frozenColumn >= 0) {
       let canvasWidthL = 0;
       this.columns.forEach((col, i) => {
@@ -3355,7 +3355,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._prevFrozenColumn = this._options.frozenColumn ?? -1; // keep ref of previous frozen column for later usage
 
       // make sure the freeze is also valid without breaking the UI (e.g. we can't freeze columns on left canvas wider than visible canvas width in the browser)
-      if (this.validateColumnFreezeAllowed(newOptions.frozenColumn)) {
+      if (this.validateColumnFreeze(newOptions.frozenColumn)) {
         this.getViewports().forEach((vp) => (vp.scrollLeft = 0));
         this.handleScroll(); // trigger scroll to realign column headers as well
       } else {
@@ -3443,7 +3443,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._options.leaveSpaceForNewRows = false;
     }
     // make sure the freeze is also valid without breaking the UI (e.g. we can't left freeze columns wider than visible left canvas width)
-    if (!this.validateColumnFreezeAllowed(this._options.frozenColumn ?? -1)) {
+    if (!this.validateColumnFreeze(this._options.frozenColumn)) {
       this._options.frozenColumn = this._prevFrozenColumn;
     }
   }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -205,6 +205,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // settings
   protected _options!: O;
   protected _defaults: BaseGridOption = {
+    alertWhenFrozenNotAllViewable: true,
     alwaysShowVerticalScroll: false,
     alwaysAllowHorizontalScroll: false,
     explicitInitialization: false,
@@ -1339,6 +1340,39 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return totalRowWidth;
   }
 
+  /**
+   * Validate that the column freeze is allowed in the browser by making sure that the frozen column is not exceeding the available and visible left canvas width.
+   * @param {Number} frozenColumn the column index to freeze at
+   * @param {Boolean} displayAlert optional flag to indicate if an alert should be displayed when not valid (default to True)
+   */
+  validateColumnFreezeAllowed(frozenColumn = -1): boolean {
+    if (frozenColumn >= 0) {
+      let canvasWidthL = 0;
+      this.columns.forEach((col, i) => {
+        if (!col.hidden && i <= frozenColumn) {
+          canvasWidthL += col.width || this._options.defaultColumnWidth!;
+        }
+      });
+
+      const cWidth = Utils.width(this._container) || 0;
+      if (cWidth > 0 && canvasWidthL > cWidth) {
+        const errorMsg =
+          '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
+          'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
+          'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.';
+        if (this._options.alertWhenFrozenNotAllViewable || this._options.throwWhenFrozenNotAllViewable) {
+          if (this._options.throwWhenFrozenNotAllViewable) {
+            throw new Error(errorMsg);
+          }
+          alert(errorMsg);
+        }
+        console.error(errorMsg); // always log the error
+        return false;
+      }
+    }
+    return true;
+  }
+
   protected updateCanvasWidth(forceColumnWidthsUpdate?: boolean): void {
     const oldCanvasWidth = this.canvasWidth;
     const oldCanvasWidthL = this.canvasWidthL;
@@ -1360,14 +1394,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       Utils.width(this._headerR, this.headersWidthR);
 
       if (this.hasFrozenColumns()) {
-        const cWidth = Utils.width(this._container) || 0;
-        if (cWidth > 0 && this.canvasWidthL > cWidth && this._options.throwWhenFrozenNotAllViewable) {
-          throw new Error(
-            '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
-              'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
-              'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.'
-          );
-        }
         Utils.width(this._canvasTopR, this.canvasWidthR);
 
         Utils.width(this._paneHeaderL, this.canvasWidthL);
@@ -3327,8 +3353,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // before applying column freeze, we need our viewports to be scrolled back to left to avoid misaligned column headers
     if (newOptions.frozenColumn !== undefined && newOptions.frozenColumn >= 0) {
       this._prevFrozenColumn = this._options.frozenColumn ?? -1; // keep ref of previous frozen column for later usage
-      this.getViewports().forEach((vp) => (vp.scrollLeft = 0));
-      this.handleScroll(); // trigger scroll to realign column headers as well
+
+      // make sure the freeze is also valid without breaking the UI (e.g. we can't freeze columns on left canvas wider than visible canvas width in the browser)
+      if (this.validateColumnFreezeAllowed(newOptions.frozenColumn)) {
+        this.getViewports().forEach((vp) => (vp.scrollLeft = 0));
+        this.handleScroll(); // trigger scroll to realign column headers as well
+      } else {
+        newOptions.frozenColumn = this._prevFrozenColumn;
+      }
     }
 
     const originalOptions = extend(true, {}, this._options);
@@ -3409,6 +3441,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected validateAndEnforceOptions(): void {
     if (this._options.autoHeight) {
       this._options.leaveSpaceForNewRows = false;
+    }
+    // make sure the freeze is also valid without breaking the UI (e.g. we can't left freeze columns wider than visible left canvas width)
+    if (!this.validateColumnFreezeAllowed(this._options.frozenColumn ?? -1)) {
+      this._options.frozenColumn = this._prevFrozenColumn;
     }
   }
 

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -59,6 +59,7 @@ const gridStub = {
   setSortColumns: vi.fn(),
   updateColumnHeader: vi.fn(),
   updateColumns: vi.fn(),
+  validateColumnFreezeAllowed: vi.fn(),
   onBeforeSetColumns: new SlickEvent(),
   onBeforeHeaderCellDestroy: new SlickEvent(),
   onClick: new SlickEvent(),
@@ -867,6 +868,7 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect menu related to Freeze Columns when "hideFreezeColumnsCommand" is disabled and also expect grid "setOptions" method to be called with current column position', async () => {
+        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
@@ -917,6 +919,7 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect menu related to Unfreeze Columns when "hideFreezeColumnsCommand" is disabled and column is already frozen to that index and then also expect grid "setOptions" method to be called with current column position', async () => {
+        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
@@ -974,6 +977,7 @@ describe('HeaderMenu Plugin', () => {
         sharedService.hasColumnsReordered = true;
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
+        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           headerMenu: { hideFreezeColumnsCommand: false, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true },
@@ -1374,6 +1378,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ frozenColumn: 0 } as GridOption);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
+        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(originalColumnDefinitions);
         sharedService.hasColumnsReordered = false;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
@@ -1417,6 +1422,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ frozenColumn: 0 } as GridOption);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
+        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(visibleColumnDefinitions);
         sharedService.hasColumnsReordered = true;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -59,7 +59,7 @@ const gridStub = {
   setSortColumns: vi.fn(),
   updateColumnHeader: vi.fn(),
   updateColumns: vi.fn(),
-  validateColumnFreezeAllowed: vi.fn(),
+  validateColumnFreeze: vi.fn(),
   onBeforeSetColumns: new SlickEvent(),
   onBeforeHeaderCellDestroy: new SlickEvent(),
   onClick: new SlickEvent(),
@@ -868,7 +868,7 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect menu related to Freeze Columns when "hideFreezeColumnsCommand" is disabled and also expect grid "setOptions" method to be called with current column position', async () => {
-        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
@@ -919,7 +919,7 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect menu related to Unfreeze Columns when "hideFreezeColumnsCommand" is disabled and column is already frozen to that index and then also expect grid "setOptions" method to be called with current column position', async () => {
-        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
@@ -977,7 +977,7 @@ describe('HeaderMenu Plugin', () => {
         sharedService.hasColumnsReordered = true;
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
-        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           headerMenu: { hideFreezeColumnsCommand: false, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true },
@@ -1378,7 +1378,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ frozenColumn: 0 } as GridOption);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
-        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(originalColumnDefinitions);
         sharedService.hasColumnsReordered = false;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
@@ -1422,7 +1422,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ frozenColumn: 0 } as GridOption);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
-        vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(visibleColumnDefinitions);
         sharedService.hasColumnsReordered = true;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -511,9 +511,8 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     // the bug is highlighted in this issue comment:: https://github.com/6pac/SlickGrid/issues/592#issuecomment-822885069
     const previousColumns = this.grid.getColumns();
 
-    // make sure it's really that the column freeze is allowed before doing anything
-    const isFreezeAllowed = this.grid.validateColumnFreezeAllowed(newGridOptions.frozenColumn);
-    if (isFreezeAllowed) {
+    // make sure column freeze is allowed before applying the change
+    if (this.grid.validateColumnFreeze(newGridOptions.frozenColumn)) {
       this.grid.setOptions(newGridOptions, false, true); // suppress the setColumns (3rd argument) since we'll do that ourselves
       let finalVisibleColumns = visibleColumns || [];
 

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -511,40 +511,31 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     // the bug is highlighted in this issue comment:: https://github.com/6pac/SlickGrid/issues/592#issuecomment-822885069
     const previousColumns = this.sharedService.slickGrid.getColumns();
 
-    this.grid.setOptions(newGridOptions, false, true); // suppress the setColumns (3rd argument) since we'll do that ourselves
-    let finalVisibleColumns = visibleColumns || [];
+    this.sharedService.slickGrid.setOptions(newGridOptions, false, true); // suppress the setColumns (3rd argument) since we'll do that ourselves
+    this.sharedService.gridOptions.frozenColumn = newGridOptions.frozenColumn;
+    this.sharedService.gridOptions.enableMouseWheelScrollHandler = newGridOptions.enableMouseWheelScrollHandler;
+    this.sharedService.frozenVisibleColumnId = column.id;
 
-    // make sure it's really assigned (it could have failed when freezing columns wider than viewport, see `throwWhenFrozenNotAllViewable`)
-    // call `updateColumns()` to force a "freeze vs viewport" condition check, if wider it will reset frozen column to -1 and we should consider this a failure and abort
-    this.grid.updateColumns();
-    const isFreezeAllowed = this.grid.getOptions().frozenColumn === newGridOptions.frozenColumn; // when it fails, it would reset to -1 and not equal new frozen column
-    if (isFreezeAllowed) {
-      // remove the last freeze/unfreeze command called from Header Menu since it will be replaced by the other one when reopening the menu
-      const columnHeaderMenuItems: Array<MenuCommandItem | 'divider'> = column?.header?.menu?.commandItems ?? [];
-      this.removeCommandWhenFound(columnHeaderMenuItems, command);
-
-      this.sharedService.gridOptions.frozenColumn = newGridOptions.frozenColumn;
-      this.sharedService.gridOptions.enableMouseWheelScrollHandler = newGridOptions.enableMouseWheelScrollHandler;
-      this.sharedService.frozenVisibleColumnId = newGridOptions.frozenColumn >= 0 ? column.id : '';
-
-      if (command === 'freeze-columns') {
-        // to freeze columns, we need to take only the visible columns and we also need to use setColumns() when some of them are hidden
-        // to make sure that we only use the visible columns, not doing this will have the undesired effect of showing back some of the hidden columns
-        // prettier-ignore
-        if (this.sharedService.hasColumnsReordered || (Array.isArray(visibleColumns) && Array.isArray(this.sharedService.allColumns) && visibleColumns.length !== this.sharedService.allColumns.length)) {
-            finalVisibleColumns = visibleColumns;
-          } else {
-            // to circumvent a bug in SlickGrid core lib re-apply same column definitions that were backed up before calling setOptions()
-            finalVisibleColumns = previousColumns;
-          }
+    let finalVisibleColumns = [];
+    if (command === 'freeze-columns') {
+      // to freeze columns, we need to take only the visible columns and we also need to use setColumns() when some of them are hidden
+      // to make sure that we only use the visible columns, not doing this will have the undesired effect of showing back some of the hidden columns
+      // prettier-ignore
+      if (this.sharedService.hasColumnsReordered || (Array.isArray(visibleColumns) && Array.isArray(this.sharedService.allColumns) && visibleColumns.length !== this.sharedService.allColumns.length)) {
+        finalVisibleColumns = visibleColumns;
+      } else {
+        // to circumvent a bug in SlickGrid core lib re-apply same column definitions that were backed up before calling setOptions()
+        finalVisibleColumns = previousColumns;
       }
-      this.grid.setColumns(finalVisibleColumns);
+    } else {
+      finalVisibleColumns = visibleColumns;
+    }
+    this.sharedService.slickGrid.setColumns(finalVisibleColumns);
 
-      // we also need to autosize columns if the option is enabled
-      const gridOptions = this.grid.getOptions();
-      if (gridOptions.enableAutoSizeColumns) {
-        this.grid.autosizeColumns();
-      }
+    // we also need to autosize columns if the option is enabled
+    const gridOptions = this.sharedService.slickGrid.getOptions();
+    if (gridOptions.enableAutoSizeColumns) {
+      this.sharedService.slickGrid.autosizeColumns();
     }
   }
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -846,10 +846,15 @@ export interface GridOption<C extends Column = Column> {
   textExportOptions?: TextExportOption;
 
   /**
-   * Defaults to false, should we throw an erro when frozenColumn is wider than the grid viewport width.
-   * When that happens the unfrozen section on the right is in a phantom area that is not viewable neither clickable unless we enable double-scroll on the grid container.
+   * @deprecated @use `alertWhenFrozenNotAllViewable` Defaults to false, should we throw an error when frozenColumn is wider than the grid viewport width.
    */
   throwWhenFrozenNotAllViewable?: boolean;
+
+  /**
+   * Defaults to true, show a browser alert when the user tries to set a frozenColumn that is wider than the visible grid viewport width in the browser.
+   * We can't freeze wider than the viewport because the right canvas will never be visible and left canvas will not be scrollable which breaks the UX.
+   */
+  alertWhenFrozenNotAllViewable?: boolean;
 
   /** What is the top panel height in pixels (only type the number) */
   topPanelHeight?: number;

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -851,9 +851,6 @@ export interface GridOption<C extends Column = Column> {
    */
   throwWhenFrozenNotAllViewable?: boolean;
 
-  /** Defaults to true, show a browser alert to advise the user when frozenColumn is wider than the grid viewport width (same as `throwWhenFrozenNotAllViewable` but uses an alert instead of throwing) */
-  alertWhenFrozenNotAllViewable?: boolean;
-
   /** What is the top panel height in pixels (only type the number) */
   topPanelHeight?: number;
 

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -94,6 +94,7 @@ const gridStub = {
   scrollRowIntoView: vi.fn(),
   updateColumns: vi.fn(),
   updateRow: vi.fn(),
+  validateColumnFreezeAllowed: vi.fn(),
 } as unknown as SlickGrid;
 
 const paginationServiceStub = {
@@ -1590,6 +1591,7 @@ describe('Grid Service', () => {
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       const gridOptionSetterSpy = vi.spyOn(SharedService.prototype, 'gridOptions', 'set');
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
+      vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
 
       service.setPinning(mockPinning);
 
@@ -1605,6 +1607,7 @@ describe('Grid Service', () => {
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       const gridOptionSetterSpy = vi.spyOn(SharedService.prototype, 'gridOptions', 'set');
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
+      vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
 
       service.setPinning(mockPinning, false);
 

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -94,7 +94,7 @@ const gridStub = {
   scrollRowIntoView: vi.fn(),
   updateColumns: vi.fn(),
   updateRow: vi.fn(),
-  validateColumnFreezeAllowed: vi.fn(),
+  validateColumnFreeze: vi.fn(),
 } as unknown as SlickGrid;
 
 const paginationServiceStub = {
@@ -1591,7 +1591,7 @@ describe('Grid Service', () => {
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       const gridOptionSetterSpy = vi.spyOn(SharedService.prototype, 'gridOptions', 'set');
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
-      vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+      vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
 
       service.setPinning(mockPinning);
 
@@ -1607,7 +1607,7 @@ describe('Grid Service', () => {
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       const gridOptionSetterSpy = vi.spyOn(SharedService.prototype, 'gridOptions', 'set');
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
-      vi.spyOn(gridStub, 'validateColumnFreezeAllowed').mockReturnValue(true);
+      vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
 
       service.setPinning(mockPinning, false);
 

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -121,11 +121,17 @@ export class GridService {
     if (isObjectEmpty(pinningOptions)) {
       this.clearPinning();
     } else {
+      let isFreezeAllowed = true;
       if (pinningOptions.frozenColumn !== undefined) {
-        this.sharedService.frozenVisibleColumnId = this._grid.getColumns()[pinningOptions.frozenColumn]?.id || '';
+        isFreezeAllowed = this._grid.validateColumnFreezeAllowed(pinningOptions.frozenColumn);
+        if (isFreezeAllowed) {
+          this.sharedService.frozenVisibleColumnId = this._grid.getColumns()[pinningOptions.frozenColumn]?.id || '';
+        }
       }
-      this.sharedService.slickGrid.setOptions(pinningOptions, suppressRender, suppressColumnSet);
-      this.sharedService.gridOptions = { ...this.sharedService.gridOptions, ...pinningOptions };
+      if (isFreezeAllowed) {
+        this.sharedService.slickGrid.setOptions(pinningOptions, suppressRender, suppressColumnSet);
+        this.sharedService.gridOptions = { ...this.sharedService.gridOptions, ...pinningOptions };
+      }
     }
 
     if (shouldAutosizeColumns) {

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -123,7 +123,7 @@ export class GridService {
     } else {
       let isFreezeAllowed = true;
       if (pinningOptions.frozenColumn !== undefined) {
-        isFreezeAllowed = this._grid.validateColumnFreezeAllowed(pinningOptions.frozenColumn);
+        isFreezeAllowed = this._grid.validateColumnFreeze(pinningOptions.frozenColumn);
         if (isFreezeAllowed) {
           this.sharedService.frozenVisibleColumnId = this._grid.getColumns()[pinningOptions.frozenColumn]?.id || '';
         }

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -271,7 +271,7 @@ const mockGrid = {
   setHeaderRowVisibility: vi.fn(),
   setOptions: vi.fn(),
   setSelectedRows: vi.fn(),
-  validateColumnFreezeAllowed: vi.fn(),
+  validateColumnFreeze: vi.fn(),
   onClick: new MockSlickEvent(),
   onClicked: new MockSlickEvent(),
   onColumnsReordered: new MockSlickEvent(),
@@ -400,7 +400,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   });
 
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {
-    vi.spyOn(mockGrid, 'validateColumnFreezeAllowed').mockReturnValue(true);
+    vi.spyOn(mockGrid, 'validateColumnFreeze').mockReturnValue(true);
     component.gridOptions.frozenColumn = 0;
     component.initialization(divContainer, slickEventHandler);
 

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -66,7 +66,7 @@ vi.mock('@slickgrid-universal/common', async (importOriginal) => ({
   },
 }));
 
-const addVanillaEventPropagation = function (event) {
+const addVanillaEventPropagation = function (event: any) {
   Object.defineProperty(event, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
   Object.defineProperty(event, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
   return event;
@@ -271,6 +271,7 @@ const mockGrid = {
   setHeaderRowVisibility: vi.fn(),
   setOptions: vi.fn(),
   setSelectedRows: vi.fn(),
+  validateColumnFreezeAllowed: vi.fn(),
   onClick: new MockSlickEvent(),
   onClicked: new MockSlickEvent(),
   onColumnsReordered: new MockSlickEvent(),
@@ -305,7 +306,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   let translateService: TranslateServiceStub;
   const http = new HttpStub();
   const container = new UniversalContainerService();
-  let dataset = [];
+  let dataset: any[] = [];
 
   beforeEach(() => {
     divContainer = document.createElement('div');
@@ -399,6 +400,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   });
 
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {
+    vi.spyOn(mockGrid, 'validateColumnFreezeAllowed').mockReturnValue(true);
     component.gridOptions.frozenColumn = 0;
     component.initialization(divContainer, slickEventHandler);
 
@@ -414,7 +416,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
     component.gridOptions = { enableFiltering: true };
     component.initialization(divContainer, slickEventHandler);
-    mockGrid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns, grid: mockGrid });
+    mockGrid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns, grid: mockGrid, previousColumnOrder: ['firstName', 'lastName'] });
 
     expect(component.eventHandler).toEqual(slickEventHandler);
     expect(sharedService.hasColumnsReordered).toBe(true);
@@ -725,7 +727,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           try {
             component.initialization(divContainer, slickEventHandler);
             component.dataset = mockData;
-          } catch (e) {
+          } catch (e: any) {
             expect(e.toString()).toContain(
               '[Slickgrid-Universal] You cannot enable both autosize/fit viewport & resize by content, you must choose which resize technique to use.'
             );
@@ -747,7 +749,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           try {
             component.initialization(divContainer, slickEventHandler);
             component.dataset = mockData;
-          } catch (e) {
+          } catch (e: any) {
             expect(e.toString()).toContain(
               '[Slickgrid-Universal] You cannot enable both autosize/fit viewport & resize by content, you must choose which resize technique to use.'
             );
@@ -2531,9 +2533,9 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor with 
   let sharedService: SharedService;
   let eventPubSubService: EventPubSubService;
   let translateService: TranslateServiceStub;
-  let dataset = [];
+  let dataset: any[] = [];
   let hierarchicalDataset: any = null;
-  let hierarchicalSpy;
+  let hierarchicalSpy: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -2603,7 +2605,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor with 
   let sharedService: SharedService;
   let eventPubSubService: EventPubSubService;
   let translateService: TranslateServiceStub;
-  let dataset = [];
+  let dataset: any[] = [];
 
   beforeEach(() => {
     divContainer = document.createElement('div');

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -606,12 +606,10 @@ export class SlickVanillaGridBundle<TData = any> {
     if (
       frozenColumnIndex >= 0 &&
       frozenColumnIndex <= this.sharedService.visibleColumns.length &&
-      this.sharedService.visibleColumns.length > 0
+      this.sharedService.visibleColumns.length > 0 &&
+      this.slickGrid.validateColumnFreeze(frozenColumnIndex)
     ) {
-      const isFreezeAllowed = this.slickGrid.validateColumnFreezeAllowed(frozenColumnIndex);
-      if (isFreezeAllowed) {
-        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
-      }
+      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
     }
 
     // get any possible Services that user want to register

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -608,7 +608,10 @@ export class SlickVanillaGridBundle<TData = any> {
       frozenColumnIndex <= this.sharedService.visibleColumns.length &&
       this.sharedService.visibleColumns.length > 0
     ) {
-      this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+      const isFreezeAllowed = this.slickGrid.validateColumnFreezeAllowed(frozenColumnIndex);
+      if (isFreezeAllowed) {
+        this.sharedService.frozenVisibleColumnId = this.sharedService.visibleColumns[frozenColumnIndex]?.id ?? '';
+      }
     }
 
     // get any possible Services that user want to register

--- a/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
+++ b/packages/vanilla-force-bundle/src/__tests__/vanilla-force-bundle.spec.ts
@@ -271,7 +271,7 @@ describe('Vanilla-Force-Grid-Bundle Component instantiated via Constructor', () 
   let eventPubSubService: EventPubSubService;
   let translateService: TranslateServiceStub;
   const container = new UniversalContainerService();
-  let dataset = [];
+  let dataset: any[] = [];
 
   beforeEach(() => {
     dataset = [];

--- a/test/cypress/e2e/example17.cy.ts
+++ b/test/cypress/e2e/example17.cy.ts
@@ -329,5 +329,24 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
       cy.get('.grid17-1 .slick-pane-left .slick-header-column').should('have.length', 4);
       cy.get('.grid17-1 .slick-pane-right .slick-header-column').should('have.length', 34);
     });
+
+    it('should try to set frozen columns wider than possible and expect an error and abort of the execution', () => {
+      const stub = cy.stub();
+      cy.on('window:alert', stub);
+      cy.get('[data-test="frozen-column-count"]').clear().type('12');
+      cy.get('[data-test="set-frozen-columns-btn"]')
+        .click()
+        .then(() => {
+          expect(stub.getCall(0)).to.be.calledWith(
+            '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
+              'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
+              'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.'
+          );
+
+          // it should still have previous pinning
+          cy.get('.grid17-1 .slick-pane-left .slick-header-column').should('have.length', 4);
+          cy.get('.grid17-1 .slick-pane-right .slick-header-column').should('have.length', 34);
+        });
+    });
   });
 });

--- a/test/cypress/e2e/example17.cy.ts
+++ b/test/cypress/e2e/example17.cy.ts
@@ -329,24 +329,5 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
       cy.get('.grid17-1 .slick-pane-left .slick-header-column').should('have.length', 4);
       cy.get('.grid17-1 .slick-pane-right .slick-header-column').should('have.length', 34);
     });
-
-    it('should try to set frozen columns wider than possible and expect an error and abort of the execution', () => {
-      const stub = cy.stub();
-      cy.on('window:alert', stub);
-      cy.get('[data-test="frozen-column-count"]').clear().type('12');
-      cy.get('[data-test="set-frozen-columns-btn"]')
-        .click()
-        .then(() => {
-          expect(stub.getCall(0)).to.be.calledWith(
-            '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
-              'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
-              'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.'
-          );
-
-          // it should still have previous pinning
-          cy.get('.grid17-1 .slick-pane-left .slick-header-column').should('have.length', 4);
-          cy.get('.grid17-1 .slick-pane-right .slick-header-column').should('have.length', 34);
-        });
-    });
   });
 });


### PR DESCRIPTION
- fully reimplement frozen column check because PR #2129 was causing a big negative side effect in our Salesforce implementation and in some occasions even hang the browser because it would fall into infinite loop when trying to resize the browser smaller than visible pinned column (this is caused by the constant auto-resize loop that is required for it to work in Salesforce)
- the fix is really to **only** inspect it once when changing or assigning the grid options, and **not** do it on every column or grid resize which is what the previous code was doing. So doing the check only when assigning is a much lighter approach and will not trigger a recheck every column/grid resize like previously which was way too much and caused the issue mentioned above.