### PR TITLE
fix: column cannot be resized when column not orderable

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2145,6 +2145,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       ghostClass: 'slick-sortable-placeholder',
       draggable: '.slick-header-column',
       dragoverBubble: false,
+      preventOnFilter: false, // allow column to be resized even when they are not orderable
       revertClone: true,
       scroll: !this.hasFrozenColumns(), // enable auto-scroll
       // lock unorderable columns by using a combo of filter + onMove


### PR DESCRIPTION
Replicates a SlickGrid [PR](https://github.com/6pac/SlickGrid/pull/1155) that fixes an issue with a column that isn't reordable was blocking the resize of the same column

> I spotted the following issue, in the following context:
> 
> 1. The columns are resizable
> 2. A column is marked with reorderable = false
> 
> In this case, this column cannot be resized.
> 
> The conclusion of my investigations is that the issue is coming from SortableJS which prevents the drag event by default when applying a filter of the column (which is done by Slickgrid when setting reorderable to false). A quick fix for that is just to change this default behavior by amending the sortableOptions.
> 
> My commit includes this fix, plus a change of a test file to light up the problem.
> 
> Please note that I did not perform any further test on the potential impact of the above change. Happy to discuss potential consequences.

