### PR TITLE
fix(utils): htmlDecode should decodes all multi-layered HTML entities

### DIFF
--- a/packages/utils/src/__tests__/domUtils.spec.ts
+++ b/packages/utils/src/__tests__/domUtils.spec.ts
@@ -344,6 +344,21 @@ describe('Service/domUtilies', () => {
       const result = htmlDecode(`&#x30cf;&#x30ed;&#x30fc;&#x30ef;&#x30fc;&#x30eb;&#x30c9;`);
       expect(result).toBe(`ハローワールド`);
     });
+
+    it('should decode nested/double-encoded entities', () => {
+      const result = htmlDecode('What&amp;#39;s &amp;quot;New&amp;quot;!');
+      expect(result).toBe(`What's "New"!`);
+    });
+
+    it('should decode mixed named and numeric entities in one string', () => {
+      const result = htmlDecode('&lt;span&gt;Tom &amp; Jerry&#39;s &amp;quot;Show&amp;quot;&lt;/span&gt;');
+      expect(result).toBe(`<span>Tom & Jerry's "Show"</span>`);
+    });
+
+    it('should decode multiple layers of encoding', () => {
+      const result = htmlDecode('&amp;amp;lt;div&amp;amp;gt;Test&amp;amp;lt;/div&amp;amp;gt;');
+      expect(result).toBe('<div>Test</div>');
+    });
   });
 
   describe('htmlEncode() method', () => {


### PR DESCRIPTION
This PR improves the `htmlDecode` utility to reliably decode all HTML entities, including multi-layered/nested encodings and emoji/unicode surrogate pairs. This fixes an issue that happened when my string input had multiple encoded value and the function did not decode them all.

### Highlights
- Decodes all numeric and named HTML entities, even if nested or double-encoded
- Supports emoji and full Unicode via surrogate pair handling
- Adds clear comments for maintainability
- All related unit tests now pass
