### PR TITLE
fix: toggling Row Detail under a Group should become out of viewport

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example47-detail-view.html
+++ b/demos/aurelia/src/examples/slickgrid/example47-detail-view.html
@@ -1,7 +1,7 @@
 <div class="container-fluid" style="margin-top: 10px">
   <h3>${model.title}</h3>
   <div class="row">
-    <div class="col-3 detail-label"><label>Assignee:</label> <input class="form-control" value.bind="model.assignee" /></div>
+    <div class="col-3 detail-label"><label>Assignee:</label> <input class="form-control assignee" value.bind="model.assignee" /></div>
     <div class="col-3 detail-label"><label>Reporter:</label> <span>${model.reporter}</span></div>
     <div class="col-3 detail-label"><label>Duration:</label> <span>${model.duration | decimal: 2}</span></div>
     <div class="col-3 detail-label"><label>% Complete:</label> <span>${model.percentComplete}</span></div>

--- a/demos/aurelia/src/examples/slickgrid/example47.html
+++ b/demos/aurelia/src/examples/slickgrid/example47.html
@@ -34,10 +34,10 @@
     <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="clear-grouping-btn" click.trigger="clearGrouping()">
       <i class="mdi mdi-close"></i> Clear grouping
     </button>
-    <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="collapse-all-group-btn" click.trigger="collapseAllGroups()">
+    <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="collapse-all-groups-btn" click.trigger="collapseAllGroups()">
       <i class="mdi mdi-arrow-collapse"></i> Collapse all groups
     </button>
-    <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="expand-all-btn" click.trigger="expandAllGroups()">
+    <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="expand-all-groups-btn" click.trigger="expandAllGroups()">
       <i class="mdi mdi-arrow-expand"></i> Expand all groups
     </button>
 

--- a/demos/aurelia/test/cypress/e2e/example47.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example47.cy.ts
@@ -83,7 +83,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-group-toggle.collapsed').should('have.length', 0);
     cy.get('.slick-group-toggle.expanded').should('have.length.at.least', 2);
 
-    cy.get('[data-test=collapse-all-group-btn]').click();
+    cy.get('[data-test=collapse-all-groups-btn]').click();
 
     cy.get('.slick-group-toggle.expanded').should('have.length', 0);
     cy.get('.slick-group-toggle.collapsed').should('have.length.at.least', 2);
@@ -105,5 +105,88 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
+  });
+
+  it('should re-open first Row Details and be able to click on the "Click Me" button and expect an alert message', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+    let assigneeName = '';
+
+    cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should collapse first Group, then re-expand first Group and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.slick-group-toggle.expanded').first().click();
+    cy.wait(50);
+    cy.get('.slick-group-toggle.collapsed').first().click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should click on "Collapsed all groups" button, then click on "Expand all groups" button and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('[data-test=collapse-all-groups-btn]').click();
+    cy.wait(50);
+    cy.get('[data-test=expand-all-groups-btn]').click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
   });
 });

