### PR TITLE
fix: validate to always have 1 or more column on right freeze section

### DIFF
--- a/docs/grid-functionalities/frozen-columns-rows.md
+++ b/docs/grid-functionalities/frozen-columns-rows.md
@@ -34,7 +34,10 @@ export class GridBasicComponent {
 ```
 
 > **Caution**
-> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `alertWhenFrozenNotAllViewable` (it will still do the validation but won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `invalidColumnFreezeWidthCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+
+> **Caution**
+> Also be aware that you also cannot uncheck (from Column Picker or Grid Menu) more columns than the actual `frozenColumn` index (in other words, you need to have at least 1, or more, columns on the right section of the freeze/pinning). Also similar as above you can disable it by setting `invalidColumnFreezePickerCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
 
 ## Rows Pinning starting from bottom
 This is basically the same thing as previous code sample, except that you will set the Grid Option property `frozenBottom` to true and that it's.

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/frozen-columns-rows.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/frozen-columns-rows.md
@@ -44,7 +44,10 @@ export class GridBasicComponent implements OnInit {
 ```
 
 > **Caution**
-> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `alertWhenFrozenNotAllViewable` (it will still do the validation but won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `invalidColumnFreezeWidthCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+
+> **Caution**
+> Also be aware that you also cannot uncheck (from Column Picker or Grid Menu) more columns than the actual `frozenColumn` index (in other words, you need to have at least 1, or more, columns on the right section of the freeze/pinning). Also similar as above you can disable it by setting `invalidColumnFreezePickerCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
 
 ## Rows Pinning starting from bottom
 This is basically the same thing as previous code sample, except that you will set the Grid Option property `frozenBottom` to true and that it's.

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/frozen-columns-rows.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/frozen-columns-rows.md
@@ -43,7 +43,10 @@ export class GridBasicComponent {
 ```
 
 > **Caution**
-> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `alertWhenFrozenNotAllViewable` (it will still do the validation but won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `invalidColumnFreezeWidthCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+
+> **Caution**
+> Also be aware that you also cannot uncheck (from Column Picker or Grid Menu) more columns than the actual `frozenColumn` index (in other words, you need to have at least 1, or more, columns on the right section of the freeze/pinning). Also similar as above you can disable it by setting `invalidColumnFreezePickerCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
 
 ## Rows Pinning starting from bottom
 This is basically the same thing as previous code sample, except that you will set the Grid Option property `frozenBottom` to true and that it's.

--- a/frameworks/slickgrid-react/docs/grid-functionalities/frozen-columns-rows.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/frozen-columns-rows.md
@@ -44,7 +44,10 @@ const Example: React.FC = () => {
 ```
 
 > **Caution**
-> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `alertWhenFrozenNotAllViewable` (it will still do the validation but won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `invalidColumnFreezeWidthCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+
+> **Caution**
+> Also be aware that you also cannot uncheck (from Column Picker or Grid Menu) more columns than the actual `frozenColumn` index (in other words, you need to have at least 1, or more, columns on the right section of the freeze/pinning). Also similar as above you can disable it by setting `invalidColumnFreezePickerCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
 
 ## Rows Pinning starting from bottom
 This is basically the same thing as previous code sample, except that you will set the Grid Option property `frozenBottom` to true and that it's.

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/frozen-columns-rows.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/frozen-columns-rows.md
@@ -50,7 +50,10 @@ function defineGrid() {
 ```
 
 > **Caution**
-> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `alertWhenFrozenNotAllViewable` (it will still do the validation but won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+> Please be aware that `frozenColumn` (left canvas) **cannot** be wider than the actual grid viewport width and you will get an alert when you try to do this. You can disable it by setting `invalidColumnFreezeWidthCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
+
+> **Caution**
+> Also be aware that you also cannot uncheck (from Column Picker or Grid Menu) more columns than the actual `frozenColumn` index (in other words, you need to have at least 1, or more, columns on the right section of the freeze/pinning). Also similar as above you can disable it by setting `invalidColumnFreezePickerCallback` to `undefined` (which will still do the validation but it won't show an alert to the end user) or set `skipFreezeColumnValidation` to completely skip the validation. Also note that if the condition is invalid, it will cancel the action and reapply previous `frozenColumn` value (unless skip validation is enabled).
 
 ## Rows Pinning starting from bottom
 This is basically the same thing as previous code sample, except that you will set the Grid Option property `frozenBottom` to true and that it's.

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -663,7 +663,6 @@ describe('SlickGrid core file', () => {
 
     it('should show an alert when frozen column is wider than actual grid width and invalidColumnFreezeWidthCallback is defined', () => {
       const alertSpy = vi.spyOn(global, 'alert').mockReturnValue();
-      const consoleSpy = vi.spyOn(global.console, 'error').mockReturnValue();
       const columns = [
         { id: 'firstName', field: 'firstName', name: 'First Name', minWidth: 40, maxWidth: 70 },
         { id: 'lastName', field: 'lastName', name: 'Last Name', minWidth: 40 },
@@ -689,12 +688,10 @@ describe('SlickGrid core file', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
       grid.validateColumnFreezeWidth(gridOptions.frozenColumn);
       expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
     });
 
     it('should show an alert when trying to use setOptions with frozen column that is wider than actual grid width and invalidColumnFreezeWidthCallback is defined', () => {
       const alertSpy = vi.spyOn(global, 'alert').mockReturnValue();
-      const consoleSpy = vi.spyOn(global.console, 'error').mockReturnValue();
       const columns = [
         { id: 'firstName', field: 'firstName', name: 'First Name' },
         { id: 'lastName', field: 'lastName', name: 'Last Name' },
@@ -719,12 +716,10 @@ describe('SlickGrid core file', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
       grid.setOptions({ frozenColumn: 0 });
       expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid] You are trying to freeze/pin more columns than the grid can support.'));
     });
 
     it('should show an alert when trying to call setColumn() with less than 1 column on the right section of the column freeze and when invalidColumnFreezePickerCallback is defined', () => {
       const alertSpy = vi.spyOn(global, 'alert').mockReturnValue();
-      const consoleSpy = vi.spyOn(global.console, 'error').mockReturnValue();
       const onAfterSetColumnsSpy = vi.spyOn(grid.onAfterSetColumns, 'notify');
       const columns = [
         { id: 'firstName', field: 'firstName', name: 'First Name' },
@@ -750,11 +745,6 @@ describe('SlickGrid core file', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, gridOptions);
       grid.setColumns(columns.slice(0, 2)); // remove last column to cause the error
       expect(alertSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          '[SlickGrid] Action not allowed and aborted, you need to have at least one or more column on the right section of the column freeze/pining.'
-        )
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           '[SlickGrid] Action not allowed and aborted, you need to have at least one or more column on the right section of the column freeze/pining.'
         )

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -751,12 +751,12 @@ describe('SlickGrid core file', () => {
       grid.setColumns(columns.slice(0, 2)); // remove last column to cause the error
       expect(alertSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          '[SlickGrid] Action not allowed and cancelled, you need to have at least 1 or more column on the right section of the frozen column.'
+          '[SlickGrid] Action not allowed and aborted, you need to have at least one or more column on the right section of the column freeze/pining.'
         )
       );
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          '[SlickGrid] Action not allowed and cancelled, you need to have at least 1 or more column on the right section of the frozen column.'
+          '[SlickGrid] Action not allowed and aborted, you need to have at least one or more column on the right section of the column freeze/pining.'
         )
       );
       expect(onAfterSetColumnsSpy).not.toHaveBeenCalled();

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1383,7 +1383,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             this._options.invalidColumnFreezeWidthCallback?.(this._options.invalidColumnFreezeWidthMessage!);
             this._invalidfrozenAlerted = true;
           }
-          console.error(this._options.invalidColumnFreezeWidthMessage); // always log the error
         }
         return false;
       }
@@ -1406,7 +1405,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if ((forceAlert !== false && !this._invalidfrozenAlerted) || forceAlert === true) {
         this._options.invalidColumnFreezePickerCallback?.(this._options.invalidColumnFreezePickerMessage!);
         this._invalidfrozenAlerted = true;
-        console.error(this._options.invalidColumnFreezePickerMessage); // always log the error
       }
       return false;
     }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1401,11 +1401,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    *  - if `false` it will do the condition check but always skip the alert
    */
   validateSetColumnFreeze(newColumns: C[], forceAlert?: boolean): boolean {
-    if (
-      this._options.frozenColumn! >= 0 &&
-      this._options.frozenColumn! > newColumns.length - 2 &&
-      !this._options.skipFreezeColumnValidation
-    ) {
+    const frozenColumn = this._options.frozenColumn ?? -1;
+    if (frozenColumn >= 0 && frozenColumn > newColumns.length - 2 && !this._options.skipFreezeColumnValidation) {
       if ((forceAlert !== false && !this._invalidfrozenAlerted) || forceAlert === true) {
         this._options.invalidColumnFreezePickerCallback?.(this._options.invalidColumnFreezePickerMessage!);
         this._invalidfrozenAlerted = true;

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -134,6 +134,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // Events
   onActiveCellChanged: SlickEvent<OnActiveCellChangedEventArgs>;
   onActiveCellPositionChanged: SlickEvent<{ grid: SlickGrid }>;
+  onActivateChangedOptions: SlickEvent<OnActivateChangedOptionsEventArgs>;
   onAddNewRow: SlickEvent<OnAddNewRowEventArgs>;
   onAfterSetColumns: SlickEvent<OnAfterSetColumnsEventArgs>;
   onAutosizeColumns: SlickEvent<OnAutosizeColumnsEventArgs>;
@@ -187,7 +188,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onScroll: SlickEvent<OnScrollEventArgs>;
   onSelectedRowsChanged: SlickEvent<OnSelectedRowsChangedEventArgs>;
   onSetOptions: SlickEvent<OnSetOptionsEventArgs>;
-  onActivateChangedOptions: SlickEvent<OnActivateChangedOptionsEventArgs>;
   onSort: SlickEvent<SingleColumnSort | MultiColumnSort>;
   onValidationError: SlickEvent<OnValidationErrorEventArgs>;
   onViewportChanged: SlickEvent<{ grid: SlickGrid }>;
@@ -205,7 +205,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // settings
   protected _options!: O;
   protected _defaults: BaseGridOption = {
-    alertWhenFrozenNotAllViewable: true,
+    invalidColumnFreezePickerCallback: (error) => alert(error),
+    invalidColumnFreezeWidthCallback: (error) => alert(error),
+    invalidColumnFreezeWidthMessage:
+      '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
+      'Make sure to have less columns pinned (on the left) than the actual visible grid width.',
+    invalidColumnFreezePickerMessage:
+      '[SlickGrid] Action not allowed and cancelled, you need to have at least 1 or more column on the right section of the frozen column. ' +
+      'You could alternatively "Unfreeze all the columns" before trying again.',
     skipFreezeColumnValidation: false,
     alwaysShowVerticalScroll: false,
     alwaysAllowHorizontalScroll: false,
@@ -1345,14 +1352,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /**
    * Validate that the column freeze is allowed in the browser by making sure that the frozen column is not exceeding the available and visible left canvas width.
-   * Note that it will only validate when `alertWhenFrozenNotAllViewable` or `throwWhenFrozenNotAllViewable` grid option is enabled.
+   * Note that it will only validate when `invalidColumnFreezeWidthCallback` or `throwWhenFrozenNotAllViewable` grid option is enabled.
    * @param {Number} frozenColumn the column index to freeze at
    * @param {Boolean} [forceAlert] tri-state flag to alert when frozen column is invalid
-   *  - if `undefined` it will alert only once
-   *  - if `true` it will always alert even if it was called before
-   *  - if `false` it will always skip the alert and only do the condition check
+   *  - if `undefined` it will do the condition check and never alert more than once
+   *  - if `true` it will do the condition check and always alert even if it was called before
+   *  - if `false` it will do the condition check but always skip the alert
    */
-  validateColumnFreeze(frozenColumn = -1, forceAlert?: boolean): boolean {
+  validateColumnFreezeWidth(frozenColumn = -1, forceAlert?: boolean): boolean {
     if (frozenColumn >= 0) {
       let canvasWidthL = 0;
       this.columns.forEach((col, i) => {
@@ -1369,21 +1376,42 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const cWidth = Utils.width(this._container) || 0;
       if (cWidth > 0 && canvasWidthL > cWidth && !this._options.skipFreezeColumnValidation) {
         if ((forceAlert !== false && !this._invalidfrozenAlerted) || forceAlert === true) {
-          const errorMsg =
-            '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
-            'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
-            'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.';
-          if (this._options.alertWhenFrozenNotAllViewable || this._options.throwWhenFrozenNotAllViewable) {
+          if (this._options.invalidColumnFreezeWidthCallback || this._options.throwWhenFrozenNotAllViewable) {
             if (this._options.throwWhenFrozenNotAllViewable) {
-              throw new Error(errorMsg);
+              throw new Error(this._options.invalidColumnFreezeWidthMessage);
             }
-            alert(errorMsg);
+            this._options.invalidColumnFreezeWidthCallback?.(this._options.invalidColumnFreezeWidthMessage!);
             this._invalidfrozenAlerted = true;
           }
-          console.error(errorMsg); // always log the error
+          console.error(this._options.invalidColumnFreezeWidthMessage); // always log the error
         }
         return false;
       }
+    }
+    return true;
+  }
+
+  /**
+   * Validate that there is at least 1, or more, column to the right of the frozen column otherwise show an error (we do this check before calling `setColumns()`).
+   * Note that it will only validate when `invalidColumnFreezePickerCallback` grid option is enabled.
+   * @param {Column[]} newColumns the new columns that will later be provided to `setColumns()`
+   * @param {Boolean} [forceAlert] tri-state flag to alert when frozen column is invalid
+   *  - if `undefined` it will do the condition check and never alert more than once
+   *  - if `true` it will do the condition check and always alert even if it was called before
+   *  - if `false` it will do the condition check but always skip the alert
+   */
+  validateSetColumnFreeze(newColumns: C[], forceAlert?: boolean): boolean {
+    if (
+      this._options.frozenColumn! >= 0 &&
+      this._options.frozenColumn! > newColumns.length - 2 &&
+      !this._options.skipFreezeColumnValidation
+    ) {
+      if ((forceAlert !== false && !this._invalidfrozenAlerted) || forceAlert === true) {
+        this._options.invalidColumnFreezePickerCallback?.(this._options.invalidColumnFreezePickerMessage!);
+        this._invalidfrozenAlerted = true;
+        console.error(this._options.invalidColumnFreezePickerMessage); // always log the error
+      }
+      return false;
     }
     return true;
   }
@@ -3314,6 +3342,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   setColumns(columns: C[]): void {
     this.triggerEvent(this.onBeforeSetColumns, { previousColumns: this.columns, newColumns: columns, grid: this });
+    const isValidFreeze = this.validateSetColumnFreeze(columns);
+    if (!isValidFreeze) {
+      return; // exit early if freeze is invalid
+    }
     this.columns = columns;
     this.updateColumnsInternal();
     this.triggerEvent(this.onAfterSetColumns, { newColumns: columns, grid: this });
@@ -3385,7 +3417,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (!suppressColumnSet) {
         this._invalidfrozenAlerted = false; // reset frozen alert
       }
-      if (this.validateColumnFreeze(newOptions.frozenColumn)) {
+      if (this.validateColumnFreezeWidth(newOptions.frozenColumn)) {
         this.getViewports().forEach((vp) => (vp.scrollLeft = 0));
         this.handleScroll(); // trigger scroll to realign column headers as well
       } else {
@@ -3473,7 +3505,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._options.leaveSpaceForNewRows = false;
     }
     // make sure the freeze is also valid without breaking the UI (e.g. we can't left freeze columns wider than visible left canvas width)
-    if (!this.validateColumnFreeze(this._options.frozenColumn)) {
+    if (!this.validateColumnFreezeWidth(this._options.frozenColumn)) {
       this._options.frozenColumn = this._prevFrozenColumn < this._options.frozenColumn! ? this._prevFrozenColumn : -1;
     }
   }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -211,7 +211,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
       'Make sure to have less columns pinned (on the left) than the actual visible grid width.',
     invalidColumnFreezePickerMessage:
-      '[SlickGrid] Action not allowed and cancelled, you need to have at least 1 or more column on the right section of the frozen column. ' +
+      '[SlickGrid] Action not allowed and aborted, you need to have at least one or more column on the right section of the column freeze/pining. ' +
       'You could alternatively "Unfreeze all the columns" before trying again.',
     skipFreezeColumnValidation: false,
     alwaysShowVerticalScroll: false,

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -60,7 +60,7 @@ const gridStub = {
   setSortColumns: vi.fn(),
   updateColumnHeader: vi.fn(),
   updateColumns: vi.fn(),
-  validateColumnFreeze: vi.fn(),
+  validateColumnFreezeWidth: vi.fn(),
   onBeforeSetColumns: new SlickEvent(),
   onBeforeHeaderCellDestroy: new SlickEvent(),
   onClick: new SlickEvent(),
@@ -869,7 +869,7 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect menu related to Freeze Columns when "hideFreezeColumnsCommand" is disabled and also expect grid "setOptions" method to be called with current column position', async () => {
-        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
@@ -920,7 +920,7 @@ describe('HeaderMenu Plugin', () => {
       });
 
       it('should expect menu related to Unfreeze Columns when "hideFreezeColumnsCommand" is disabled and column is already frozen to that index and then also expect grid "setOptions" method to be called with current column position', async () => {
-        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
@@ -978,7 +978,7 @@ describe('HeaderMenu Plugin', () => {
         sharedService.hasColumnsReordered = true;
         const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
-        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
           ...gridOptionsMock,
           headerMenu: { hideFreezeColumnsCommand: false, hideColumnHideCommand: true, hideColumnResizeByContentCommand: true },
@@ -1379,7 +1379,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ frozenColumn: 0 } as GridOption);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
-        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(originalColumnDefinitions);
         sharedService.hasColumnsReordered = false;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({
@@ -1423,7 +1423,7 @@ describe('HeaderMenu Plugin', () => {
         const setColSpy = vi.spyOn(gridStub, 'setColumns');
         vi.spyOn(gridStub, 'getOptions').mockReturnValueOnce({ frozenColumn: 0 } as GridOption);
         vi.spyOn(gridStub, 'getColumns').mockReturnValue(originalColumnDefinitions);
-        vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+        vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
         vi.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(visibleColumnDefinitions);
         sharedService.hasColumnsReordered = true;
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue({

--- a/packages/common/src/extensions/extensionCommonUtils.ts
+++ b/packages/common/src/extensions/extensionCommonUtils.ts
@@ -5,6 +5,7 @@ import type { Column, ColumnPickerOption, DOMEvent, GridMenuOption } from '../in
 import { SlickColumnPicker } from './slickColumnPicker.js';
 import { SlickGridMenu } from './slickGridMenu.js';
 import { applyHtmlToElement } from '../core/utils.js';
+import type { SlickGrid } from '../core/slickGrid.js';
 
 const PICKER_CHECK_ICON = 'mdi-icon-picker-check';
 const PICKER_UNCHECK_ICON = 'mdi-icon-picker-uncheck';
@@ -75,7 +76,9 @@ export function handleColumnPickerItemClick(this: SlickColumnPicker | SlickGridM
       }
     });
 
-    if (!visibleColumns.length) {
+    // validate that the checkbox changes is allowed before going any further
+    const isFrozenAllowed = (context.grid as SlickGrid).validateSetColumnFreeze(visibleColumns, true);
+    if (!isFrozenAllowed || !visibleColumns.length) {
       event.target.checked = true;
       togglePickerCheckbox(iconElm, true);
       return;

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -512,7 +512,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
     const previousColumns = this.grid.getColumns();
 
     // make sure column freeze is allowed before applying the change
-    if (this.grid.validateColumnFreeze(newGridOptions.frozenColumn, true)) {
+    if (this.grid.validateColumnFreezeWidth(newGridOptions.frozenColumn, true)) {
       this.grid.setOptions(newGridOptions, false, true); // suppress the setColumns (3rd argument) since we'll do that ourselves
       let finalVisibleColumns = visibleColumns || [];
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -849,15 +849,29 @@ export interface GridOption<C extends Column = Column> {
   skipFreezeColumnValidation?: boolean;
 
   /**
-   * @deprecated @use `alertWhenFrozenNotAllViewable` Defaults to false, should we throw an error when frozenColumn is wider than the grid viewport width.
+   * @deprecated @use `invalidColumnFreezeWidthCallback` Defaults to false, should we throw an error when frozenColumn is wider than the grid viewport width.
    */
   throwWhenFrozenNotAllViewable?: boolean;
 
+  /** Message to show when the frozen column is invalid and `invalidColumnFreezeWidthCallbackPicker` is enabled */
+  invalidColumnFreezePickerMessage?: string;
+
   /**
-   * Defaults to true, show a browser alert when the user tries to set a frozenColumn that is wider than the visible grid viewport width in the browser.
-   * We can't freeze wider than the viewport because the right canvas will never be visible and left canvas will not be scrollable which breaks the UX.
+   * Defaults to `alert(error)`, which will trigger when the user tries to uncheck too many columns via ColumnPicker/GridMenu.
+   * We need to have 1 or more columns visible on the right side of the frozen column.
+   * NOTE: the error is **always** logged via `console.error` even when this callback is unset.
    */
-  alertWhenFrozenNotAllViewable?: boolean;
+  invalidColumnFreezePickerCallback?: (error: string) => void;
+
+  /** Message to show when the frozen column width is invalid and `invalidColumnFreezeWidthCallbackWidth` or `throwWhenFrozenNotAllViewable` is enabled */
+  invalidColumnFreezeWidthMessage?: string;
+
+  /**
+   * Defaults to `alert(error)`, which will trigger when the user tries to set a `frozenColumn` that is wider than the visible grid viewport width in the browser.
+   * We can't freeze wider than the viewport because the right canvas will never be visible and since the left canvas is never scrollable this would break the UX.
+   * NOTE: the error is **always** logged via `console.error` even when this callback is unset.
+   */
+  invalidColumnFreezeWidthCallback?: (error: string) => void;
 
   /** What is the top panel height in pixels (only type the number) */
   topPanelHeight?: number;

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -859,7 +859,6 @@ export interface GridOption<C extends Column = Column> {
   /**
    * Defaults to `alert(error)`, which will trigger when the user tries to uncheck too many columns via ColumnPicker/GridMenu.
    * We need to have 1 or more columns visible on the right side of the frozen column.
-   * NOTE: the error is **always** logged via `console.error` even when this callback is unset.
    */
   invalidColumnFreezePickerCallback?: (error: string) => void;
 
@@ -869,7 +868,6 @@ export interface GridOption<C extends Column = Column> {
   /**
    * Defaults to `alert(error)`, which will trigger when the user tries to set a `frozenColumn` that is wider than the visible grid viewport width in the browser.
    * We can't freeze wider than the viewport because the right canvas will never be visible and since the left canvas is never scrollable this would break the UX.
-   * NOTE: the error is **always** logged via `console.error` even when this callback is unset.
    */
   invalidColumnFreezeWidthCallback?: (error: string) => void;
 

--- a/packages/common/src/services/__tests__/grid.service.spec.ts
+++ b/packages/common/src/services/__tests__/grid.service.spec.ts
@@ -95,7 +95,7 @@ const gridStub = {
   scrollRowIntoView: vi.fn(),
   updateColumns: vi.fn(),
   updateRow: vi.fn(),
-  validateColumnFreeze: vi.fn(),
+  validateColumnFreezeWidth: vi.fn(),
 } as unknown as SlickGrid;
 
 const paginationServiceStub = {
@@ -1591,7 +1591,7 @@ describe('Grid Service', () => {
       const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
-      vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+      vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
 
       service.setPinning(mockPinning);
 
@@ -1605,7 +1605,7 @@ describe('Grid Service', () => {
       const setOptionsSpy = vi.spyOn(gridStub, 'setOptions');
       const autosizeColumnsSpy = vi.spyOn(gridStub, 'autosizeColumns');
       vi.spyOn(gridStub, 'getColumns').mockReturnValue(columnsMock);
-      vi.spyOn(gridStub, 'validateColumnFreeze').mockReturnValue(true);
+      vi.spyOn(gridStub, 'validateColumnFreezeWidth').mockReturnValue(true);
 
       service.setPinning(mockPinning, false);
 

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -560,6 +560,66 @@ describe('Example 04 - Frozen Grid', () => {
       .each(($child, index) => expect($child.text()).to.eq(withoutTitleRowTitles[index]));
   });
 
+  it('should open Column Picker and try unchecked all the columns on the right of the column pinning and expect an error and abort of the execution', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+    cy.get('[data-test=set-3frozen-columns]').click({ force: true });
+
+    const leftColumns = ['', 'Title', '% Complete'];
+    const rightColumns = ['Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
+    cy.get('.grid4').find('.slick-header-column').first().trigger('mouseover').trigger('contextmenu').invoke('show');
+
+    cy.get('.slick-column-picker')
+      .find('.slick-column-picker-list')
+      .children()
+      .each(($child, index) => {
+        if (index >= leftColumns.length) {
+          if ($child.text() === rightColumns[index - leftColumns.length]) {
+            expect($child.text()).to.eq(rightColumns[index - leftColumns.length]);
+            if (index <= rightColumns.length + 1) {
+              cy.wrap($child).children('label').click();
+            } else {
+              cy.wrap($child)
+                .children('label')
+                .click()
+                .then(() => {
+                  expect(stub.getCall(0)).to.be.calledWith(
+                    '[SlickGrid] Action not allowed and cancelled, you need to have at least 1 or more column on the right section of the frozen column. ' +
+                      'You could alternatively "Unfreeze all the columns" before trying again.'
+                  );
+                });
+            }
+          }
+        }
+      });
+  });
+
+  it('should reset hidden column from the Column Picker and expect all columns to be back', () => {
+    const leftColumns = ['', 'Title', '% Complete'];
+    const rightColumns = ['Start', 'Finish', 'Completed', 'Cost | Duration', 'City of Origin', 'Action'];
+
+    cy.get('.slick-column-picker')
+      .find('.slick-column-picker-list')
+      .children()
+      .each(($child, index) => {
+        if (index >= leftColumns.length) {
+          if ($child.text() === rightColumns[index - leftColumns.length]) {
+            expect($child.text()).to.eq(rightColumns[index - leftColumns.length]);
+            if (index <= rightColumns.length + 1) {
+              cy.wrap($child).children('label').click();
+            }
+          }
+        }
+      });
+
+    cy.get('.slick-column-picker:visible').find('.close').trigger('click').click();
+
+    cy.get('.grid4')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(withoutTitleRowTitles[index]));
+  });
+
   describe('Test UI rendering after Scrolling with large columns', () => {
     it('should unfreeze all columns/rows', () => {
       cy.get('.grid4').find('button.slick-grid-menu-button').click({ force: true });

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -584,7 +584,7 @@ describe('Example 04 - Frozen Grid', () => {
                 .click()
                 .then(() => {
                   expect(stub.getCall(0)).to.be.calledWith(
-                    '[SlickGrid] Action not allowed and cancelled, you need to have at least 1 or more column on the right section of the frozen column. ' +
+                    '[SlickGrid] Action not allowed and aborted, you need to have at least one or more column on the right section of the column freeze/pining. ' +
                       'You could alternatively "Unfreeze all the columns" before trying again.'
                   );
                 });

--- a/test/cypress/e2e/example17.cy.ts
+++ b/test/cypress/e2e/example17.cy.ts
@@ -339,8 +339,7 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
         .then(() => {
           expect(stub.getCall(0)).to.be.calledWith(
             '[SlickGrid] You are trying to freeze/pin more columns than the grid can support. ' +
-              'Make sure to have less columns pinned (on the left) than the actual visible grid width. ' +
-              'Also, please remember that only the columns on the right are scrollable and the pinned columns are not.'
+              'Make sure to have less columns pinned (on the left) than the actual visible grid width.'
           );
 
           // it should still have previous pinning


### PR DESCRIPTION
- if a user tries to hide too many columns on the right side of the column freeze, it would make the UI unusable. So we need to add a validation function to make sure that there's at least 1 or more column on the right side of the column freeze/pinning to avoid UI problems
- the new code will now show an alert of the error when invalid and will abort the action

![brave_n9SkXhf1g3](https://github.com/user-attachments/assets/b5cec909-5bc2-4cb5-9194-fdc0be64cdb5)
