### PR TITLE
chore: use native popover to show custom toast

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/utilities.ts
+++ b/demos/aurelia/src/examples/slickgrid/utilities.ts
@@ -5,25 +5,37 @@ export function randomNumber(min: number, max: number, floor = true) {
 
 export function showToast(msg: string, type: 'danger' | 'info' | 'warning', time = 2000) {
   const divContainer = document.createElement('div');
+  divContainer.setAttribute('popover', '');
   divContainer.className = `toast align-items-center text-bg-${type} border-0`;
   divContainer.style.position = 'absolute';
-  divContainer.style.left = '50%';
-  divContainer.style.top = '20px';
-  divContainer.style.transform = 'translate(-50%)';
   divContainer.style.zIndex = '9999';
-  divContainer.style.display = 'block';
-
-  const divFlex = document.createElement('div');
-  divFlex.className = 'd-flex align-items-center';
 
   const divBody = document.createElement('div');
   divBody.className = 'toast-body';
   divBody.textContent = msg;
-
-  divContainer.appendChild(divFlex);
-  divFlex.appendChild(divBody);
+  divContainer.appendChild(divBody);
   document.body.appendChild(divContainer);
 
+  // When popover is supported, use it to display the message.
+  // Baseline 2024: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover
+  if (typeof divContainer.showPopover === 'function') {
+    divContainer.style.display = 'block';
+    divContainer.style.margin = '0 auto';
+    divContainer.style.marginTop = '20px';
+    divContainer.style.borderWidth = '0px';
+    divContainer.showPopover();
+    setTimeout(() => {
+      divContainer.hidePopover();
+      divContainer.remove();
+    }, time);
+    return;
+  }
+
+  // @deprecated, remove fallback in next major release
+  // otherwise, fallback (when popover is not supported): keep the div visible as regular HTML and remove after timeout.
+  divContainer.style.left = '50%';
+  divContainer.style.top = '20px';
+  divContainer.style.transform = 'translateX(-50%)';
   setTimeout(() => divContainer.remove(), time);
 }
 

--- a/demos/react/src/examples/slickgrid/utilities.ts
+++ b/demos/react/src/examples/slickgrid/utilities.ts
@@ -5,25 +5,37 @@ export function randomNumber(min: number, max: number, floor = true) {
 
 export function showToast(msg: string, type: 'danger' | 'info' | 'warning', time = 2000) {
   const divContainer = document.createElement('div');
+  divContainer.setAttribute('popover', '');
   divContainer.className = `toast align-items-center text-bg-${type} border-0`;
   divContainer.style.position = 'absolute';
-  divContainer.style.left = '50%';
-  divContainer.style.top = '20px';
-  divContainer.style.transform = 'translate(-50%)';
   divContainer.style.zIndex = '9999';
-  divContainer.style.display = 'block';
-
-  const divFlex = document.createElement('div');
-  divFlex.className = 'd-flex align-items-center';
 
   const divBody = document.createElement('div');
   divBody.className = 'toast-body';
   divBody.textContent = msg;
-
-  divContainer.appendChild(divFlex);
-  divFlex.appendChild(divBody);
+  divContainer.appendChild(divBody);
   document.body.appendChild(divContainer);
 
+  // When popover is supported, use it to display the message.
+  // Baseline 2024: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover
+  if (typeof divContainer.showPopover === 'function') {
+    divContainer.style.display = 'block';
+    divContainer.style.margin = '0 auto';
+    divContainer.style.marginTop = '20px';
+    divContainer.style.borderWidth = '0px';
+    divContainer.showPopover();
+    setTimeout(() => {
+      divContainer.hidePopover();
+      divContainer.remove();
+    }, time);
+    return;
+  }
+
+  // @deprecated, remove fallback in next major release
+  // otherwise, fallback (when popover is not supported): keep the div visible as regular HTML and remove after timeout.
+  divContainer.style.left = '50%';
+  divContainer.style.top = '20px';
+  divContainer.style.transform = 'translateX(-50%)';
   setTimeout(() => divContainer.remove(), time);
 }
 

--- a/demos/vanilla/src/examples/utilities.ts
+++ b/demos/vanilla/src/examples/utilities.ts
@@ -29,15 +29,33 @@ export function randomNumber(min: number, max: number, floor = true) {
 
 export function showToast(msg: string, type: 'danger' | 'info' | 'warning', time = 2000) {
   const div = document.createElement('div');
+  div.setAttribute('popover', '');
   div.className = `notification is-light is-${type} is-small is-narrow toast`;
+  div.style.display = 'block';
   div.style.position = 'absolute';
-  div.style.left = '50%';
-  div.style.top = '20px';
-  div.style.transform = 'translate(-50%)';
   div.style.zIndex = '999';
   div.textContent = msg;
   document.body.appendChild(div);
 
+  // When popover is supported, use it to display the message.
+  // Baseline 2024: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover
+  if (typeof div.showPopover === 'function') {
+    div.style.margin = '0 auto';
+    div.style.marginTop = '20px';
+    div.style.borderWidth = '0px';
+    div.showPopover();
+    setTimeout(() => {
+      div.hidePopover();
+      div.remove();
+    }, time);
+    return;
+  }
+
+  // @deprecated, remove fallback in next major release
+  // otherwise, fallback (when popover is not supported): keep the div visible as regular HTML and remove after timeout.
+  div.style.left = '50%';
+  div.style.top = '20px';
+  div.style.transform = 'translateX(-50%)';
   setTimeout(() => div.remove(), time);
 }
 

--- a/demos/vue/src/components/utilities.ts
+++ b/demos/vue/src/components/utilities.ts
@@ -5,25 +5,37 @@ export function randomNumber(min: number, max: number, floor = true) {
 
 export function showToast(msg: string, type: 'danger' | 'info' | 'warning', time = 2000) {
   const divContainer = document.createElement('div');
+  divContainer.setAttribute('popover', '');
   divContainer.className = `toast align-items-center text-bg-${type} border-0`;
   divContainer.style.position = 'absolute';
-  divContainer.style.left = '50%';
-  divContainer.style.top = '20px';
-  divContainer.style.transform = 'translate(-50%)';
   divContainer.style.zIndex = '9999';
-  divContainer.style.display = 'block';
-
-  const divFlex = document.createElement('div');
-  divFlex.className = 'd-flex align-items-center';
 
   const divBody = document.createElement('div');
   divBody.className = 'toast-body';
   divBody.textContent = msg;
-
-  divContainer.appendChild(divFlex);
-  divFlex.appendChild(divBody);
+  divContainer.appendChild(divBody);
   document.body.appendChild(divContainer);
 
+  // When popover is supported, use it to display the message.
+  // Baseline 2024: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover
+  if (typeof divContainer.showPopover === 'function') {
+    divContainer.style.display = 'block';
+    divContainer.style.margin = '0 auto';
+    divContainer.style.marginTop = '20px';
+    divContainer.style.borderWidth = '0px';
+    divContainer.showPopover();
+    setTimeout(() => {
+      divContainer.hidePopover();
+      divContainer.remove();
+    }, time);
+    return;
+  }
+
+  // @deprecated, remove fallback in next major release
+  // otherwise, fallback (when popover is not supported): keep the div visible as regular HTML and remove after timeout.
+  divContainer.style.left = '50%';
+  divContainer.style.top = '20px';
+  divContainer.style.transform = 'translateX(-50%)';
   setTimeout(() => divContainer.remove(), time);
 }
 

--- a/frameworks/angular-slickgrid/src/demos/examples/utilities.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/utilities.ts
@@ -5,26 +5,37 @@ export function randomNumber(min: number, max: number, floor = true) {
 
 export function showToast(msg: string, type: 'danger' | 'info' | 'warning', time = 2000) {
   const divContainer = document.createElement('div');
+  divContainer.setAttribute('popover', '');
   divContainer.className = `toast align-items-center text-bg-${type} border-0`;
   divContainer.style.position = 'absolute';
-  divContainer.style.left = '50%';
-  divContainer.style.top = '20px';
-  divContainer.style.transform = 'translate(-50%)';
   divContainer.style.zIndex = '9999';
-  divContainer.style.display = 'block';
-
-  const divFlex = document.createElement('div');
-  divFlex.className = 'd-flex align-items-center';
 
   const divBody = document.createElement('div');
   divBody.className = 'toast-body';
   divBody.textContent = msg;
-
-  divContainer.appendChild(divFlex);
-  divFlex.appendChild(divBody);
+  divContainer.appendChild(divBody);
   document.body.appendChild(divContainer);
-  console.log('div toast', divContainer.outerHTML);
 
+  // When popover is supported, use it to display the message.
+  // Baseline 2024: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover
+  if (typeof divContainer.showPopover === 'function') {
+    divContainer.style.display = 'block';
+    divContainer.style.margin = '0 auto';
+    divContainer.style.marginTop = '20px';
+    divContainer.style.borderWidth = '0px';
+    divContainer.showPopover();
+    setTimeout(() => {
+      divContainer.hidePopover();
+      divContainer.remove();
+    }, time);
+    return;
+  }
+
+  // @deprecated, remove fallback in next major release
+  // otherwise, fallback (when popover is not supported): keep the div visible as regular HTML and remove after timeout.
+  divContainer.style.left = '50%';
+  divContainer.style.top = '20px';
+  divContainer.style.transform = 'translateX(-50%)';
   setTimeout(() => divContainer.remove(), time);
 }
 


### PR DESCRIPTION
popover should be supported by all browser, but let's use a fallback until at least next major release since it's considered as Baseline 2024
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover

This is a custom toast, it's just used by the examples and is a mainly a playground to test before using it in the future in our Custom Tooltip (though that will take much longer, since I also want to use css-anchor for Custom Tooltip and this is still not supported by Firefox yet, hopefully by end of 2025, they will)