### PR TITLE
fix: unable to drag row when the cell formatter renders html elements

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1081,7 +1081,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (Draggable) {
         this.slickDraggableInstance = Draggable({
           containerElement: this._container,
-          allowDragFrom: 'div.slick-cell, div.' + this.dragReplaceEl.cssClass,
+          allowDragFrom: `div.slick-cell, div.slick-cell *, div.${this.dragReplaceEl.cssClass}`,
           dragFromClassDetectArr: [{ tag: 'dragReplaceHandle', id: this.dragReplaceEl.id }],
           // the slick cell parent must always contain `.dnd` and/or `.cell-reorder` class to be identified as draggable
           allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',


### PR DESCRIPTION
Reimplements a bug fix provided by an external user in SlickGrid 
https://github.com/6pac/SlickGrid/pull/1163

> I noticed that when a column has a move or "selectAndMove" behavior, if this column has fancy html rendering, the drag is not working. This commit fixes it. It may me enhanced by filtering some of the inner html elements (I think about input/select when the editor is active). Happy to discuss about it.

