### PR TITLE
fix: Compound Input Operator w/o SearchVal shouldn't start filtering

### DIFF
--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -271,6 +271,23 @@ describe('CompoundDateFilter', () => {
     expect(callbackSpy).not.toHaveBeenCalled();
   });
 
+  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is undefined and value is also undefined', () => {
+    mockColumn.filter!.operator = '>';
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = undefined;
+    const callbackSpy = vi.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['']);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-finish input.date-picker') as HTMLInputElement;
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-finish select') as HTMLInputElement;
+
+    filterInputElm.value = undefined as any;
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+
   it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True and value is empty string', () => {
     mockColumn.filter!.operator = '>';
     mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;

--- a/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
@@ -193,6 +193,20 @@ describe('CompoundInputFilter', () => {
     expect(callbackSpy).not.toHaveBeenCalled();
   });
 
+  it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as undefined and value is also undefined', () => {
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = undefined;
+    mockColumn.type = FieldType.number;
+    const callbackSpy = vi.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-duration select') as HTMLInputElement;
+
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).not.toHaveBeenCalled();
+  });
+
   it('should change operator dropdown without a value entered and not expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as True and value is empty string', () => {
     mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
     mockColumn.type = FieldType.number;

--- a/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundSliderFilter.spec.ts
@@ -186,6 +186,19 @@ describe('CompoundSliderFilter', () => {
     expect(callbackSpy).not.toHaveBeenCalled();
   });
 
+  it('should change operator dropdown without a value entered and expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is undefined', () => {
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = undefined;
+    const callbackSpy = vi.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    const filterSelectElm = divContainer.querySelector('.search-filter.filter-duration select') as HTMLInputElement;
+
+    filterSelectElm.value = '<=';
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(callbackSpy).toHaveBeenCalled();
+  });
+
   it('should change operator dropdown without a value entered and expect the callback to be called when "skipCompoundOperatorFilterWithNullInput" is defined as False', () => {
     mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = false;
     const callbackSpy = vi.spyOn(filterArguments, 'callback');

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -377,7 +377,9 @@ export class InputFilter implements Filter {
       const typingDelay = eventType === 'keyup' && (event as KeyboardEvent)?.key !== 'Enter' ? this._debounceTypingDelay : 0;
 
       const skipNullInput =
-        this.columnFilter.skipCompoundOperatorFilterWithNullInput ?? this.gridOptions.skipCompoundOperatorFilterWithNullInput;
+        this.columnFilter.skipCompoundOperatorFilterWithNullInput ??
+        this.gridOptions.skipCompoundOperatorFilterWithNullInput ??
+        this.gridOptions.skipCompoundOperatorFilterWithNullInput === undefined;
       const hasSkipNullValChanged =
         (skipNullInput && isDefined(this._currentValue)) || (this._currentValue === '' && isDefined(this._lastSearchValue));
 

--- a/packages/common/src/interfaces/columnFilter.interface.ts
+++ b/packages/common/src/interfaces/columnFilter.interface.ts
@@ -160,9 +160,9 @@ export interface ColumnFilter {
   emptySearchTermReturnAllValues?: boolean;
 
   /**
-   * Should we skip filtering when the Operator is changed before the Compound Filter input.
+   * Should we skip filtering when the Operator is changed without a search value.
    * For example, with a CompoundDate Filter it's probably better to wait until we have a date filled before filtering even if we start with the operator.
-   * Defaults to True only for the Compound Date Filter (all other compound filters will still filter even when operator is first changed).
+   * Defaults to True for all Compound Filters except for Compound Slider.
    */
   skipCompoundOperatorFilterWithNullInput?: boolean;
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -743,9 +743,9 @@ export interface GridOption<C extends Column = Column> {
   resizeByContentOptions?: ResizeByContentOption;
 
   /**
-   * Should we skip filtering when the Operator is changed before the Compound Filter input.
+   * Should we skip filtering when the Operator is changed without a search value.
    * For example, with a CompoundDate Filter it's probably better to wait until we have a date filled before filtering even if we start with the operator.
-   * Defaults to True only for the Compound Date Filter (all other compound filters will still filter even when operator is first changed).
+   * Defaults to True for all Compound Filters except for Compound Slider.
    */
   skipCompoundOperatorFilterWithNullInput?: boolean;
 


### PR DESCRIPTION
fixes #2163

changing a compound operator without search value, shouldn't automatically start filtering because that is confusing for some users. I added `skipCompoundOperatorFilterWithNullInput` a while ago but it was also defaulting to True for Date Filter, however I think it makes sense to enable it for all Compound Input except for the Compound Slider since it already has a value