### PR TITLE
feat: Drag-Fill capability and Hybrid SelectionModel plugin

### DIFF
--- a/demos/vanilla/src/app-routing.ts
+++ b/demos/vanilla/src/app-routing.ts
@@ -36,6 +36,8 @@ import Example32 from './examples/example32.js';
 import Example33 from './examples/example33.js';
 import Example34 from './examples/example34.js';
 import Example35 from './examples/example35.js';
+import Example36 from './examples/example36.js';
+import Example37 from './examples/example37.js';
 
 export class AppRouting {
   constructor(private config: RouterConfig) {
@@ -77,6 +79,8 @@ export class AppRouting {
       { route: 'example33', name: 'example33', view: './examples/example33.html', viewModel: Example33, title: 'Example33' },
       { route: 'example34', name: 'example34', view: './examples/example34.html', viewModel: Example34, title: 'Example34' },
       { route: 'example35', name: 'example35', view: './examples/example35.html', viewModel: Example35, title: 'Example35' },
+      { route: 'example36', name: 'example36', view: './examples/example36.html', viewModel: Example36, title: 'Example36' },
+      { route: 'example37', name: 'example37', view: './examples/example37.html', viewModel: Example37, title: 'Example37' },
       { route: '', redirect: 'example01' },
       { route: '**', redirect: 'example01' },
     ];

--- a/demos/vanilla/src/app.html
+++ b/demos/vanilla/src/app.html
@@ -75,6 +75,8 @@
           <a class="navbar-item" onclick.trigger="loadRoute('example33')">Example33 - Colspan/Rowspan (large dataset)</a>
           <a class="navbar-item" onclick.trigger="loadRoute('example34')">Example34 - Infinite Scroll & Row Move/Selection</a>
           <a class="navbar-item" onclick.trigger="loadRoute('example35')">Example35 - Tree Data with Lazy Loading</a>
+          <a class="navbar-item" onclick.trigger="loadRoute('example36')">Example36 - Hybrid Selection Model</a>
+          <a class="navbar-item" onclick.trigger="loadRoute('example37')">Example37 - Spreadsheet Drag-Fill</a>
         </div>
       </div>
     </div>

--- a/demos/vanilla/src/examples/example17.scss
+++ b/demos/vanilla/src/examples/example17.scss
@@ -29,7 +29,7 @@
     font-style: italic;
   }
   .slick-row:not(.slick-group) > .cell-unselectable {
-    background: #ececec !important;
+    background: #f4f4f4 !important;
   }
   .slick-row .slick-cell.frozen:last-child,
   .slick-header-column.frozen:last-child,

--- a/demos/vanilla/src/examples/example36.html
+++ b/demos/vanilla/src/examples/example36.html
@@ -1,0 +1,51 @@
+<style>
+  .blocked-cell {
+    background: darkred !important;
+    color: #999;
+  }
+</style>
+<h3 class="title is-3">
+  Example 36 - Hybrid Selection Model
+  <div class="subtitle code-link">
+    <span class="is-size-6">see</span>
+    <a
+      class="is-size-5"
+      target="_blank"
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vanilla/src/examples/example36.ts"
+    >
+      <span class="mdi mdi-link-variant"></span> code
+    </a>
+  </div>
+</h3>
+
+<h5 class="mb-3 italic example-details">
+  <ul>
+    <li>
+      <code>SlickHybridSelectionModel</code> This Selection Model is an hybrid approach that uses a combination of the row or cell
+      selections depending on certain conditions.
+    </li>
+    <li>
+      1. clicking on the first column (<code>id</code>) will use <code>RowSelectionModel</code> because of our configuration of
+      <code>rowSelectColumnIdArr: ['id']</code> as the columns that will trigger row selection.
+    </li>
+    <li>2. clicking on the any other columns will use <code>CellSelectionModel</code> by default</li>
+  </ul>
+</h5>
+
+<div class="columns">
+  <div class="column field is-narrow">
+    <h5 class="title is-5">Grid 1</h5>
+  </div>
+</div>
+<div class="grid36-1"></div>
+
+<div class="column is-half">
+  <hr class="my-4" />
+</div>
+
+<div class="columns">
+  <div class="column field is-narrow">
+    <h5 class="title is-5">Grid 2</h5>
+  </div>
+</div>
+<div class="grid36-2"></div>

--- a/demos/vanilla/src/examples/example36.scss
+++ b/demos/vanilla/src/examples/example36.scss
@@ -1,0 +1,6 @@
+/** override slick-cell to make it look like Excel sheet */
+.grid36-1 {
+  .slick-row .slick-cell:first-child {
+    border-right: 1px solid #d4d4d4;
+  }
+}

--- a/demos/vanilla/src/examples/example36.ts
+++ b/demos/vanilla/src/examples/example36.ts
@@ -1,0 +1,190 @@
+import {
+  type Column,
+  Editors,
+  Formatters,
+  type GridOption,
+  SlickEventHandler,
+  SlickHybridSelectionModel,
+} from '@slickgrid-universal/common';
+import { ExcelExportService } from '@slickgrid-universal/excel-export';
+import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+
+import { ExampleGridOptions } from './example-grid-options.js';
+import './example36.scss';
+
+const NB_ITEMS = 1000;
+
+export default class Example36 {
+  protected _eventHandler: SlickEventHandler;
+
+  gridOptions1!: GridOption;
+  gridOptions2!: GridOption;
+  columnDefinitions1!: Column[];
+  columnDefinitions2!: Column[];
+  dataset1!: any[];
+  dataset2!: any[];
+  sgb1!: SlickVanillaGridBundle;
+  sgb2!: SlickVanillaGridBundle;
+
+  attached() {
+    this._eventHandler = new SlickEventHandler();
+
+    // define the grid options & columns and then create the grid itself
+    this.defineGrids();
+
+    // mock some data (different in each dataset)
+    this.dataset1 = this.getData(NB_ITEMS);
+    this.dataset2 = this.getData(NB_ITEMS);
+
+    this.sgb1 = new Slicker.GridBundle(
+      document.querySelector('.grid36-1') as HTMLDivElement,
+      this.columnDefinitions1,
+      { ...ExampleGridOptions, ...this.gridOptions1 },
+      this.dataset1
+    );
+    this.sgb2 = new Slicker.GridBundle(
+      document.querySelector('.grid36-2') as HTMLDivElement,
+      this.columnDefinitions2,
+      {
+        ...ExampleGridOptions,
+        ...this.gridOptions2,
+      },
+      this.dataset2
+    );
+
+    document.body.classList.add('material-theme');
+
+    // bind any of the grid events, e.g. onSelectedRangesChanged to show selection range on screen
+    const cellSelectionModel1 = this.sgb1.slickGrid!.getSelectionModel()!;
+    const cellSelectionModel2 = this.sgb2.slickGrid!.getSelectionModel()!;
+    this._eventHandler.subscribe(cellSelectionModel1.onSelectedRangesChanged, (_e, args) => {
+      const targetRange = document.querySelector('#selectionRange') as HTMLSpanElement;
+      targetRange.textContent = '';
+      for (const slickRange of args) {
+        targetRange.textContent += JSON.stringify(slickRange);
+      }
+    });
+    this._eventHandler.subscribe(cellSelectionModel2.onSelectedRangesChanged, (_e, args) => {
+      const targetRange = document.querySelector('#selectionRange') as HTMLSpanElement;
+      targetRange.textContent = '';
+      for (const slickRange of args) {
+        targetRange.textContent += JSON.stringify(slickRange);
+      }
+    });
+
+    this.sgb1.slickGrid?.setSelectionModel(new SlickHybridSelectionModel({ selectActiveRow: true, rowSelectColumnIdArr: ['id'] }));
+    this.sgb2.slickGrid?.setSelectionModel(
+      new SlickHybridSelectionModel({ selectActiveRow: false, rowSelectColumnIdArr: ['id', '_checkbox_selector'] })
+    );
+  }
+
+  dispose() {
+    this._eventHandler.unsubscribeAll();
+    this.sgb1?.dispose();
+    this.sgb2?.dispose();
+    document.body.classList.remove('material-theme');
+  }
+
+  /* Define grid Options and Columns */
+  defineGrids() {
+    this.columnDefinitions1 = [
+      { id: 'id', name: '#', field: 'id', width: 32, maxWidth: 40, excludeFromHeaderMenu: true },
+      { id: 'title', name: 'Title', field: 'title', width: 90, cssClass: 'cell-title', editor: { model: Editors.Text } },
+      { id: 'complete', name: '% Complete', field: 'percentComplete', sortable: true, width: 90 },
+      { id: 'start', name: 'Start', field: 'start', type: 'date', sortable: true, formatter: Formatters.dateUs },
+      { id: 'finish', name: 'Finish', field: 'finish', type: 'date', sortable: true, formatter: Formatters.dateUs },
+      {
+        id: 'priority',
+        name: 'Priority',
+        field: 'priority',
+        width: 80,
+        resizable: false,
+        sortable: true,
+        type: 'number',
+        sortComparer: (x, y, direction) => {
+          return (direction ?? 0) * (x === y ? 0 : x > y ? 1 : -1);
+        },
+        formatter: (_row, _cell, value) => {
+          if (!value) {
+            return '';
+          }
+          const count = +(value >= 3 ? 3 : value);
+          return count === 3 ? 'High' : count === 2 ? 'Medium' : 'Low';
+        },
+      },
+      {
+        id: 'effortDriven',
+        name: 'Effort Driven',
+        field: 'effortDriven',
+        cssClass: 'text-center',
+        width: 95,
+        maxWidth: 120,
+        type: 'boolean',
+        sortable: true,
+        exportCustomFormatter: (_row, _cell, value) => (value ? 'Yes' : 'No'),
+        formatter: Formatters.checkmarkMaterial,
+      },
+    ];
+    this.columnDefinitions2 = [...this.columnDefinitions1];
+
+    this.gridOptions1 = {
+      autoResize: {
+        container: '.demo-container',
+      },
+      gridHeight: 250,
+      gridWidth: 800,
+      enableCellNavigation: true,
+      autoEdit: true,
+      editable: true,
+      headerRowHeight: 35,
+      rowHeight: 40,
+      enableExcelExport: true,
+      excelExportOptions: {
+        exportWithFormatter: true,
+      },
+      externalResources: [new ExcelExportService()],
+
+      // when using the ExcelCopyBuffer, you can see what the selection range is
+      enableExcelCopyBuffer: true,
+      excelCopyBufferOptions: {
+        copyActiveEditorCell: true,
+        removeDoubleQuotesOnPaste: true,
+        replaceNewlinesWith: ' ',
+      },
+    };
+    this.gridOptions2 = {
+      ...this.gridOptions1,
+      // you can also enable checkbox selection & row selection, make sure to use `rowSelectColumnIdArr: ['id', '_checkbox_selector']`
+      enableCheckboxSelector: true,
+      enableRowSelection: true,
+      rowSelectionOptions: {
+        // True (Single Selection), False (Multiple Selections)
+        selectActiveRow: false,
+      },
+    };
+  }
+
+  // mock a dataset
+  getData(itemCount: number) {
+    const data: any[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const randomYear = 2000 + Math.floor(Math.random() * 10);
+      const randomMonth = Math.floor(Math.random() * 11);
+      const randomDay = Math.floor(Math.random() * 29);
+      const randomFinishYear = randomYear + Math.floor(Math.random() * 10);
+      const randomFinish = new Date(randomFinishYear, randomMonth + 1, randomDay);
+
+      data[i] = {
+        id: i,
+        title: 'Task ' + i,
+        duration: Math.floor(Math.random() * 25) + ' days',
+        percentComplete: Math.floor(Math.random() * 100),
+        start: new Date(randomYear, randomMonth, randomDay, randomDay),
+        finish: randomFinish,
+        priority: i % 3 ? 2 : i % 5 ? 3 : 1,
+        effortDriven: i % 4 === 0,
+      };
+    }
+    return data;
+  }
+}

--- a/demos/vanilla/src/examples/example37.html
+++ b/demos/vanilla/src/examples/example37.html
@@ -1,0 +1,44 @@
+<style>
+  .blocked-cell {
+    background: darkred !important;
+    color: #999;
+  }
+</style>
+<h3 class="title is-3">
+  Example 37 - Spreadsheet Drag-Fill
+  <div class="subtitle code-link">
+    <span class="is-size-6">see</span>
+    <a
+      class="is-size-5"
+      target="_blank"
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vanilla/src/examples/example37.ts"
+    >
+      <span class="mdi mdi-link-variant"></span> code
+    </a>
+  </div>
+</h3>
+
+<h5 class="mb-3 italic example-details">
+  Spreadsheet with drag-fill, hybrid selection model and context menu
+  <ul>
+    <li>Select a range of cells with a mouse</li>
+    <li>
+      Drag from the handle at the bottom right of the selected range to fill the dragged-over area with the values from the selected range.
+      Drag-fill can be done in any direction
+    </li>
+    <li>
+      Drag-fill selection border (css) is different to regular selection (uses <code>copyToSelectionCss</code> from CellRangeDecorator
+      rather than the usual <code>selectionCss</code>)
+    </li>
+    <li>
+      By default uses <code>Slick.SelectionUtils.defaultCopyDraggedCellRange</code> to copy dragged cells by subscribing to
+      <code>onDragReplaceCells</code>. Use this event to customise behaviour. The default function is ideal as a starting example.
+    </li>
+    <li>
+      Also uses hybrid selection model plugin to select a row if the left hand cell (containing row index) is selected, or select a cell
+      otherwise.
+    </li>
+  </ul>
+</h5>
+
+<div class="grid37"></div>

--- a/demos/vanilla/src/examples/example37.scss
+++ b/demos/vanilla/src/examples/example37.scss
@@ -1,5 +1,5 @@
 /** override slick-cell to make it look like Excel sheet */
-.grid19 {
+.grid37 {
   --slick-border-color: #d4d4d4;
   --slick-cell-odd-background-color: #fbfbfb;
   --slick-cell-border-left: 1px solid var(--slick-border-color);
@@ -11,4 +11,10 @@
   --slick-text-editor-border: 0px;
   --slick-text-editor-background: white;
   --slick-text-editor-focus-box-shadow: none;
+
+  .slick-cell.copied {
+    background: blue;
+    background: rgba(0, 0, 255, 0.2);
+    transition: 0.5s background;
+  }
 }

--- a/demos/vanilla/src/examples/example37.ts
+++ b/demos/vanilla/src/examples/example37.ts
@@ -1,0 +1,129 @@
+import {
+  type Column,
+  Editors,
+  type GridOption,
+  // Handler,
+  // OnDragReplaceCellsEventArgs,
+  SlickEventHandler,
+  SlickHybridSelectionModel,
+  SlickSelectionUtils,
+} from '@slickgrid-universal/common';
+import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+
+import { ExampleGridOptions } from './example-grid-options.js';
+import './example37.scss';
+
+const NB_ITEMS = 100;
+
+export default class Example37 {
+  protected _eventHandler: SlickEventHandler;
+
+  columnDefinitions: Column[] = [];
+  dataset: any[] = [];
+  gridOptions!: GridOption;
+  gridContainerElm: HTMLDivElement;
+  sgb: SlickVanillaGridBundle;
+
+  attached() {
+    this._eventHandler = new SlickEventHandler();
+
+    // define the grid options & columns and then create the grid itself
+    this.defineGrid();
+
+    // mock some data (different in each dataset)
+    this.dataset = this.getData(NB_ITEMS);
+    this.gridContainerElm = document.querySelector<HTMLDivElement>('.grid37') as HTMLDivElement;
+    this.sgb = new Slicker.GridBundle(
+      document.querySelector('.grid37') as HTMLDivElement,
+      this.columnDefinitions,
+      { ...ExampleGridOptions, ...this.gridOptions },
+      this.dataset
+    );
+    document.body.classList.add('salesforce-theme');
+
+    const cellSelectionModel = new SlickHybridSelectionModel({ selectActiveRow: true, rowSelectColumnIdArr: ['selector'] });
+    this.sgb.slickGrid?.setSelectionModel(cellSelectionModel);
+
+    this.sgb.slickGrid?.onAddNewRow.subscribe((_e, args) => {
+      const item = args.item;
+      this.sgb.slickGrid?.invalidateRow(this.dataset.length);
+      this.dataset.push(item);
+      this.sgb.slickGrid?.updateRowCount();
+      this.sgb.slickGrid?.render();
+    });
+    this.sgb.slickGrid?.onDragReplaceCells.subscribe(SlickSelectionUtils.defaultCopyDraggedCellRange);
+  }
+
+  dispose() {
+    this._eventHandler.unsubscribeAll();
+    this.sgb?.dispose();
+    this.gridContainerElm.remove();
+    document.body.classList.remove('salesforce-theme');
+  }
+
+  /* Define grid Options and Columns */
+  defineGrid() {
+    this.columnDefinitions = [
+      {
+        id: 'selector',
+        name: '',
+        field: 'num',
+        width: 30,
+      },
+    ];
+
+    for (let i = 0; i < NB_ITEMS; i++) {
+      this.columnDefinitions.push({
+        id: i,
+        name:
+          i < 26
+            ? String.fromCharCode('A'.charCodeAt(0) + (i % 26))
+            : String.fromCharCode('A'.charCodeAt(0) + Math.floor(i / 26) - 1) + String.fromCharCode('A'.charCodeAt(0) + (i % 26)),
+        field: String(i),
+        minWidth: 60,
+        width: 60,
+        editor: { model: Editors.text },
+      });
+    }
+
+    this.gridOptions = {
+      autoResize: {
+        container: '.demo-container',
+      },
+      enableCellNavigation: true,
+      autoEdit: true,
+      autoCommitEdit: true,
+      editable: true,
+      headerRowHeight: 35,
+      rowHeight: 30,
+      editorNavigateOnArrows: true, // enable editor navigation using arrow keys
+
+      // when using the ExcelCopyBuffer, you can see what the selection range is
+      enableExcelCopyBuffer: true,
+      excelCopyBufferOptions: {
+        //   onCopyCells: (e, args: { ranges: SelectedRange[] }) => console.log('onCopyCells', args.ranges),
+        //   onPasteCells: (e, args: { ranges: SelectedRange[] }) => console.log('onPasteCells', args.ranges),
+        //   onCopyCancelled: (e, args: { ranges: SelectedRange[] }) => console.log('onCopyCancelled', args.ranges),
+        onBeforePasteCell: (_e, args) => {
+          // deny the whole first row and the cells C-E of the second row
+          return !(args.row === 0 || (args.row === 1 && args.cell > 2 && args.cell < 6));
+        },
+        copyActiveEditorCell: true,
+        removeDoubleQuotesOnPaste: true,
+        replaceNewlinesWith: ' ',
+      },
+    };
+  }
+
+  getData(itemCount: number) {
+    // mock a dataset
+    const datasetTmp: any[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const d: any = (datasetTmp[i] = {});
+      d['id'] = i;
+      d['num'] = i;
+    }
+
+    return datasetTmp;
+  }
+}

--- a/demos/vanilla/src/material-styles.scss
+++ b/demos/vanilla/src/material-styles.scss
@@ -15,6 +15,7 @@
     --slick-header-menu-display: inline-block;
     --slick-compound-filter-operator-select-border: 1px solid #00c840;
     --slick-row-mouse-hover-color: #ebfaef;
+    --slick-cell-selected-color: #d4f6d7;
     --slick-row-selected-color: #d4f6d7;
     --slick-row-mouse-hover-box-shadow: none;
     --slick-cell-odd-background-color: #f5f5f5;
@@ -175,7 +176,8 @@
       --slick-pagination-icon-color: #66bb6a;
       --slick-row-mouse-hover-box-shadow: none;
       --slick-row-mouse-hover-color: #505050;
-      --slick-row-selected-color: #474747;
+      --slick-cell-selected-color: #474a45;
+      --slick-row-selected-color: #474a45;
       --slick-menu-color: #ededed;
       --slick-menu-bg-color: #212121;
       --slick-menu-border: 1px solid #505050;

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -111,6 +111,7 @@ describe('Draggable class', () => {
       deltaY: 0,
       dragHandle: containerElement,
       dragSource: containerElement,
+      matchClassTag: '',
       target: window,
     });
     expect(dragStartSpy).toHaveBeenCalled(); // TODO: revisit calledWith X/Y pos, after migrating to TS class
@@ -233,7 +234,7 @@ describe('MouseWheel class', () => {
 
 describe('Resizable class', () => {
   let rsz: any;
-  let containerElement;
+  let containerElement: HTMLElement;
 
   beforeEach(() => {
     containerElement = document.createElement('div');

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -6,7 +6,8 @@
  * @namespace Slick
  */
 import type { MergeTypes } from '../enums/index.js';
-import type { CSSStyleDeclarationWritable, EditController } from '../interfaces/index.js';
+import type { CSSStyleDeclarationWritable, DragRange, EditController, OnDragReplaceCellsEventArgs } from '../interfaces/index.js';
+import type { SlickGrid } from './slickGrid.js';
 
 export type Handler<ArgType = any> = (e: SlickEventData<ArgType>, args: ArgType) => void;
 
@@ -374,6 +375,24 @@ export class SlickRange {
   }
 
   /**
+   * Row Count.
+   * @method rowCount
+   * @return {Number}
+   */
+  rowCount(): number {
+    return this.toRow - this.fromRow + 1;
+  }
+
+  /**
+   * Cell Count.
+   * @method cellCount
+   * @return {Number}
+   */
+  cellCount(): number {
+    return this.toCell - this.fromCell + 1;
+  }
+
+  /**
    * Returns a readable representation of a range.
    * @method toString
    * @return {String}
@@ -383,6 +402,57 @@ export class SlickRange {
       return `(${this.fromRow}:${this.fromCell})`;
     } else {
       return `(${this.fromRow}:${this.fromCell} - ${this.toRow}:${this.toCell})`;
+    }
+  }
+}
+
+/**
+ * A structure containing a range of cells to copy to.
+ * @class SlickCopyRange
+ * @constructor
+ * @param {Integer} fromRow Starting row.
+ * @param {Integer} fromCell Starting cell.
+ * @param {Integer} rowCount Row Count.
+ * @param {Integer} cellCount Cell Count.
+ */
+export class SlickCopyRange {
+  fromRow: number;
+  fromCell: number;
+  rowCount: number;
+  cellCount: number;
+
+  constructor(fromRow: number, fromCell: number, rowCount: number, cellCount: number) {
+    this.fromRow = fromRow;
+    this.fromCell = fromCell;
+    this.rowCount = rowCount;
+    this.cellCount = cellCount;
+  }
+}
+
+/**
+ * Create a handle element for Excel style drag-replace
+ * @class DragExtendHandle
+ * @constructor
+ * @param gridUid {String} string UID of parent grid
+ */
+export class SlickDragExtendHandle {
+  id: string;
+  cssClass = 'slick-drag-replace-handle';
+
+  constructor(gridUid: string) {
+    this.id = gridUid + '_drag_replace_handle';
+  }
+
+  removeEl(): void {
+    document.getElementById(this.id)?.remove();
+  }
+
+  createEl(activeCellNode: HTMLDivElement | null): void {
+    if (activeCellNode) {
+      const dragReplaceEl = document.createElement('div');
+      dragReplaceEl.className = 'slick-drag-replace-handle';
+      dragReplaceEl.setAttribute('id', this.id);
+      activeCellNode.appendChild(dragReplaceEl);
     }
   }
 }
@@ -740,6 +810,150 @@ export class Utils {
         if (scope[prop] instanceof SlickEvent && typeof (scope[prop] as SlickEvent).setPubSubService === 'function') {
           (scope[prop] as SlickEvent).setPubSubService(pubSub);
         }
+      }
+    }
+  }
+}
+
+export class SlickSelectionUtils {
+  //   |---0----|---1----|---2----|---3----|---4----|---5----|
+  // 0 |        |        |        |     ^  |        |        |
+  //   |--------|--------|--------|--------|--------|--------|
+  // 1 |        |        |        |        |        |        |
+  //   |--------|--------|--------|--------|--------|--------|
+  // 2 |        |        |   1    |   2    |    > h |        |
+  //   |--------|--------|--------|--------|--------|--------|
+  // 3 |   <    |        |   4    |   5   x|    > h |    >   |
+  //   |--------|--------|--------|--------|--------|--------|
+  // 4 |        |        |    > v |    > v |    > v |        |
+  //   |--------|--------|--------|--------|--------|--------|
+  // 5 |        |        |        |    v   |        |        |
+  //   |--------|--------|--------|--------|--------|--------|
+  //
+  // original range (1,2,4,5) expanded one cell to right and down
+  //  '> h' indicates horizontal target copy area
+  //  '> v' indicates vertical target copy area
+  // note bottom right (corner) cell is considered part of vertical copy area
+
+  public static normaliseDragRange(rawRange: DragRange): DragRange {
+    // depending how the range is created (drag up/down) the start row/cell may be
+    // greater or less thatn the end row/cell. Create a guaranteed left/down
+    // progressive range (ie. start row/cell < end row/cell)
+
+    const rtn: DragRange = {
+      start: {
+        row: (rawRange.end.row ?? 0) > (rawRange.start.row ?? 0) ? rawRange.start.row : rawRange.end.row,
+        cell: (rawRange.end.cell ?? 0) > (rawRange.start.cell ?? 0) ? rawRange.start.cell : rawRange.end.cell,
+      },
+      end: {
+        row: (rawRange.end.row ?? 0) > (rawRange.start.row ?? 0) ? rawRange.end.row : rawRange.start.row,
+        cell: (rawRange.end.cell ?? 0) > (rawRange.start.cell ?? 0) ? rawRange.end.cell : rawRange.start.cell,
+      },
+    };
+    rtn.rowCount = (rtn.end.row ?? 0) - (rtn.start.row ?? 0) + 1;
+    rtn.cellCount = (rtn.end.cell ?? 0) - (rtn.start.cell ?? 0) + 1;
+
+    rtn.wasDraggedUp = (rawRange.end.row ?? 0) < (rawRange.start.row ?? 0);
+    rtn.wasDraggedLeft = (rawRange.end.row ?? 0) < (rawRange.start.row ?? 0);
+
+    return rtn;
+  }
+
+  public static copyRangeIsLarger(baseRange: SlickRange, copyToRange: SlickRange): boolean {
+    return (
+      copyToRange.fromRow < baseRange.fromRow ||
+      copyToRange.fromCell < baseRange.fromCell ||
+      copyToRange.toRow > baseRange.toRow ||
+      copyToRange.toCell > baseRange.toCell
+    );
+  }
+
+  public static normalRangeOppositeCellFromCopy(
+    normalisedDragRange: DragRange,
+    targetCell: { row: number; cell: number }
+  ): { row: number; cell: number } {
+    const row = targetCell.row < (normalisedDragRange.end.row || 0) ? normalisedDragRange.end.row || 0 : normalisedDragRange.start.row || 0;
+    const cell =
+      targetCell.cell < (normalisedDragRange.end.cell || 0) ? normalisedDragRange.end.cell || 0 : normalisedDragRange.start.cell || 0;
+    return { row: row, cell: cell };
+  }
+
+  // copy to range above or below - includes corner space target range
+  public static verticalTargetRange(baseRange: SlickRange, copyToRange: SlickRange): SlickRange | null {
+    const copyUp = copyToRange.fromRow < baseRange.fromRow;
+    const copyDown = copyToRange.toRow > baseRange.toRow;
+    if (!copyUp && !copyDown) {
+      return null;
+    }
+    let rtn;
+    if (copyUp) {
+      rtn = new SlickRange(copyToRange.fromRow, copyToRange.fromCell, baseRange.fromRow - 1, copyToRange.toCell);
+    } else {
+      rtn = new SlickRange(baseRange.toRow + 1, copyToRange.fromCell, copyToRange.toRow, copyToRange.toCell);
+    }
+    return rtn;
+  }
+
+  // copy to range left or right - excludes corner space target range
+  public static horizontalTargetRange(baseRange: SlickRange, copyToRange: SlickRange): SlickRange | null {
+    const copyLeft = copyToRange.fromCell < baseRange.fromCell;
+    const copyRight = copyToRange.toCell > baseRange.toCell;
+    if (!copyLeft && !copyRight) {
+      return null;
+    }
+    let rtn;
+    if (copyLeft) {
+      rtn = new SlickRange(baseRange.fromRow, copyToRange.fromCell, baseRange.toRow, baseRange.fromCell - 1);
+    } else {
+      rtn = new SlickRange(baseRange.fromRow, baseRange.toCell + 1, baseRange.toRow, copyToRange.toCell);
+    }
+    return rtn;
+  }
+
+  public static defaultCopyDraggedCellRange(_e: SlickEventData<any>, args: OnDragReplaceCellsEventArgs): void {
+    const verticalTargetRange = SlickSelectionUtils.verticalTargetRange(args.prevSelectedRange, args.selectedRange);
+    const horizontalTargetRange = SlickSelectionUtils.horizontalTargetRange(args.prevSelectedRange, args.selectedRange);
+
+    if (verticalTargetRange) {
+      SlickSelectionUtils.copyCellsToTargetRange(args.prevSelectedRange, verticalTargetRange, args.grid);
+    }
+    if (horizontalTargetRange) {
+      SlickSelectionUtils.copyCellsToTargetRange(args.prevSelectedRange, horizontalTargetRange, args.grid);
+    }
+  }
+
+  public static copyCellsToTargetRange(baseRange: SlickRange, targetRange: SlickRange, grid: SlickGrid): void {
+    let fromRowOffset = 0,
+      fromCellOffset = 0;
+    const columns = grid.getVisibleColumns();
+    const options = grid.getOptions();
+
+    for (let i = 0; i < targetRange.rowCount(); i++) {
+      const toRow = grid.getDataItem(targetRange.fromRow + i);
+      const fromRow = grid.getDataItem(baseRange.fromRow + fromRowOffset);
+      fromCellOffset = 0;
+
+      for (let j = 0; j < targetRange.cellCount(); j++) {
+        const toColDef = columns[targetRange.fromCell + j];
+        const fromColDef = columns[baseRange.fromCell + fromCellOffset];
+
+        if (!toColDef.hidden && !fromColDef.hidden) {
+          let val = fromRow[fromColDef.field];
+          if (options.dataItemColumnValueExtractor) {
+            val = options.dataItemColumnValueExtractor(fromRow, fromColDef);
+          }
+          toRow[toColDef.field] = val;
+        }
+
+        fromCellOffset++;
+        if (fromCellOffset >= baseRange.cellCount()) {
+          fromCellOffset = 0;
+        }
+      }
+
+      fromRowOffset++;
+      if (fromRowOffset >= baseRange.rowCount()) {
+        fromRowOffset = 0;
       }
     }
   }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -19,11 +19,13 @@ import type { TrustedHTML } from 'trusted-types/lib';
 import {
   type BasePubSub,
   preClickClassName,
+  SlickDragExtendHandle,
   type SlickEditorLock,
   SlickGlobalEditorLock,
   SlickEvent,
   SlickEventData,
   SlickRange,
+  SlickSelectionUtils,
   Utils,
 } from './slickCore.js';
 import { Draggable, MouseWheel, Resizable } from './slickInteractions.js';
@@ -75,6 +77,7 @@ import type {
   OnColumnsResizeDblClickEventArgs,
   OnCompositeEditorChangeEventArgs,
   OnDblClickEventArgs,
+  OnDragReplaceCellsEventArgs,
   OnFooterRowCellRenderedEventArgs,
   OnFooterContextMenuEventArgs,
   OnHeaderCellRenderedEventArgs,
@@ -99,6 +102,7 @@ import type {
 import type { SlickDataView } from './slickDataview.js';
 import { copyCellToClipboard } from '../formatters/formatterUtilities.js';
 import { applyHtmlToElement, runOptionalHtmlSanitizer } from './utils.js';
+import type { CellSelectionMode } from '../extensions/slickCellSelectionModel.js';
 
 /**
  * @license
@@ -191,6 +195,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   onSort: SlickEvent<SingleColumnSort | MultiColumnSort>;
   onValidationError: SlickEvent<OnValidationErrorEventArgs>;
   onViewportChanged: SlickEvent<{ grid: SlickGrid }>;
+  onDragReplaceCells: SlickEvent<OnDragReplaceCellsEventArgs>;
 
   // ---
   // protected variables
@@ -325,6 +330,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected initialized = false;
   protected _container!: HTMLElement;
   protected uid = `slickgrid_${Math.round(1000000 * Math.random())}`;
+  protected dragReplaceEl: SlickDragExtendHandle = new SlickDragExtendHandle(this.uid);
   protected _focusSink!: HTMLDivElement;
   protected _focusSink2!: HTMLDivElement;
   protected _groupHeaders: HTMLDivElement[] = [];
@@ -408,9 +414,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected lastRenderedScrollLeft = 0;
   protected prevScrollLeft = 0;
   protected scrollLeft = 0;
+  protected selectionBottomRow!: number;
+  protected selectionRightCell!: number;
 
   protected selectionModel?: SelectionModel;
   protected selectedRows: number[] = [];
+  protected selectedRanges: SlickRange[] = [];
 
   protected plugins: SlickPlugin[] = [];
   protected cellCssClasses: CssStyleHash = {};
@@ -581,6 +590,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.onSort = new SlickEvent<SingleColumnSort | MultiColumnSort>('onSort', externalPubSub);
     this.onValidationError = new SlickEvent<OnValidationErrorEventArgs>('onValidationError', externalPubSub);
     this.onViewportChanged = new SlickEvent<{ grid: SlickGrid }>('onViewportChanged', externalPubSub);
+    this.onDragReplaceCells = new SlickEvent<OnDragReplaceCellsEventArgs>('onDragReplaceCells', externalPubSub);
 
     this.initialize(options);
   }
@@ -1065,7 +1075,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (Draggable) {
         this.slickDraggableInstance = Draggable({
           containerElement: this._container,
-          allowDragFrom: 'div.slick-cell',
+          allowDragFrom: 'div.slick-cell, div.' + this.dragReplaceEl.cssClass,
+          dragFromClassDetectArr: [{ tag: 'dragReplaceHandle', id: this.dragReplaceEl.id }],
           // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
           allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
           preventDragFromKeys: this._options.preventDragFromKeys,
@@ -3183,7 +3194,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected handleSelectedRangesChanged(e: SlickEventData, ranges: SlickRange[]): void {
     const ne = e.getNativeEvent<CustomEvent>();
+    const selectionMode: CellSelectionMode = ne?.detail?.selectionMode ?? '';
+    const addDragHandle = !!ne?.detail?.addDragHandle;
+
+    // drag and replace functionality
+    const prevSelectedRanges = this.selectedRanges.slice(0);
+    this.selectedRanges = ranges;
+
+    if (selectionMode === 'REP' && prevSelectedRanges?.length === 1 && this.selectedRanges?.length === 1) {
+      const prevSelectedRange = prevSelectedRanges[0];
+      const selectedRange = this.selectedRanges[0];
+
+      // check range has expanded
+      if (SlickSelectionUtils.copyRangeIsLarger(prevSelectedRange, selectedRange)) {
+        this.triggerEvent(this.onDragReplaceCells, { prevSelectedRange, selectedRange });
+        this.invalidate();
+      }
+    }
+
     const previousSelectedRows = this.selectedRows.slice(0); // shallow copy previously selected rows for later comparison
+    this.selectionBottomRow = -1;
+    this.selectionRightCell = -1;
+    this.dragReplaceEl.removeEl();
     this.selectedRows = [];
     const hash: CssStyleHash = {};
     for (let i = 0; i < ranges.length; i++) {
@@ -3199,9 +3231,20 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           }
         }
       }
+      if (this.selectionBottomRow < ranges[i].toRow) {
+        this.selectionBottomRow = ranges[i].toRow;
+      }
+      if (this.selectionRightCell < ranges[i].toCell) {
+        this.selectionRightCell = ranges[i].toCell;
+      }
     }
 
     this.setCellCssStyles(this._options.selectedCellCssClass || '', hash);
+
+    if (this.selectionBottomRow >= 0 && this.selectionRightCell >= 0 && addDragHandle) {
+      const lowerRightCell = this.getCellNode(this.selectionBottomRow, this.selectionRightCell);
+      this.dragReplaceEl.createEl(lowerRightCell);
+    }
 
     // check if the selected rows have changed (index order isn't important, so we'll sort them both before comparing them)
     if (!this.arrayEquals(previousSelectedRows.sort(), this.selectedRows.sort())) {
@@ -3860,6 +3903,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         ? formatterResult
         : (formatterResult as FormatterResultWithHtml).html || (formatterResult as FormatterResultWithText).text;
       applyHtmlToElement(cellDiv, cellResult as string | HTMLElement, this._options);
+
+      // add drag-to-replace handle
+      if (row === this.selectionBottomRow && cell === this.selectionRightCell && this._options.showCellSelection) {
+        this.dragReplaceEl.createEl(cellDiv);
+      }
     }
     divRow.appendChild(cellDiv);
 
@@ -5550,6 +5598,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return false;
     }
 
+    if (this.currentEditor && !this.getEditorLock().commitCurrentEdit()) {
+      return false;
+    }
+
     const retval = this.triggerEvent(this.onDragStart, dd, e);
     if (retval.isImmediatePropagationStopped()) {
       return retval.getReturnValue();
@@ -7162,7 +7214,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (self.currentEditor) {
       if (self.currentEditor.isValueChanged()) {
-        const validationResults = self.currentEditor.validate();
+        const validationResults = self.currentEditor.validate(undefined, {
+          rowIndex: self.activeRow,
+          cellIndex: self.activeCell,
+        });
 
         if (validationResults.valid) {
           const row = self.activeRow;

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -1,6 +1,13 @@
 import { windowScrollPosition } from '@slickgrid-universal/utils';
 
-import type { DragItem, DragPosition, DraggableOption, MouseWheelOption, ResizableOption } from '../interfaces/index.js';
+import type {
+  ClassDetectElement,
+  DragItem,
+  DragPosition,
+  DraggableOption,
+  MouseWheelOption,
+  ResizableOption,
+} from '../interfaces/index.js';
 
 /***
  * Interactions, add basic behaviors to any element.
@@ -16,6 +23,8 @@ import type { DragItem, DragPosition, DraggableOption, MouseWheelOption, Resizab
  *   https://betterprogramming.pub/perfecting-drag-and-drop-in-pure-vanilla-javascript-a761184b797a
  * available optional options:
  *   - containerElement: container DOM element, defaults to "document"
+ *   - dragFromClassDetectArr: array of tags and query selectors/ids to match on dragstart, used to determine
+ *     drag source element. eg:  [ { tag: 'B', id: 'myElement' }, { tag: 'A', cssSelector: 'div.myClass' } ]
  *   - allowDragFrom: when defined, only allow dragging from an element that matches a specific query selector
  *   - allowDragFromClosest: when defined, only allow dragging from an element or its parent matching a specific .closest() query selector
  *   - onDragInit: drag initialized callback
@@ -37,6 +46,7 @@ export function Draggable(options: DraggableOption): {
   let deltaX: number;
   let deltaY: number;
   let dragStarted: boolean;
+  let matchClassTag: string;
 
   if (!containerElement) {
     containerElement = document.body;
@@ -96,12 +106,24 @@ export function Draggable(options: DraggableOption): {
         (options.allowDragFromClosest && element.closest(options.allowDragFromClosest))
       ) {
         originaldd.dragHandle = element as HTMLElement;
+        matchClassTag = '';
+        if (options.dragFromClassDetectArr) {
+          for (let o: ClassDetectElement, i = 0; i < options.dragFromClassDetectArr.length; i++) {
+            o = options.dragFromClassDetectArr[i];
+
+            if ((o.id && element.id === o.id) || (o.cssSelector && element.matches(o.cssSelector))) {
+              matchClassTag = o.tag;
+              break;
+            }
+          }
+        }
+
         const winScrollPos = windowScrollPosition();
         startX = winScrollPos.left + targetEvent.clientX;
         startY = winScrollPos.top + targetEvent.clientY;
         deltaX = targetEvent.clientX - targetEvent.clientX;
         deltaY = targetEvent.clientY - targetEvent.clientY;
-        originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
+        originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target, matchClassTag });
         const result = executeDragCallbackWhenDefined(
           onDragInit as (e: DragEvent, dd: DragPosition) => boolean | void,
           event,
@@ -128,12 +150,12 @@ export function Draggable(options: DraggableOption): {
       const { target } = targetEvent;
 
       if (!dragStarted) {
-        originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
+        originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target, matchClassTag });
         executeDragCallbackWhenDefined(onDragStart, event, originaldd as DragItem);
         dragStarted = true;
       }
 
-      originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target });
+      originaldd = Object.assign(originaldd, { deltaX, deltaY, startX, startY, target, matchClassTag });
       executeDragCallbackWhenDefined(onDrag, event, originaldd as DragItem);
     }
   }

--- a/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/autocompleterEditor.spec.ts
@@ -38,7 +38,7 @@ const gridStub = {
   render: vi.fn(),
   onBeforeEditCell: new SlickEvent(),
   onCompositeEditorChange: new SlickEvent(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 describe('AutocompleterEditor', () => {
@@ -342,7 +342,7 @@ describe('AutocompleterEditor', () => {
 
       it('should return item data with an empty string in its value when calling "applyValue" which fails the custom validation', () => {
         mockColumn.editor!.validator = (value: any) => {
-          if (value.label.length < 10) {
+          if (value.length < 10) {
             return { valid: false, msg: 'Must be at least 10 chars long.' };
           }
           return { valid: true, msg: '' };
@@ -506,7 +506,7 @@ describe('AutocompleterEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, '');
+        const validation = editor.validate(null, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -514,7 +514,7 @@ describe('AutocompleterEditor', () => {
       it('should return True when field is required and input is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -522,7 +522,7 @@ describe('AutocompleterEditor', () => {
       it('should return False when field is lower than a minLength defined', () => {
         mockColumn.editor!.minLength = 5;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
       });
@@ -531,7 +531,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.minLength = 5;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
       });
@@ -539,7 +539,7 @@ describe('AutocompleterEditor', () => {
       it('should return True when field is equal to the minLength defined', () => {
         mockColumn.editor!.minLength = 4;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -547,7 +547,7 @@ describe('AutocompleterEditor', () => {
       it('should return False when field is greater than a maxLength defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
@@ -556,7 +556,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.maxLength = 10;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
       });
@@ -564,7 +564,7 @@ describe('AutocompleterEditor', () => {
       it('should return True when field is equal to the maxLength defined', () => {
         mockColumn.editor!.maxLength = 16;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -573,7 +573,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -582,7 +582,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
       });
@@ -591,7 +591,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 10;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
       });
@@ -600,7 +600,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 16;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -610,7 +610,7 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.maxLength = 15;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -620,8 +620,8 @@ describe('AutocompleterEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new AutocompleterEditor(editorArguments);
-        const validation1 = editor.validate(null, 'text is 16 chars');
-        const validation2 = editor.validate(null, 'text');
+        const validation1 = editor.validate(null, { inputValue: 'text is 16 chars' });
+        const validation2 = editor.validate(null, { inputValue: 'text' });
 
         expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
         expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
@@ -630,7 +630,7 @@ describe('AutocompleterEditor', () => {
       it('should return False when field is greater than a maxValue defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new AutocompleterEditor(editorArguments);
-        const validation = editor.validate(null, 'Task is longer than 10 chars');
+        const validation = editor.validate(null, { inputValue: 'Task is longer than 10 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });

--- a/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/checkboxEditor.spec.ts
@@ -364,9 +364,9 @@ describe('CheckboxEditor', () => {
         const expectation = { valid: false, msg: 'Field is required' };
         mockColumn.editor!.required = true;
         editor = new CheckboxEditor(editorArguments);
-        const validation1 = editor.validate(null, '');
-        const validation2 = editor.validate(null, null);
-        const validation3 = editor.validate(null, false);
+        const validation1 = editor.validate(null, { inputValue: '' });
+        const validation2 = editor.validate(null, { inputValue: null });
+        const validation3 = editor.validate(null, { inputValue: false });
 
         expect(validation1).toEqual(expectation);
         expect(validation2).toEqual(expectation);
@@ -376,7 +376,7 @@ describe('CheckboxEditor', () => {
       it('should return True when field is required and input is provided with True', () => {
         mockColumn.editor!.required = true;
         editor = new CheckboxEditor(editorArguments);
-        const validation = editor.validate(null, true);
+        const validation = editor.validate(null, { inputValue: true });
 
         expect(validation).toEqual({ valid: true, msg: null });
       });
@@ -384,7 +384,7 @@ describe('CheckboxEditor', () => {
       it('should return True when field is required and input is provided with any text', () => {
         mockColumn.editor!.required = true;
         editor = new CheckboxEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: null });
       });

--- a/packages/common/src/editors/__tests__/dateEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dateEditor.spec.ts
@@ -35,7 +35,7 @@ const gridStub = {
   render: vi.fn(),
   onBeforeEditCell: new SlickEvent(),
   onCompositeEditorChange: new SlickEvent(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 const gridId = 'grid1';
@@ -735,7 +735,7 @@ describe('DateEditor', () => {
         mockColumn.editor!.required = true;
         editor = new DateEditor(editorArguments);
         vi.runAllTimers();
-        const validation = editor.validate(null, '');
+        const validation = editor.validate(null, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -744,7 +744,7 @@ describe('DateEditor', () => {
         mockColumn.editor!.required = true;
         editor = new DateEditor(editorArguments);
         vi.runAllTimers();
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: null });
       });

--- a/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/dualInputEditor.spec.ts
@@ -73,7 +73,7 @@ describe('DualInputEditor', () => {
       new Promise((done: any) => {
         try {
           editor = new DualInputEditor({ grid: gridStub } as any);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.toString()).toContain(
             `[Slickgrid-Universal] Please make sure that your Combo Input Editor has params defined with "leftInput" and "rightInput"`
           );

--- a/packages/common/src/editors/__tests__/floatEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/floatEditor.spec.ts
@@ -446,7 +446,7 @@ describe('FloatEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, '');
+        const validation = editor.validate(null, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -454,7 +454,7 @@ describe('FloatEditor', () => {
       it('should return False when field is not a valid float number', () => {
         mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 'abc');
+        const validation = editor.validate(null, { inputValue: 'abc' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number' });
       });
@@ -462,7 +462,7 @@ describe('FloatEditor', () => {
       it('should return False when field is lower than a minValue defined', () => {
         mockColumn.editor!.minValue = 10.2;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10);
+        const validation = editor.validate(null, { inputValue: 10 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number that is greater than or equal to 10.2' });
       });
@@ -471,7 +471,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.minValue = 10.2;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10);
+        const validation = editor.validate(null, { inputValue: 10 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number that is greater than 10.2' });
       });
@@ -479,7 +479,7 @@ describe('FloatEditor', () => {
       it('should return True when field is equal to the minValue defined', () => {
         mockColumn.editor!.minValue = 10.2;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.2);
+        const validation = editor.validate(null, { inputValue: 10.2 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -487,7 +487,7 @@ describe('FloatEditor', () => {
       it('should return False when field is greater than a maxValue defined', () => {
         mockColumn.editor!.maxValue = 10.2;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.22);
+        const validation = editor.validate(null, { inputValue: 10.22 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number that is lower than or equal to 10.2' });
       });
@@ -496,7 +496,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.maxValue = 10.2;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.22);
+        const validation = editor.validate(null, { inputValue: 10.22 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number that is lower than 10.2' });
       });
@@ -504,7 +504,7 @@ describe('FloatEditor', () => {
       it('should return True when field is equal to the maxValue defined', () => {
         mockColumn.editor!.maxValue = 10.2;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.2);
+        const validation = editor.validate(null, { inputValue: 10.2 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -513,7 +513,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.maxValue = 10.2;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.2);
+        const validation = editor.validate(null, { inputValue: 10.2 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -522,7 +522,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.maxValue = 10.2;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.2);
+        const validation = editor.validate(null, { inputValue: 10.2 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number that is lower than 10.2' });
       });
@@ -531,7 +531,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.minValue = 10.5;
         mockColumn.editor!.maxValue = 99.5;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 99.6);
+        const validation = editor.validate(null, { inputValue: 99.6 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number between 10.5 and 99.5' });
       });
@@ -540,7 +540,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.minValue = 10.5;
         mockColumn.editor!.maxValue = 99.5;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 99.5);
+        const validation = editor.validate(null, { inputValue: 99.5 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -550,7 +550,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.maxValue = 99.5;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 10.5);
+        const validation = editor.validate(null, { inputValue: 10.5 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -560,8 +560,8 @@ describe('FloatEditor', () => {
         mockColumn.editor!.maxValue = 99.5;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new FloatEditor(editorArguments);
-        const validation1 = editor.validate(null, 99.5);
-        const validation2 = editor.validate(null, 10.5);
+        const validation1 = editor.validate(null, { inputValue: 99.5 });
+        const validation2 = editor.validate(null, { inputValue: 10.5 });
 
         expect(validation1).toEqual({ valid: false, msg: 'Please enter a valid number between 10.5 and 99.5' });
         expect(validation2).toEqual({ valid: false, msg: 'Please enter a valid number between 10.5 and 99.5' });
@@ -571,7 +571,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 99.6433);
+        const validation = editor.validate(null, { inputValue: 99.6433 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number with a maximum of 2 decimals' });
       });
@@ -580,7 +580,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 99.6);
+        const validation = editor.validate(null, { inputValue: 99.6 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -589,7 +589,7 @@ describe('FloatEditor', () => {
         mockColumn.editor!.params = { decimalPlaces: 2 };
 
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 99.65);
+        const validation = editor.validate(null, { inputValue: 99.65 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -597,7 +597,7 @@ describe('FloatEditor', () => {
       it('should return True when field is required and field is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, 2.5);
+        const validation = editor.validate(null, { inputValue: 2.5 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -605,7 +605,7 @@ describe('FloatEditor', () => {
       it('should return True when field is required and field is a valid decimal value without 0 suffix', () => {
         mockColumn.editor!.required = true;
         editor = new FloatEditor(editorArguments);
-        const validation = editor.validate(null, '.5');
+        const validation = editor.validate(null, { inputValue: '.5' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });

--- a/packages/common/src/editors/__tests__/inputEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputEditor.spec.ts
@@ -393,7 +393,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, '');
+        const validation = editor.validate(null, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -401,7 +401,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return True when field is required and input is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -409,7 +409,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return False when field is lower than a minLength defined', () => {
         mockColumn.editor!.minLength = 5;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
       });
@@ -418,7 +418,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.minLength = 5;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
       });
@@ -426,7 +426,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return True when field is equal to the minLength defined', () => {
         mockColumn.editor!.minLength = 4;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -434,7 +434,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return False when field is greater than a maxLength defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
@@ -443,7 +443,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.maxLength = 10;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
       });
@@ -451,7 +451,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return True when field is equal to the maxLength defined', () => {
         mockColumn.editor!.maxLength = 16;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -460,7 +460,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -469,7 +469,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
       });
@@ -478,7 +478,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 10;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
       });
@@ -487,7 +487,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 16;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -497,7 +497,7 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.maxLength = 15;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -507,8 +507,8 @@ describe('InputEditor (TextEditor)', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputEditor(editorArguments, 'text');
-        const validation1 = editor.validate(null, 'text is 16 chars');
-        const validation2 = editor.validate(null, 'text');
+        const validation1 = editor.validate(null, { inputValue: 'text is 16 chars' });
+        const validation2 = editor.validate(null, { inputValue: 'text' });
 
         expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
         expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
@@ -517,7 +517,7 @@ describe('InputEditor (TextEditor)', () => {
       it('should return False when field is greater than a maxValue defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new InputEditor(editorArguments, 'text');
-        const validation = editor.validate(null, 'Task is longer than 10 chars');
+        const validation = editor.validate(null, { inputValue: 'Task is longer than 10 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });

--- a/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/inputPasswordEditor.spec.ts
@@ -377,7 +377,7 @@ describe('InputPasswordEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, '');
+        const validation = editor.validate(null, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -385,7 +385,7 @@ describe('InputPasswordEditor', () => {
       it('should return True when field is required and input is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -393,7 +393,7 @@ describe('InputPasswordEditor', () => {
       it('should return False when field is lower than a minLength defined', () => {
         mockColumn.editor!.minLength = 5;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
       });
@@ -402,7 +402,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.minLength = 5;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
       });
@@ -410,7 +410,7 @@ describe('InputPasswordEditor', () => {
       it('should return True when field is equal to the minLength defined', () => {
         mockColumn.editor!.minLength = 4;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -418,7 +418,7 @@ describe('InputPasswordEditor', () => {
       it('should return False when field is greater than a maxLength defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
@@ -427,7 +427,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.maxLength = 10;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
       });
@@ -435,7 +435,7 @@ describe('InputPasswordEditor', () => {
       it('should return True when field is equal to the maxLength defined', () => {
         mockColumn.editor!.maxLength = 16;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -444,7 +444,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -453,7 +453,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
       });
@@ -462,7 +462,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 10;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
       });
@@ -471,7 +471,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 16;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text is 16 chars');
+        const validation = editor.validate(null, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -481,7 +481,7 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.maxLength = 15;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'text');
+        const validation = editor.validate(null, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -491,8 +491,8 @@ describe('InputPasswordEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new InputPasswordEditor(editorArguments);
-        const validation1 = editor.validate(null, 'text is 16 chars');
-        const validation2 = editor.validate(null, 'text');
+        const validation1 = editor.validate(null, { inputValue: 'text is 16 chars' });
+        const validation2 = editor.validate(null, { inputValue: 'text' });
 
         expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
         expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
@@ -501,7 +501,7 @@ describe('InputPasswordEditor', () => {
       it('should return False when field is greater than a maxValue defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new InputPasswordEditor(editorArguments);
-        const validation = editor.validate(null, 'Task is longer than 10 chars');
+        const validation = editor.validate(null, { inputValue: 'Task is longer than 10 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });

--- a/packages/common/src/editors/__tests__/integerEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/integerEditor.spec.ts
@@ -414,7 +414,7 @@ describe('IntegerEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, '');
+        const validation = editor.validate(null, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -422,7 +422,7 @@ describe('IntegerEditor', () => {
       it('should return False when field is not a valid integer', () => {
         mockColumn.editor!.required = true;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, '.2');
+        const validation = editor.validate(null, { inputValue: '.2' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number' });
       });
@@ -430,7 +430,7 @@ describe('IntegerEditor', () => {
       it('should return False when field is lower than a minValue defined', () => {
         mockColumn.editor!.minValue = 10;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 3);
+        const validation = editor.validate(null, { inputValue: 3 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number that is greater than or equal to 10' });
       });
@@ -439,7 +439,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.minValue = 10;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 3);
+        const validation = editor.validate(null, { inputValue: 3 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number that is greater than 10' });
       });
@@ -447,7 +447,7 @@ describe('IntegerEditor', () => {
       it('should return True when field is equal to the minValue defined', () => {
         mockColumn.editor!.minValue = 9;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 9);
+        const validation = editor.validate(null, { inputValue: 9 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -455,7 +455,7 @@ describe('IntegerEditor', () => {
       it('should return False when field is greater than a maxValue defined', () => {
         mockColumn.editor!.maxValue = 10;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 33);
+        const validation = editor.validate(null, { inputValue: 33 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number that is lower than or equal to 10' });
       });
@@ -464,7 +464,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.maxValue = 10;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 33);
+        const validation = editor.validate(null, { inputValue: 33 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number that is lower than 10' });
       });
@@ -472,7 +472,7 @@ describe('IntegerEditor', () => {
       it('should return True when field is equal to the maxValue defined', () => {
         mockColumn.editor!.maxValue = 99;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 99);
+        const validation = editor.validate(null, { inputValue: 99 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -481,7 +481,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.maxValue = 9;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 9);
+        const validation = editor.validate(null, { inputValue: 9 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -490,7 +490,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.maxValue = 9;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 9);
+        const validation = editor.validate(null, { inputValue: 9 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number that is lower than 9' });
       });
@@ -499,7 +499,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.minValue = 10;
         mockColumn.editor!.maxValue = 99;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 345);
+        const validation = editor.validate(null, { inputValue: 345 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid integer number between 10 and 99' });
       });
@@ -508,7 +508,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.minValue = 10;
         mockColumn.editor!.maxValue = 89;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 89);
+        const validation = editor.validate(null, { inputValue: 89 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -518,7 +518,7 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.maxValue = 89;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 10);
+        const validation = editor.validate(null, { inputValue: 10 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -528,8 +528,8 @@ describe('IntegerEditor', () => {
         mockColumn.editor!.maxValue = 89;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new IntegerEditor(editorArguments);
-        const validation1 = editor.validate(null, 89);
-        const validation2 = editor.validate(null, 10);
+        const validation1 = editor.validate(null, { inputValue: 89 });
+        const validation2 = editor.validate(null, { inputValue: 10 });
 
         expect(validation1).toEqual({ valid: false, msg: 'Please enter a valid integer number between 10 and 89' });
         expect(validation2).toEqual({ valid: false, msg: 'Please enter a valid integer number between 10 and 89' });
@@ -538,7 +538,7 @@ describe('IntegerEditor', () => {
       it('should return True when field is required and field is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new IntegerEditor(editorArguments);
-        const validation = editor.validate(null, 2);
+        const validation = editor.validate(null, { inputValue: 2 });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });

--- a/packages/common/src/editors/__tests__/longTextEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/longTextEditor.spec.ts
@@ -661,7 +661,7 @@ describe('LongTextEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, '');
+        const validation = editor.validate(undefined, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -669,7 +669,7 @@ describe('LongTextEditor', () => {
       it('should return True when field is required and input is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text');
+        const validation = editor.validate(undefined, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -677,7 +677,7 @@ describe('LongTextEditor', () => {
       it('should return False when field is lower than a minLength defined', () => {
         mockColumn.editor!.minLength = 5;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text');
+        const validation = editor.validate(undefined, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
       });
@@ -686,7 +686,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.minLength = 5;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text');
+        const validation = editor.validate(undefined, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
       });
@@ -694,7 +694,7 @@ describe('LongTextEditor', () => {
       it('should return True when field is equal to the minLength defined', () => {
         mockColumn.editor!.minLength = 4;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text');
+        const validation = editor.validate(undefined, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -702,7 +702,7 @@ describe('LongTextEditor', () => {
       it('should return False when field is greater than a maxLength defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
@@ -711,7 +711,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.maxLength = 10;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
       });
@@ -719,7 +719,7 @@ describe('LongTextEditor', () => {
       it('should return True when field is equal to the maxLength defined', () => {
         mockColumn.editor!.maxLength = 16;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -728,7 +728,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -737,7 +737,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
       });
@@ -746,7 +746,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 10;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
       });
@@ -755,7 +755,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.minLength = 0;
         mockColumn.editor!.maxLength = 16;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text is 16 chars');
+        const validation = editor.validate(undefined, { inputValue: 'text is 16 chars' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -765,7 +765,7 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.maxLength = 15;
         mockColumn.editor!.operatorConditionalType = 'inclusive';
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'text');
+        const validation = editor.validate(undefined, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
@@ -775,8 +775,8 @@ describe('LongTextEditor', () => {
         mockColumn.editor!.maxLength = 16;
         mockColumn.editor!.operatorConditionalType = 'exclusive';
         editor = new LongTextEditor(editorArguments);
-        const validation1 = editor.validate(undefined, 'text is 16 chars');
-        const validation2 = editor.validate(undefined, 'text');
+        const validation1 = editor.validate(undefined, { inputValue: 'text is 16 chars' });
+        const validation2 = editor.validate(undefined, { inputValue: 'text' });
 
         expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
         expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
@@ -785,7 +785,7 @@ describe('LongTextEditor', () => {
       it('should return False when field is greater than a maxValue defined', () => {
         mockColumn.editor!.maxLength = 10;
         editor = new LongTextEditor(editorArguments);
-        const validation = editor.validate(undefined, 'Task is longer than 10 chars');
+        const validation = editor.validate(undefined, { inputValue: 'Task is longer than 10 chars' });
 
         expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });

--- a/packages/common/src/editors/__tests__/selectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/selectEditor.spec.ts
@@ -43,7 +43,7 @@ const gridStub = {
   render: vi.fn(),
   onBeforeEditCell: new SlickEvent(),
   onCompositeEditorChange: new SlickEvent(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 describe('SelectEditor', () => {
@@ -85,7 +85,7 @@ describe('SelectEditor', () => {
         try {
           mockColumn.editor!.collection = undefined;
           editor = new SelectEditor(editorArguments, true);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.toString()).toContain(
             `[Slickgrid-Universal] You need to pass a "collection" (or "collectionAsync") inside Column Definition Editor for the MultipleSelect/SingleSelect Editor to work correctly.`
           );
@@ -98,7 +98,7 @@ describe('SelectEditor', () => {
         try {
           mockColumn.editor!.collection = { hello: 'world' } as any;
           editor = new SelectEditor(editorArguments, true);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.toString()).toContain(`The "collection" passed to the Select Editor is not a valid array.`);
           done();
         }
@@ -109,7 +109,7 @@ describe('SelectEditor', () => {
         try {
           mockColumn.editor!.collection = [{ hello: 'world' }];
           editor = new SelectEditor(editorArguments, true);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.toString()).toContain(
             `[Slickgrid-Universal] Select Filter/Editor collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`
           );
@@ -127,7 +127,7 @@ describe('SelectEditor', () => {
             { value: 'female', label: 'female' },
           ];
           editor = new SelectEditor(editorArguments, true);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.toString()).toContain(
             `[Slickgrid-Universal] requires a Translate Service to be installed and configured when the grid option "enableTranslate" is enabled.`
           );
@@ -793,7 +793,7 @@ describe('SelectEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new SelectEditor(editorArguments, true);
-        const validation = editor.validate(null as any, '');
+        const validation = editor.validate(null as any, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -801,7 +801,7 @@ describe('SelectEditor', () => {
       it('should return True when field is required and input is a valid input value', () => {
         mockColumn.editor!.required = true;
         editor = new SelectEditor(editorArguments, true);
-        const validation = editor.validate(null as any, 'text');
+        const validation = editor.validate(null as any, { inputValue: 'text' });
 
         expect(validation).toEqual({ valid: true, msg: null });
       });

--- a/packages/common/src/editors/__tests__/singleSelectEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/singleSelectEditor.spec.ts
@@ -36,7 +36,7 @@ const gridStub = {
   navigateNext: vi.fn(),
   navigatePrev: vi.fn(),
   render: vi.fn(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 describe('SingleSelectEditor', () => {

--- a/packages/common/src/editors/__tests__/sliderEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/sliderEditor.spec.ts
@@ -573,7 +573,7 @@ describe('SliderEditor', () => {
       it('should return False when field is required and field is empty', () => {
         mockColumn.editor!.required = true;
         editor = new SliderEditor(editorArguments);
-        const validation = editor.validate(null as any, '');
+        const validation = editor.validate(null as any, { inputValue: '' });
 
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
@@ -582,7 +582,7 @@ describe('SliderEditor', () => {
         mockColumn.editor!.minValue = 10;
         mockColumn.editor!.maxValue = 99;
         editor = new SliderEditor(editorArguments);
-        const validation = editor.validate(null as any, 100);
+        const validation = editor.validate(null as any, { inputValue: 100 });
 
         expect(validation).toEqual({ valid: false, msg: 'Please enter a valid number between 10 and 99' });
       });

--- a/packages/common/src/editors/autocompleterEditor.ts
+++ b/packages/common/src/editors/autocompleterEditor.ts
@@ -19,6 +19,7 @@ import type {
   EditorValidationResult,
   GridOption,
   Locale,
+  ValidateOption,
 } from '../interfaces/index.js';
 import { textValidator } from '../editorValidators/textValidator.js';
 import { addAutocompleteLoadingByOverridingFetch } from '../commonEditorFilter/commonEditorFilterUtils.js';
@@ -408,7 +409,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
     return this._currentValue;
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -419,7 +420,7 @@ export class AutocompleterEditor<T extends AutocompleteItem = any> implements Ed
       return { valid: true, msg: '' };
     }
 
-    const val = inputValue !== undefined ? inputValue : this._inputElm?.value;
+    const val = options?.inputValue ?? this._inputElm?.value;
     return textValidator(val, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,

--- a/packages/common/src/editors/checkboxEditor.ts
+++ b/packages/common/src/editors/checkboxEditor.ts
@@ -11,6 +11,7 @@ import type {
   EditorValidator,
   EditorValidationResult,
   GridOption,
+  ValidateOption,
 } from './../interfaces/index.js';
 import { getDescendantProperty } from '../services/utilities.js';
 import { SlickEventData, type SlickGrid } from '../core/index.js';
@@ -259,9 +260,9 @@ export class CheckboxEditor implements Editor {
     return this._input?.checked ?? false;
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     const isRequired = this.args?.compositeEditorOptions ? false : this.columnEditor.required;
-    const isChecked = inputValue !== undefined ? inputValue : this._input?.checked;
+    const isChecked = options?.inputValue ?? this._input?.checked;
     const errorMsg = this.columnEditor.errorMessage;
 
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -15,6 +15,7 @@ import type {
   EditorValidationResult,
   GridOption,
   VanillaCalendarOption,
+  ValidateOption,
 } from './../interfaces/index.js';
 import { getDescendantProperty } from './../services/utilities.js';
 import type { TranslaterService } from '../services/translater.service.js';
@@ -435,9 +436,9 @@ export class DateEditor implements Editor {
     return domValue;
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     const isRequired = this.args?.compositeEditorOptions ? false : this.columnEditor.required;
-    const elmValue = inputValue ?? this._inputElm?.value;
+    const elmValue = options?.inputValue ?? this._inputElm?.value;
     const errorMsg = this.columnEditor.errorMessage;
 
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form

--- a/packages/common/src/editors/dualInputEditor.ts
+++ b/packages/common/src/editors/dualInputEditor.ts
@@ -12,6 +12,7 @@ import type {
   EditorValidator,
   EditorValidationResult,
   GridOption,
+  ValidateOption,
 } from '../interfaces/index.js';
 import { getDescendantProperty } from '../services/utilities.js';
 import { floatValidator, integerValidator, textValidator } from '../editorValidators/index.js';
@@ -454,7 +455,7 @@ export class DualInputEditor implements Editor {
     return '1';
   }
 
-  validate(_targetElm?: any, inputValidation?: { position: 'leftInput' | 'rightInput'; inputValue: any }): EditorValidationResult {
+  validate(_targetElm?: HTMLElement | null, options?: ValidateOption & { position?: 'leftInput' | 'rightInput' }): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -465,10 +466,12 @@ export class DualInputEditor implements Editor {
       return { valid: true, msg: '' };
     }
 
-    if (inputValidation) {
-      const posValidation = this.validateByPosition(inputValidation.position, inputValidation.inputValue);
+    if (options) {
+      const position = options.position || 'leftInput';
+      const posValidation = this.validateByPosition(position, options.inputValue);
       if (!posValidation.valid) {
-        inputValidation.position === 'leftInput' ? this._leftInput.select() : this._rightInput.select();
+        const input = position === 'leftInput' ? this._leftInput : this._rightInput;
+        input.select();
         return posValidation;
       }
     } else {

--- a/packages/common/src/editors/floatEditor.ts
+++ b/packages/common/src/editors/floatEditor.ts
@@ -1,4 +1,4 @@
-import type { EditorArguments, EditorValidationResult } from '../interfaces/index.js';
+import type { EditorArguments, EditorValidationResult, ValidateOption } from '../interfaces/index.js';
 import { floatValidator } from '../editorValidators/floatValidator.js';
 import { InputEditor } from './inputEditor.js';
 import { getDescendantProperty } from '../services/utilities.js';
@@ -43,7 +43,7 @@ export class FloatEditor extends InputEditor {
     return rtn;
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -54,7 +54,7 @@ export class FloatEditor extends InputEditor {
       return { valid: true, msg: '' };
     }
 
-    const elmValue = inputValue !== undefined ? inputValue : this._input?.value;
+    const elmValue = options?.inputValue ?? this._input?.value;
     return floatValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,

--- a/packages/common/src/editors/inputEditor.ts
+++ b/packages/common/src/editors/inputEditor.ts
@@ -10,6 +10,7 @@ import type {
   EditorValidator,
   EditorValidationResult,
   GridOption,
+  ValidateOption,
 } from '../interfaces/index.js';
 import { getDescendantProperty } from '../services/utilities.js';
 import { textValidator } from '../editorValidators/textValidator.js';
@@ -117,7 +118,13 @@ export class InputEditor implements Editor {
     this._bindEventService.bind(this._input, 'keydown', ((event: KeyboardEvent) => {
       this._isValueTouched = true;
       this._lastInputKeyEvent = event;
-      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+
+      // by default arrow usage will move the cursor within the input text
+      // unless `editorNavigateOnArrows` is enabled which will instead move to the cell following the arrow direction
+      if (
+        !this.gridOptions.editorNavigateOnArrows &&
+        (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End')
+      ) {
         event.stopImmediatePropagation();
       }
     }) as EventListener);
@@ -306,7 +313,7 @@ export class InputEditor implements Editor {
     return this._input?.value ?? '';
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -317,7 +324,7 @@ export class InputEditor implements Editor {
       return { valid: true, msg: '' };
     }
 
-    const elmValue = inputValue !== undefined ? inputValue : this._input && this._input.value;
+    const elmValue = options?.inputValue ?? this._input?.value;
     return textValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,

--- a/packages/common/src/editors/integerEditor.ts
+++ b/packages/common/src/editors/integerEditor.ts
@@ -1,4 +1,4 @@
-import type { EditorArguments, EditorValidationResult } from '../interfaces/index.js';
+import type { EditorArguments, EditorValidationResult, ValidateOption } from '../interfaces/index.js';
 import { integerValidator } from '../editorValidators/integerValidator.js';
 import { InputEditor } from './inputEditor.js';
 import { getDescendantProperty } from '../services/utilities.js';
@@ -31,7 +31,7 @@ export class IntegerEditor extends InputEditor {
     return isNaN(+output) ? elmValue : output;
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -42,7 +42,7 @@ export class IntegerEditor extends InputEditor {
       return { valid: true, msg: '' };
     }
 
-    const elmValue = inputValue !== undefined ? inputValue : this.getValue();
+    const elmValue = options?.inputValue ?? this.getValue();
     return integerValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,

--- a/packages/common/src/editors/longTextEditor.ts
+++ b/packages/common/src/editors/longTextEditor.ts
@@ -14,6 +14,7 @@ import type {
   GridOption,
   Locale,
   LongTextEditorOption,
+  ValidateOption,
 } from '../interfaces/index.js';
 import { getDescendantProperty, getTranslationPrefix } from '../services/utilities.js';
 import type { TranslaterService } from '../services/translater.service.js';
@@ -377,7 +378,7 @@ export class LongTextEditor implements Editor {
     return this._textareaElm.value;
   }
 
-  validate(_targetElm?: HTMLElement, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: HTMLElement, options?: ValidateOption): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -388,7 +389,7 @@ export class LongTextEditor implements Editor {
       return { valid: true, msg: '' };
     }
 
-    const elmValue = inputValue !== undefined ? inputValue : this._textareaElm?.value;
+    const elmValue = options?.inputValue ?? this._textareaElm?.value;
     return textValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,

--- a/packages/common/src/editors/selectEditor.ts
+++ b/packages/common/src/editors/selectEditor.ts
@@ -18,6 +18,7 @@ import type {
   GridOption,
   Locale,
   SelectOption,
+  ValidateOption,
 } from './../interfaces/index.js';
 import {
   createBlankSelectEntry,
@@ -600,9 +601,9 @@ export class SelectEditor implements Editor {
     }
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     const isRequired = this.isCompositeEditor ? false : this.columnEditor?.required;
-    const elmValue = inputValue !== undefined ? inputValue : this._msInstance?.getSelects(); // && this.$editorElm.val && this.$editorElm.val();
+    const elmValue = options?.inputValue ?? this._msInstance?.getSelects(); // && this.$editorElm.val && this.$editorElm.val();
     const errorMsg = this.columnEditor?.errorMessage;
 
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
@@ -616,7 +617,7 @@ export class SelectEditor implements Editor {
     }
 
     if (this.validator) {
-      const value = inputValue !== undefined ? inputValue : this.isMultipleSelect ? this.currentValues : this.currentValue;
+      const value = options !== undefined ? options : this.isMultipleSelect ? this.currentValues : this.currentValue;
       return this.validator(value, this.args);
     }
 

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -13,6 +13,7 @@ import type {
   EditorValidationResult,
   GridOption,
   SliderOption,
+  ValidateOption,
 } from '../interfaces/index.js';
 import { getDescendantProperty } from '../services/utilities.js';
 import { sliderValidator } from '../editorValidators/sliderValidator.js';
@@ -313,7 +314,7 @@ export class SliderEditor implements Editor {
     return elmValue !== '' ? parseInt(elmValue, 10) : this._originalValue;
   }
 
-  validate(_targetElm?: any, inputValue?: any): EditorValidationResult {
+  validate(_targetElm?: any, options?: ValidateOption): EditorValidationResult {
     // when using Composite Editor, we also want to recheck if the field if disabled/enabled since it might change depending on other inputs on the composite form
     if (this.args.compositeEditorOptions) {
       this.applyInputUsabilityState();
@@ -324,7 +325,7 @@ export class SliderEditor implements Editor {
       return { valid: true, msg: '' };
     }
 
-    const elmValue = inputValue !== undefined ? inputValue : this._inputElm?.value;
+    const elmValue = options?.inputValue ?? this._inputElm?.value;
     return sliderValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,

--- a/packages/common/src/enums/selectionModel.type.ts
+++ b/packages/common/src/enums/selectionModel.type.ts
@@ -5,5 +5,5 @@ export type SelectionModel = SlickPlugin & {
   refreshSelections: () => void;
   onSelectedRangesChanged: SlickEvent<SlickRange[]>;
   getSelectedRanges: () => SlickRange[];
-  setSelectedRanges: (ranges: SlickRange[], caller?: string) => void;
+  setSelectedRanges: (ranges: SlickRange[], caller?: string, selectionMode?: string) => void;
 };

--- a/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
@@ -9,7 +9,7 @@ vi.useFakeTimers();
 
 const GRID_UID = 'slickgrid_12345';
 
-const addVanillaEventPropagation = function (event) {
+const addVanillaEventPropagation = function (event: any) {
   Object.defineProperty(event, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
   Object.defineProperty(event, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
   return event;
@@ -267,12 +267,15 @@ describe('CellRangeSelector Plugin', () => {
 
     expect(focusSpy).toHaveBeenCalled();
     expect(onBeforeCellSpy).toHaveBeenCalled();
-    expect(decoratorShowSpy).toHaveBeenCalledWith({
-      fromCell: 4,
-      fromRow: 5,
-      toCell: 4,
-      toRow: 5,
-    });
+    expect(decoratorShowSpy).toHaveBeenCalledWith(
+      {
+        fromCell: 4,
+        fromRow: 5,
+        toCell: 4,
+        toRow: 5,
+      },
+      false
+    );
     expect(plugin.getCurrentRange()).toEqual({ start: { cell: 4, row: 5 }, end: {} });
   });
 
@@ -334,14 +337,19 @@ describe('CellRangeSelector Plugin', () => {
         toCell: 4,
         toRow: 5,
       },
+      allowAutoEdit: false,
+      selectionMode: 'SEL',
     });
     expect(decoratorHideSpy).toHaveBeenCalled();
-    expect(decoratorShowSpy).toHaveBeenCalledWith({
-      fromCell: 4,
-      fromRow: 5,
-      toCell: 4,
-      toRow: 5,
-    });
+    expect(decoratorShowSpy).toHaveBeenCalledWith(
+      {
+        fromCell: 4,
+        fromRow: 5,
+        toCell: 4,
+        toRow: 5,
+      },
+      false
+    );
     expect(plugin.getCurrentRange()).toEqual({ start: { cell: 4, row: 5 }, end: {} });
   });
 
@@ -394,12 +402,15 @@ describe('CellRangeSelector Plugin', () => {
     expect(onBeforeCellRangeSpy).toHaveBeenCalled();
     expect(onCellRangeSpy).not.toHaveBeenCalled();
     expect(decoratorHideSpy).not.toHaveBeenCalled();
-    expect(decoratorShowSpy).toHaveBeenCalledWith({
-      fromCell: 4,
-      fromRow: 5,
-      toCell: 4,
-      toRow: 5,
-    });
+    expect(decoratorShowSpy).toHaveBeenCalledWith(
+      {
+        fromCell: 4,
+        fromRow: 5,
+        toCell: 4,
+        toRow: 5,
+      },
+      false
+    );
     expect(plugin.getCurrentRange()).toEqual({ start: { cell: 4, row: 5 }, end: {} });
     expect(scrollSpy).toHaveBeenCalledWith(5, 4);
     expect(onCellRangeSelectingSpy).not.toHaveBeenCalled();
@@ -454,13 +465,16 @@ describe('CellRangeSelector Plugin', () => {
     expect(onBeforeCellRangeSpy).toHaveBeenCalled();
     expect(onCellRangeSpy).not.toHaveBeenCalled();
     expect(decoratorHideSpy).not.toHaveBeenCalled();
-    expect(decoratorShowSpy).toHaveBeenCalledWith({
-      fromCell: 4,
-      fromRow: 5,
-      toCell: 4,
-      toRow: 5,
-    });
-    expect(plugin.getCurrentRange()).toEqual({ start: { cell: 4, row: 5 }, end: {} });
+    expect(decoratorShowSpy).toHaveBeenCalledWith(
+      {
+        fromCell: 4,
+        fromRow: 5,
+        toCell: 4,
+        toRow: 5,
+      },
+      false
+    );
+    expect(plugin.getCurrentRange()).toEqual({ start: { cell: 2, row: 3 }, end: { cell: 4, row: 5 } });
     expect(scrollSpy).toHaveBeenCalledWith(5, 4);
     expect(onCellRangeSelectingSpy).toHaveBeenCalledWith({
       range: {
@@ -469,6 +483,8 @@ describe('CellRangeSelector Plugin', () => {
         toCell: 4,
         toRow: 5,
       },
+      allowAutoEdit: false,
+      selectionMode: '',
     });
   });
 
@@ -571,12 +587,15 @@ describe('CellRangeSelector Plugin', () => {
       toCell: 4,
       toRow: 5, // from handleDrag
     });
-    expect(decoratorShowSpy).toHaveBeenCalledWith({
-      fromCell: 4,
-      fromRow: 0,
-      toCell: 4,
-      toRow: 0, // from handleDragStart
-    });
+    expect(decoratorShowSpy).toHaveBeenCalledWith(
+      {
+        fromCell: 4,
+        fromRow: 0,
+        toCell: 4,
+        toRow: 0, // from handleDragStart
+      },
+      false
+    );
   });
 
   it('should call onDrag and handle drag outside the viewport when drag is detected as outside the viewport', () => {
@@ -594,7 +613,7 @@ describe('CellRangeSelector Plugin', () => {
     vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
     vi.spyOn(plugin, 'getMouseOffsetViewport').mockReturnValue({
       e: new MouseEvent('dragstart'),
-      dd: { startX: 5, startY: 15, range: { start: { row: 2, cell: 22 }, end: { row: 5, cell: 22 } } },
+      dd: { startX: 5, startY: 15, range: { start: { row: 2, cell: 22 }, end: { row: 5, cell: 22 } }, matchClassTag: '' },
       viewport: { left: 23, top: 24, right: 25, bottom: 26, offset: { left: 27, top: 28, right: 29, bottom: 30 } },
       offset: { x: 0, y: 0 },
       isOutsideViewport: true,
@@ -658,7 +677,7 @@ describe('CellRangeSelector Plugin', () => {
     vi.spyOn(gridStub, 'getCellFromPoint').mockReturnValue({ cell: 4, row: 5 });
     vi.spyOn(plugin, 'getMouseOffsetViewport').mockReturnValue({
       e: new MouseEvent('dragstart'),
-      dd: { startX: 5, startY: 15, range: { start: { row: 2, cell: 22 }, end: { row: 5, cell: 22 } } },
+      dd: { startX: 5, startY: 15, range: { start: { row: 2, cell: 22 }, end: { row: 5, cell: 22 } }, matchClassTag: '' },
       viewport: { left: 23, top: 24, right: 25, bottom: 26, offset: { left: 27, top: 28, right: 29, bottom: 30 } },
       offset: { x: 1, y: 1 },
       isOutsideViewport: true,
@@ -699,12 +718,14 @@ describe('CellRangeSelector Plugin', () => {
     vi.advanceTimersByTime(7);
 
     expect(onCellRangeSelectingSpy).toHaveBeenCalledWith({
+      allowAutoEdit: false,
       range: {
         fromCell: 4,
         fromRow: 2,
         toCell: 22,
         toRow: 5,
       },
+      selectionMode: '',
     });
   });
 
@@ -723,7 +744,7 @@ describe('CellRangeSelector Plugin', () => {
     vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValueOnce(true);
     vi.spyOn(plugin, 'getMouseOffsetViewport').mockReturnValue({
       e: new MouseEvent('dragstart'),
-      dd: { startX: 5, startY: 15, range: { start: { row: 2, cell: 22 }, end: { row: 5, cell: 22 } } },
+      dd: { startX: 5, startY: 15, range: { start: { row: 2, cell: 22 }, end: { row: 5, cell: 22 } }, matchClassTag: '' },
       viewport: { left: 23, top: 24, right: 25, bottom: 26, offset: { left: 27, top: 28, right: 29, bottom: 30 } },
       offset: { x: -2, y: -4 },
       isOutsideViewport: true,
@@ -764,12 +785,14 @@ describe('CellRangeSelector Plugin', () => {
     vi.advanceTimersByTime(7);
 
     expect(onCellRangeSelectingSpy).toHaveBeenCalledWith({
+      allowAutoEdit: false,
       range: {
         fromCell: 4,
         fromRow: 2,
         toCell: 22,
         toRow: 5,
       },
+      selectionMode: '',
     });
   });
 

--- a/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickDraggableGrouping.spec.ts
@@ -5,7 +5,7 @@ vi.mock('sortablejs', () => ({
     el: undefined,
     options: {} as SortableOptions,
     constructor: vi.fn(),
-    create: (el, options) => {
+    create: (el: HTMLElement, options: SortableOptions) => {
       return {
         el,
         options,
@@ -14,7 +14,7 @@ vi.mock('sortablejs', () => ({
       };
     },
     utils: {
-      clone: (el) => el.cloneNode(true),
+      clone: (el: HTMLElement) => el.cloneNode(true),
     },
   },
 }));

--- a/packages/common/src/extensions/__tests__/slickRowSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowSelectionModel.spec.ts
@@ -8,7 +8,7 @@ import { SlickRowSelectionModel } from '../slickRowSelectionModel.js';
 
 const GRID_UID = 'slickgrid_12345';
 
-const addVanillaEventPropagation = function (event, commandKey = '', keyName = '') {
+const addVanillaEventPropagation = function (event: any, commandKey = '', keyName = '') {
   Object.defineProperty(event, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
   Object.defineProperty(event, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
   if (commandKey) {
@@ -431,16 +431,20 @@ describe('SlickRowSelectionModel Plugin', () => {
 
       plugin.init(gridStub);
       const scrollEvent = addVanillaEventPropagation(new Event('scroll'));
-      plugin.getCellRangeSelector()!.onCellRangeSelected.notify({ range: new SlickRange(3, 2, 5, 4) }, scrollEvent, gridStub);
+      plugin.getCellRangeSelector()!.onCellRangeSelected.notify({ range: new SlickRange(3, 2, 5, 4) } as any, scrollEvent, gridStub);
 
-      expect(setSelectedRangeSpy).toHaveBeenCalledWith([
-        {
-          fromCell: 0,
-          fromRow: 3,
-          toCell: 2,
-          toRow: 5,
-        },
-      ]);
+      expect(setSelectedRangeSpy).toHaveBeenCalledWith(
+        [
+          {
+            fromCell: 0,
+            fromRow: 3,
+            toCell: 2,
+            toRow: 5,
+          },
+        ],
+        undefined,
+        undefined
+      );
     });
 
     it('should be able to manually create Row Selection and then call "setSelectedRanges" when "onCellRangeSelected" event is triggered', () => {
@@ -458,9 +462,9 @@ describe('SlickRowSelectionModel Plugin', () => {
       });
       plugin.init(gridStub);
       const scrollEvent = addVanillaEventPropagation(new Event('scroll'));
-      plugin.getCellRangeSelector()!.onCellRangeSelected.notify({ range: new SlickRange(3, 2, 5, 4) }, scrollEvent, gridStub);
+      plugin.getCellRangeSelector()!.onCellRangeSelected.notify({ range: new SlickRange(3, 2, 5, 4) } as any, scrollEvent, gridStub);
 
-      expect(setSelectedRangeSpy).toHaveBeenCalledWith([{ fromCell: 0, fromRow: 3, toCell: 2, toRow: 5 }]);
+      expect(setSelectedRangeSpy).toHaveBeenCalledWith([{ fromCell: 0, fromRow: 3, toCell: 2, toRow: 5 }], undefined, undefined);
     });
 
     it('should call "setSelectedRanges" when "onCellRangeSelected" event is triggered', () => {
@@ -469,7 +473,7 @@ describe('SlickRowSelectionModel Plugin', () => {
 
       plugin.init(gridStub);
       const scrollEvent = addVanillaEventPropagation(new Event('scroll'));
-      plugin.getCellRangeSelector()!.onCellRangeSelected.notify({ range: new SlickRange(3, 2, 5, 4) }, scrollEvent, gridStub);
+      plugin.getCellRangeSelector()!.onCellRangeSelected.notify({ range: new SlickRange(3, 2, 5, 4) } as any, scrollEvent, gridStub);
 
       expect(setSelectedRangeSpy).not.toHaveBeenCalled();
     });

--- a/packages/common/src/extensions/index.ts
+++ b/packages/common/src/extensions/index.ts
@@ -14,6 +14,7 @@ export * from './slickGridMenu.js';
 export * from './slickGroupItemMetadataProvider.js';
 export * from './slickHeaderButtons.js';
 export * from './slickHeaderMenu.js';
+export * from './slickHybridSelectionModel.js';
 export * from './slickRowBasedEdit.js';
 export * from './slickRowMoveManager.js';
 export * from './slickRowSelectionModel.js';

--- a/packages/common/src/extensions/slickCellRangeSelector.ts
+++ b/packages/common/src/extensions/slickCellRangeSelector.ts
@@ -9,18 +9,27 @@ import type {
   MouseOffsetViewport,
   OnScrollEventArgs,
 } from '../interfaces/index.js';
-import { SlickCellRangeDecorator } from './index.js';
-import { SlickEvent, type SlickEventData, SlickEventHandler, type SlickGrid, SlickRange, Utils as SlickUtils } from '../core/index.js';
+import { SlickCellRangeDecorator, type CellSelectionMode } from './index.js';
+import {
+  SlickEvent,
+  type SlickEventData,
+  SlickEventHandler,
+  type SlickGrid,
+  SlickRange,
+  SlickSelectionUtils,
+  Utils as SlickUtils,
+} from '../core/index.js';
 
 export class SlickCellRangeSelector {
   pluginName: 'CellRangeSelector' = 'CellRangeSelector' as const;
   onBeforeCellRangeSelected: SlickEvent<{ row: number; cell: number }>;
-  onCellRangeSelecting: SlickEvent<{ range: SlickRange }>;
-  onCellRangeSelected: SlickEvent<{ range: SlickRange }>;
+  onCellRangeSelecting: SlickEvent<{ range: SlickRange; selectionMode: string; allowAutoEdit: boolean }>;
+  onCellRangeSelected: SlickEvent<{ range: SlickRange; selectionMode: string; allowAutoEdit: boolean }>;
 
   protected _activeCanvas!: HTMLElement;
   protected _options!: CellRangeSelectorOption;
   protected _currentlySelectedRange: DragRange | null = null;
+  protected _previousSelectedRange: DragRange | null = null;
   protected _canvas: HTMLElement | null = null;
   protected _decorator!: SlickCellRangeDecorator;
   protected _dragging = false;
@@ -28,6 +37,9 @@ export class SlickCellRangeSelector {
   protected _grid!: SlickGrid;
   protected _gridOptions!: GridOption;
   protected _gridUid = '';
+  protected _dragReplaceHandleCell: { row: number; cell: number } | null = null;
+  protected _selectionMode: CellSelectionMode = 'SEL';
+  protected _dragReplaceHandleActive = false;
 
   // Frozen row & column variables
   protected _columnOffset = 0;
@@ -61,8 +73,10 @@ export class SlickCellRangeSelector {
 
   constructor(options?: Partial<CellRangeSelectorOption>) {
     this.onBeforeCellRangeSelected = new SlickEvent<{ row: number; cell: number }>('onBeforeCellRangeSelected');
-    this.onCellRangeSelecting = new SlickEvent<{ range: SlickRange }>('onCellRangeSelecting');
-    this.onCellRangeSelected = new SlickEvent<{ range: SlickRange }>('onCellRangeSelected');
+    this.onCellRangeSelecting = new SlickEvent<{ range: SlickRange; selectionMode: string; allowAutoEdit: boolean }>(
+      'onCellRangeSelecting'
+    );
+    this.onCellRangeSelected = new SlickEvent<{ range: SlickRange; selectionMode: string; allowAutoEdit: boolean }>('onCellRangeSelected');
     this._eventHandler = new SlickEventHandler();
     this._options = deepMerge(this._defaults, options);
   }
@@ -125,6 +139,10 @@ export class SlickCellRangeSelector {
     return this._currentlySelectedRange;
   }
 
+  getPreviousRange(): DragRange | null {
+    return this._previousSelectedRange;
+  }
+
   getMouseOffsetViewport(e: MouseEvent | TouchEvent, dd: DragPosition): MouseOffsetViewport {
     const targetEvent: MouseEvent | Touch = (e as TouchEvent)?.touches?.[0] ?? e;
     const viewportLeft = this._activeViewport.scrollLeft;
@@ -168,6 +186,14 @@ export class SlickCellRangeSelector {
     }
     result.isOutsideViewport = !!result.offset.x || !!result.offset.y;
     return result;
+  }
+
+  getSelectionMode(): string {
+    return this._selectionMode;
+  }
+
+  setSelectionMode(mode: CellSelectionMode): void {
+    this._selectionMode = mode;
   }
 
   stopIntervalTimer(): void {
@@ -311,9 +337,19 @@ export class SlickCellRangeSelector {
 
       if (dd?.range) {
         dd.range.end = end;
-        const range = new SlickRange(dd.range.start.row ?? 0, dd.range.start.cell ?? 0, end.row, end.cell);
-        this._decorator.show(range);
-        this.onCellRangeSelecting.notify({ range });
+        const cornerCell = !this._previousSelectedRange
+          ? dd.range.start
+          : SlickSelectionUtils.normalRangeOppositeCellFromCopy(this._previousSelectedRange, end);
+        this._currentlySelectedRange = dd.range;
+
+        const range = new SlickRange(cornerCell.row!, cornerCell.cell!, end.row, end.cell);
+
+        this._decorator.show(range, this._dragReplaceHandleActive);
+        this.onCellRangeSelecting.notify({
+          range,
+          selectionMode: '',
+          allowAutoEdit: false,
+        });
       }
     }
   }
@@ -321,20 +357,27 @@ export class SlickCellRangeSelector {
   protected handleDragEnd(e: any, dd: DragRowMove): void {
     this._decorator.hide();
 
-    if (this._dragging && dd.range) {
-      this._dragging = false;
-      e.stopImmediatePropagation();
-
-      this.stopIntervalTimer();
-      this.onCellRangeSelected.notify({
-        range: new SlickRange(dd.range.start.row ?? 0, dd.range.start.cell ?? 0, dd.range.end.row, dd.range.end.cell),
-      });
-    } else if (this._autoScrollTimerId) {
-      this.stopIntervalTimer(); // stop the auto-scroll timer if it was running
+    if (!this._dragging || !dd.range) {
+      if (this._autoScrollTimerId) {
+        this.stopIntervalTimer(); // stop the auto-scroll timer if it was running
+      }
+      return;
     }
+    this._dragging = false;
+    e.stopImmediatePropagation();
+
+    this.stopIntervalTimer();
+    const r = new SlickRange(dd.range.start.row ?? 0, dd.range.start.cell ?? 0, dd.range.end.row, dd.range.end.cell);
+
+    this.onCellRangeSelected.notify({
+      range: r,
+      selectionMode: this._selectionMode,
+      allowAutoEdit: this._selectionMode === 'SEL' && r.isSingleCell(),
+    });
+    this._previousSelectedRange = SlickSelectionUtils.normaliseDragRange(dd.range);
   }
 
-  protected handleDragInit(e: SlickEventData): void {
+  protected handleDragInit(e: SlickEventData, dd: DragRowMove): void {
     // Set the active canvas node because the decorator needs to append its
     // box to the correct canvas
     this._activeCanvas = this._grid.getActiveCanvasNode(e);
@@ -364,6 +407,13 @@ export class SlickCellRangeSelector {
       this._columnOffset = document.querySelector(`${this.gridUidSelector} .grid-canvas-left`)?.clientWidth ?? 0;
     }
 
+    this._dragReplaceHandleActive = dd.matchClassTag === 'dragReplaceHandle';
+    if (this._dragReplaceHandleActive) {
+      this._dragReplaceHandleCell = this._grid.getCellFromEvent(e);
+    } else {
+      this._previousSelectedRange = null;
+    }
+
     // prevent the grid from cancelling drag'n'drop by default
     // unless an editor is open on the current cell.
     // if so keep bubbling the event to avoid breaking editor inputs focusing/selecting
@@ -377,7 +427,10 @@ export class SlickCellRangeSelector {
   }
 
   protected handleDragStart(e: SlickEventData, dd: DragRowMove): HTMLDivElement | undefined {
-    const cellObj = this._grid.getCellFromEvent(e);
+    let cellObj = this._grid.getCellFromEvent(e);
+    if (this._dragReplaceHandleActive) {
+      cellObj = this._dragReplaceHandleCell;
+    }
     if (
       cellObj &&
       this.onBeforeCellRangeSelected.notify(cellObj).getReturnValue() !== false &&
@@ -404,10 +457,16 @@ export class SlickCellRangeSelector {
       startY += this._scrollTop;
     }
 
-    const start = this._grid.getCellFromPoint(startX, startY);
+    let start: { row: number | undefined; cell: number | undefined } | null;
+    this._selectionMode = this._dragReplaceHandleActive ? 'REP' : 'SEL';
+    if (!this._dragReplaceHandleActive) {
+      start = this._grid.getCellFromPoint(startX, startY);
+    } else {
+      start = this._grid.getActiveCell() || { row: undefined, cell: undefined };
+    }
     dd.range = { start, end: {} };
     this._currentlySelectedRange = dd.range;
-    return this._decorator.show(new SlickRange(start.row, start.cell));
+    return this._decorator.show(new SlickRange(start.row ?? 0, start.cell ?? 0), this._dragReplaceHandleActive);
   }
 
   protected handleScroll(_e: SlickEventData, args: OnScrollEventArgs): void {

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -10,6 +10,8 @@ export interface CellSelectionModelOption {
   cellRangeSelector: SlickCellRangeSelector;
 }
 
+export type CellSelectionMode = 'SEL' | 'REP';
+
 export class SlickCellSelectionModel implements SelectionModel {
   onSelectedRangesChanged: SlickEvent<SlickRange[]>;
   pluginName: 'CellSelectionModel' = 'CellSelectionModel' as const;

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -156,7 +156,7 @@ export class SlickCheckboxSelectColumn<T = any> {
         } else {
           columns.unshift(selectionColumn);
         }
-        this.pubSubService.publish(`onPluginColumnsChanged`, {
+        this.pubSubService.publish('onPluginColumnsChanged', {
           columns,
           pluginName: this.pluginName,
         });

--- a/packages/common/src/extensions/slickHybridSelectionModel.ts
+++ b/packages/common/src/extensions/slickHybridSelectionModel.ts
@@ -1,0 +1,539 @@
+import { isDefined } from '@slickgrid-universal/utils';
+import { SlickEvent, SlickEventData, SlickRange, Utils as SlickUtils } from '../core/index.js';
+import type { SlickDataView } from '../core/slickDataview.js';
+import type { SlickGrid } from '../core/slickGrid.js';
+import type { CustomDataView, OnActiveCellChangedEventArgs } from '../interfaces/index.js';
+import { SlickCellRangeSelector } from './slickCellRangeSelector.js';
+import { SlickCellRangeDecorator } from './slickCellRangeDecorator.js';
+import { Draggable } from '../core/slickInteractions.js';
+import type { SlickRowMoveManager } from './slickRowMoveManager.js';
+import type { GridOption, SelectionModel } from '../index.js';
+
+export declare type RowSelectOverride = (
+  data: OnActiveCellChangedEventArgs,
+  selectionModel: SlickHybridSelectionModel,
+  grid: SlickGrid
+) => boolean;
+
+const noop = () => {};
+
+export interface HybridSelectionModelOption {
+  selectActiveCell: boolean;
+  selectActiveRow: boolean;
+  cellRangeSelector?: SlickCellRangeSelector;
+  dragToSelect: boolean;
+  autoScrollWhenDrag: boolean;
+  handleRowMoveManagerColumn: boolean; // Row Selection on RowMoveManage column
+  rowSelectColumnIdArr: string[]; // Row Selection on these columns
+  rowSelectOverride: RowSelectOverride | undefined; // function to toggle Row Selection Models
+}
+
+export class SlickHybridSelectionModel implements SelectionModel {
+  // hybrid selection model is CellSelectionModel except when selecting
+  // specific columns, which behave as RowSelectionModel
+
+  // --
+  // public API
+  pluginName = 'HybridSelectionModel' as const;
+  onSelectedRangesChanged: SlickEvent = new SlickEvent<SlickRange[]>('onSelectedRangesChanged');
+
+  // --
+  // protected props
+  protected _cachedPageRowCount = 0;
+  protected _dataView?: CustomDataView | SlickDataView;
+  protected _grid!: SlickGrid;
+  protected _prevSelectedRow?: number;
+  protected _prevKeyDown = '';
+  protected _ranges: SlickRange[] = [];
+  protected _selector: SlickCellRangeSelector;
+  protected _isRowMoveManagerHandler: any;
+  protected _activeSelectionIsRow = false;
+  protected _options?: HybridSelectionModelOption;
+  protected _defaults: HybridSelectionModelOption = {
+    selectActiveCell: true,
+    selectActiveRow: true,
+    dragToSelect: false,
+    autoScrollWhenDrag: true,
+    handleRowMoveManagerColumn: true, // Row Selection on RowMoveManage column
+    rowSelectColumnIdArr: [], // Row Selection on these columns
+    rowSelectOverride: undefined, // function to toggle Row Selection Models
+    cellRangeSelector: undefined,
+  };
+
+  constructor(options?: Partial<HybridSelectionModelOption>) {
+    this._options = { ...this._defaults, ...options };
+
+    if (options === undefined || options.cellRangeSelector === undefined) {
+      this._selector = new SlickCellRangeSelector({
+        selectionCss: { border: '2px solid black' } as CSSStyleDeclaration,
+        copyToSelectionCss: { border: '2px solid purple' } as CSSStyleDeclaration,
+      });
+    } else {
+      this._selector = options.cellRangeSelector;
+    }
+  }
+
+  get addonOptions(): HybridSelectionModelOption | undefined {
+    return this._options;
+  }
+
+  get gridOptions(): GridOption {
+    return this._grid?.getOptions();
+  }
+
+  // Region: Setup
+  // -----------------------------------------------------------------------------
+
+  init(grid: SlickGrid): void {
+    if (Draggable === undefined) {
+      throw new Error('Slick.Draggable is undefined, make sure to import "slick.interactions.js"');
+    }
+
+    this._grid = grid;
+    SlickUtils.addSlickEventPubSubWhenDefined(grid.getPubSubService()!, this);
+
+    if (!this._selector && this._options?.dragToSelect) {
+      if (!SlickCellRangeDecorator) {
+        throw new Error('Slick.CellRangeDecorator is required when option dragToSelect set to true');
+      }
+      this._selector = new SlickCellRangeSelector({
+        selectionCss: { border: 'none' } as CSSStyleDeclaration,
+        autoScroll: this._options?.autoScrollWhenDrag,
+      });
+    }
+
+    if (grid.hasDataView()) {
+      this._dataView = grid.getData<CustomDataView | SlickDataView>();
+    }
+    this._grid.onActiveCellChanged.subscribe(this.handleActiveCellChange.bind(this));
+    this._grid.onKeyDown.subscribe(this.handleKeyDown.bind(this));
+    this._grid.onClick.subscribe(this.handleClick.bind(this));
+    if (this._selector) {
+      grid.registerPlugin(this._selector);
+      this._selector.onCellRangeSelected.subscribe(this.handleCellRangeSelected.bind(this));
+      this._selector.onBeforeCellRangeSelected.subscribe(this.handleBeforeCellRangeSelected.bind(this));
+    }
+
+    // not entirely sure why but it seems that we need to invalidate & rerender all the cells to avoid seeing blank cells
+    this._grid.invalidate();
+  }
+
+  destroy(): void {
+    this._grid.onActiveCellChanged.unsubscribe(this.handleActiveCellChange.bind(this));
+    this._grid.onKeyDown.unsubscribe(this.handleKeyDown.bind(this));
+    this._grid.onClick.unsubscribe(this.handleClick.bind(this));
+    this._selector.onCellRangeSelected.unsubscribe(this.handleCellRangeSelected.bind(this));
+    this._selector.onBeforeCellRangeSelected.unsubscribe(this.handleBeforeCellRangeSelected.bind(this));
+    this._grid.unregisterPlugin(this._selector);
+    this._selector?.destroy();
+  }
+
+  // Region: CellSelectionModel Members
+  // -----------------------------------------------------------------------------
+
+  protected removeInvalidRanges(ranges: SlickRange[]): SlickRange[] {
+    const result: SlickRange[] = [];
+
+    for (let i = 0; i < ranges.length; i++) {
+      const r = ranges[i];
+      if (this._grid.canCellBeSelected(r.fromRow, r.fromCell) && this._grid.canCellBeSelected(r.toRow, r.toCell)) {
+        result.push(r);
+      }
+    }
+
+    return result;
+  }
+
+  protected rangesAreEqual(range1: SlickRange[], range2: SlickRange[]): boolean {
+    let areDifferent = range1.length !== range2.length;
+    if (!areDifferent) {
+      for (let i = 0; i < range1.length; i++) {
+        if (
+          range1[i].fromCell !== range2[i].fromCell ||
+          range1[i].fromRow !== range2[i].fromRow ||
+          range1[i].toCell !== range2[i].toCell ||
+          range1[i].toRow !== range2[i].toRow
+        ) {
+          areDifferent = true;
+          break;
+        }
+      }
+    }
+    return !areDifferent;
+  }
+
+  // Region: RowSelectionModel Members
+  // -----------------------------------------------------------------------------
+
+  protected rangesToRows(ranges: SlickRange[]): number[] {
+    const rows: number[] = [];
+    for (let i = 0; i < ranges.length; i++) {
+      for (let j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
+        rows.push(j);
+      }
+    }
+    return rows;
+  }
+
+  protected rowsToRanges(rows: number[]): SlickRange[] {
+    const ranges: SlickRange[] = [];
+    const lastCell = this._grid.getColumns().length - 1;
+    rows.forEach((row) => ranges.push(new SlickRange(row, 0, row, lastCell)));
+    return ranges;
+  }
+
+  protected getRowsRange(from: number, to: number): number[] {
+    let i;
+    const rows: number[] = [];
+    for (i = from; i <= to; i++) {
+      rows.push(i);
+    }
+    for (i = to; i < from; i++) {
+      rows.push(i);
+    }
+    return rows;
+  }
+
+  getSelectedRows(): number[] {
+    return this.rangesToRows(this._ranges);
+  }
+
+  setSelectedRows(rows: number[]): void {
+    this.setSelectedRanges(this.rowsToRanges(rows), 'SlickRowSelectionModel.setSelectedRows', '');
+  }
+
+  // Region: Shared Members
+  // -----------------------------------------------------------------------------
+
+  /** Provide a way to force a recalculation of page row count (for example on grid resize) */
+  resetPageRowCount(): void {
+    this._cachedPageRowCount = 0;
+  }
+
+  setSelectedRanges(ranges: SlickRange[], caller = 'SlickHybridSelectionModel.setSelectedRanges', selectionMode = ''): void {
+    // simple check for: empty selection didn't change, prevent firing onSelectedRangesChanged
+    if ((!this._ranges || this._ranges.length === 0) && (!ranges || ranges.length === 0)) {
+      return;
+    }
+
+    // if range has not changed, don't fire onSelectedRangesChanged
+    const rangeHasChanged = !this.rangesAreEqual(this._ranges, ranges);
+
+    if (this._activeSelectionIsRow) {
+      this._ranges = ranges;
+
+      // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
+      // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
+      const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller, selectionMode } }), this._ranges);
+      this.onSelectedRangesChanged.notify(this._ranges, eventData);
+    } else {
+      this._ranges = this.removeInvalidRanges(ranges);
+      if (rangeHasChanged) {
+        // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
+        // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
+        const eventData = new SlickEventData(
+          new CustomEvent('click', { detail: { caller, selectionMode, addDragHandle: true } }),
+          this._ranges
+        );
+        this.onSelectedRangesChanged.notify(this._ranges, eventData);
+      }
+    }
+  }
+
+  currentSelectionModeIsRow(): boolean {
+    return this._activeSelectionIsRow;
+  }
+
+  getSelectedRanges(): SlickRange[] {
+    return this._ranges;
+  }
+
+  refreshSelections(): void {
+    if (this._activeSelectionIsRow) {
+      this.setSelectedRows(this.getSelectedRows());
+    } else {
+      this.setSelectedRanges(this.getSelectedRanges(), undefined, '');
+    }
+  }
+
+  getRowMoveManagerPlugin(): SlickRowMoveManager | undefined {
+    return this._grid.getPluginByName('RowMoveManager') || this._grid.getPluginByName('CrossGridRowMoveManager');
+  }
+
+  rowSelectionModelIsActive(data: OnActiveCellChangedEventArgs): boolean {
+    // work out required selection mode
+    if (this._options?.rowSelectOverride) {
+      return this._options?.rowSelectOverride(data, this, this._grid);
+    }
+
+    if (this._options?.handleRowMoveManagerColumn) {
+      const rowMoveManager = this.getRowMoveManagerPlugin();
+      if (rowMoveManager?.isHandlerColumn(data.cell)) {
+        return true;
+      }
+    }
+
+    const targetColumn = this._grid.getVisibleColumns()[data.cell];
+    return this._options?.rowSelectColumnIdArr.includes(`${targetColumn.id}`) || false;
+  }
+
+  protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs): void {
+    this._prevSelectedRow = undefined;
+    const isCellDefined = isDefined(args.cell);
+    const isRowDefined = isDefined(args.row);
+    this._activeSelectionIsRow = this.rowSelectionModelIsActive(args);
+
+    if (this._activeSelectionIsRow) {
+      if (this._options?.selectActiveRow && args.row !== null) {
+        this.setSelectedRanges([new SlickRange(args.row, 0, args.row, this._grid.getColumns().length - 1)], undefined, '');
+      }
+    } else {
+      if (this._options?.selectActiveCell && isRowDefined && isCellDefined) {
+        this.setSelectedRanges([new SlickRange(args.row, args.cell)], undefined, '');
+      } else if (!this._options?.selectActiveCell || (!isRowDefined && !isCellDefined)) {
+        // clear the previous selection once the cell changes
+        this.setSelectedRanges([], undefined, '');
+      }
+    }
+  }
+
+  protected isKeyAllowed(key: string): boolean {
+    return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageDown', 'PageUp', 'Home', 'End'].some((k) => k === key);
+  }
+
+  protected handleKeyDown(e: SlickEventData): void {
+    if (!this._activeSelectionIsRow) {
+      let ranges: SlickRange[], last: SlickRange;
+      const colLn = this._grid.getColumns().length;
+      const active = this._grid.getActiveCell();
+      let dataLn = 0;
+      if (this._dataView && 'getPagingInfo' in this._dataView) {
+        dataLn = this._dataView?.getPagingInfo().pageSize || this._dataView.getLength();
+      } else {
+        dataLn = this._grid.getDataLength();
+      }
+
+      if (active && (e.shiftKey || e.ctrlKey) && !e.altKey && this.isKeyAllowed(e.key as string)) {
+        ranges = this.getSelectedRanges().slice();
+        if (!ranges.length) {
+          ranges.push(new SlickRange(active.row, active.cell));
+        }
+        // keyboard can work with last range only
+        last = ranges.pop() as SlickRange;
+
+        // can't handle selection out of active cell
+        if (!last.contains(active.row, active.cell)) {
+          last = new SlickRange(active.row, active.cell);
+        }
+
+        let dRow = last.toRow - last.fromRow;
+        let dCell = last.toCell - last.fromCell;
+
+        // walking direction
+        const dirRow = active.row === last.fromRow ? 1 : -1;
+        const dirCell = active.cell === last.fromCell ? 1 : -1;
+        const isSingleKeyMove = e.key!.startsWith('Arrow');
+        let toCell: undefined | number = undefined;
+        let toRow = 0;
+
+        if (isSingleKeyMove && !e.ctrlKey) {
+          // single cell move: (Arrow{Up/ArrowDown/ArrowLeft/ArrowRight})
+          if (e.key === 'ArrowLeft') {
+            dCell -= dirCell;
+          } else if (e.key === 'ArrowRight') {
+            dCell += dirCell;
+          } else if (e.key === 'ArrowUp') {
+            dRow -= dirRow;
+          } else if (e.key === 'ArrowDown') {
+            dRow += dirRow;
+          }
+          toRow = active.row + dirRow * dRow;
+        } else {
+          // multiple cell moves: (Home, End, Page{Up/Down})
+          if (this._cachedPageRowCount < 1) {
+            this._cachedPageRowCount = this._grid.getViewportRowCount();
+          }
+          if (this._prevSelectedRow === undefined) {
+            this._prevSelectedRow = active.row;
+          }
+
+          if (e.shiftKey && !e.ctrlKey && e.key === 'Home') {
+            toCell = 0;
+            toRow = active.row;
+          } else if (e.shiftKey && !e.ctrlKey && e.key === 'End') {
+            toCell = colLn - 1;
+            toRow = active.row;
+          } else if (e.ctrlKey && e.shiftKey && e.key === 'Home') {
+            toCell = 0;
+            toRow = 0;
+          } else if (e.ctrlKey && e.shiftKey && e.key === 'End') {
+            toCell = colLn - 1;
+            toRow = dataLn - 1;
+          } else if (e.key === 'PageUp') {
+            if (this._prevSelectedRow >= 0) {
+              toRow = this._prevSelectedRow - this._cachedPageRowCount;
+            }
+            if (toRow < 0) {
+              toRow = 0;
+            }
+          } else if (e.key === 'PageDown') {
+            if (this._prevSelectedRow <= dataLn - 1) {
+              toRow = this._prevSelectedRow + this._cachedPageRowCount;
+            }
+            if (toRow > dataLn - 1) {
+              toRow = dataLn - 1;
+            }
+          }
+          this._prevSelectedRow = toRow;
+        }
+
+        // define new selection range
+        toCell ??= active.cell + dirCell * dCell;
+        const new_last = new SlickRange(active.row, active.cell, toRow, toCell);
+        if (this.removeInvalidRanges([new_last]).length) {
+          ranges.push(new_last);
+          const viewRow = dirRow > 0 ? new_last.toRow : new_last.fromRow;
+          const viewCell = dirCell > 0 ? new_last.toCell : new_last.fromCell;
+
+          if (isSingleKeyMove) {
+            this._grid.scrollRowIntoView(viewRow);
+            this._grid.scrollCellIntoView(viewRow, viewCell);
+          } else {
+            this._grid.scrollRowIntoView(toRow);
+            this._grid.scrollCellIntoView(toRow, viewCell);
+          }
+        } else {
+          ranges.push(last);
+        }
+
+        this.setSelectedRanges(ranges, undefined, '');
+
+        e.preventDefault();
+        e.stopPropagation();
+        this._prevKeyDown = e.key as string;
+      }
+    } else {
+      const activeRow = this._grid.getActiveCell();
+      if (
+        this._grid.getOptions().multiSelect &&
+        activeRow &&
+        e.shiftKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        (e.key === 'ArrowUp' || e.key === 'ArrowDown')
+      ) {
+        let selectedRows = this.getSelectedRows();
+        selectedRows.sort(function (x, y) {
+          return x - y;
+        });
+
+        if (!selectedRows.length) {
+          selectedRows = [activeRow.row];
+        }
+
+        let top = selectedRows[0];
+        let bottom = selectedRows[selectedRows.length - 1];
+        let active: number;
+
+        if (e.key === 'ArrowDown') {
+          active = activeRow.row < bottom || top === bottom ? ++bottom : ++top;
+        } else {
+          active = activeRow.row < bottom ? --bottom : --top;
+        }
+
+        if (active >= 0 && active < this._grid.getDataLength()) {
+          this._grid.scrollRowIntoView(active);
+          const tempRanges = this.rowsToRanges(this.getRowsRange(top, bottom));
+          this.setSelectedRanges(tempRanges, undefined, '');
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+  }
+
+  protected handleClick(e: SlickEventData): boolean | void {
+    if (!this._activeSelectionIsRow) {
+      return;
+    }
+
+    const cell = this._grid.getCellFromEvent(e);
+    if (!cell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
+      return false;
+    }
+
+    if (!this._grid.getOptions().multiSelect || (!e.ctrlKey && !e.shiftKey && !e.metaKey)) {
+      return false;
+    }
+
+    let selection = this.rangesToRows(this._ranges);
+    const idx = selection.indexOf(cell.row);
+
+    if (idx === -1 && (e.ctrlKey || e.metaKey)) {
+      selection.push(cell.row);
+      this._grid.setActiveCell(cell.row, cell.cell);
+    } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
+      selection = selection.filter((o) => o !== cell.row);
+      this._grid.setActiveCell(cell.row, cell.cell);
+    } else if (selection.length && e.shiftKey) {
+      const last = selection.pop() as number;
+      const from = Math.min(cell.row, last);
+      const to = Math.max(cell.row, last);
+      selection = [];
+      for (let i = from; i <= to; i++) {
+        if (i !== last) {
+          selection.push(i);
+        }
+      }
+      selection.push(last);
+      this._grid.setActiveCell(cell.row, cell.cell);
+    }
+
+    const tempRanges = this.rowsToRanges(selection);
+    this.setSelectedRanges(tempRanges, undefined, '');
+    e.stopImmediatePropagation();
+
+    return true;
+  }
+
+  protected handleBeforeCellRangeSelected(e: SlickEventData, cell: { row: number; cell: number }): boolean | void {
+    if (this._activeSelectionIsRow) {
+      if (!this._isRowMoveManagerHandler) {
+        const rowMoveManager = this._grid.getPluginByName<SlickRowMoveManager>('RowMoveManager');
+        this._isRowMoveManagerHandler = rowMoveManager ? rowMoveManager.isHandlerColumn : noop;
+      }
+      if (this._grid.getEditorLock().isActive() || this._isRowMoveManagerHandler(cell.cell)) {
+        e.stopPropagation();
+        return false;
+      }
+      this._grid.setActiveCell(cell.row, cell.cell);
+    } else {
+      if (this._grid.getEditorLock().isActive()) {
+        e.stopPropagation();
+        return false;
+      }
+    }
+  }
+
+  protected handleCellRangeSelected(
+    _e: SlickEventData,
+    args: { range: SlickRange; selectionMode: string; allowAutoEdit?: boolean }
+  ): boolean {
+    if (this._activeSelectionIsRow) {
+      if (!this.gridOptions.multiSelect || !this.addonOptions?.selectActiveRow) {
+        return false;
+      }
+      this.setSelectedRanges(
+        [new SlickRange(args.range.fromRow, 0, args.range.toRow, this._grid.getColumns().length - 1)],
+        undefined,
+        args.selectionMode
+      );
+    } else {
+      this._grid.setActiveCell(args.range.fromRow, args.range.fromCell, args.allowAutoEdit ? undefined : false, false, true);
+      this.setSelectedRanges([args.range], undefined, args.selectionMode);
+    }
+    return true;
+  }
+}

--- a/packages/common/src/extensions/slickRowMoveManager.ts
+++ b/packages/common/src/extensions/slickRowMoveManager.ts
@@ -91,6 +91,10 @@ export class SlickRowMoveManager {
       .subscribe(this._grid.onDragEnd, this.handleDragEnd.bind(this));
   }
 
+  destroy(): void {
+    this.dispose();
+  }
+
   /** Dispose (destroy) the SlickGrid 3rd party plugin */
   dispose(): void {
     this._eventHandler?.unsubscribeAll();
@@ -161,6 +165,10 @@ export class SlickRowMoveManager {
 
   setOptions(newOptions: RowMoveManagerOption): void {
     this._addonOptions = { ...this._addonOptions, ...newOptions };
+  }
+
+  isHandlerColumn(columnIndex: number | string): boolean {
+    return /move|selectAndMove/.test(this._grid.getColumns()[+columnIndex].behavior || '');
   }
 
   // --

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -112,7 +112,7 @@ export class SlickRowSelectionModel implements SelectionModel {
     this.setSelectedRanges(this.rowsToRanges(rows), 'SlickRowSelectionModel.setSelectedRows');
   }
 
-  setSelectedRanges(ranges: SlickRange[], caller = 'SlickRowSelectionModel.setSelectedRanges'): void {
+  setSelectedRanges(ranges: SlickRange[], caller = 'SlickRowSelectionModel.setSelectedRanges', selectionMode?: string): void {
     // simple check for: empty selection didn't change, prevent firing onSelectedRangesChanged
     if ((!this._ranges || this._ranges.length === 0) && (!ranges || ranges.length === 0)) {
       return;
@@ -121,7 +121,7 @@ export class SlickRowSelectionModel implements SelectionModel {
 
     // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
     // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
-    const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller } }), this._ranges);
+    const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller, selectionMode } }), this._ranges);
     this.onSelectedRangesChanged.notify(this._ranges, eventData);
   }
 
@@ -153,11 +153,15 @@ export class SlickRowSelectionModel implements SelectionModel {
     this._grid.setActiveCell(cell.row, cell.cell);
   }
 
-  protected handleCellRangeSelected(_e: SlickEventData, args: { range: SlickRange }): boolean | void {
+  protected handleCellRangeSelected(_e: SlickEventData, args: { range: SlickRange; selectionMode: string }): boolean | void {
     if (!this.gridOptions.multiSelect || !this.addonOptions.selectActiveRow) {
       return false;
     }
-    this.setSelectedRanges([new SlickRange(args.range.fromRow, 0, args.range.toRow, this._grid.getColumns().length - 1)]);
+    this.setSelectedRanges(
+      [new SlickRange(args.range.fromRow, 0, args.range.toRow, this._grid.getColumns().length - 1)],
+      undefined,
+      args.selectionMode
+    );
   }
 
   protected handleActiveCellChange(_e: SlickEventData, args: OnActiveCellChangedEventArgs): void {

--- a/packages/common/src/filters/__tests__/autocompleterFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/autocompleterFilter.spec.ts
@@ -29,7 +29,7 @@ const gridStub = {
   getColumns: vi.fn(),
   getHeaderRowColumn: vi.fn(),
   render: vi.fn(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 describe('AutocompleterFilter', () => {
@@ -37,7 +37,7 @@ describe('AutocompleterFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: AutocompleterFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column & { filter: ColumnFilter };
   let collectionService: CollectionService;
   const http = new HttpStub();
@@ -82,7 +82,7 @@ describe('AutocompleterFilter', () => {
       try {
         mockColumn.filter.collection = undefined;
         filter.init(filterArguments);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.toString()).toContain(
           `[Slickgrid-Universal] You need to pass a "collection" (or "collectionAsync") for the AutoComplete Filter to work correctly.`
         );
@@ -375,7 +375,7 @@ describe('AutocompleterFilter', () => {
       options: {
         triggerOnEveryKeyStroke: true,
         showOnFocus: true,
-        fetch: (searchText) => {
+        fetch: (searchText: string) => {
           callbackMock(searchText);
         },
       },
@@ -402,7 +402,7 @@ describe('AutocompleterFilter', () => {
     mockColumn.filter = {
       filterOptions: {
         showOnFocus: true,
-        fetch: (_, updateCallback) => updateCallback(mockDataResponse),
+        fetch: (_: string, updateCallback: (data: any) => void) => updateCallback(mockDataResponse),
       },
     };
 
@@ -431,7 +431,7 @@ describe('AutocompleterFilter', () => {
     mockColumn.filter = {
       options: {
         showOnFocus: true,
-        fetch: (_, updateCallback) => updateCallback(mockDataResponse),
+        fetch: (_: string, updateCallback: (data: any) => void) => updateCallback(mockDataResponse),
       },
     };
 

--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -30,7 +30,7 @@ const gridStub = {
   getColumns: vi.fn(),
   getHeaderRowColumn: vi.fn(),
   render: vi.fn(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 vi.useFakeTimers();
@@ -39,7 +39,7 @@ describe('CompoundDateFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: CompoundDateFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
   let translateService: TranslateServiceStub;
 
@@ -371,7 +371,7 @@ describe('CompoundDateFilter', () => {
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
-    expect(filter.currentDateOrDates![0].toISOString()).toBe('2000-01-01T05:00:00.000Z');
+    expect((filter.currentDateOrDates as any)[0].toISOString()).toBe('2000-01-01T05:00:00.000Z');
     expect(filterInputElm.value).toBe('2000-01-01T05:00:00.000Z');
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), {
       columnDef: mockColumn,
@@ -399,7 +399,7 @@ describe('CompoundDateFilter', () => {
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
-    expect(format(filter.currentDateOrDates![0], mapTempoDateFormatWithFieldType(FieldType.dateTimeIso))).toBe('2000-01-02 00:00:00');
+    expect(format((filter.currentDateOrDates as any)[0], mapTempoDateFormatWithFieldType(FieldType.dateTimeIso))).toBe('2000-01-02 00:00:00');
     expect(filterInputElm.value).toBe('2000-01-02');
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: '<=', searchTerms: ['2000-01-02'], shouldTriggerQuery: true });
   });
@@ -422,7 +422,7 @@ describe('CompoundDateFilter', () => {
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
-    expect(format(filter.currentDateOrDates![0], mapTempoDateFormatWithFieldType(FieldType.dateTimeIso))).toBe('2000-01-02 00:00:00');
+    expect(format((filter.currentDateOrDates as any)[0], mapTempoDateFormatWithFieldType(FieldType.dateTimeIso))).toBe('2000-01-02 00:00:00');
     expect(filterInputElm.value).toBe('2000-01-02');
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: '<=', searchTerms: ['2000-01-02'], shouldTriggerQuery: true });
   });
@@ -445,7 +445,7 @@ describe('CompoundDateFilter', () => {
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
-    expect(format(filter.currentDateOrDates![0], mapTempoDateFormatWithFieldType(FieldType.dateTimeIso))).toBe('2000-01-02 00:00:00');
+    expect(format((filter.currentDateOrDates as any)[0], mapTempoDateFormatWithFieldType(FieldType.dateTimeIso))).toBe('2000-01-02 00:00:00');
     expect(filterInputElm.value).toBe('2000-01-02');
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: '<=', searchTerms: ['2000-01-02'], shouldTriggerQuery: true });
   });
@@ -514,7 +514,7 @@ describe('CompoundDateFilter', () => {
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
-    expect(filter.currentDateOrDates![0].toISOString()).toBe('2000-01-01T05:00:00.000Z');
+    expect((filter.currentDateOrDates as any)[0].toISOString()).toBe('2000-01-01T05:00:00.000Z');
     expect(filterInputElm.value).toBe('2000-01-01T05:00:00.000Z');
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), {
       columnDef: mockColumn,
@@ -606,7 +606,7 @@ describe('CompoundDateFilter', () => {
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('.form-group.search-filter.filter-finish.filled');
 
     expect(filterFilledElms.length).toBe(1);
-    expect(filter.currentDateOrDates![0].toISOString()).toBe('2000-01-01T05:00:00.000Z');
+    expect((filter.currentDateOrDates as any)[0].toISOString()).toBe('2000-01-01T05:00:00.000Z');
     expect(filterInputElm.value).toBe('2000-01-01T05:00:00.000Z');
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), {
       columnDef: mockColumn,

--- a/packages/common/src/filters/__tests__/compoundInputNumberFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputNumberFilter.spec.ts
@@ -29,7 +29,7 @@ describe('CompoundInputNumberFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: CompoundInputNumberFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/compoundInputPasswordFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputPasswordFilter.spec.ts
@@ -29,7 +29,7 @@ describe('CompoundInputPasswordFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: CompoundInputPasswordFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
@@ -39,7 +39,7 @@ describe('CompoundSliderFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: CompoundSliderFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
@@ -23,14 +23,14 @@ const gridStub = {
   getColumns: vi.fn(),
   getHeaderRowColumn: vi.fn(),
   render: vi.fn(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 describe('DateRangeFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: DateRangeFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
   let translateService: TranslateServiceStub;
 

--- a/packages/common/src/filters/__tests__/inputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputFilter.spec.ts
@@ -28,7 +28,7 @@ describe('InputFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: InputFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/inputMaskFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputMaskFilter.spec.ts
@@ -25,7 +25,7 @@ describe('InputMaskFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: InputMaskFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/inputNumberFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputNumberFilter.spec.ts
@@ -26,7 +26,7 @@ describe('InputNumberFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: InputNumberFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/inputPasswordFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/inputPasswordFilter.spec.ts
@@ -26,7 +26,7 @@ describe('InputPasswordFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: InputPasswordFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/multipleSelectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/multipleSelectFilter.spec.ts
@@ -29,7 +29,7 @@ describe('SelectFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: MultipleSelectFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
   let collectionService: CollectionService;
 

--- a/packages/common/src/filters/__tests__/selectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/selectFilter.spec.ts
@@ -27,7 +27,7 @@ const gridStub = {
   getColumns: vi.fn(),
   getHeaderRowColumn: vi.fn(),
   render: vi.fn(),
-  sanitizeHtmlString: (str) => str,
+  sanitizeHtmlString: (str: string) => str,
 } as unknown as SlickGrid;
 
 describe('SelectFilter', () => {
@@ -35,7 +35,7 @@ describe('SelectFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: SelectFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
   let collectionService: CollectionService;
   const http = new HttpStub();
@@ -78,7 +78,7 @@ describe('SelectFilter', () => {
     new Promise((done: any) => {
       try {
         filter.init(filterArguments);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toContain(
           `[Slickgrid-Universal] You need to pass a "collection" (or "collectionAsync") for the MultipleSelect/SingleSelect Filter to work correctly.`
         );
@@ -106,7 +106,7 @@ describe('SelectFilter', () => {
         ];
         filter = new SelectFilter(translateService, collectionService);
         filter.init(filterArguments);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.toString()).toContain(
           `[select-filter] The Translate Service is required for the Select Filter to work correctly when "enableTranslateLabel" is set.`
         );

--- a/packages/common/src/filters/__tests__/singleSelectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/singleSelectFilter.spec.ts
@@ -31,7 +31,7 @@ describe('SelectFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: SingleSelectFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
   let collectionService: CollectionService;
 

--- a/packages/common/src/filters/__tests__/singleSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/singleSliderFilter.spec.ts
@@ -32,7 +32,7 @@ describe('SingleSliderFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: SingleSliderFilter;
   let filterArgs: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/filters/__tests__/sliderRangeFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/sliderRangeFilter.spec.ts
@@ -32,7 +32,7 @@ describe('SliderRangeFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: SliderRangeFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -121,6 +121,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
     dropPlaceHolderTextKey: 'DROP_COLUMN_HEADER_TO_GROUP_BY',
   },
   editable: false,
+  editorNavigateOnArrows: false,
   editorTypingDebounce: 450,
   filterTypingDebounce: 0,
   enableEmptyDataWarningMessage: true,

--- a/packages/common/src/interfaces/drag.interface.ts
+++ b/packages/common/src/interfaces/drag.interface.ts
@@ -9,12 +9,14 @@ export interface DragItem {
   target: HTMLElement;
   startX: number;
   startY: number;
+  matchClassTag: string;
 }
 
 export interface DragPosition {
   startX: number;
   startY: number;
   range: DragRange;
+  matchClassTag: string;
 }
 
 export interface DragRange {
@@ -26,6 +28,10 @@ export interface DragRange {
     row?: number;
     cell?: number;
   };
+  rowCount?: number;
+  cellCount?: number;
+  wasDraggedUp?: boolean;
+  wasDraggedLeft?: boolean;
 }
 
 export interface DragRowMove {
@@ -39,6 +45,7 @@ export interface DragRowMove {
   grid: SlickGrid;
   guide: HTMLElement;
   insertBefore: number;
+  matchClassTag: string;
   offsetX: number;
   offsetY: number;
   originalX: number;

--- a/packages/common/src/interfaces/editor.interface.ts
+++ b/packages/common/src/interfaces/editor.interface.ts
@@ -1,5 +1,11 @@
 import type { EditorArguments, EditorValidationResult } from './index.js';
 
+export interface ValidateOption {
+  rowIndex?: number;
+  cellIndex?: number;
+  inputValue?: number | string | boolean | null;
+}
+
 /**
  * SlickGrid Editor interface, more info can be found on the SlickGrid repo
  * https://github.com/6pac/SlickGrid/wiki/Writing-custom-cell-editors
@@ -119,7 +125,7 @@ export interface Editor {
    * if the input is valid then the validation result output would be returning { valid:true, msg:null }
    * The first argument "targetElm" is ONLY used internally by the Composite Editor in most cases you want to make this null or undefined
    */
-  validate: (targetElm?: HTMLElement, options?: any) => EditorValidationResult;
+  validate: (targetElm?: HTMLElement, options?: ValidateOption) => EditorValidationResult;
 }
 
 export type EditorConstructor = {

--- a/packages/common/src/interfaces/gridEvents.interface.ts
+++ b/packages/common/src/interfaces/gridEvents.interface.ts
@@ -7,7 +7,7 @@ import type {
   EditorValidationResult,
   GridOption,
 } from './index.js';
-import type { SlickGrid } from '../core/index.js';
+import type { SlickGrid, SlickRange } from '../core/index.js';
 
 export interface SlickGridArg {
   grid: SlickGrid;
@@ -194,4 +194,9 @@ export interface OnDragEventArgs extends SlickGridArg {
   rows: number[];
   startX: number;
   startY: number;
+}
+export interface OnDragReplaceCellsEventArgs extends SlickGridArg {
+  prevSelectedRange: SlickRange;
+  selectedRange: SlickRange;
+  copyToRange?: SlickRange;
 }

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -344,6 +344,9 @@ export interface GridOption<C extends Column = Column> {
   /** Defaults to false, editor cell navigation left/right keys */
   editorCellNavOnLRKeys?: boolean;
 
+  /** Defaults to false, when enabled will allow editor navigation using arrow keys */
+  editorNavigateOnArrows?: boolean;
+
   /** option to intercept edit commands and implement undo support. */
   editCommandHandler?: (item: any, column: C, command: EditCommand) => void;
 

--- a/packages/common/src/interfaces/interactions.interface.ts
+++ b/packages/common/src/interfaces/interactions.interface.ts
@@ -7,6 +7,17 @@ export interface InteractionBase {
   destroy: () => void;
 }
 
+export interface ClassDetectElement {
+  /** element id to match */
+  id?: string;
+
+  /** element cssSelector to match */
+  cssSelector?: string;
+
+  /** tag to be returned on match */
+  tag: string;
+}
+
 export interface DraggableOption {
   /** container DOM element, defaults to "document" */
   containerElement?: HTMLElement | Document;
@@ -16,6 +27,9 @@ export interface DraggableOption {
 
   /** when defined, will allow dragging from a specific element or its closest parent by using the .closest() query selector. */
   allowDragFromClosest?: string;
+
+  /** array of elements to match for drag start */
+  dragFromClassDetectArr?: Array<ClassDetectElement>;
 
   /** Defaults to `['ctrlKey', 'metaKey']`, list of keys that when pressed will prevent Draggable events from triggering (e.g. prevent onDrag when Ctrl key is pressed while dragging) */
   preventDragFromKeys?: Array<'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>;

--- a/packages/common/src/styles/_variables-theme-material.scss
+++ b/packages/common/src/styles/_variables-theme-material.scss
@@ -90,6 +90,7 @@ $slick-editor-input-group-clear-btn-icon-color:               inherit !default;
   $slick-editor-input-height:                                 100% !default,
   $slick-editor-input-group-clear-btn-icon-padding:           1px 6px !default,
   $slick-row-mouse-hover-color:                               #ebfaef !default,
+  $slick-cell-selected-color:                                 #d4f6d7 !default,
   $slick-row-selected-color:                                  #d4f6d7 !default,
   $slick-pagination-icon-color:                               $primary-color !default,
   $slick-pagination-button-border-radius:                     2px !default,
@@ -130,7 +131,8 @@ $slick-dark-text-color:                                   #d4d4d4;
   --slick-checkbox-icon-color:                    #4dae52;
   --slick-row-mouse-hover-box-shadow:             none;
   --slick-row-mouse-hover-color:                  #575757;
-  --slick-row-selected-color:                     #4b4b4b;
+  --slick-cell-selected-color:                    #474a45;
+  --slick-row-selected-color:                     #474a45;
   --slick-checkbox-icon-color:                    #59c55f;
   --slick-checkbox-icon-height:                   22px;
   --slick-checkbox-icon-bg-color:                 transparent;

--- a/packages/common/src/styles/_variables-theme-salesforce.scss
+++ b/packages/common/src/styles/_variables-theme-salesforce.scss
@@ -122,6 +122,7 @@ $slick-editor-grid-cell-border-width-modified:                  1px 7px 1px 1px 
   $slick-editor-modal-title-text-align:                         center !default,
   $slick-large-editor-button-border-radius:                     3px !default,
   $slick-slider-filter-runnable-track-bgcolor:                  #ECEBEA !default,
+  $slick-cell-selected-color:                                   #ECEBEA !default,
   $slick-row-selected-color:                                    #ECEBEA !default,
   $slick-row-highlight-background-color:                        #{color.adjust($slick-highlight-color, $lightness: 50%)} !default,
   $slick-row-mouse-hover-color:                                 #f3f2f2 !default,

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -98,6 +98,8 @@ $slick-cell-odd-active-background-color:                    color.adjust($slick-
 $slick-cell-padding-top-bottom:                             5px !default;
 $slick-cell-padding-left-right:                             6px !default;
 $slick-cell-padding:                                        $slick-cell-padding-top-bottom $slick-cell-padding-left-right !default;
+$slick-cell-selected-editable-color:                        #ffffff !default;
+$slick-cell-selected-color:                                 #dae8f1 !default;
 $slick-icon-with-text-valign:                               middle !default;
 
 /** 4x available slick-pane (top, bottom, left, right) */
@@ -107,7 +109,7 @@ $slick-pane-top-border-top:                                 none !default;
 $slick-row-mouse-hover-color:                               #eff5fc !default;
 $slick-row-mouse-hover-box-shadow:                          none !default;
 $slick-row-mouse-hover-z-index:                             5 !default;
-$slick-row-selected-color:                                  #dae8f1 !default;
+$slick-row-selected-color:                                  $slick-cell-selected-color !default;
 $slick-row-highlight-background-color:                      color.adjust($slick-row-selected-color, $lightness: -5%) !default;
 $slick-row-highlight-fade-animation:                        1s linear !default;
 $slick-row-checkbox-selector-background:                    inherit !default;
@@ -1146,6 +1148,7 @@ $slick-dark-text-color:                                   #d4d4d4 !default;
   --slick-pagination-page-input-bgcolor:                  #2b2f34;
   --slick-pagination-page-select-bg-color:                #1c1c1c;
   --slick-pagination-text-color:                          #cfcfcf;
+  --slick-cell-selected-color:                             #474747;
   --slick-row-selected-color:                             #474747;
   --slick-scrollbar-color:                                #828282 #424242;
   --slick-sorting-header-color:                           var(--slick-base-dark-text-color);

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -136,9 +136,6 @@
     }
     &.odd .slick-cell {
       background: inherit;
-      &.selected {
-        background-color: var(--slick-row-selected-color, v.$slick-row-selected-color);
-      }
       &.copied {
         background: var(--slick-copied-cell-bg-color-transition, v.$slick-copied-cell-bg-color-transition);
         transition: var(--slick-copied-cell-transition, v.$slick-copied-cell-transition);
@@ -531,7 +528,10 @@
         text-align: left;
       }
       &.selected {
-        background-color: var(--slick-row-selected-color, v.$slick-row-selected-color);
+        background-color: var(--slick-cell-selected-color, v.$slick-cell-selected-color);
+        &.editable {
+          background-color: var(--slick-cell-selected-editable-color, v.$slick-cell-selected-editable-color);
+        }
       }
       &.copied {
         background: var(--slick-copied-cell-bg-color-transition, v.$slick-copied-cell-bg-color-transition);

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -1260,3 +1260,12 @@ li.hidden {
     z-index: var(--slick-detail-view-container-z-index, v.$slick-detail-view-container-z-index);
   }
 }
+
+.slick-drag-replace-handle {
+  height: 7px;
+  width: 7px;
+  background: gray;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}

--- a/test/cypress/e2e/example36.cy.ts
+++ b/test/cypress/e2e/example36.cy.ts
@@ -1,0 +1,169 @@
+describe('Example 36 - Hybrid Selection Model', () => {
+  const grid1Titles = ['#', 'Title', '% Complete', 'Start', 'Finish', 'Priority', 'Effort Driven'];
+  const grid2Titles = ['', '#', 'Title', '% Complete', 'Start', 'Finish', 'Priority', 'Effort Driven'];
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example36`);
+    cy.get('h3').should('contain', 'Example 36 - Hybrid Selection Model');
+  });
+
+  describe('Grid 1', () => {
+    it('should have exact column titles in first grid', () => {
+      cy.get('.grid36-1')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => {
+          if (index > 0 && index < grid1Titles.length) {
+            expect($child.text()).to.eq(grid1Titles[index]);
+          }
+        });
+    });
+
+    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+      cy.get('.grid36-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
+      cy.get('@task1').should('contain', 'Task 1');
+      cy.get('@task1').click().should('have.class', 'selected');
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 1);
+
+      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+
+      cy.get('.grid36-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 4);
+    });
+
+    it('should be able to expand the cell selections further to the right', () => {
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 4);
+      cy.get('.grid36-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
+        .find('.slick-drag-replace-handle')
+        .trigger('mousedown', { which: 1, force: true });
+
+      cy.get('.grid36-1 .slick-row[data-row="2"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 6);
+    });
+
+    it('should be able to expand the cell selections further to the bottom', () => {
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 6);
+      cy.get('.grid36-1 .slick-row[data-row="2"] .slick-cell.l3.r3')
+        .find('.slick-drag-replace-handle')
+        .trigger('mousedown', { which: 1, force: true });
+
+      cy.get('.grid36-1 .slick-row[data-row="3"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 9);
+    });
+
+    it('should click on 1st column and then row 2 and 3, then expect the full (single) row to be selected', () => {
+      cy.get('.grid36-1 .slick-row[data-row="1"] .slick-cell.l0.r0').as('task1');
+      cy.get('@task1').should('contain', '1');
+      cy.get('@task1').click().should('have.class', 'selected');
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 7);
+
+      // select another row
+      cy.get('.grid36-1 .slick-row[data-row="2"] .slick-cell.l0.r0').as('task2');
+      cy.get('@task2').should('contain', '2');
+      cy.get('@task2').click().should('have.class', 'selected');
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 7);
+    });
+
+    it('should be able to select 3 rows (from Task 4 to 6) when holding Shift key and clicking on the next 2 rows (again on same column index 0)', () => {
+      cy.get('.grid36-1 .slick-row[data-row="4"] .slick-cell.l0.r0').as('task4');
+      cy.get('@task4').should('contain', '4');
+      cy.get('@task4').click().should('have.class', 'selected');
+
+      cy.get('.grid36-1 .slick-row[data-row="6"] .slick-cell.l0.r0').click({ shiftKey: true }).should('have.class', 'selected');
+      cy.get('.grid36-1 .slick-cell.selected').should('have.length', 7 * 3);
+    });
+  });
+
+  describe('Grid 2', () => {
+    it('should have exact column titles in second grid', () => {
+      cy.get('.grid36-2')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => {
+          if (index > 0 && index < grid2Titles.length) {
+            expect($child.text()).to.eq(grid2Titles[index]);
+          }
+        });
+    });
+
+    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+      cy.get('.grid36-2 .slick-row[data-row="1"] .slick-cell.l2.r2').as('task1');
+      cy.get('@task1').should('contain', 'Task 1');
+      cy.get('@task1').click().should('have.class', 'active');
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 0);
+
+      cy.get('@task1').trigger('mousemove', 'bottomRight');
+      cy.get('@task1').type('{shift}{rightArrow}', { force: true }); // hold the Shift key while dragging
+
+      cy.get('.grid36-2 .slick-row[data-row="1"] .slick-cell.l3.r3').trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-row[data-row="1"] .slick-cell.l3.r3')
+        .find('.slick-drag-replace-handle')
+        .trigger('mousedown', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-row[data-row="2"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 4);
+    });
+
+    it('should be able to expand the cell selections further to the right', () => {
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 4);
+      cy.get('.grid36-2 .slick-row[data-row="2"] .slick-cell.l3.r3')
+        .find('.slick-drag-replace-handle')
+        .trigger('mousedown', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-row[data-row="2"] .slick-cell.l4.r4')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 6);
+    });
+
+    it('should be able to expand the cell selections further to the bottom', () => {
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 6);
+      cy.get('.grid36-2 .slick-row[data-row="2"] .slick-cell.l4.r4')
+        .find('.slick-drag-replace-handle')
+        .trigger('mousedown', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-row[data-row="3"] .slick-cell.l4.r4')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 9);
+    });
+
+    it('should click on a cell outside of the selected range and expect previous selection to remain', () => {
+      cy.get('.grid36-2 .slick-row[data-row="4"] .slick-cell.l2.r2').as('task4');
+      cy.get('@task4').should('contain', 'Task 4').click();
+      cy.get('.grid36-2 .slick-viewport-top.slick-viewport-left').scrollTo('top');
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 9);
+    });
+
+    it('should click on row 4 and 5 row checkbox and expect 5 full rows to be selected', () => {
+      cy.get('.grid36-2 .slick-row[data-row="4"] .slick-cell.l0.r0').as('task4');
+      cy.get('.grid36-2 .slick-row[data-row="4"] .slick-cell.l1.r1').should('contain', '4');
+      cy.get('@task4').click();
+      cy.get('@task4').should('have.class', 'selected');
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 8 * 4);
+
+      // select another row
+      cy.get('.grid36-2 .slick-row[data-row="5"] .slick-cell.l0.r0').as('task5');
+      cy.get('.grid36-2 .slick-row[data-row="5"] .slick-cell.l1.r1').should('contain', '5');
+      cy.get('@task5').click();
+      cy.get('.grid36-2 .slick-viewport-top.slick-viewport-left').scrollTo('top');
+      cy.get('@task5').should('have.class', 'selected');
+      cy.get('.grid36-2 .slick-cell.selected').should('have.length', 8 * 5);
+    });
+  });
+});

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -1,0 +1,132 @@
+describe('Example 37 - Spreadsheet Drag-Fill', () => {
+  const titles = [
+    '',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N',
+    'O',
+    'P',
+    'Q',
+    'R',
+    'S',
+    'T',
+    'U',
+    'V',
+    'W',
+    'X',
+    'Y',
+    'Z',
+    'AA',
+    'AB',
+    'AC',
+    'AD',
+    'AE',
+    'AF',
+    'AG',
+    'AH',
+    'AI',
+    'AJ',
+    'AK',
+  ];
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example37`);
+    cy.get('h3').should('contain', 'Example 37 - Spreadsheet Drag-Fill');
+  });
+
+  it('should have exact column titles on 1st grid', () => {
+    cy.get('.grid37')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => {
+        if (index > 0 && index < titles.length) {
+          expect($child.text()).to.eq(titles[index]);
+        }
+      });
+  });
+
+  it('should click on B1 cell, type "1" and then replicate the same on C1 and D1 by increasing the value by +1 (1,2,3)', () => {
+    cy.get('.grid37 .slick-row[data-row="1"] .slick-cell.l2.r2').as('cellB1');
+    cy.get('@cellB1').click().type('1').type('{enter}');
+    cy.get('@cellB1').should('contain', '1');
+
+    cy.get('.grid37 .slick-row[data-row="1"] .slick-cell.l3.r3').as('cellC1');
+    cy.get('@cellC1').click().type('2').type('{enter}');
+    cy.get('@cellC1').should('contain', '2');
+
+    cy.get('.grid37 .slick-row[data-row="1"] .slick-cell.l4.r4').as('cellD1');
+    cy.get('@cellD1').click().type('3').type('{enter}');
+    cy.get('@cellD1').should('contain', '3');
+  });
+
+  it('should click on B2 cell, type "4" and then replicate the same on C2 and D2 by increasing the value by +1 again (4,5,6)', () => {
+    cy.get('.grid37 .slick-row[data-row="2"] .slick-cell.l2.r2').as('cellB2');
+    cy.get('@cellB2').click().type('4').type('{enter}');
+    cy.get('@cellB2').should('contain', '4');
+
+    cy.get('.grid37 .slick-row[data-row="2"] .slick-cell.l3.r3').as('cellC2');
+    cy.get('@cellC2').click().type('5').type('{enter}');
+    cy.get('@cellC2').should('contain', '5');
+
+    cy.get('.grid37 .slick-row[data-row="2"] .slick-cell.l4.r4').as('cellD2');
+    cy.get('@cellD2').click().type('6').type('{enter}');
+    cy.get('@cellD2').should('contain', '6');
+  });
+
+  it('should click back on B1 cell and expand the cell selections to include all 6 modified cells', () => {
+    cy.get('.grid37 .slick-row[data-row="1"] .slick-cell.l2.r2').as('B1');
+    cy.get('@B1').should('contain', '1');
+    cy.get('@B1')
+      .click()
+      .type('{esc}') // make sure to click Escape to allow dragging
+      .should('have.class', 'selected');
+    cy.get('.grid37 .slick-cell.selected').should('have.length', 1);
+
+    cy.get('@B1').trigger('mousedown', { which: 1, force: true }).trigger('mousemove', 'bottomRight');
+
+    cy.get('.grid37 .slick-row[data-row="2"] .slick-cell.l4.r4')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+    cy.get('.grid37 .slick-cell.selected').should('have.length', 6);
+  });
+
+  it('should now be able to drag from bottom right corner to expand the cell selections to include an extra row and an extra column', () => {
+    cy.get('.grid37 .slick-row[data-row="2"] .slick-cell.l4.r4').as('D2');
+    cy.get('@D2').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+
+    cy.get('.grid37 .slick-row[data-row="4"] .slick-cell.l6.r6')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+
+    cy.get('.grid37 .slick-cell.selected').should('have.length', 20);
+  });
+
+  it('should expect new cell selections with replicated values', () => {
+    cy.get('.grid37 .slick-cell.selected').should('have.length', 20);
+
+    const filledValues = [
+      [1, 2, 3, 1, 2],
+      [4, 5, 6, 4, 5],
+      [1, 2, 3, 1, 2],
+      [4, 5, 6, 4, 5],
+    ];
+
+    for (let i = 0; i < filledValues.length; i++) {
+      for (let j = 0; j < filledValues[i].length; j++) {
+        cy.get(`.grid37 .slick-row[data-row="${i + 1}"] .slick-cell.l${j + 2}.r${j + 2}`).should('contain', filledValues[i][j]);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Thanks to Ben (6pac) for starting this new feature in SlickGrid repo:

> New HybridSelectionModel combines cell and row selection models. It functions like CellSelectionModel except when certain conditions switch it into RowSelectionModel. If the options.rowSelectOverride function exists, then HybridSelectionModel calls it expecting a boolean return to determine whether to behave like RowSelectionModel. If this option is not set, then selection of a column that is a member of the array options.rowSelectColumnObjectArr will be treated with the behaviour of RowSelectionModel.
> 
> Drag and Replace option mirrors Excel as closely as possible. When a range of cells is selected, a grey box appears at the bottom right of the selection area, and dragging that grey box expands the selection area and replaces the newly selected cells will the contents of the existing cells. Excel specifically only allows expansion horizontally or vertically, but here we allow both. The current behaviour may be modified. Note that the spreadsheet example the FormulaEditor causes problems with this new feature because it creates a new CellRangeSelector each time a cell is edited. This editor needs to add an event to the existing grid's CellRangeSelector, or create a new one.

![SlickPR_DragFill_Hybrid](https://github.com/user-attachments/assets/4fc5c49e-b166-4a9e-aee8-641789a305b4)
