### PR TITLE
chore: use JSDOM only for unit tests & stop relying on happy-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "eslint-plugin-cypress": "catalog:",
     "eslint-plugin-n": "catalog:",
     "globals": "catalog:",
-    "happy-dom": "^20.0.0",
     "jsdom": "catalog:",
     "jsdom-global": "catalog:",
     "npm-run-all2": "catalog:",

--- a/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellRangeSelector.spec.ts
@@ -209,7 +209,7 @@ describe('CellRangeSelector Plugin', () => {
     const dragEventStart = addVanillaEventPropagation(new Event('dragStart'));
     gridStub.onDragStart.notify({ offsetX: 6, offsetY: 7, row: 1, startX: 3, startY: 4 } as any, dragEventStart, gridStub);
 
-    const dragEvent = addVanillaEventPropagation(new DragEvent('drag'));
+    const dragEvent = addVanillaEventPropagation(new Event('drag'));
     Object.defineProperty(dragEvent, 'pageX', { writable: true, configurable: true, value: 0 });
     Object.defineProperty(dragEvent, 'pageY', { writable: true, configurable: true, value: 0 });
     gridStub.onDrag.notify(
@@ -256,7 +256,7 @@ describe('CellRangeSelector Plugin', () => {
     const dragEventStart = addVanillaEventPropagation(new Event('dragStart'));
     gridStub.onDragStart.notify({ offsetX: 6, offsetY: 7, row: 1, startX: 3, startY: 4 } as any, dragEventStart, gridStub);
 
-    const dragEvent = addVanillaEventPropagation(new DragEvent('drag'));
+    const dragEvent = addVanillaEventPropagation(new Event('drag'));
     (dragEvent as any).pageX = -2;
     (dragEvent as any).pageY = -156;
     gridStub.onDrag.notify(
@@ -810,7 +810,7 @@ describe('CellRangeSelector Plugin', () => {
     const dragEventStart = addVanillaEventPropagation(new Event('dragStart'));
     gridStub.onDragStart.notify({ offsetX: 6, offsetY: 7, row: 1, startX: 3, startY: 4 } as any, dragEventStart, gridStub);
 
-    const dragEvent = addVanillaEventPropagation(new DragEvent('drag'));
+    const dragEvent = addVanillaEventPropagation(new Event('drag'));
     Object.defineProperty(dragEvent, 'pageX', { writable: true, configurable: true, value: 0 });
     Object.defineProperty(dragEvent, 'pageY', { writable: true, configurable: true, value: 0 });
     gridStub.onDrag.notify(
@@ -863,7 +863,7 @@ describe('CellRangeSelector Plugin', () => {
     const dragEventStart = addVanillaEventPropagation(new Event('dragStart'));
     gridStub.onDragStart.notify({ offsetX: 6, offsetY: 7, row: 1, startX: 3, startY: 4 } as any, dragEventStart, gridStub);
 
-    const dragEvent = addVanillaEventPropagation(new DragEvent('drag'));
+    const dragEvent = addVanillaEventPropagation(new Event('drag'));
     Object.defineProperty(dragEvent, 'pageX', { writable: true, configurable: true, value: 0 });
     Object.defineProperty(dragEvent, 'pageY', { writable: true, configurable: true, value: 0 });
     gridStub.onDrag.notify(

--- a/packages/common/src/extensions/__tests__/slickRowSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowSelectionModel.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 
-import { SlickEvent, type SlickGrid, SlickRange } from '../../core/index.js';
+import { type SlickEditorLock, SlickEvent, type SlickGrid, SlickRange } from '../../core/index.js';
 import type { Column, GridOption } from '../../interfaces/index.js';
 import { SlickCellRangeSelector } from '../slickCellRangeSelector.js';
 import { SlickRowSelectionModel } from '../slickRowSelectionModel.js';
@@ -36,7 +36,7 @@ const pubSubServiceStub = {
 const getEditorLockMock = {
   commitCurrentEdit: vi.fn(),
   isActive: vi.fn(),
-};
+} as unknown as SlickEditorLock;
 
 const gridStub = {
   canCellBeActive: vi.fn(),

--- a/packages/common/src/filters/__tests__/autocompleterFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/autocompleterFilter.spec.ts
@@ -6,7 +6,7 @@ import { AutocompleterFilter } from '../autocompleterFilter.js';
 import { FieldType, OperatorType } from '../../enums/index.js';
 import type { AutocompleterOption, Column, ColumnFilter, FilterArguments, GridOption } from '../../interfaces/index.js';
 import { CollectionService } from '../../services/collection.service.js';
-import { HttpStub } from '../../../../../test/httpClientStub.js';
+import { basicFetchStub } from '../../../../../test/httpClientStub.js';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub.js';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub.js';
 import type { SlickGrid } from '../../core/index.js';
@@ -40,7 +40,6 @@ describe('AutocompleterFilter', () => {
   let spyGetHeaderRow: any;
   let mockColumn: Column & { filter: ColumnFilter };
   let collectionService: CollectionService;
-  const http = new HttpStub();
 
   beforeEach(() => {
     translaterService = new TranslateServiceStub();
@@ -470,13 +469,7 @@ describe('AutocompleterFilter', () => {
   it('should create the filter with a default search term when using "collectionAsync" is a Fetch Promise and triggerOnEveryKeyStroke is enabled', async () => {
     const spyCallback = vi.spyOn(filterArguments, 'callback');
     const mockCollection = ['male', 'female'];
-
-    http.status = 200;
-    http.object = mockCollection;
-    http.returnKey = 'date';
-    http.returnValue = '6/24/1984';
-    http.responseHeaders = { accept: 'json' };
-    mockColumn.filter.collectionAsync = http.fetch('http://locahost/api', { method: 'GET' });
+    mockColumn.filter.collectionAsync = basicFetchStub('http://locahost/api', { method: 'GET' }, mockCollection);
     mockColumn.filter.filterOptions = { showOnFocus: true, triggerOnEveryKeyStroke: true } as AutocompleterOption;
 
     filterArguments.searchTerms = ['female'];

--- a/packages/common/src/filters/__tests__/selectFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/selectFilter.spec.ts
@@ -8,7 +8,7 @@ import { CollectionService } from '../../services/collection.service.js';
 import { Filters } from '../filters.index.js';
 import { SelectFilter } from '../selectFilter.js';
 import type { SlickGrid } from '../../core/index.js';
-import { HttpStub } from '../../../../../test/httpClientStub.js';
+import { basicFetchStub } from '../../../../../test/httpClientStub.js';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub.js';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub.js';
 
@@ -38,7 +38,6 @@ describe('SelectFilter', () => {
   let spyGetHeaderRow: any;
   let mockColumn: Column;
   let collectionService: CollectionService;
-  const http = new HttpStub();
 
   beforeEach(() => {
     translateService = new TranslateServiceStub();
@@ -904,12 +903,7 @@ describe('SelectFilter', () => {
     const spyCallback = vi.spyOn(filterArguments, 'callback');
     const mockCollection = ['male', 'female'];
 
-    http.status = 200;
-    http.object = mockCollection;
-    http.returnKey = 'date';
-    http.returnValue = '6/24/1984';
-    http.responseHeaders = { accept: 'json' };
-    mockColumn.filter!.collectionAsync = http.fetch('http://locahost/api', { method: 'GET' });
+    mockColumn.filter!.collectionAsync = basicFetchStub('http://locahost/api', { method: 'GET' }, mockCollection);
 
     filterArguments.searchTerms = ['female'];
     await filter.init(filterArguments);
@@ -1084,12 +1078,7 @@ describe('SelectFilter', () => {
       const spyCallback = vi.spyOn(filterArguments, 'callback');
       const mockCollection = ['male', 'female'];
 
-      http.status = 200;
-      http.object = mockCollection;
-      http.returnKey = 'date';
-      http.returnValue = '6/24/1984';
-      http.responseHeaders = { accept: 'json' };
-      mockColumn.filter!.collectionLazy = () => http.fetch('http://locahost/api', { method: 'GET' });
+      mockColumn.filter!.collectionLazy = () => basicFetchStub('http://locahost/api', { method: 'GET' }, mockCollection);
 
       filterArguments.searchTerms = ['female'];
       await filter.init(filterArguments);

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -32,7 +32,7 @@ import {
 } from '../utilities.js';
 import { SumAggregator } from '../../aggregators/sumAggregator.js';
 import { Constants } from '../../constants.js';
-import { HttpStub } from '../../../../../test/httpClientStub.js';
+import { basicFetchStub } from '../../../../../test/httpClientStub.js';
 
 describe('applyHtmlToElement() method', () => {
   const defaultOptions: GridOption = {
@@ -1407,14 +1407,8 @@ describe('Service/Utilies', () => {
     });
 
     it('should be able to load async collection from a Fetch Promise', async () => {
-      const http = new HttpStub();
       const mockCollection = ['male', 'female'];
-      http.status = 200;
-      http.object = mockCollection;
-      http.returnKey = 'date';
-      http.returnValue = '6/24/1984';
-      http.responseHeaders = { accept: 'json' };
-      const collectionAsync = http.fetch('http://locahost/api', { method: 'GET' });
+      const collectionAsync = basicFetchStub('http://locahost/api', { method: 'GET' }, mockCollection);
 
       const output = fetchAsPromise(collectionAsync);
 
@@ -1433,15 +1427,9 @@ describe('Service/Utilies', () => {
     });
 
     it('should throw an error when Fetch Promise response bodyUsed is true', async () => {
-      const http = new HttpStub();
       const consoleSpy = vi.spyOn(global.console, 'warn').mockReturnValue();
       const mockCollection = ['male', 'female'];
-      http.status = 200;
-      http.object = mockCollection;
-      http.returnKey = 'date';
-      http.returnValue = '6/24/1984';
-      http.responseHeaders = { accept: 'json' };
-      const collectionAsync = http.fetch('http://invalid-url', { method: 'GET' });
+      const collectionAsync = basicFetchStub('http://invalid-url', { method: 'GET' }, mockCollection);
 
       await fetchAsPromise(collectionAsync);
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[SlickGrid-Universal] The response body passed to Fetch was already read.'));

--- a/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
+++ b/packages/custom-tooltip-plugin/src/__tests__/slickCustomTooltip.spec.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-import { type Column, getOffset, type GridOption, type SlickGrid, type SlickDataView, SlickEvent, SlickEventData } from '@slickgrid-universal/common';
+import {
+  type Column,
+  getOffset,
+  type GridOption,
+  type SlickGrid,
+  type SlickDataView,
+  type SlickEditorLock,
+  SlickEvent,
+  SlickEventData,
+} from '@slickgrid-universal/common';
 import { delay, of, throwError } from 'rxjs';
 
 import { SlickCustomTooltip } from '../slickCustomTooltip.js';
@@ -27,7 +36,7 @@ const dataviewStub = {
 
 const getEditorLockMock = {
   isActive: vi.fn(),
-};
+} as unknown as SlickEditorLock;
 
 const gridStub = {
   getCellFromEvent: vi.fn(),

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -51,7 +51,7 @@ import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 
 import { SlickVanillaGridBundle } from '../slick-vanilla-grid-bundle.js';
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub.js';
-import { HttpStub } from '../../../../../test/httpClientStub.js';
+import { basicFetchStub } from '../../../../../test/httpClientStub.js';
 import { MockSlickEvent, MockSlickEventHandler } from '../../../../../test/mockSlickEvent.js';
 import { UniversalContainerService } from '../../services/universalContainer.service.js';
 import { RxJsResourceStub } from '../../../../../test/rxjsResourceStub.js';
@@ -311,7 +311,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
   let sharedService: SharedService;
   let eventPubSubService: EventPubSubService;
   let translateService: TranslateServiceStub;
-  const http = new HttpStub();
   const container = new UniversalContainerService();
   let dataset: any[] = [];
 
@@ -907,12 +906,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should be able to load async editors with a Fetch Promise', async () => {
         const mockCollection = ['male', 'female'];
-        http.status = 200;
-        http.object = mockCollection;
-        http.returnKey = 'date';
-        http.returnValue = '6/24/1984';
-        http.responseHeaders = { accept: 'json' };
-        const collectionAsync = http.fetch('http://locahost/api', { method: 'GET' });
+        const collectionAsync = basicFetchStub('http://locahost/api', { method: 'GET' }, mockCollection);
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync } }] as Column[];
 
         component.columnDefinitions = mockColDefs;
@@ -945,12 +939,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
       it('should throw an error when Fetch Promise response bodyUsed is true', async () => {
         const consoleSpy = vi.spyOn(global.console, 'warn').mockReturnValue();
         const mockCollection = ['male', 'female'];
-        http.status = 200;
-        http.object = mockCollection;
-        http.returnKey = 'date';
-        http.returnValue = '6/24/1984';
-        http.responseHeaders = { accept: 'json' };
-        const collectionAsync = http.fetch('http://invalid-url', { method: 'GET' });
+        const collectionAsync = basicFetchStub('http://invalid-url', { method: 'GET' }, mockCollection);
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync } }] as Column[];
         component.columnDefinitions = mockColDefs;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,9 +203,6 @@ importers:
       globals:
         specifier: 'catalog:'
         version: 16.4.0
-      happy-dom:
-        specifier: ^20.0.0
-        version: 20.0.0
       jsdom:
         specifier: 'catalog:'
         version: 27.0.0(postcss@8.5.6)
@@ -3702,9 +3699,6 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
-
-  '@napi-rs/wasm-runtime@1.0.5':
-    resolution: {integrity: sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==}
 
   '@napi-rs/wasm-runtime@1.0.7':
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
@@ -14827,13 +14821,6 @@ snapshots:
       '@emnapi/runtime': 1.5.0
       '@tybys/wasm-util': 0.9.0
 
-  '@napi-rs/wasm-runtime@1.0.5':
-    dependencies:
-      '@emnapi/core': 1.5.0
-      '@emnapi/runtime': 1.5.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -15884,7 +15871,7 @@ snapshots:
 
   '@rspack/binding-wasm32-wasi@1.5.8':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.5
+      '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.5.8':
@@ -16214,6 +16201,7 @@ snapshots:
   '@types/node@20.19.18':
     dependencies:
       undici-types: 6.21.0
+    optional: true
 
   '@types/node@22.18.7':
     dependencies:
@@ -16282,7 +16270,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/whatwg-mimetype@3.0.2': {}
+  '@types/whatwg-mimetype@3.0.2':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -19126,6 +19115,7 @@ snapshots:
       '@types/node': 20.19.18
       '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
+    optional: true
 
   has-bigints@1.1.0: {}
 
@@ -23722,7 +23712,8 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
-  whatwg-mimetype@3.0.0: {}
+  whatwg-mimetype@3.0.0:
+    optional: true
 
   whatwg-mimetype@4.0.0: {}
 

--- a/test/httpClientStub.ts
+++ b/test/httpClientStub.ts
@@ -1,50 +1,34 @@
-export class HttpStub {
-  status = 0;
-  statusText = '';
-  object: any = {};
-  returnKey = '';
-  returnValue: any;
-  responseHeaders: any;
+export function basicFetchStub(input: string, init?: RequestInit, data?: any | any[]) {
+  const isInvalidUrl = input.includes('invalid-url');
 
-  fetch(input: any, init: any) {
-    let request;
-    const responseInit: any = {};
-    responseInit.headers = new Headers();
-
-    for (const name in this.responseHeaders || {}) {
-      if (name) {
-        responseInit.headers.set(name, this.responseHeaders[name]);
+  const response = {
+    ok: !isInvalidUrl,
+    status: 200,
+    url: input,
+    method: init?.method || 'GET',
+    json: () => {
+      if (isInvalidUrl) {
+        return Promise.reject(new Error('Invalid URL'));
       }
-    }
-
-    responseInit.status = this.status || 200;
-
-    if (Request.prototype.isPrototypeOf(input)) {
-      request = input;
-    } else {
-      request = new Request(input, init || {});
-    }
-    if (request.body && request.body.type) {
-      request.headers.set('Content-Type', request.body.type);
-    }
-
-    const promise = Promise.resolve().then(() => {
-      if (request.headers.get('Content-Type') === 'application/json' && request.method !== 'GET') {
-        return request.json().then((object: any) => {
-          object[this.returnKey] = this.returnValue;
-          const data = JSON.stringify(object);
-          const response = new Response(data, responseInit);
-          return this.status >= 200 && this.status < 300 ? Promise.resolve(response) : Promise.reject(response);
-        });
-      } else {
-        const data = JSON.stringify(this.object);
-        const response = new Response(data, responseInit);
-        if (input.includes('invalid-url')) {
-          Object.defineProperty(response, 'bodyUsed', { writable: true, configurable: true, value: true });
-        }
-        return this.status >= 200 && this.status < 300 ? Promise.resolve(response) : Promise.reject(response);
+      return Promise.resolve(data);
+    },
+    text: () => {
+      if (isInvalidUrl) {
+        return Promise.reject(new Error('Invalid URL'));
       }
+      return Promise.resolve(JSON.stringify(data));
+    },
+    headers: new Headers(init?.headers),
+  };
+
+  // Simulate bodyUsed for invalid URLs
+  if (isInvalidUrl) {
+    Object.defineProperty(response, 'bodyUsed', {
+      writable: true,
+      configurable: true,
+      value: true,
     });
-    return promise;
   }
+
+  return Promise.resolve(response);
 }

--- a/test/vitest.config.mts
+++ b/test/vitest.config.mts
@@ -26,7 +26,15 @@ export default defineConfig({
       reportOnFailure: true,
     },
     exclude: [...configDefaults.exclude, 'frameworks/*'],
-    environment: 'happy-dom',
+    environment: 'jsdom',
+    onUnhandledError: (error) => {
+      // Ignore specific error patterns
+      // not really sure why JSDOM throws these errors but it doesn't impact the tests
+      // see https://github.com/jsdom/jsdom/issues/2156
+      const ignoredErrors = [/removeEventListener/, /invalid EventTarget/];
+
+      return !ignoredErrors.some((pattern) => pattern.test(error.message));
+    },
     fakeTimers: {
       toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'queueMicrotask'],
     },


### PR DESCRIPTION
when I migrated from Jest to Vitest in PR #1663, I could only get it working by using a mix of JSDOM and Happy-DOM and I wanted to eventually come back to this approach in the future. In this PR I finally found how to drop this mix and only rely on JSDOM and nothing else. It does still show some unhandled errors in the console but we can safely ignore them by using `onUnhandledError` in Vitest config (see https://github.com/jsdom/jsdom/issues/2156). This new approach is also much more stable, since the recent upgrade of Happy-Dom major version wasn't very stable in the CI, now it's a thing of the past :)