### PR TITLE
feat: add Grid Menu `autoResizeColumns` to disable resize w/closing menu

### DIFF
--- a/demos/vanilla/src/examples/example01.ts
+++ b/demos/vanilla/src/examples/example01.ts
@@ -98,6 +98,7 @@ export default class Example01 {
       gridWidth: 800,
       rowHeight: 33,
       gridMenu: {
+        // autoResizeColumns: false, // disable auto-resize columns after closing the Grid Menu
         hideToggleDarkModeCommand: false, // disabled command by default
         onCommand: (_, args) => {
           if (args.command === 'toggle-dark-mode') {

--- a/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGridMenu.spec.ts
@@ -839,6 +839,48 @@ describe('GridMenuControl', () => {
         expect(autosizeSpy).toHaveBeenCalled();
       });
 
+      it('should close the Grid Menu by calling "hideMenu" and not expect "autosizeColumns" to be called when "autoResizeColumns" Grid Menu option is disabled', () => {
+        gridOptionsMock.enableAutoSizeColumns = true;
+        const autosizeSpy = vi.spyOn(gridStub, 'autosizeColumns');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+        vi.spyOn(gridStub, 'validateSetColumnFreeze').mockReturnValueOnce(true);
+
+        control.columns = columnsMock;
+        control.init();
+        const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+        buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+        const pickerField1Elm = document.querySelector('input[type="checkbox"][data-columnid="field1"]') as HTMLInputElement;
+        pickerField1Elm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+
+        expect(control.menuElement!.style.display).toBe('block');
+
+        control.addonOptions.autoResizeColumns = false;
+        control.hideMenu(new Event('click', { bubbles: true, cancelable: true, composed: false }) as DOMEvent<HTMLDivElement>);
+        expect(control.menuElement).toBeFalsy();
+        expect(autosizeSpy).not.toHaveBeenCalled();
+      });
+
+      it('should close the Grid Menu by calling "hideMenu" and expect "autosizeColumns" to be called when "autoResizeColumns" Grid Menu option is enabled', () => {
+        gridOptionsMock.enableAutoSizeColumns = true;
+        const autosizeSpy = vi.spyOn(gridStub, 'autosizeColumns');
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+        vi.spyOn(gridStub, 'validateSetColumnFreeze').mockReturnValueOnce(true);
+
+        control.columns = columnsMock;
+        control.init();
+        const buttonElm = document.querySelector('.slick-grid-menu-button') as HTMLDivElement;
+        buttonElm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+        const pickerField1Elm = document.querySelector('input[type="checkbox"][data-columnid="field1"]') as HTMLInputElement;
+        pickerField1Elm.dispatchEvent(new Event('click', { bubbles: true, cancelable: true, composed: false }));
+
+        expect(control.menuElement!.style.display).toBe('block');
+
+        control.addonOptions.autoResizeColumns = true;
+        control.hideMenu(new Event('click', { bubbles: true, cancelable: true, composed: false }) as DOMEvent<HTMLDivElement>);
+        expect(control.menuElement).toBeFalsy();
+        expect(autosizeSpy).toHaveBeenCalled();
+      });
+
       it('should add a custom Grid Menu item and expect the "action" and "onCommand" callbacks to be called when command is clicked in the list', () => {
         const helpFnMock = vi.fn();
         const onCommandMock = vi.fn();

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -364,7 +364,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     this._isMenuOpen = false;
 
     // we also want to resize the columns if the user decided to hide certain column(s)
-    if (typeof this.grid?.autosizeColumns === 'function') {
+    if (typeof this.grid?.autosizeColumns === 'function' && this._addonOptions?.autoResizeColumns !== false) {
       // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree)
       const gridUid = this.grid.getUID() || '';
       if (this._areVisibleColumnDifferent && gridUid && document.querySelector(`.${gridUid}`) !== null) {

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -12,6 +12,9 @@ export interface GridMenuOption {
   /** Defaults to true, Auto-align drop menu to the left or right depending on grid viewport available space */
   autoAlignSide?: boolean;
 
+  /** Defaults to true, which will automatically resize column headers to fit the grid after closing the Grid Menu */
+  autoResizeColumns?: boolean;
+
   /**
    * All the commands text labels
    * NOTE: some of the text have other properties outside of this option (like 'clearAllFiltersCommand', 'exportExcelCommand', ...) and that is because they were created prior to this refactoring of labels


### PR DESCRIPTION
addresses issue #2214 1st issue by adding a new Grid Menu option: `gridMenu.autoResizeColumns: false` to not auto-resize column headers after closing the Grid Menu