--- a/demos/react/src/examples/slickgrid/Example47-detail-view.tsx
+++ b/demos/react/src/examples/slickgrid/Example47-detail-view.tsx
@@ -54,7 +54,7 @@ const Example47DetailView: React.FC<RowDetailViewProps<Item, any>> = forwardRef(
         <div className="col-3 detail-label">
           <label>Assignee:</label>{' '}
           <input
-            className="form-control"
+            className="form-control assignee"
             value={assignee}
             onInput={function ($event) {
               assigneeChanged(($event.target as HTMLInputElement).value);

--- a/demos/react/src/examples/slickgrid/Example47.tsx
+++ b/demos/react/src/examples/slickgrid/Example47.tsx
@@ -394,12 +394,16 @@ const Example47: React.FC = () => {
             </button>
             <button
               className="btn btn-outline-secondary btn-sm btn-icon"
-              data-test="collapse-all-group-btn"
+              data-test="collapse-all-groups-btn"
               onClick={() => collapseAllGroups()}
             >
               <i className="mdi mdi-arrow-collapse"></i> Collapse all groups
             </button>
-            <button className="btn btn-outline-secondary btn-sm btn-icon" data-test="expand-all-btn" onClick={() => expandAllGroups()}>
+            <button
+              className="btn btn-outline-secondary btn-sm btn-icon"
+              data-test="expand-all-groups-btn"
+              onClick={() => expandAllGroups()}
+            >
               <i className="mdi mdi-arrow-expand"></i> Expand all groups
             </button>
 

--- a/demos/react/test/cypress/e2e/example47.cy.ts
+++ b/demos/react/test/cypress/e2e/example47.cy.ts
@@ -83,7 +83,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-group-toggle.collapsed').should('have.length', 0);
     cy.get('.slick-group-toggle.expanded').should('have.length.at.least', 2);
 
-    cy.get('[data-test=collapse-all-group-btn]').click();
+    cy.get('[data-test=collapse-all-groups-btn]').click();
 
     cy.get('.slick-group-toggle.expanded').should('have.length', 0);
     cy.get('.slick-group-toggle.collapsed').should('have.length.at.least', 2);
@@ -105,5 +105,88 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
+  });
+
+  it('should re-open first Row Details and be able to click on the "Click Me" button and expect an alert message', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+    let assigneeName = '';
+
+    cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should collapse first Group, then re-expand first Group and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.slick-group-toggle.expanded').first().click();
+    cy.wait(50);
+    cy.get('.slick-group-toggle.collapsed').first().click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should click on "Collapsed all groups" button, then click on "Expand all groups" button and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('[data-test=collapse-all-groups-btn]').click();
+    cy.wait(50);
+    cy.get('[data-test=expand-all-groups-btn]').click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
   });
 });

--- a/demos/vanilla/src/examples/example36.html
+++ b/demos/vanilla/src/examples/example36.html
@@ -48,11 +48,11 @@
 
 <section class="mb-2">
   <div class="row">
-    <button class="button is-small" data-test="collapse-all-group-btn" onclick.trigger="collapseAllGroups()">
+    <button class="button is-small" data-test="collapse-all-groups-btn" onclick.trigger="collapseAllGroups()">
       <span class="mdi mdi-arrow-collapse"></span>
       <span>Collapse all groups</span>
     </button>
-    <button class="button is-small" data-test="expand-all-btn" onclick.trigger="expandAllGroups()">
+    <button class="button is-small" data-test="expand-all-groups-btn" onclick.trigger="expandAllGroups()">
       <span class="mdi mdi-arrow-expand"></span>
       <span>Expand all groups</span>
     </button>

--- a/demos/vanilla/src/examples/example36.ts
+++ b/demos/vanilla/src/examples/example36.ts
@@ -209,6 +209,8 @@ export default class Example36 {
         preTemplate: this.loadingTemplate.bind(this),
         postTemplate: this.loadView.bind(this),
         process: this.simulateServerAsyncCall.bind(this),
+        loadOnce: true,
+        singleRowExpand: false,
 
         // how many grid rows do we want to use for the detail panel
         // also note that the detail view adds an extra 1 row for padding purposes
@@ -265,14 +267,19 @@ export default class Example36 {
     });
 
     this._eventHandler.subscribe(this.rowDetail.onAfterRowDetailToggle, (_e, args) => {
-      console.log('after toggling row detail', args.item);
+      // console.log('after toggling row detail', args.item);
       if (args.item._collapsed) {
         this.disposeRowDetailElementListeners(args.item.id);
+      } else {
+        // reset & recreate event listeners associated to that row detail
+        this.disposeRowDetailElementListeners(args.item.id);
+        this.addDeleteRowOnClickListener(args.item.id);
+        this.addAssigneeOnClickListener(args.item.id);
       }
     });
 
     this._eventHandler.subscribe(this.rowDetail.onAsyncEndUpdate, (_e, args) => {
-      console.log('finished updating the post async template', args);
+      // console.log('finished updating the post async template', args);
       this.addDeleteRowOnClickListener(args.item.id);
       this.addAssigneeOnClickListener(args.item.id);
     });
@@ -284,7 +291,8 @@ export default class Example36 {
     });
 
     this._eventHandler.subscribe(this.rowDetail.onRowBackToViewportRange, (_e, args) => {
-      // this.addDeleteRowOnClickListener(args.item.id);
+      // console.log('row is back to viewport range', args);
+      this.addDeleteRowOnClickListener(args.item.id);
       this.addAssigneeOnClickListener(args.item.id);
     });
   }
