### PR TITLE
fix: hide column shouldn't cause header/data misalignments, fixes #2214

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -216,6 +216,32 @@ describe('SlickGrid core file', () => {
     expect(grid.getColumnByIndex(99)).toEqual(undefined);
   });
 
+  it('should call setColumns() and wait a cycle before updating the column headers', () => {
+    const columns = [
+      { id: 'firstName', field: 'firstName', name: 'First Name', headerCssClass: 'header-class', headerCellAttrs: { 'some-attr': 3 } },
+    ] as Column[];
+    grid = new SlickGrid<any, Column>('#myGrid', [], columns, defaultOptions);
+    grid.init();
+    grid.setOptions({ addNewRowCssClass: 'new-class' });
+    const colHeaderElms = container.querySelectorAll('.slick-header-columns .slick-header-column');
+    const onAfterSetColumnsSpy = vi.spyOn(grid.onAfterSetColumns, 'notify');
+
+    expect(grid).toBeTruthy();
+    expect(colHeaderElms.length).toBe(1);
+    expect(grid.getColumns()).toEqual(columns);
+
+    const columnsMock = [
+      { id: 'firstName', field: 'firstName', name: 'First Name' },
+      { id: 'lastName', field: 'lastName', name: 'Last Name' },
+      { id: 'age', field: 'age', name: 'Age' },
+    ] as Column[];
+    grid.setColumns(columnsMock, true);
+    vi.runAllTimers(); // fast-forward timer
+
+    expect(grid.getColumns()).toEqual(columnsMock);
+    expect(onAfterSetColumnsSpy).toHaveBeenCalled();
+  });
+
   it('should be able to instantiate SlickGrid and set headerCssClass and expect it in column header', () => {
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name', headerCssClass: 'header-class  other-class' }] as Column[];
     grid = new SlickGrid<any, Column>('#myGrid', [], columns, defaultOptions);

--- a/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHeaderMenu.spec.ts
@@ -601,7 +601,7 @@ describe('HeaderMenu Plugin', () => {
 
         expect(setOptionSpy).not.toHaveBeenCalled();
         expect(visibleSpy).toHaveBeenCalledWith(updatedColumnsMock);
-        expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock);
+        expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock, true);
       });
 
       it('should call hideColumn and expect "setOptions" to be called with new "frozenColumn" index when the grid is detected to be a frozen grid', () => {
@@ -626,7 +626,7 @@ describe('HeaderMenu Plugin', () => {
 
         expect(setOptionSpy).toHaveBeenCalledWith({ frozenColumn: 0 });
         expect(visibleSpy).toHaveBeenCalledWith(updatedColumnsMock);
-        expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock);
+        expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock, true);
       });
     });
 

--- a/packages/common/src/extensions/slickHeaderMenu.ts
+++ b/packages/common/src/extensions/slickHeaderMenu.ts
@@ -111,7 +111,7 @@ export class SlickHeaderMenu extends MenuBaseClass<HeaderMenu> {
       // then proceed with hiding the column in SlickGrid & trigger an event when done
       const visibleColumns = arrayRemoveItemByIndex<Column>(currentVisibleColumns, columnIndex);
       this.sharedService.visibleColumns = visibleColumns;
-      this.grid.setColumns(visibleColumns);
+      this.grid.setColumns(visibleColumns, true);
       this.pubSubService.publish('onHideColumns', { columns: visibleColumns, hiddenColumn: column });
     }
   }

--- a/packages/common/src/services/__tests__/extension.service.spec.ts
+++ b/packages/common/src/services/__tests__/extension.service.spec.ts
@@ -801,7 +801,7 @@ describe('ExtensionService', () => {
       service.hideColumn(columnsMock[1]);
 
       expect(sharedService.visibleColumns).toEqual(updatedColumnsMock);
-      expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock);
+      expect(setColumnsSpy).toHaveBeenCalledWith(updatedColumnsMock, true);
     });
 
     it('should call the refreshBackendDataset method on the GridMenu Extension when service with same method name is called', () => {

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -432,7 +432,7 @@ export class ExtensionService {
     if (typeof this.sharedService?.slickGrid?.getColumns === 'function') {
       const columnIndex = this.sharedService.slickGrid.getColumnIndex(column.id);
       this.sharedService.visibleColumns = this.removeColumnByIndex(this.sharedService.slickGrid.getColumns(), columnIndex);
-      this.sharedService.slickGrid.setColumns(this.sharedService.visibleColumns);
+      this.sharedService.slickGrid.setColumns(this.sharedService.visibleColumns, true);
     }
   }
 


### PR DESCRIPTION
fixes #2214 - 2nd issue

- hiding a column dynamically could cause a small column headers & data misalignments, adding a small wait of a cycle seems to fix this misalignment. 

> Note, the 1st issue of #2214 isn't a problem and can be disabled via `enableAutoSizeColumns: false` grid option