### PR TITLE
feat: add `useArrowToSlide` to Slider Editor

### DIFF
--- a/packages/common/src/editors/__tests__/sliderEditor.spec.ts
+++ b/packages/common/src/editors/__tests__/sliderEditor.spec.ts
@@ -272,6 +272,75 @@ describe('SliderEditor', () => {
       expect(cellMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
     });
 
+    describe('keydown event', () => {
+      it('should decrease slider number value and tooltip when using ArrowLeft keydown with "useArrowToSlide" undefined', () => {
+        const inputValue = 17;
+        const cellMouseEnterSpy = vi.spyOn(gridStub.onMouseEnter, 'notify');
+        mockColumn.editor!.options = { hideSliderNumber: false, useArrowToSlide: undefined };
+        mockItemData = { id: 1, price: 32, isActive: true };
+        editor = new SliderEditor(editorArguments);
+        editor.loadValue(mockItemData);
+        editor.setValue(inputValue);
+
+        const inputElm = divContainer.querySelector('.slider-editor-input.editor-price') as HTMLDivElement;
+        const editorNumberElm = divContainer.querySelector('.input-group-text') as HTMLInputElement;
+        const mockEvent = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
+        const prevDefaultSpy = vi.spyOn(mockEvent, 'preventDefault');
+        const stopPropSpy = vi.spyOn(mockEvent, 'stopPropagation');
+        inputElm.dispatchEvent(mockEvent);
+
+        expect(editor.isValueChanged()).toBe(true);
+        expect(editorNumberElm.textContent).toBe(`${inputValue - 1}`);
+        expect(cellMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
+        expect(prevDefaultSpy).toHaveBeenCalled();
+        expect(stopPropSpy).toHaveBeenCalled();
+      });
+
+      it('should increase slider number value and tooltip when using ArrowRight keydown with "useArrowToSlide" enabled', () => {
+        const inputValue = 17;
+        const cellMouseEnterSpy = vi.spyOn(gridStub.onMouseEnter, 'notify');
+        mockColumn.editor!.options = { hideSliderNumber: false, useArrowToSlide: true };
+        mockItemData = { id: 1, price: 32, isActive: true };
+        editor = new SliderEditor(editorArguments);
+        editor.loadValue(mockItemData);
+        editor.setValue(inputValue);
+
+        const inputElm = divContainer.querySelector('.slider-editor-input.editor-price') as HTMLDivElement;
+        const editorNumberElm = divContainer.querySelector('.input-group-text') as HTMLInputElement;
+        const mockEvent = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
+        const prevDefaultSpy = vi.spyOn(mockEvent, 'preventDefault');
+        const stopPropSpy = vi.spyOn(mockEvent, 'stopPropagation');
+        inputElm.dispatchEvent(mockEvent);
+
+        expect(editor.isValueChanged()).toBe(true);
+        expect(editorNumberElm.textContent).toBe(`${inputValue + 1}`);
+        expect(cellMouseEnterSpy).toHaveBeenCalledWith({ column: mockColumn, grid: gridStub }, expect.anything());
+        expect(prevDefaultSpy).toHaveBeenCalled();
+        expect(stopPropSpy).toHaveBeenCalled();
+      });
+
+      it('should not decrease or increase slider number value when "useArrowToSlide" is disabled', () => {
+        const inputValue = 17;
+        mockColumn.editor!.options = { hideSliderNumber: false, useArrowToSlide: false };
+        mockItemData = { id: 1, price: 32, isActive: true };
+        editor = new SliderEditor(editorArguments);
+        editor.loadValue(mockItemData);
+        editor.setValue(inputValue);
+
+        const inputElm = divContainer.querySelector('.slider-editor-input.editor-price') as HTMLDivElement;
+        const editorNumberElm = divContainer.querySelector('.input-group-text') as HTMLInputElement;
+        const mockEvent = new (window.window as any).KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
+        const prevDefaultSpy = vi.spyOn(mockEvent, 'preventDefault');
+        const stopPropSpy = vi.spyOn(mockEvent, 'stopPropagation');
+        inputElm.dispatchEvent(mockEvent);
+
+        expect(editor.isValueChanged()).toBe(true);
+        expect(editorNumberElm.textContent).toBe(`${inputValue}`);
+        expect(prevDefaultSpy).not.toHaveBeenCalled();
+        expect(stopPropSpy).not.toHaveBeenCalled();
+      });
+    });
+
     describe('changeEditorOption() method', () => {
       it('should be able to change enableSliderTrackColoring option', () => {
         editor = new SliderEditor(editorArguments);
@@ -587,39 +656,41 @@ describe('SliderEditor', () => {
       });
     });
 
-    it('should enableSliderTrackColoring and trigger a change event and expect slider track to have background color', () => {
-      mockColumn.editor!.options = { sliderStartValue: 5, enableSliderTrackColoring: true };
-      mockItemData = { id: 1, price: 80, isActive: true };
-      editor = new SliderEditor(editorArguments);
-      editor.loadValue(mockItemData);
-      editor.setValue(45);
+    describe('slider track', () => {
+      it('should enableSliderTrackColoring and trigger a change event and expect slider track to have background color', () => {
+        mockColumn.editor!.options = { sliderStartValue: 5, enableSliderTrackColoring: true };
+        mockItemData = { id: 1, price: 80, isActive: true };
+        editor = new SliderEditor(editorArguments);
+        editor.loadValue(mockItemData);
+        editor.setValue(45);
 
-      const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;
-      editorElm.dispatchEvent(new Event('change'));
+        const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;
+        editorElm.dispatchEvent(new Event('change'));
 
-      expect(editor.sliderOptions?.sliderTrackBackground).toBe(
-        'linear-gradient(to right, #eee 0%, var(--slick-slider-filter-thumb-color, #86bff8) 0%, var(--slick-slider-filter-thumb-color, #86bff8) 45%, #eee 45%)'
-      );
-    });
+        expect(editor.sliderOptions?.sliderTrackBackground).toBe(
+          'linear-gradient(to right, #eee 0%, var(--slick-slider-filter-thumb-color, #86bff8) 0%, var(--slick-slider-filter-thumb-color, #86bff8) 45%, #eee 45%)'
+        );
+      });
 
-    it('should click on the slider track and expect handle to move to the new position', () => {
-      mockColumn.editor!.editorOptions = { sliderStartValue: 5, enableSliderTrackColoring: true };
-      editor = new SliderEditor(editorArguments);
+      it('should click on the slider track and expect handle to move to the new position', () => {
+        mockColumn.editor!.editorOptions = { sliderStartValue: 5, enableSliderTrackColoring: true };
+        editor = new SliderEditor(editorArguments);
 
-      const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;
-      editorElm.dispatchEvent(new Event('change'));
+        const editorElm = divContainer.querySelector('.slider-editor input.editor-price') as HTMLInputElement;
+        editorElm.dispatchEvent(new Event('change'));
 
-      const sliderInputs = divContainer.querySelectorAll<HTMLInputElement>('.slider-editor-input');
-      const sliderTrackElm = divContainer.querySelector('.slider-track') as HTMLDivElement;
+        const sliderInputs = divContainer.querySelectorAll<HTMLInputElement>('.slider-editor-input');
+        const sliderTrackElm = divContainer.querySelector('.slider-track') as HTMLDivElement;
 
-      const sliderRightChangeSpy = vi.spyOn(sliderInputs[0], 'dispatchEvent');
+        const sliderRightChangeSpy = vi.spyOn(sliderInputs[0], 'dispatchEvent');
 
-      const clickEvent = new Event('click');
-      Object.defineProperty(clickEvent, 'offsetX', { writable: true, configurable: true, value: 56 });
-      Object.defineProperty(sliderTrackElm, 'offsetWidth', { writable: true, configurable: true, value: 75 });
-      sliderTrackElm.dispatchEvent(clickEvent);
+        const clickEvent = new Event('click');
+        Object.defineProperty(clickEvent, 'offsetX', { writable: true, configurable: true, value: 56 });
+        Object.defineProperty(sliderTrackElm, 'offsetWidth', { writable: true, configurable: true, value: 75 });
+        sliderTrackElm.dispatchEvent(clickEvent);
 
-      expect(sliderRightChangeSpy).toHaveBeenCalled();
+        expect(sliderRightChangeSpy).toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/common/src/editors/sliderEditor.ts
+++ b/packages/common/src/editors/sliderEditor.ts
@@ -103,18 +103,19 @@ export class SliderEditor implements Editor {
       // create HTML string template
       this._editorElm = this.buildDomElement();
 
-      if (!compositeEditorOptions) {
-        this.focus();
-      }
-
       // watch on change event
       this._cellContainerElm.appendChild(this._editorElm);
       this._bindEventService.bind(this._sliderTrackElm, ['click', 'mouseup'], this.sliderTrackClicked.bind(this) as EventListener);
       this._bindEventService.bind(this._inputElm, ['change', 'mouseup', 'touchend'], this.handleChangeEvent.bind(this) as EventListener);
+      this._bindEventService.bind(this._inputElm, ['keydown'], this.handleKeyDown.bind(this) as EventListener);
 
       // if user chose to display the slider number on the right side, then update it every time it changes
       // we need to use both "input" and "change" event to be all cross-browser
       this._bindEventService.bind(this._inputElm, ['input', 'change'], this.handleChangeSliderNumber.bind(this));
+
+      if (!compositeEditorOptions) {
+        this.focus();
+      }
     }
   }
 
@@ -295,10 +296,7 @@ export class SliderEditor implements Editor {
   }
 
   save(): void {
-    const validation = this.validate();
-    const isValid = (validation && validation.valid) || false;
-
-    if (this.hasAutoCommitEdit && isValid) {
+    if (this.hasAutoCommitEdit && this.validate()?.valid) {
       // do not use args.commitChanges() as this sets the focus to the next row.
       // also the select list will stay shown when clicking off the grid
       this.grid.getEditorLock().commitCurrentEdit();
@@ -344,10 +342,10 @@ export class SliderEditor implements Editor {
   protected buildDomElement(): HTMLDivElement {
     const columnId = this.columnDef?.id ?? '';
     const title = this.columnEditor.title ?? '';
-    const minValue = +(this.columnEditor.minValue ?? Constants.SLIDER_DEFAULT_MIN_VALUE);
-    const maxValue = +(this.columnEditor.maxValue ?? Constants.SLIDER_DEFAULT_MAX_VALUE);
-    const step = +(this.columnEditor.valueStep ?? Constants.SLIDER_DEFAULT_STEP);
-    const defaultValue = this.editorOptions.sliderStartValue ?? minValue;
+
+    // merge options with optional user's custom options
+    this._sliderOptions = this.getSliderConfigs();
+    const defaultValue = this.editorOptions.sliderStartValue ?? this._sliderOptions.minValue;
     this._defaultValue = +defaultValue;
 
     this._sliderTrackElm = createDomElement('div', { className: 'slider-track' });
@@ -356,10 +354,10 @@ export class SliderEditor implements Editor {
       title,
       defaultValue: `${defaultValue}`,
       value: `${defaultValue}`,
-      min: `${minValue}`,
-      max: `${maxValue}`,
+      min: `${this._sliderOptions.minValue}`,
+      max: `${this._sliderOptions.maxValue}`,
       step: `${this.columnEditor.valueStep ?? Constants.SLIDER_DEFAULT_STEP}`,
-      ariaLabel: this.columnEditor.ariaLabel ?? `${toSentenceCase(columnId + '')} Slider Editor`,
+      ariaLabel: this.columnEditor.ariaLabel ?? `${toSentenceCase(`${columnId}`)} Slider Editor`,
       className: `slider-editor-input editor-${columnId}`,
     });
 
@@ -371,10 +369,15 @@ export class SliderEditor implements Editor {
 
     this.renderSliderNumber(divContainerElm, defaultValue);
 
-    // merge options with optional user's custom options
-    this._sliderOptions = { minValue, maxValue, step };
-
     return divContainerElm;
+  }
+
+  protected getSliderConfigs(): Omit<CurrentSliderOption, 'sliderTrackBackground'> {
+    return {
+      minValue: +(this.columnEditor.minValue ?? Constants.SLIDER_DEFAULT_MIN_VALUE),
+      maxValue: +(this.columnEditor.maxValue ?? Constants.SLIDER_DEFAULT_MAX_VALUE),
+      step: +(this.columnEditor.valueStep ?? Constants.SLIDER_DEFAULT_STEP),
+    };
   }
 
   protected renderSliderNumber(divContainerElm: HTMLDivElement, defaultValue: number | string): void {
@@ -470,6 +473,24 @@ export class SliderEditor implements Editor {
       },
       new SlickEventData(event)
     );
+  }
+
+  /** use keydown event to increase/decrease slider value */
+  protected handleKeyDown(e: KeyboardEvent): void {
+    if (this.editorOptions.useArrowToSlide !== false && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+      const { minValue, maxValue, step } = this.getSliderConfigs();
+      const currentValue = Number(this._inputElm.value);
+      let newValue = e.key === 'ArrowLeft' ? currentValue - step : currentValue + step;
+      newValue = newValue < minValue ? minValue : newValue > maxValue ? maxValue : newValue; // make we are within limits
+
+      // Update input value & trigger an event to update tooltip as well
+      this._inputElm.value = `${newValue}`;
+      this.handleChangeSliderNumber(e);
+
+      // Prevent default arrow key behavior
+      e.stopPropagation();
+      e.preventDefault();
+    }
   }
 
   protected sliderTrackClicked(e: MouseEvent): void {

--- a/packages/common/src/interfaces/sliderOption.interface.ts
+++ b/packages/common/src/interfaces/sliderOption.interface.ts
@@ -13,6 +13,9 @@ export interface SliderOption {
 
   /** Defaults to "#3C97DD", what will be the color to use to represent slider range */
   sliderTrackFilledColor?: string;
+
+  /** Defaults to true, use arrow to slide and increase/decrease values in the Slider Editor instead of the default cell left/right navigation. */
+  useArrowToSlide?: boolean;
 }
 
 export interface SliderRangeOption extends Omit<SliderOption, 'hideSliderNumber'> {


### PR DESCRIPTION
#### What
Previously, when using `Editors.slider` and clicking on the cell, it was opening the Slider Editor but the user had to use his mouse to slide to update the value. With this PR, it now allows to use the arrow left/right to decrease/increase the value, this PR also fixes an issue with the element focus which was called way too early since it was trying to focus on the element before it was even added to the DOM.

#### Why
This change helps to be a bit more focus on keyboard only approach

![brave_aUz6bGBTrg](https://github.com/user-attachments/assets/ac65ce3a-dc25-4d9e-98e0-cc931a252f95)