@@ -346,7 +354,7 @@ export default class Example36 {
         <div class="container">
           <div class="columns">
             <div class="column is-half">
-            <div class="detail"><label>Assignee:</label> <input class="input is-small is-8 column mt-1" id="assignee_${itemDetail.id}" type="text" value="${itemDetail.assignee}"/></div>
+            <div class="detail"><label>Assignee:</label> <input class="input is-small is-8 column mt-1 assignee" id="assignee_${itemDetail.id}" type="text" value="${itemDetail.assignee}"/></div>
               <div class="detail"><label>Reporter:</label> <span>${itemDetail.reporter}</span></div>
               <div class="detail"><label>Duration:</label> <span>${itemDetail.duration}</span></div>
               <div class="detail"><label>% Complete:</label> <span>${itemDetail.percentComplete}</span></div>

--- a/demos/vue/src/components/Example47.vue
+++ b/demos/vue/src/components/Example47.vue
@@ -380,10 +380,10 @@ function vueGridReady(grid: SlickgridVueInstance) {
         <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="clear-grouping-btn" @click="clearGrouping()">
           <i class="mdi mdi-close"></i> Clear grouping
         </button>
-        <button class="btn btn-outline-secondary btn-sm btn-icon mx-1" data-test="collapse-all-group-btn" @click="collapseAllGroups()">
+        <button class="btn btn-outline-secondary btn-sm btn-icon mx-1" data-test="collapse-all-groups-btn" @click="collapseAllGroups()">
           <i class="mdi mdi-arrow-collapse"></i> Collapse all groups
         </button>
-        <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="expand-all-btn" @click="expandAllGroups()">
+        <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="expand-all-groups-btn" @click="expandAllGroups()">
           <i class="mdi mdi-arrow-expand"></i> Expand all groups
         </button>
 

--- a/demos/vue/src/components/Example47Detail.vue
+++ b/demos/vue/src/components/Example47Detail.vue
@@ -44,7 +44,7 @@ function showNotification(model: Item) {
   <div class="container-fluid" style="margin-top: 10px">
     <h3>{{ model.title }}</h3>
     <div class="row">
-      <div class="col-3 detail-label"><label>Assignee:</label> <input :value="model.assignee" class="form-control" /></div>
+      <div class="col-3 detail-label"><label>Assignee:</label> <input :value="model.assignee" class="form-control assignee" /></div>
       <div class="col-3 detail-label">
         <label>Reporter:</label> <span>{{ model.reporter }}</span>
       </div>

--- a/demos/vue/test/cypress/e2e/example47.cy.ts
+++ b/demos/vue/test/cypress/e2e/example47.cy.ts
@@ -83,7 +83,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-group-toggle.collapsed').should('have.length', 0);
     cy.get('.slick-group-toggle.expanded').should('have.length.at.least', 2);
 
-    cy.get('[data-test=collapse-all-group-btn]').click();
+    cy.get('[data-test=collapse-all-groups-btn]').click();
 
     cy.get('.slick-group-toggle.expanded').should('have.length', 0);
     cy.get('.slick-group-toggle.collapsed').should('have.length.at.least', 2);
@@ -105,5 +105,88 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
+  });
+
+  it('should re-open first Row Details and be able to click on the "Click Me" button and expect an alert message', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+    let assigneeName = '';
+
+    cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should collapse first Group, then re-expand first Group and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.slick-group-toggle.expanded').first().click();
+    cy.wait(50);
+    cy.get('.slick-group-toggle.collapsed').first().click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should click on "Collapsed all groups" button, then click on "Expand all groups" button and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('[data-test=collapse-all-groups-btn]').click();
+    cy.wait(50);
+    cy.get('[data-test=expand-all-groups-btn]').click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
   });
 });

--- a/frameworks/angular-slickgrid/src/demos/examples/example47-rowdetail.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example47-rowdetail.component.html
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <h3>{{ model?.title }}</h3>
   <div class="row">
