### PR TITLE
fix: calculate grid's width using window.innerWidth only when parent-container autoresize is not enabled

### DIFF
--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -256,30 +256,29 @@ export class ResizerService {
 
     let gridHeight = 0;
     let gridOffsetTop = 0;
-    let gridWidth = 0;
 
     // which DOM element are we using to calculate the available size for the grid?
     if (autoResizeOptions.calculateAvailableSizeBy === 'container') {
-      // uses the container's height and width to calculate grid's dimensions without any offset
+      // uses the container's height to calculate grid height without any top offset
       gridHeight = getInnerSize(this._pageContainerElm, 'height') || 0;
-      gridWidth = getInnerSize(this._pageContainerElm, 'width') || 0;
     } else {
       // uses the browser's window height with its top offset to calculate grid height
       gridHeight = window.innerHeight || 0;
       gridOffsetTop = gridElmOffset.top;
-
-      // uses the browser's window width to calculate grid width
-      gridWidth = window.innerWidth || 0;
     }
 
     const availableHeight = gridHeight - gridOffsetTop - bottomPadding;
+    const availableWidth =
+      getInnerSize(this._pageContainerElm, 'width') ||
+      (autoResizeOptions.calculateAvailableSizeBy !== 'container' && window.innerWidth) ||
+      0;
     const maxHeight = autoResizeOptions?.maxHeight;
     const minHeight = autoResizeOptions?.minHeight ?? DATAGRID_MIN_HEIGHT;
     const maxWidth = autoResizeOptions?.maxWidth;
     const minWidth = autoResizeOptions?.minWidth ?? DATAGRID_MIN_WIDTH;
 
     let newHeight = availableHeight;
-    let newWidth = autoResizeOptions?.rightPadding ? gridWidth - autoResizeOptions.rightPadding : gridWidth;
+    let newWidth = autoResizeOptions?.rightPadding ? availableWidth - autoResizeOptions.rightPadding : availableWidth;
 
     // when `autoResize.autoHeight` is enabled, we'll calculate the available height by the data length + header height
     if (gridOptions.enableAutoResize && this.isAutoHeightEnabled) {


### PR DESCRIPTION
Fixes #2209 

Fix resizer.service to correctly compute grid width based on the parent container when autoresize is enabled.

Previously, the service used window.innerWidth, which could lead to incorrect sizing. This change mirrors the existing logic used for height calculation.