### PR TITLE
fix: Pre-edit Click mode (PreClick) should work with Checkbox Editor

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2621,12 +2621,13 @@ describe('SlickGrid core file', () => {
       const editor = grid.getCellEditor();
       const updateRowSpy = vi.spyOn(grid, 'updateRow');
       const onCellChangeSpy = vi.spyOn(grid.onCellChange, 'notify');
+      const preClickSpy = vi.spyOn(CheckboxEditor.prototype, 'preClick');
       vi.spyOn(editor!, 'serializeValue').mockReturnValueOnce(newValue);
       grid.editActiveCell(CheckboxEditor as any, true);
 
       const result = grid.getEditController()?.commitCurrentEdit();
 
-      // expect(preClickSpy).toHaveBeenCalled();
+      expect(preClickSpy).toHaveBeenCalled();
       expect(editor).toBeTruthy();
       expect(updateRowSpy).toHaveBeenCalledWith(0);
       expect(onCellChangeSpy).toHaveBeenCalledWith(expect.objectContaining({ command: 'execute', row: 0, cell: 1 }), expect.anything(), grid);

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5810,7 +5810,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (!this.getEditorLock()?.isActive() || this.getEditorLock()?.commitCurrentEdit()) {
         this.scrollRowIntoView(cell.row, false);
 
-        const preClickModeOn = (e as DOMEvent<HTMLDivElement>).target?.className === preClickClassName;
+        const preClickModeOn = !!(e as DOMEvent<HTMLDivElement>).target?.classList?.contains(preClickClassName);
         const column = this.columns[cell.cell];
         const suppressActiveCellChangedEvent = !!(
           this._options.editable &&


### PR DESCRIPTION
for a pre-click example, we can see 6pac/SlickGrid [Example pre-click](https://6pac.github.io/SlickGrid/examples/example3c-editing-with-pre-click.html), I won't necessarily duplicate this demo in here. 