-    <div class="col-3 detail-label"><label>Assignee:</label> <input class="form-control" [(ngModel)]="model.assignee" /></div>
+    <div class="col-3 detail-label"><label>Assignee:</label> <input class="form-control assignee" [(ngModel)]="model.assignee" /></div>
     <div class="col-3 detail-label">
       <label>Reporter:</label> <span>{{ model?.reporter }}</span>
     </div>

--- a/frameworks/angular-slickgrid/src/demos/examples/example47.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example47.component.html
@@ -43,12 +43,12 @@
       <button
         class="btn btn-outline-secondary btn-sm btn-icon"
         type="button"
-        data-test="collapse-all-group-btn"
+        data-test="collapse-all-groups-btn"
         (click)="collapseAllGroups()"
       >
         <i class="mdi mdi-arrow-collapse"></i> Collapse all groups
       </button>
-      <button class="btn btn-outline-secondary btn-sm btn-icon" type="button" data-test="expand-all-btn" (click)="expandAllGroups()">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" type="button" data-test="expand-all-groups-btn" (click)="expandAllGroups()">
         <i class="mdi mdi-arrow-expand"></i> Expand all groups
       </button>
 

--- a/frameworks/angular-slickgrid/src/library/extensions/__tests__/slickRowDetailView.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/extensions/__tests__/slickRowDetailView.spec.ts
@@ -84,6 +84,8 @@ const dataViewStub = {
   getItem: vi.fn(),
   getItems: vi.fn(),
   getItemCount: vi.fn(),
+  onGroupCollapsed: new SlickEvent(),
+  onGroupExpanded: new SlickEvent(),
   onRowCountChanged: new SlickEvent(),
   onRowsChanged: new SlickEvent(),
   onSetItemsCalled: new SlickEvent(),

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example47.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example47.cy.ts
@@ -83,7 +83,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-group-toggle.collapsed').should('have.length', 0);
     cy.get('.slick-group-toggle.expanded').should('have.length.at.least', 2);
 
-    cy.get('[data-test=collapse-all-group-btn]').click();
+    cy.get('[data-test=collapse-all-groups-btn]').click();
 
     cy.get('.slick-group-toggle.expanded').should('have.length', 0);
     cy.get('.slick-group-toggle.collapsed').should('have.length.at.least', 2);
@@ -105,5 +105,88 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
+  });
+
+  it('should re-open first Row Details and be able to click on the "Click Me" button and expect an alert message', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+    let assigneeName = '';
+
+    cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
+    cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should collapse first Group, then re-expand first Group and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.slick-group-toggle.expanded').first().click();
+    cy.wait(50);
+    cy.get('.slick-group-toggle.collapsed').first().click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
+  });
+
+  it('should click on "Collapsed all groups" button, then click on "Expand all groups" button and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('[data-test=collapse-all-groups-btn]').click();
+    cy.wait(50);
+    cy.get('[data-test=expand-all-groups-btn]').click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h3')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail-label label').should('contain', 'Assignee:');
+    cy.get('.detail-label input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assigneeName.toUpperCase()}`));
   });
 });

--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -689,6 +689,7 @@ describe('SlickDatView core file', () => {
         formatter: (g) => `Family: ${g.value} <span class="text-green">(${g.count} items)</span>`,
       } as Grouping);
 
+      expect(dv.getItemsByGroupingKey('Doe').length).toBe(2);
       expect(dv.getGroups().length).toBe(1);
       expect(refreshSpy).toHaveBeenCalled();
       expect(dv.getGrouping().length).toBe(1);

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -459,7 +459,7 @@ export class SlickGroup extends SlickNonDataItem {
    * @property rows
    * @type {Array}
    */
-  rows: number[] = [];
+  rows: any[] = [];
 
   /**
    * Sub-groups that are part of the group.
@@ -472,7 +472,7 @@ export class SlickGroup extends SlickNonDataItem {
    * A unique key used to identify the group.
    * This key can be used in calls to DataView `collapseGroup()` or `expandGroup()`.
    * @property groupingKey
-   * @type {Object}
+   * @type {String}
    */
   groupingKey = '';
 

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -849,6 +849,11 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     this.onGroupCollapsed.notify({ level, groupingKey });
   }
 
