### PR TITLE
chore: add decorators-legacy to Prettier for proper jsx formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,7 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "plugins": ["@prettier/plugin-oxc", "@ianvs/prettier-plugin-sort-imports"],
+  "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy", "@ianvs/prettier-plugin-sort-imports"],
   "overrides": [
     {
       "files": ["**/*.{js,mjs,cjs,jsx}"],

--- a/demos/aurelia/src/examples/slickgrid/example10.ts
+++ b/demos/aurelia/src/examples/slickgrid/example10.ts
@@ -1,6 +1,5 @@
 import { bindable } from 'aurelia';
-import { type AureliaGridInstance, type Column, Filters, Formatters, type GridOption, type GridStateChange } from 'aurelia-slickgrid';
-
+import { Filters, Formatters, type AureliaGridInstance, type Column, type GridOption, type GridStateChange } from 'aurelia-slickgrid';
 import './example10.scss'; // provide custom CSS/SASS styling
 
 export class Example10 {

--- a/demos/aurelia/src/examples/slickgrid/example19-detail-view.ts
+++ b/demos/aurelia/src/examples/slickgrid/example19-detail-view.ts
@@ -1,7 +1,6 @@
 import type { SlickRowDetailView } from '@slickgrid-universal/row-detail-view-plugin';
 import { bindable } from 'aurelia';
 import type { SlickDataView, SlickGrid } from 'aurelia-slickgrid';
-
 import './example19-detail-view.scss';
 
 interface Item {

--- a/demos/aurelia/src/examples/slickgrid/example19.ts
+++ b/demos/aurelia/src/examples/slickgrid/example19.ts
@@ -1,6 +1,5 @@
 import { bindable } from 'aurelia';
-import { type AureliaGridInstance, type Column, Editors, ExtensionName, Filters, Formatters, type GridOption } from 'aurelia-slickgrid';
-
+import { Editors, ExtensionName, Filters, Formatters, type AureliaGridInstance, type Column, type GridOption } from 'aurelia-slickgrid';
 import { ExampleDetailPreload } from './example-detail-preload.js';
 import { Example19DetailView } from './example19-detail-view.js';
 

--- a/demos/aurelia/src/examples/slickgrid/example21.ts
+++ b/demos/aurelia/src/examples/slickgrid/example21.ts
@@ -1,6 +1,5 @@
 import { bindable } from 'aurelia';
-import { type AureliaGridInstance, type Column, Formatters, type GridOption, type OperatorString } from 'aurelia-slickgrid';
-
+import { Formatters, type AureliaGridInstance, type Column, type GridOption, type OperatorString } from 'aurelia-slickgrid';
 import './example21.scss';
 
 export class Example21 {

--- a/demos/aurelia/src/examples/slickgrid/example28.ts
+++ b/demos/aurelia/src/examples/slickgrid/example28.ts
@@ -3,18 +3,17 @@ import { bindable } from 'aurelia';
 import {
   addWhiteSpaces,
   Aggregators,
-  type AureliaGridInstance,
-  type Column,
   decimalFormatted,
   Filters,
   findItemInTreeStructure,
-  type Formatter,
   Formatters,
-  type GridOption,
   isNumber,
+  type AureliaGridInstance,
+  type Column,
+  type Formatter,
+  type GridOption,
   type SlickDataView,
 } from 'aurelia-slickgrid';
-
 import './example28.scss'; // provide custom CSS/SASS styling
 
 export class Example28 {

--- a/demos/aurelia/src/examples/slickgrid/example42-pager.ts
+++ b/demos/aurelia/src/examples/slickgrid/example42-pager.ts
@@ -7,7 +7,6 @@ import type {
   Subscription,
 } from '@slickgrid-universal/common';
 import { bindable, customElement, resolve } from 'aurelia';
-
 import './example42-pager.scss';
 
 /** Custom Pagination Componnet, please note that you MUST `implements BasePaginationComponent` with required functions */

--- a/demos/aurelia/src/examples/slickgrid/example42.ts
+++ b/demos/aurelia/src/examples/slickgrid/example42.ts
@@ -1,16 +1,15 @@
 import { bindable } from 'aurelia';
 import {
+  Filters,
+  Formatters,
+  OperatorType,
   type AureliaGridInstance,
   type Column,
-  Formatters,
   type GridOption,
   type MultipleSelectOption,
-  Filters,
-  OperatorType,
   type Pagination,
   type SliderRangeOption,
 } from 'aurelia-slickgrid';
-
 import { CustomPagerComponent } from './example42-pager.js';
 
 const NB_ITEMS = 5000;

--- a/demos/aurelia/src/examples/slickgrid/example45-detail-view.ts
+++ b/demos/aurelia/src/examples/slickgrid/example45-detail-view.ts
@@ -1,6 +1,5 @@
 import { bindable } from 'aurelia';
 import { type AureliaGridInstance, type Column, type GridOption, type GridState } from 'aurelia-slickgrid';
-
 import './example45-detail-view.scss';
 
 export interface Distributor {

--- a/demos/aurelia/src/examples/slickgrid/example45.ts
+++ b/demos/aurelia/src/examples/slickgrid/example45.ts
@@ -1,9 +1,8 @@
 import { faker } from '@faker-js/faker';
 import { bindable } from 'aurelia';
-import { type AureliaGridInstance, type Column, ExtensionName, type GridOption, type SlickRowDetailView } from 'aurelia-slickgrid';
-
+import { ExtensionName, type AureliaGridInstance, type Column, type GridOption, type SlickRowDetailView } from 'aurelia-slickgrid';
+import { Example45DetailView, type Distributor, type OrderData } from './example45-detail-view.js';
 import { Example45Preload } from './example45-preload.js';
-import { type Distributor, Example45DetailView, type OrderData } from './example45-detail-view.js';
 
 const FAKE_SERVER_DELAY = 250;
 const NB_ITEMS = 995;

--- a/demos/aurelia/src/examples/slickgrid/example46.ts
+++ b/demos/aurelia/src/examples/slickgrid/example46.ts
@@ -1,8 +1,7 @@
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { TextExportService } from '@slickgrid-universal/text-export';
 import { bindable } from 'aurelia';
-import { type AureliaGridInstance, type Column, Filters, Formatters, type GridOption } from 'aurelia-slickgrid';
-
+import { Filters, Formatters, type AureliaGridInstance, type Column, type GridOption } from 'aurelia-slickgrid';
 import { showToast } from './utilities.js';
 import './example46.scss'; // provide custom CSS/SASS styling
 

--- a/demos/aurelia/src/examples/slickgrid/example47-detail-view.ts
+++ b/demos/aurelia/src/examples/slickgrid/example47-detail-view.ts
@@ -1,7 +1,6 @@
 import type { SlickRowDetailView } from '@slickgrid-universal/row-detail-view-plugin';
 import { bindable } from 'aurelia';
 import type { SlickDataView, SlickGrid } from 'aurelia-slickgrid';
-
 import { showToast } from './utilities.js';
 import './example47-detail-view.scss';
 

--- a/demos/aurelia/src/examples/slickgrid/example47.ts
+++ b/demos/aurelia/src/examples/slickgrid/example47.ts
@@ -1,21 +1,20 @@
 import { bindable } from 'aurelia';
 import {
   Aggregators,
-  type AureliaGridInstance,
-  type Column,
   Editors,
   ExtensionName,
   Filters,
   Formatters,
-  type GridOption,
-  type Grouping,
   GroupTotalFormatters,
-  type SlickDataView,
-  type SlickGrid,
   SortComparers,
   SortDirectionNumber,
+  type AureliaGridInstance,
+  type Column,
+  type GridOption,
+  type Grouping,
+  type SlickDataView,
+  type SlickGrid,
 } from 'aurelia-slickgrid';
-
 import { ExampleDetailPreload } from './example-detail-preload.js';
 import { Example47DetailView } from './example47-detail-view.js';
 

--- a/frameworks/angular-slickgrid/src/demos/app-routing.module.ts
+++ b/frameworks/angular-slickgrid/src/demos/app-routing.module.ts
@@ -1,8 +1,6 @@
 import { NgModule } from '@angular/core';
-import { type Routes, RouterModule, provideRouter } from '@angular/router';
+import { provideRouter, RouterModule, type Routes } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-
-import { HomeComponent } from './examples/home.component';
 import { Example1Component } from './examples/example01.component';
 import { Example2Component } from './examples/example02.component';
 import { Example3Component } from './examples/example03.component';
@@ -49,6 +47,7 @@ import { Example44Component } from './examples/example44.component';
 import { Example45Component } from './examples/example45.component';
 import { Example46Component } from './examples/example46.component';
 import { Example47Component } from './examples/example47.component';
+import { HomeComponent } from './examples/home.component';
 import { SwtCommonGridTestComponent } from './examples/swt-common-grid-test.component';
 
 const routes: Routes = [

--- a/frameworks/angular-slickgrid/src/demos/examples/editor-ng-select.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/editor-ng-select.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NgSelectComponent, NgLabelTemplateDirective, NgOptionTemplateDirective } from '@ng-select/ng-select';
+import { NgLabelTemplateDirective, NgOptionTemplateDirective, NgSelectComponent } from '@ng-select/ng-select';
 import { Subject } from 'rxjs';
 
 // the appendTo="body" (necessary for SlickGrid filter) requires the body to be position relative like so

--- a/frameworks/angular-slickgrid/src/demos/examples/example01.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example01.component.ts
@@ -1,6 +1,5 @@
 import { Component, type OnDestroy, type OnInit } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, Formatters } from '../../library';
-
+import { AngularSlickgridModule, Formatters, type AngularGridInstance, type Column, type GridOption } from '../../library';
 import { zeroPadding } from './utilities';
 
 const NB_ITEMS = 995;

--- a/frameworks/angular-slickgrid/src/demos/examples/example02.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example02.component.ts
@@ -1,5 +1,5 @@
 import { Component, type OnInit } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type Formatter, Formatters, type GridOption } from '../../library';
+import { AngularSlickgridModule, Formatters, type AngularGridInstance, type Column, type Formatter, type GridOption } from '../../library';
 
 interface DataItem {
   id: number;

--- a/frameworks/angular-slickgrid/src/demos/examples/example03.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example03.component.ts
@@ -1,31 +1,30 @@
-import { NgIf, JsonPipe } from '@angular/common';
+import { JsonPipe, NgIf } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Component, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Subject } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
+  Editors,
+  Filters,
+  Formatters,
+  OperatorType,
+  SlickGlobalEditorLock,
+  SortComparers,
+  type AngularGridInstance,
   type AutocompleterOption,
   type Column,
-  Editors,
   type EditorArguments,
   type EditorValidator,
-  Filters,
   type Formatter,
-  Formatters,
   type GridOption,
   type LongTextEditorOption,
   type MultipleSelectOption,
   type OnEventArgs,
-  OperatorType,
-  SortComparers,
-  SlickGlobalEditorLock,
   type SlickGrid,
   type SliderOption,
   type VanillaCalendarOption,
 } from '../../library';
-import { Subject } from 'rxjs';
-
 import { CustomInputEditor } from './custom-inputEditor';
 import { CustomInputFilter } from './custom-inputFilter';
 import fetchJsonp from './jsonp';

--- a/frameworks/angular-slickgrid/src/demos/examples/example04.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example04.component.ts
@@ -1,22 +1,21 @@
-import { NgIf, DatePipe } from '@angular/common';
+import { DatePipe, NgIf } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Component, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
   Formatters,
+  OperatorType,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type GridStateChange,
   type Metrics,
   type MultipleSelectOption,
-  OperatorType,
   type VanillaCalendarOption,
 } from '../../library';
-
 import { CustomInputFilter } from './custom-inputFilter';
 
 function randomBetween(min: number, max: number) {

--- a/frameworks/angular-slickgrid/src/demos/examples/example05.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example05.component.ts
@@ -1,16 +1,16 @@
-import { NgIf, DatePipe } from '@angular/common';
+import { DatePipe, NgIf } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { ChangeDetectorRef, Component, type OnInit } from '@angular/core';
-import { GridOdataService, type OdataServiceApi, type OdataOption } from '@slickgrid-universal/odata';
+import { GridOdataService, type OdataOption, type OdataServiceApi } from '@slickgrid-universal/odata';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
+  OperatorType,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type GridStateChange,
   type Metrics,
-  OperatorType,
   type Pagination,
 } from '../../library';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example06.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example06.component.ts
@@ -1,5 +1,5 @@
-import { NgIf, DatePipe } from '@angular/common';
-import { ChangeDetectorRef, Component, type OnInit, type OnDestroy } from '@angular/core';
+import { DatePipe, NgIf } from '@angular/common';
+import { ChangeDetectorRef, Component, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { addDay, format as tempoFormat } from '@formkit/tempo';
 import { TranslateService } from '@ngx-translate/core';
@@ -11,18 +11,18 @@ import {
 } from '@slickgrid-universal/graphql';
 import type { Subscription } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
-  type CursorPageInfo,
   Filters,
   Formatters,
+  OperatorType,
+  unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
+  type CursorPageInfo,
   type GridOption,
   type GridStateChange,
   type Metrics,
   type MultipleSelectOption,
-  OperatorType,
-  unsubscribeAllObservables,
 } from '../../library';
 
 const defaultPageSize = 20;

--- a/frameworks/angular-slickgrid/src/demos/examples/example07.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example07.component.ts
@@ -1,5 +1,5 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption } from '../../library';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
+import { AngularSlickgridModule, type AngularGridInstance, type Column, type GridOption } from '../../library';
 
 // create a custom Formatter to highlight negative values in red
 let columns1WithHighlightingById: any = {};

--- a/frameworks/angular-slickgrid/src/demos/examples/example08.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example08.component.ts
@@ -1,7 +1,7 @@
-import { Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, unsubscribeAllObservables } from '../../library';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import type { Subscription } from 'rxjs';
+import { AngularSlickgridModule, unsubscribeAllObservables, type AngularGridInstance, type Column, type GridOption } from '../../library';
 
 @Component({
   templateUrl: './example08.component.html',

--- a/frameworks/angular-slickgrid/src/demos/examples/example09.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example09.component.ts
@@ -1,17 +1,17 @@
-import { Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import type { Subscription } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   ExtensionName,
   Filters,
   Formatters,
+  unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type SliderOption,
-  unsubscribeAllObservables,
 } from '../../library';
-import type { Subscription } from 'rxjs';
 
 @Component({
   templateUrl: './example09.component.html',

--- a/frameworks/angular-slickgrid/src/demos/examples/example10.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example10.component.ts
@@ -1,11 +1,11 @@
 import { NgIf } from '@angular/common';
 import { ChangeDetectorRef, Component, type OnInit } from '@angular/core';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type GridStateChange,
 } from '../../library';

--- a/frameworks/angular-slickgrid/src/demos/examples/example11.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example11.component.ts
@@ -1,10 +1,10 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Editors,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type GridService,
   type OnEventArgs,

--- a/frameworks/angular-slickgrid/src/demos/examples/example12.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example12.component.ts
@@ -4,17 +4,17 @@ import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { TextExportService } from '@slickgrid-universal/text-export';
 import type { Subscription } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   DelimiterType,
   Filters,
-  type Formatter,
   Formatters,
+  unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
+  type Formatter,
   type GridOption,
   type GridStateChange,
   type SliderOption,
-  unsubscribeAllObservables,
 } from '../../library';
 
 const NB_ITEMS = 1500;

--- a/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
@@ -2,18 +2,18 @@ import { Component, type OnInit } from '@angular/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { TextExportService } from '@slickgrid-universal/text-export';
 import {
-  type AngularGridInstance,
-  AngularSlickgridModule,
   Aggregators,
-  type Column,
+  AngularSlickgridModule,
   DelimiterType,
   Filters,
   Formatters,
+  GroupTotalFormatters,
+  SortComparers,
+  SortDirectionNumber,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type Grouping,
-  GroupTotalFormatters,
-  SortDirectionNumber,
-  SortComparers,
 } from '../../library';
 
 const NB_ITEMS = 5000;

--- a/frameworks/angular-slickgrid/src/demos/examples/example14.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example14.component.ts
@@ -1,6 +1,6 @@
 import { Component, type OnInit } from '@angular/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, type ItemMetadata } from '../../library';
+import { AngularSlickgridModule, type AngularGridInstance, type Column, type GridOption, type ItemMetadata } from '../../library';
 
 @Component({
   templateUrl: './example14.component.html',

--- a/frameworks/angular-slickgrid/src/demos/examples/example15.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example15.component.ts
@@ -3,16 +3,16 @@ import { format as tempoFormat } from '@formkit/tempo';
 import { TranslateService } from '@ngx-translate/core';
 import type { Subscription } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
   Formatters,
+  unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type GridState,
   type GridStateChange,
   type MultipleSelectOption,
-  unsubscribeAllObservables,
 } from '../../library';
 
 function randomBetween(min: number, max: number) {

--- a/frameworks/angular-slickgrid/src/demos/examples/example16.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example16.component.ts
@@ -1,11 +1,11 @@
 import { Component, type OnInit } from '@angular/core';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   ExtensionName,
   Filters,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type OnEventArgs,
 } from '../../library';

--- a/frameworks/angular-slickgrid/src/demos/examples/example17.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example17.component.ts
@@ -2,7 +2,7 @@ import { NgIf } from '@angular/common';
 import { ChangeDetectorRef, Component, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, toCamelCase } from '../../library';
+import { AngularSlickgridModule, toCamelCase, type AngularGridInstance, type Column, type GridOption } from '../../library';
 
 const sampleDataRoot = 'assets/data';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example18.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example18.component.ts
@@ -1,23 +1,23 @@
 import { NgFor } from '@angular/common';
-import { type AfterViewInit, ChangeDetectorRef, Component, type OnDestroy, type OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, type AfterViewInit, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { TextExportService } from '@slickgrid-universal/text-export';
 import {
-  type AngularGridInstance,
-  AngularSlickgridModule,
   Aggregators,
-  type Column,
+  AngularSlickgridModule,
   DelimiterType,
   Editors,
   Filters,
   Formatters,
+  GroupTotalFormatters,
+  SortComparers,
+  SortDirectionNumber,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type Grouping,
   type GroupingGetterFunction,
-  GroupTotalFormatters,
-  SortDirectionNumber,
-  SortComparers,
 } from '../../library';
 
 const NB_ITEMS = 5000;

--- a/frameworks/angular-slickgrid/src/demos/examples/example19-rowdetail.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example19-rowdetail.component.ts
@@ -1,8 +1,7 @@
-import { DecimalPipe, DatePipe } from '@angular/common';
+import { DatePipe, DecimalPipe } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { SlickDataView, SlickGrid } from '../../library';
-
 import type { Example19Component } from './example19.component';
 
 @Component({

--- a/frameworks/angular-slickgrid/src/demos/examples/example19.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example19.component.ts
@@ -2,16 +2,15 @@ import { NgIf } from '@angular/common';
 import { Component, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Editors,
   Filters,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type SlickRowDetailView,
 } from '../../library';
-
 import { Example19RowDetailComponent } from './example19-rowdetail.component';
 import { RowDetailPreloadComponent } from './rowdetail-preload.component';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example20.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example20.component.ts
@@ -1,16 +1,16 @@
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Component, type OnInit, type OnDestroy, ViewEncapsulation } from '@angular/core';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
-  type ColumnEditorDualInput,
   Editors,
+  Filters,
   formatNumber,
   Formatters,
-  Filters,
-  type GridOption,
   SlickEventHandler,
+  type AngularGridInstance,
+  type Column,
+  type ColumnEditorDualInput,
+  type GridOption,
 } from '../../library';
 
 @Component({

--- a/frameworks/angular-slickgrid/src/demos/examples/example21.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example21.component.ts
@@ -1,11 +1,11 @@
 import { NgFor } from '@angular/common';
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type OperatorString,
   type SlickDataView,

--- a/frameworks/angular-slickgrid/src/demos/examples/example22.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example22.component.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, type OnInit } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, Filters } from '../../library';
-import { TabsetComponent, TabDirective } from 'ngx-bootstrap/tabs';
+import { TabDirective, TabsetComponent } from 'ngx-bootstrap/tabs';
+import { AngularSlickgridModule, Filters, type AngularGridInstance, type Column, type GridOption } from '../../library';
 
 const URL_CUSTOMERS = 'assets/data/customers_100.json';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example23.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example23.component.ts
@@ -1,27 +1,26 @@
-import { NgIf, NgFor, DatePipe } from '@angular/common';
-import { Component, type OnInit, type OnDestroy } from '@angular/core';
+import { DatePipe, NgFor, NgIf } from '@angular/common';
+import { Component, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { addDay, format } from '@formkit/tempo';
 import { TranslateService } from '@ngx-translate/core';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
+import type { Subscription } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
-  type Formatter,
   Formatters,
+  OperatorType,
+  unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
+  type Formatter,
   type GridOption,
   type GridStateChange,
   type Metrics,
   type MultipleSelectOption,
-  OperatorType,
   type SliderRangeOption,
-  unsubscribeAllObservables,
 } from '../../library';
-import type { Subscription } from 'rxjs';
-
 import { CustomInputFilter } from './custom-inputFilter';
 
 const NB_ITEMS = 1500;

--- a/frameworks/angular-slickgrid/src/demos/examples/example24.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example24.component.ts
@@ -1,18 +1,18 @@
-import { Component, type OnInit, type OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import type { Subscription } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
-  type ContextMenu,
   ExtensionName,
   Filters,
-  type Formatter,
   Formatters,
-  type GridOption,
   unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
+  type ContextMenu,
+  type Formatter,
+  type GridOption,
 } from '../../library';
 
 const actionFormatter: Formatter = (_row, _cell, _value, _columnDef, dataContext) => {

--- a/frameworks/angular-slickgrid/src/demos/examples/example25.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example25.component.ts
@@ -1,18 +1,18 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { GraphqlService, type GraphqlResult, type GraphqlServiceApi } from '@slickgrid-universal/graphql';
+import type { Observable } from 'rxjs';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
   Formatters,
+  OperatorType,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type Metrics,
   type MultipleSelectOption,
-  OperatorType,
 } from '../../library';
-import type { Observable } from 'rxjs';
 
 const COUNTRIES_API = 'https://countries.trevorblades.com/';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example26.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example26.component.ts
@@ -1,28 +1,27 @@
-import { NgIf, JsonPipe } from '@angular/common';
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { JsonPipe, NgIf } from '@angular/common';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
   AngularUtilService,
-  type Column,
   Editors,
   Filters,
   Formatters,
+  SlickGlobalEditorLock,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type MultipleSelectOption,
   type OnEventArgs,
-  SlickGlobalEditorLock,
   type SliderOption,
 } from '../../library';
-
-import { EditorNgSelectComponent } from './editor-ng-select.component';
 import { CustomAngularComponentEditor } from './custom-angularComponentEditor';
 import { CustomAngularComponentFilter } from './custom-angularComponentFilter';
-import { CustomTitleFormatterComponent } from './custom-titleFormatter.component';
-import { FilterNgSelectComponent } from './filter-ng-select.component';
 import { CustomButtonFormatterComponent } from './custom-buttonFormatter.component';
+import { CustomTitleFormatterComponent } from './custom-titleFormatter.component';
+import { EditorNgSelectComponent } from './editor-ng-select.component';
+import { FilterNgSelectComponent } from './filter-ng-select.component';
 
 const NB_ITEMS = 100;
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
@@ -1,11 +1,11 @@
-import { ChangeDetectorRef, Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type GridStateChange,
   type TreeToggledItem,

--- a/frameworks/angular-slickgrid/src/demos/examples/example28.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example28.component.ts
@@ -1,19 +1,19 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
   addWhiteSpaces,
-  type AngularGridInstance,
-  AngularSlickgridModule,
   Aggregators,
-  type Column,
+  AngularSlickgridModule,
   decimalFormatted,
   Filters,
   findItemInTreeStructure,
-  type Formatter,
   Formatters,
-  type GridOption,
   isNumber,
+  type AngularGridInstance,
+  type Column,
+  type Formatter,
+  type GridOption,
   type SlickDataView,
 } from '../../library';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example29.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example29.component.ts
@@ -1,6 +1,6 @@
-import { Component, type OnInit } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, Formatters } from '../../library';
+import { Component, type OnInit } from '@angular/core';
+import { AngularSlickgridModule, Formatters, type AngularGridInstance, type Column, type GridOption } from '../../library';
 
 const NB_ITEMS = 995;
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example30.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example30.component.ts
@@ -1,29 +1,29 @@
-import { Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { ExcelExportService } from '@slickgrid-universal/excel-export';
-import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { SlickCompositeEditor, SlickCompositeEditorComponent } from '@slickgrid-universal/composite-editor-component';
+import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
+import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
+  Editors,
+  Filters,
+  formatNumber,
+  Formatters,
+  SlickGlobalEditorLock,
+  SortComparers,
+  type AngularGridInstance,
   type AutocompleterOption,
   type Column,
   type CompositeEditorModalType,
   type EditCommand,
-  Editors,
-  Filters,
-  formatNumber,
   type Formatter,
-  Formatters,
   type GridOption,
   type GridStateChange,
   type LongTextEditorOption,
   type MultipleSelectOption,
   type OnCompositeEditorChangeEventArgs,
-  SlickGlobalEditorLock,
   type SlickGrid,
   type SliderOption,
-  SortComparers,
   type VanillaCalendarOption,
 } from '../../library';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example32.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example32.component.ts
@@ -1,24 +1,24 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
-  type GridOption,
-  Filters,
-  type Formatter,
-  type LongTextEditorOption,
   Editors,
-  Formatters,
-  type AutocompleterOption,
-  type EditCommand,
+  Filters,
   formatNumber,
-  SortComparers,
-  type SlickGrid,
+  Formatters,
   SlickGlobalEditorLock,
-  type VanillaCalendarOption,
+  SortComparers,
+  type AngularGridInstance,
+  type AutocompleterOption,
+  type Column,
+  type EditCommand,
+  type Formatter,
+  type GridOption,
+  type LongTextEditorOption,
   type SearchTerm,
+  type SlickGrid,
+  type VanillaCalendarOption,
 } from '../../library';
 
 const URL_COUNTRIES_COLLECTION = 'assets/data/countries.json';

--- a/frameworks/angular-slickgrid/src/demos/examples/example33.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example33.component.ts
@@ -1,21 +1,21 @@
 import { NgClass } from '@angular/common';
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
-  type EditCommand,
   Editors,
   Filters,
-  type Formatter,
   Formatters,
+  OperatorType,
+  type AngularGridInstance,
+  type Column,
+  type EditCommand,
+  type Formatter,
   type GridOption,
   type MenuCommandItemCallbackArgs,
   type MultipleSelectOption,
-  OperatorType,
   type SlickGrid,
   type VanillaCalendarOption,
 } from '../../library';

--- a/frameworks/angular-slickgrid/src/demos/examples/example34.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example34.component.ts
@@ -1,19 +1,19 @@
-import { Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { faker } from '@faker-js/faker';
 import sparkline from '@fnando/sparkline';
 import {
   Aggregators,
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   createDomElement,
   deepCopy,
   Filters,
-  type Formatter,
   Formatters,
-  type GridOption,
   GroupTotalFormatters,
+  type AngularGridInstance,
+  type Column,
+  type Formatter,
+  type GridOption,
 } from '../../library';
 
 const NB_ROWS = 200;

--- a/frameworks/angular-slickgrid/src/demos/examples/example35.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example35.component.ts
@@ -1,8 +1,8 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, Editors, Formatters, type GridOption } from '../../library';
 import type { Subscription } from 'rxjs';
+import { AngularSlickgridModule, Editors, Formatters, type AngularGridInstance, type Column, type GridOption } from '../../library';
 
 const NB_ITEMS = 20;
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example36.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example36.component.ts
@@ -1,23 +1,23 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type Aggregator,
   Aggregators,
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Editors,
+  Formatters,
+  GroupTotalFormatters,
+  type Aggregator,
+  type AngularGridInstance,
+  type Column,
   type ExcelCellValueParserArgs,
   type ExcelGroupValueParserArgs,
   type Formatter,
-  Formatters,
   type GridOption,
-  GroupTotalFormatters,
   type Grouping,
   type SlickGrid,
   type SlickGroupTotals,
 } from '../../library';
-import { ExcelExportService } from '@slickgrid-universal/excel-export';
 
 interface GroceryItem {
   id: number;

--- a/frameworks/angular-slickgrid/src/demos/examples/example37.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example37.component.ts
@@ -1,9 +1,9 @@
 import { Component, type OnDestroy, type OnInit } from '@angular/core';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Editors,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type OnCellChangeEventArgs,
 } from '../../library';

--- a/frameworks/angular-slickgrid/src/demos/examples/example38.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example38.component.ts
@@ -1,18 +1,18 @@
-import { NgIf, DatePipe } from '@angular/common';
+import { DatePipe, NgIf } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectorRef, Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { GridOdataService, type OdataServiceApi } from '@slickgrid-universal/odata';
 import {
   Aggregators,
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
+  SortComparers,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type Grouping,
   type Metrics,
   type OnRowCountChangedEventArgs,
-  SortComparers,
 } from '../../library';
 
 const sampleDataRoot = 'assets/data';

--- a/frameworks/angular-slickgrid/src/demos/examples/example39.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example39.component.ts
@@ -1,21 +1,20 @@
-import { NgIf, DatePipe } from '@angular/common';
+import { DatePipe, NgIf } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectorRef, Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { GraphqlService, type GraphqlPaginatedResult, type GraphqlServiceApi } from '@slickgrid-universal/graphql';
 import { type Subscription } from 'rxjs';
-
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
+  unsubscribeAllObservables,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type Metrics,
   type MultipleSelectOption,
   type OnRowCountChangedEventArgs,
-  unsubscribeAllObservables,
 } from '../../library';
 
 const sampleDataRoot = 'assets/data';

