### PR TITLE
fix: Calendar picker focus should be on selected date/month when opening

### DIFF
--- a/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
+++ b/packages/common/src/commonEditorFilter/commonEditorFilterUtils.ts
@@ -88,6 +88,17 @@ export function createBlankSelectEntry(labelName: string, valueName: string, lab
   return blankEntry;
 }
 
+export function setPickerFocus(pickerElm: HTMLElement): void {
+  setTimeout(() => {
+    const buttonElm = pickerElm.querySelector<HTMLElement>('[data-vc-date-selected] button');
+    const outlineElm = buttonElm ?? pickerElm.querySelector<HTMLElement>('[data-vc="month"]');
+    if (outlineElm) {
+      outlineElm.focus();
+      outlineElm.tabIndex = 0;
+    }
+  });
+}
+
 export function setPickerDates(
   colEditorOrFilter: ColumnEditor | ColumnFilter,
   dateInputElm: HTMLInputElement,

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -2,7 +2,7 @@ import { parse } from '@formkit/tempo';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, queueMicrotaskOrSetTimeout, setDeepValue } from '@slickgrid-universal/utils';
 import { Calendar, type FormatDateString, type Options } from 'vanilla-calendar-pro';
-import { resetDatePicker, setPickerDates } from '../commonEditorFilter/commonEditorFilterUtils.js';
+import { resetDatePicker, setPickerDates, setPickerFocus } from '../commonEditorFilter/commonEditorFilterUtils.js';
 import { SlickEventData, type SlickGrid } from '../core/index.js';
 import { FieldType } from '../enums/index.js';
 import { formatDateByFieldType, mapTempoDateFormatWithFieldType } from '../services/dateUtils.js';
@@ -127,6 +127,9 @@ export class DateEditor implements Editor {
         selectedWeekends: [],
         onClickDate: () => {
           this._lastClickIsDate = true;
+        },
+        onShow: (self) => {
+          setPickerFocus(self.context.mainElement);
         },
         onChangeToInput: (self) => {
           if (self.context.inputElement) {
@@ -412,10 +415,7 @@ export class DateEditor implements Editor {
   }
 
   save(): void {
-    const validation = this.validate();
-    const isValid = validation?.valid ?? false;
-
-    if (this.hasAutoCommitEdit && isValid) {
+    if (this.hasAutoCommitEdit && this.validate()?.valid) {
       // do not use args.commitChanges() as this sets the focus to the next row.
       // also the select list will stay shown when clicking off the grid
       this.grid.getEditorLock().commitCurrentEdit();

--- a/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundDateFilter.spec.ts
@@ -83,6 +83,16 @@ describe('CompoundDateFilter', () => {
     expect(filterCount).toBe(1);
   });
 
+  it('should initialize the editor and expect to focus on the element after a small delay', () => {
+    filter = new CompoundDateFilter(translateService);
+    filter.init(filterArguments);
+    const filterCount = divContainer.querySelectorAll('.form-group.search-filter.filter-finish').length;
+
+    vi.runAllTimers();
+
+    expect(filterCount).toBe(1);
+  });
+
   it('should have a placeholder when defined in its column definition', () => {
     const testValue = 'test placeholder';
     mockColumn.filter!.placeholder = testValue;
@@ -127,6 +137,7 @@ describe('CompoundDateFilter', () => {
       locale: 'en',
       onChangeToInput: expect.any(Function),
       onClickDate: expect.any(Function),
+      onShow: expect.any(Function),
       positionToInput: 'auto',
       sanitizerHTML: expect.any(Function),
       selectedTheme: 'light',

--- a/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/dateRangeFilter.spec.ts
@@ -116,6 +116,7 @@ describe('DateRangeFilter', () => {
       monthsToSwitch: 2,
       onChangeToInput: expect.any(Function),
       onClickDate: expect.any(Function),
+      onShow: expect.any(Function),
       positionToInput: 'auto',
       sanitizerHTML: expect.any(Function),
       selectionDatesMode: 'multiple-ranged',

--- a/packages/common/src/filters/dateFilter.ts
+++ b/packages/common/src/filters/dateFilter.ts
@@ -2,7 +2,7 @@ import { format, parse } from '@formkit/tempo';
 import { BindingEventService } from '@slickgrid-universal/binding';
 import { createDomElement, emptyElement, extend, isDefined } from '@slickgrid-universal/utils';
 import { Calendar, type Options } from 'vanilla-calendar-pro';
-import { resetDatePicker, setPickerDates } from '../commonEditorFilter/commonEditorFilterUtils.js';
+import { resetDatePicker, setPickerDates, setPickerFocus } from '../commonEditorFilter/commonEditorFilterUtils.js';
 import type { SlickGrid } from '../core/slickGrid.js';
 import { FieldType, OperatorType, type OperatorString, type SearchTerm } from '../enums/index.js';
 import type { Column, ColumnFilter, Filter, FilterArguments, FilterCallback, GridOption, OperatorDetail } from '../interfaces/index.js';
@@ -342,6 +342,9 @@ export class DateFilter implements Filter {
             this._lastClickIsDate = false;
           }
         }
+      },
+      onShow: (self) => {
+        setPickerFocus(self.context.mainElement);
       },
     };
 

--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -886,9 +886,13 @@ li.hidden {
 // Date Picker Filter
 // ----------------------------------------------
 
-.vc {
+.vc[data-vc='calendar'] {
   padding: 0.9rem;
   z-index: 9999;
+
+  [tabindex='0']:focus {
+    outline: 1px solid orange;
+  }
 }
 
 // ----------------------------------------------


### PR DESCRIPTION
#### What
When a date is selected, it will focus and show an orange outline on that date, however when no date are selected, we will rather focus on the month instead. This change is also working for both Date Editor and Filter.

#### Why
This change helps to be a bit more focus on keyboard only approach

![brave_8sgYqZgypl](https://github.com/user-attachments/assets/d4c96c03-bb3d-457d-9343-084bbbe48790)