+  /** Get all data items for a specific grouping key */
+  getItemsByGroupingKey(groupingKey: string | number): TData[] {
+    return this.groups[(groupingKey as any) || '']?.rows || [];
+  }
+
   /**
    * @param varArgs Either a SlickGroup's "groupingKey" property, or a
    *     variable argument list of grouping values denoting a unique path to the row.  For

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -851,7 +851,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
   /** Get all data items for a specific grouping key */
   getItemsByGroupingKey(groupingKey: string | number): TData[] {
-    return this.groups[(groupingKey as any) || '']?.rows || [];
+    return this.groups.find((g) => g.groupingKey === groupingKey)?.rows || [];
   }
 
   /**

--- a/test/cypress/e2e/example36.cy.ts
+++ b/test/cypress/e2e/example36.cy.ts
@@ -1,6 +1,13 @@
 describe('Example 36 - Row Detail View + Grouping', () => {
   const fullTitles = ['', '', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Cost', 'Effort Driven'];
 
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, 'log');
+    });
+  });
+
   it('should display Example title', () => {
     cy.visit(`${Cypress.config('baseUrl')}/example36`);
     cy.get('h3').should('contain', 'Example 36 - Row Detail View + Grouping');
@@ -90,7 +97,7 @@ describe('Example 36 - Row Detail View + Grouping', () => {
     cy.get('.slick-group-toggle.collapsed').should('have.length', 0);
     cy.get('.slick-group-toggle.expanded').should('have.length.at.least', 2);
 
-    cy.get('[data-test=collapse-all-group-btn]').click();
+    cy.get('[data-test=collapse-all-groups-btn]').click();
 
     cy.get('.slick-group-toggle.expanded').should('have.length', 0);
     cy.get('.slick-group-toggle.collapsed').should('have.length.at.least', 2);
@@ -112,5 +119,88 @@ describe('Example 36 - Row Detail View + Grouping', () => {
     cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.notification.is-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
+  });
+
+  it('should re-open first Row Details and be able to click on the "Click Me" button and expect an alert message', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+    let assigneeName = '';
+
+    cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
+    cy.get('[data-row="1"] > .slick-cell.l2').contains(/Task [0-9]*/);
+    cy.get('[data-row="1"] > .slick-cell.l1').click().wait(40);
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h4')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail label').should('contain', 'Assignee:');
+    cy.get('.detail input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee is ${assigneeName}`));
+  });
+
+  it('should collapse first Group, then re-expand first Group and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('.slick-group-toggle.expanded').first().click();
+    cy.wait(50);
+    cy.get('.slick-group-toggle.collapsed').first().click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h4')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail label').should('contain', 'Assignee:');
+    cy.get('.detail input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee is ${assigneeName}`));
+  });
+
+  it('should click on "Collapsed all groups" button, then click on "Expand all groups" button and still expect an alert when clicking on the "Click Me" button inside Row Detail', () => {
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy.get('[data-test=collapse-all-groups-btn]').click();
+    cy.wait(50);
+    cy.get('[data-test=expand-all-groups-btn]').click();
+
+    let assigneeName = '';
+
+    cy.get('.slick-cell + .dynamic-cell-detail')
+      .find('h4')
+      .contains(/Task [0-9]*/);
+
+    cy.get('.dynamic-cell-detail').should('have.length', 1);
+    cy.get('.detail label').should('contain', 'Assignee:');
+    cy.get('.detail input').should('exist');
+    cy.get('input.assignee')
+      .first()
+      .invoke('val')
+      .then((val) => (assigneeName = val as string));
+
+    cy.get('[data-test=assignee-btn]')
+      .first()
+      .click()
+      .then(() => expect(stub.getCall(0)).to.be.calledWith(`Assignee is ${assigneeName}`));
   });
 });


### PR DESCRIPTION
This fixes an issue that I only found in the vanilla implementation of Row Detail, the issue was that there's a "Click Me" button inside each Row Detail and it worked fine the first time we open the Row Detail but then if we collapse a Group (single and/or all groups) then the button click stopped working. Again I'm not exactly why it still worked in all other framework wrappers, but still we should consider the Row Detail to be out of the viewport when we collapse a data Group (because it's no longer visible, hence considered to be "out of viewport" so that we can trigger some events related that change, which are remove all button events and re-add them back when we open the Group again)