--- a/frameworks/angular-slickgrid/src/demos/examples/example40.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example40.component.ts
@@ -1,21 +1,20 @@
-import { NgIf, DatePipe } from '@angular/common';
+import { DatePipe, NgIf } from '@angular/common';
 import { Component, type OnInit } from '@angular/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
   Aggregators,
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
   Formatters,
+  SortComparers,
+  SortDirectionNumber,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type Grouping,
   type Metrics,
   type OnRowCountChangedEventArgs,
-  SortComparers,
-  SortDirectionNumber,
 } from '../../library';
-
 import { randomNumber } from './utilities';
 
 const FETCH_SIZE = 50;

--- a/frameworks/angular-slickgrid/src/demos/examples/example41.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example41.component.ts
@@ -1,13 +1,13 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Editors,
   Formatters,
-  type GridOption,
   isDefined,
   SlickGlobalEditorLock,
+  type AngularGridInstance,
+  type Column,
+  type GridOption,
 } from '../../library';
 
 @Component({

--- a/frameworks/angular-slickgrid/src/demos/examples/example42.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example42.component.ts
@@ -1,17 +1,16 @@
 import { Component, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
   AngularUtilService,
-  type Column,
   Filters,
   Formatters,
+  type AngularGridInstance,
+  type Column,
   type GridOption,
   type MultipleSelectOption,
   type SliderRangeOption,
 } from '../../library';
-
 import { CustomPagerComponent } from './grid-custom-pager.component';
 
 const NB_ITEMS = 5000;

--- a/frameworks/angular-slickgrid/src/demos/examples/example43.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example43.component.ts
@@ -1,6 +1,6 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, Editors, type GridOption, type ItemMetadata } from '../../library';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
+import { AngularSlickgridModule, Editors, type AngularGridInstance, type Column, type GridOption, type ItemMetadata } from '../../library';
 
 @Component({
   styleUrls: ['example43.component.scss'],

--- a/frameworks/angular-slickgrid/src/demos/examples/example44.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example44.component.ts
@@ -1,9 +1,9 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
+  type AngularGridInstance,
   type Column,
   type Formatter,
   type GridOption,

--- a/frameworks/angular-slickgrid/src/demos/examples/example45-detail.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example45-detail.component.ts
@@ -1,5 +1,5 @@
-import { Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, type GridState } from '../../library';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
+import { AngularSlickgridModule, type AngularGridInstance, type Column, type GridOption, type GridState } from '../../library';
 
 export interface Distributor {
   id: number;

--- a/frameworks/angular-slickgrid/src/demos/examples/example45.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example45.component.ts
@@ -1,9 +1,8 @@
-import { Component, type OnDestroy, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { faker } from '@faker-js/faker';
-import { type AngularGridInstance, AngularSlickgridModule, type Column, type GridOption, type SlickRowDetailView } from '../../library';
-
-import { type Distributor, Example45DetailComponent, type OrderData } from './example45-detail.component';
+import { AngularSlickgridModule, type AngularGridInstance, type Column, type GridOption, type SlickRowDetailView } from '../../library';
+import { Example45DetailComponent, type Distributor, type OrderData } from './example45-detail.component';
 import { RowDetailPreloadComponent } from './rowdetail-preload.component';
 
 const FAKE_SERVER_DELAY = 250;

--- a/frameworks/angular-slickgrid/src/demos/examples/example46.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example46.component.ts
@@ -1,15 +1,14 @@
-import { Component, type OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { TextExportService } from '@slickgrid-universal/text-export';
-
 import {
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Filters,
-  type Formatter,
   Formatters,
+  type AngularGridInstance,
+  type Column,
+  type Formatter,
   type GridOption,
 } from '../../library';
 import { showToast } from './utilities';

--- a/frameworks/angular-slickgrid/src/demos/examples/example47-rowdetail.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example47-rowdetail.component.ts
@@ -1,8 +1,7 @@
-import { DecimalPipe, DatePipe } from '@angular/common';
+import { DatePipe, DecimalPipe } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { SlickDataView, SlickGrid } from '../../library';
-
 import type { Example47Component } from './example47.component';
 import { showToast } from './utilities';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example47.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example47.component.ts
@@ -2,20 +2,19 @@ import { Component, type OnDestroy, type OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
   Aggregators,
-  type AngularGridInstance,
   AngularSlickgridModule,
-  type Column,
   Editors,
   Filters,
   Formatters,
-  type GridOption,
-  type Grouping,
   GroupTotalFormatters,
-  type SlickRowDetailView,
   SortComparers,
   SortDirectionNumber,
+  type AngularGridInstance,
+  type Column,
+  type GridOption,
+  type Grouping,
+  type SlickRowDetailView,
 } from '../../library';
-
 import { Example47RowDetailComponent } from './example47-rowdetail.component';
 import { RowDetailPreloadComponent } from './rowdetail-preload.component';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/filter-ng-select.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/filter-ng-select.component.ts
@@ -1,6 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NgSelectComponent, NgLabelTemplateDirective, NgOptionTemplateDirective } from '@ng-select/ng-select';
+import { NgLabelTemplateDirective, NgOptionTemplateDirective, NgSelectComponent } from '@ng-select/ng-select';
 import { type SearchTerm } from '@slickgrid-universal/common';
 import { Subject } from 'rxjs';
 

--- a/frameworks/angular-slickgrid/src/demos/examples/grid-remote.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/grid-remote.component.ts
@@ -1,5 +1,5 @@
-import { Component, type OnInit, type OnDestroy } from '@angular/core';
-import { type AngularGridInstance, type Column, type Formatter, type GridOption, SlickEventHandler } from '../../library';
+import { Component, type OnDestroy, type OnInit } from '@angular/core';
+import { SlickEventHandler, type AngularGridInstance, type Column, type Formatter, type GridOption } from '../../library';
 
 const brandFormatter: Formatter = (_row, _cell, _value, _columnDef, dataContext) => {
   return (dataContext && dataContext.brand && dataContext.brand.name) || '';

--- a/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid-pagination.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid-pagination.component.ts
@@ -1,10 +1,11 @@
+import { NgClass } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 import { Component, Input, type OnInit } from '@angular/core';
+import { TranslateDirective } from '@ngx-translate/core';
+import { type GridOption } from '../../library';
 import { type SwtCommonGridComponent } from './swt-common-grid.component';
 import { Logger } from './swt-logger.service';
-import { HttpClient } from '@angular/common/http';
-import { type GridOption } from '../../library';
-import { NgClass } from '@angular/common';
-import { TranslateDirective } from '@ngx-translate/core';
+
 /**
  * Custom pagination component: It allows editing the page number manually
  *  << < Page [1] of 5 > >>

--- a/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid-test.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid-test.component.ts
@@ -1,11 +1,10 @@
-import { type AfterViewInit, Component, type OnInit, ViewChild } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-
-import { SwtCommonGridComponent } from './swt-common-grid.component';
-import { SwtCommonGridPaginationComponent } from './swt-common-grid-pagination.component';
+import { Component, ViewChild, type AfterViewInit, type OnInit } from '@angular/core';
 import type { FilterChangedArgs, PaginationChangedArgs } from '../../library';
-
+import { SwtCommonGridPaginationComponent } from './swt-common-grid-pagination.component';
+import { SwtCommonGridComponent } from './swt-common-grid.component';
 import { Logger } from './swt-logger.service';
+
 /**
  * Main test Component
  *

--- a/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid.component.ts
@@ -1,23 +1,23 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 /* eslint-disable @angular-eslint/no-output-on-prefix */
-import { type AfterViewInit, Component, ElementRef, EventEmitter, Input, type OnInit, Output, ViewChild, Renderer2 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild, type AfterViewInit, type OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import {
+  AngularSlickgridModule,
   type AngularGridInstance,
   type AngularSlickgridComponent,
-  AngularSlickgridModule,
   type BackendService,
   type BackendServiceOption,
   type Column,
   type FilterChangedArgs,
   type GridOption,
-  type PaginationChangedArgs,
   type Pagination,
+  type PaginationChangedArgs,
   type SlickDataView,
 } from '../../library';
-import { TranslateService } from '@ngx-translate/core';
-import { Logger } from './swt-logger.service';
 import { type SwtCommonGridPaginationComponent } from './swt-common-grid-pagination.component';
+import { Logger } from './swt-logger.service';
 
 /**
  * Custom wrapper of angular-slickgrid components, allows easily interacting with SwtCommonGridPaginationComponent

--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -1,8 +1,13 @@
-import { type ApplicationRef, ChangeDetectorRef, Component, ElementRef } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, type ApplicationRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { TranslateService, TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   autoAddEditorFormatterToColumnsWithEditor,
+  Editors,
+  Filters,
+  SharedService,
+  SlickDataView,
+  SlickGroupItemMetadataProvider,
   type BackendService,
   type BackendServiceApi,
   type BackendUtilityService,
@@ -15,11 +20,9 @@ import {
   type CurrentPinning,
   type CurrentSorter,
   type Editor,
-  Editors,
   type ExtensionList,
   type ExtensionService,
   type ExtensionUtility,
-  Filters,
   type FilterService,
   type Formatter,
   type GridEventService,
@@ -34,28 +37,24 @@ import {
   type PaginationMetadata,
   type PaginationService,
   type ResizerService,
-  SharedService,
-  SlickDataView,
   type SlickEventHandler,
   type SlickGrid,
-  SlickGroupItemMetadataProvider,
   type SortService,
   type TreeDataService,
 } from '@slickgrid-universal/common';
 import { type SlickFooterComponent } from '@slickgrid-universal/custom-footer-component';
-import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
+import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import type { GraphqlPaginatedResult, GraphqlService, GraphqlServiceApi, GraphqlServiceOption } from '@slickgrid-universal/graphql';
 import { of, throwError } from 'rxjs';
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-
-import { AngularSlickgridComponent } from '../angular-slickgrid.component.js';
-import { type SlickRowDetailView } from '../../extensions/slickRowDetailView.js';
-import { TranslaterServiceStub } from '../../../../test/translaterServiceStub.js';
-import { type AngularUtilService, ContainerService, type TranslaterService } from '../../services/index.js';
-import { type GridOption } from '../../models/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { MockSlickEvent, MockSlickEventHandler } from '../../../../test/mockSlickEvent.js';
 import { RxJsResourceStub } from '../../../../test/rxjsResourceStub.js';
+import { TranslaterServiceStub } from '../../../../test/translaterServiceStub.js';
+import { type SlickRowDetailView } from '../../extensions/slickRowDetailView.js';
+import { type GridOption } from '../../models/index.js';
+import { ContainerService, type AngularUtilService, type TranslaterService } from '../../services/index.js';
+import { AngularSlickgridComponent } from '../angular-slickgrid.component.js';
 
 // mocked modules
 vi.mock('@slickgrid-universal/common', async (importOriginal) => ({

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -1,5 +1,4 @@
 import {
-  type AfterViewInit,
   ApplicationRef,
   ChangeDetectorRef,
   Component,
@@ -8,12 +7,42 @@ import {
   EventEmitter,
   Inject,
   Input,
-  type OnDestroy,
   Optional,
   Output,
+  type AfterViewInit,
+  type OnDestroy,
   type TemplateRef,
 } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import {
+  // utilities
+  autoAddEditorFormatterToColumnsWithEditor,
+  // services
+  BackendUtilityService,
+  CollectionService,
+  emptyElement,
+  EventNamingStyle,
+  ExtensionName,
+  ExtensionService,
+  ExtensionUtility,
+  FilterFactory,
+  FilterService,
+  GridEventService,
+  GridService,
+  GridStateService,
+  HeaderGroupingService,
+  isColumnDateType,
+  PaginationService,
+  ResizerService,
+  SharedService,
+  SlickDataView,
+  SlickEventHandler,
+  SlickGrid,
+  SlickgridConfig,
+  SlickGroupItemMetadataProvider,
+  SortService,
+  TreeDataService,
+  unsubscribeAll,
   type AutocompleterEditor,
   type BackendService,
   type BackendServiceApi,
@@ -23,64 +52,29 @@ import {
   type DataViewOption,
   type EventSubscription,
   type ExternalResource,
-  isColumnDateType,
   type Locale,
   type Metrics,
   type Pagination,
   type PaginationMetadata,
   type RxJsFacade,
   type SelectEditor,
-  SlickDataView,
-  SlickEventHandler,
-  SlickGrid,
 } from '@slickgrid-universal/common';
-import {
-  ExtensionName,
-  ExtensionUtility,
-  SlickGroupItemMetadataProvider,
-
-  // services
-  BackendUtilityService,
-  CollectionService,
-  EventNamingStyle,
-  ExtensionService,
-  FilterFactory,
-  FilterService,
-  GridEventService,
-  GridService,
-  GridStateService,
-  HeaderGroupingService,
-  PaginationService,
-  ResizerService,
-  SharedService,
-  SlickgridConfig,
-  SortService,
-  TreeDataService,
-
-  // utilities
-  autoAddEditorFormatterToColumnsWithEditor,
-  emptyElement,
-  unsubscribeAll,
-} from '@slickgrid-universal/common';
-import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
-import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
 import { SlickFooterComponent } from '@slickgrid-universal/custom-footer-component';
+import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
+import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickPaginationComponent } from '@slickgrid-universal/pagination-component';
 import { RxJsResource } from '@slickgrid-universal/rxjs-observable';
 import { extend } from '@slickgrid-universal/utils';
-import { TranslateService } from '@ngx-translate/core';
 import { dequal } from 'dequal/lite';
 import { Observable } from 'rxjs';
-
 import { Constants } from '../constants';
-import type { AngularGridInstance, ExternalTestingDependencies, GridOption } from '../models/index';
+import { SlickRowDetailView } from '../extensions/slickRowDetailView';
 import { GlobalGridOptions } from '../global-grid-options';
-import { TranslaterService } from '../services/translater.service';
-
+import type { AngularGridInstance, ExternalTestingDependencies, GridOption } from '../models/index';
 // Services
 import { AngularUtilService } from '../services/angularUtil.service';
-import { SlickRowDetailView } from '../extensions/slickRowDetailView';
 import { ContainerService } from '../services/container.service';
+import { TranslaterService } from '../services/translater.service';
 
 const WARN_NO_PREPARSE_DATE_SIZE = 10000; // data size to warn user when pre-parse isn't enabled
 

--- a/frameworks/angular-slickgrid/src/library/extensions/__tests__/slickRowDetailView.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/extensions/__tests__/slickRowDetailView.spec.ts
@@ -1,21 +1,20 @@
-import { type ApplicationRef, Component } from '@angular/core';
+import { Component, type ApplicationRef } from '@angular/core';
 import {
-  type Column,
-  type OnSelectedRowsChangedEventArgs,
   SlickEvent,
   SlickEventData,
   SlickEventHandler,
-  type SlickGrid,
   SlickRowSelectionModel,
+  type Column,
+  type OnSelectedRowsChangedEventArgs,
+  type SlickGrid,
 } from '@slickgrid-universal/common';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { type GridOption } from '../../models/gridOption.interface.js';
-import { type AngularUtilService } from '../../services/index.js';
-import { type RowDetailView } from '../../models/rowDetailView.interface.js';
 import { RxJsResourceStub } from '../../../../test/rxjsResourceStub.js';
+import { type GridOption } from '../../models/gridOption.interface.js';
+import { type RowDetailView } from '../../models/rowDetailView.interface.js';
+import { type AngularUtilService } from '../../services/index.js';
 import { SlickRowDetailView } from '../slickRowDetailView.js';
 
 vi.mock('@slickgrid-universal/common', async () => ({

--- a/frameworks/angular-slickgrid/src/library/modules/angular-slickgrid.module.ts
+++ b/frameworks/angular-slickgrid/src/library/modules/angular-slickgrid.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { type ModuleWithProviders, NgModule } from '@angular/core';
+import { NgModule, type ModuleWithProviders } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-
 import { AngularSlickgridComponent } from '../components/angular-slickgrid.component';
 import type { GridOption } from '../models/gridOption.interface';
 import { AngularUtilService } from '../services/angularUtil.service';

--- a/frameworks/angular-slickgrid/src/library/services/__tests__/angularUtilService.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/services/__tests__/angularUtilService.spec.ts
@@ -1,7 +1,6 @@
 import { Component, ViewContainerRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { AngularUtilService } from '../angularUtil.service.js';
 
 const DOM_ELEMENT_ID = 'row-detail123';

--- a/frameworks/angular-slickgrid/src/library/services/angularUtil.service.ts
+++ b/frameworks/angular-slickgrid/src/library/services/angularUtil.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, ViewContainerRef } from '@angular/core';
 import type { EmbeddedViewRef, EnvironmentInjector, Injector, NgModuleRef, Type } from '@angular/core';
-
 import type { AngularComponentOutput } from '../models/angularComponentOutput.interface';
 
 interface CreateComponentOption {

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -1,12 +1,10 @@
 import type { ICollectionObserver, ICollectionSubscriber } from '@aurelia/runtime';
-import { bindable, BindingMode, customElement, IContainer, IEventAggregator, type IDisposable, IObserverLocator, resolve } from 'aurelia';
-import { dequal } from 'dequal/lite';
 import type {
-  BackendService,
-  BasePaginationComponent,
   AutocompleterEditor,
+  BackendService,
   BackendServiceApi,
   BackendServiceOption,
+  BasePaginationComponent,
   Column,
   DataViewOption,
   EventSubscription,
@@ -34,10 +32,8 @@ import {
   GridStateService,
   HeaderGroupingService,
   isColumnDateType,
-  type Observable,
   PaginationService,
   ResizerService,
-  type RxJsFacade,
   SharedService,
   SlickDataView,
   SlickEventHandler,
@@ -46,18 +42,21 @@ import {
   SlickGroupItemMetadataProvider,
   SortService,
   TreeDataService,
+  type Observable,
+  type RxJsFacade,
 } from '@slickgrid-universal/common';
-import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickFooterComponent } from '@slickgrid-universal/custom-footer-component';
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
+import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickPaginationComponent } from '@slickgrid-universal/pagination-component';
 import { extend } from '@slickgrid-universal/utils';
-
+import { bindable, BindingMode, customElement, IContainer, IEventAggregator, IObserverLocator, resolve, type IDisposable } from 'aurelia';
+import { dequal } from 'dequal/lite';
 import { Constants } from '../constants.js';
+import { SlickRowDetailView } from '../extensions/slickRowDetailView.js';
 import { GlobalGridOptions } from '../global-grid-options.js';
 import type { AureliaGridInstance, GridOption } from '../models/index.js';
 import { AureliaUtilService, ContainerService, disposeAllSubscriptions, TranslaterService } from '../services/index.js';
-import { SlickRowDetailView } from '../extensions/slickRowDetailView.js';
 
 const WARN_NO_PREPARSE_DATE_SIZE = 10000; // data size to warn user when pre-parse isn't enabled
 

--- a/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
+++ b/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
@@ -1,19 +1,18 @@
+import type { ICustomElementController } from '@aurelia/runtime-html';
 import {
   addToArrayWhenNotExists,
   createDomElement,
+  SlickEventData,
+  SlickRowSelectionModel,
+  unsubscribeAll,
   type EventSubscription,
   type OnBeforeRowDetailToggleArgs,
   type OnRowBackOrOutOfViewportRangeArgs,
-  SlickEventData,
   type SlickGrid,
-  SlickRowSelectionModel,
-  unsubscribeAll,
 } from '@slickgrid-universal/common';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickRowDetailView as UniversalSlickRowDetailView } from '@slickgrid-universal/row-detail-view-plugin';
-import type { ICustomElementController } from '@aurelia/runtime-html';
-import { type Constructable, resolve, transient } from 'aurelia';
-
+import { resolve, transient, type Constructable } from 'aurelia';
 import type { CreatedView, GridOption, RowDetailView, ViewModelBindableInputData } from '../models/index.js';
 import { AureliaUtilService } from '../services/aureliaUtil.service.js';
 

--- a/frameworks/aurelia-slickgrid/src/services/aureliaUtil.service.ts
+++ b/frameworks/aurelia-slickgrid/src/services/aureliaUtil.service.ts
@@ -1,6 +1,5 @@
-import { AppTask, type Constructable, CustomElement, type IAppRoot, IAurelia, type INode, resolve, singleton } from 'aurelia';
 import { type Writable } from '@aurelia/kernel';
-
+import { AppTask, CustomElement, IAurelia, resolve, singleton, type Constructable, type IAppRoot, type INode } from 'aurelia';
 import type { ViewModelBindableInputData } from '../models/index.js';
 
 @singleton()

--- a/frameworks/aurelia-slickgrid/src/services/translater.service.ts
+++ b/frameworks/aurelia-slickgrid/src/services/translater.service.ts
@@ -1,5 +1,5 @@
-import type { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
 import { I18N } from '@aurelia/i18n';
+import type { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
 import { inject, optional } from 'aurelia';
 
 /**


### PR DESCRIPTION
This fixes an issue I encountered after adding the `prettier-plugin-sort-imports`
> [error] [prettier-plugin-sort-imports]: import sorting aborted due to parsing error:
SyntaxError: This experimental syntax requires enabling one of the following parser plugin(s): "decorators", "decorators-legacy". (22:0)

and after fixing the issue, a few more files got reformatted properly