### PR TITLE
chore(angular): fix a problem with HMR in Angular-Slickgrid demo

### DIFF
--- a/demos/aurelia/package.json
+++ b/demos/aurelia/package.json
@@ -65,7 +65,7 @@
     "sass": "catalog:",
     "tslib": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:",
+    "vite": "catalog:vite7",
     "vite-plugin-sass-dts": "^1.3.31"
   }
 }

--- a/demos/react/package.json
+++ b/demos/react/package.json
@@ -70,7 +70,7 @@
     "rxjs": "catalog:",
     "sass": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:",
+    "vite": "catalog:vite7",
     "vite-tsconfig-paths": "catalog:"
   }
 }

--- a/demos/vanilla/package.json
+++ b/demos/vanilla/package.json
@@ -37,6 +37,6 @@
     "@types/node": "catalog:",
     "sass": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:vite7"
   }
 }

--- a/demos/vue/package.json
+++ b/demos/vue/package.json
@@ -45,6 +45,6 @@
     "cypress-real-events": "catalog:",
     "sass": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:vite7"
   }
 }

--- a/frameworks/angular-slickgrid/package.json
+++ b/frameworks/angular-slickgrid/package.json
@@ -129,7 +129,7 @@
     "tslib": "catalog:",
     "typescript": "~5.8.3",
     "typescript-eslint": "catalog:",
-    "vite": "^6.3.6",
+    "vite": "catalog:vite6",
     "vite-tsconfig-paths": "catalog:",
     "vitest": "catalog:",
     "yaml": "^2.8.1",

--- a/frameworks/slickgrid-react/package.json
+++ b/frameworks/slickgrid-react/package.json
@@ -107,7 +107,7 @@
     "rxjs": "catalog:",
     "sass": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:",
+    "vite": "catalog:vite7",
     "vite-tsconfig-paths": "catalog:"
   }
 }

--- a/frameworks/slickgrid-vue/package.json
+++ b/frameworks/slickgrid-vue/package.json
@@ -75,7 +75,7 @@
     "i18next-vue": "catalog:",
     "sass": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:",
+    "vite": "catalog:vite7",
     "vite-plugin-dts": "^4.5.4",
     "vue": "catalog:",
     "vue-tsc": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@angular/build>vite": "^6.3.6",
-      "@vitejs/plugin-basic-ssl>vite": "catalog:",
+      "@angular/build>vite": "catalog:vite6",
+      "@vitejs/plugin-basic-ssl>vite": "catalog:vite7",
       "@vitest/coverage-v8>vite": "npm:rolldown-vite@latest",
       "@vitest/ui>vite": "npm:rolldown-vite@latest",
       "axios": "^1.12.2",

--- a/packages/vanilla-force-bundle/package.json
+++ b/packages/vanilla-force-bundle/package.json
@@ -65,6 +65,6 @@
     "fflate": "^0.8.2",
     "normalize-path": "^3.0.0",
     "tinyglobby": "^0.2.15",
-    "vite": "catalog:"
+    "vite": "catalog:vite7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ catalogs:
     typescript-eslint:
       specifier: ^8.45.0
       version: 8.45.0
-    vite:
-      specifier: ^7.1.7
-      version: 7.1.9
     vite-tsconfig-paths:
       specifier: ^5.1.4
       version: 5.1.4
@@ -129,10 +126,18 @@ catalogs:
     vue:
       specifier: ^3.5.22
       version: 3.5.22
+  vite6:
+    vite:
+      specifier: ^6.3.6
+      version: 6.3.6
+  vite7:
+    vite:
+      specifier: ^7.1.9
+      version: 7.1.9
 
 overrides:
   '@angular/build>vite': ^6.3.6
-  '@vitejs/plugin-basic-ssl>vite': ^7.1.7
+  '@vitejs/plugin-basic-ssl>vite': ^7.1.9
   '@vitest/coverage-v8>vite': npm:rolldown-vite@latest
   '@vitest/ui>vite': npm:rolldown-vite@latest
   axios: ^1.12.2
@@ -352,7 +357,7 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-sass-dts:
         specifier: ^1.3.31
@@ -482,7 +487,7 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: 'catalog:'
@@ -564,7 +569,7 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
 
   demos/vue:
@@ -658,7 +663,7 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
 
   frameworks/angular-slickgrid:
@@ -887,7 +892,7 @@ importers:
         specifier: 'catalog:'
         version: 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.8.3)
       vite:
-        specifier: ^6.3.6
+        specifier: catalog:vite6
         version: 6.3.6(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: 'catalog:'
@@ -1076,7 +1081,7 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: 'catalog:'
@@ -1134,7 +1139,7 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-dts:
         specifier: ^4.5.4
@@ -1437,7 +1442,7 @@ importers:
         specifier: ^0.2.15
         version: 0.2.15
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:vite7
         version: 7.1.9(@types/node@24.6.0)(jiti@2.6.0)(less@4.4.1)(lightningcss@1.30.2)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
 
 packages:
@@ -4978,7 +4983,7 @@ packages:
     resolution: {integrity: sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
-      vite: ^7.1.7
+      vite: ^7.1.9
 
   '@vitejs/plugin-react@5.0.4':
     resolution: {integrity: sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,14 @@ catalog:
   tslib: ^2.8.1
   typescript: ^5.8.3
   typescript-eslint: ^8.45.0
-  vite: ^7.1.7
   vite-tsconfig-paths: ^5.1.4
   vitest: ^4.0.0-beta.13
   vue: ^3.5.22
+
+# add a few named catalog: for Lerna-Lite to test its own code with real projects
+catalogs:
+  # Can be referenced through "catalog:vite6" or "catalog:vite7"
+  vite6:
+    vite: ^6.3.6
+  vite7:
+    vite: ^7.1.9


### PR DESCRIPTION
it looks like Angular 19 is only compatible with Vite 6.x, so let's downgrade Vite in Angular-Slickgrid demo