### PR TITLE
chore: no need to call `grid.render()` after calling `grid.invalidate()`

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example11.ts
+++ b/demos/aurelia/src/examples/slickgrid/example11.ts
@@ -37,7 +37,6 @@ export class Example11 {
     /*
     this.dataView.getItemMetadata = this.updateItemMetadataForDurationOver50(this.dataView.getItemMetadata);
     this.grid.invalidate();
-    this.grid.render();
     */
   }
 
@@ -204,7 +203,6 @@ export class Example11 {
     this.dataView.getItemMetadata = this.updateItemMetadataForDurationOver40(this.dataView.getItemMetadata);
     // also re-render the grid for the styling to be applied right away
     this.grid.invalidate();
-    this.grid.render();
     // or use the Aurelia-SlickGrid GridService
     // this.gridService.renderGrid();
   }

--- a/demos/react/src/examples/slickgrid/Example11.tsx
+++ b/demos/react/src/examples/slickgrid/Example11.tsx
@@ -30,7 +30,6 @@ const Example11: React.FC = () => {
     /*
     dataView.getItemMetadata = updateItemMetadataForDurationOver50(dataView.getItemMetadata);
     grid.invalidate();
-    grid.render();
     */
   }
 
@@ -198,7 +197,6 @@ const Example11: React.FC = () => {
     reactGridRef.current!.dataView.getItemMetadata = updateItemMetadataForDurationOver40(reactGridRef.current!.dataView.getItemMetadata);
     // also re-render the grid for the styling to be applied right away
     reactGridRef.current!.slickGrid.invalidate();
-    reactGridRef.current!.slickGrid.render();
     // or use the SlickGrid-React GridService
     // gridService.renderGrid();
   }

--- a/demos/vue/src/components/Example11.vue
+++ b/demos/vue/src/components/Example11.vue
@@ -178,7 +178,6 @@ function changeDurationBackgroundColor() {
   vueGrid.dataView.getItemMetadata = updateItemMetadataForDurationOver40(vueGrid.dataView.getItemMetadata);
   // also re-render the grid for the styling to be applied right away
   vueGrid.slickGrid.invalidate();
-  vueGrid.slickGrid.render();
   // or use the SlickGrid-Vue GridService
   // gridService.renderGrid();
 }

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/dynamic-item-metadata.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/dynamic-item-metadata.md
@@ -42,7 +42,6 @@ export class Example {
 
     // also re-render the grid for the styling to be applied right away
     this.grid.invalidate();
-    this.grid.render();
   }
 
   /**
@@ -91,7 +90,6 @@ export class Example {
     // you would put the code here, also make sure to re-render the grid for the styling to be applied right away
     this.dataView.getItemMetadata = this.updateItemMetadataForDurationOver50(this.dataView.getItemMetadata);
     this.grid.invalidate();
-    this.grid.render();
   }
 
   /**

--- a/frameworks/angular-slickgrid/src/demos/examples/example11.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example11.component.ts
@@ -45,7 +45,6 @@ export class Example11Component implements OnInit {
     /*
     this.dataView.getItemMetadata = this.updateItemMetadataForDurationOver50(this.dataView.getItemMetadata);
     this.grid.invalidate();
-    this.grid.render();
     */
   }
 
@@ -216,7 +215,6 @@ export class Example11Component implements OnInit {
 
     // also re-render the grid for the styling to be applied right away
     this.grid.invalidate();
-    this.grid.render();
 
     // or use the Angular-SlickGrid GridService
     // this.gridService.renderGrid();

--- a/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/swt-common-grid.component.ts
@@ -298,7 +298,6 @@ export class SwtCommonGridComponent implements OnInit, AfterViewInit, BackendSer
     // this.gridObj.setSortColumns([{'columnId':'excludeType','sortAsc':true}]);
 
     // this.gridObj.invalidate();
-    // this.gridObj.render();
   }
 
   get gridData(): any {

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/dynamic-item-metadata.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/dynamic-item-metadata.md
@@ -36,7 +36,6 @@ export class Example {
 
     // also re-render the grid for the styling to be applied right away
     this.grid.invalidate();
-    this.grid.render();
   }
 
   /**
@@ -84,7 +83,6 @@ export class Example {
     // you would put the code here, also make sure to re-render the grid for the styling to be applied right away
     this.dataView.getItemMetadata = this.updateItemMetadataForDurationOver50(this.dataView.getItemMetadata);
     this.grid.invalidate();
-    this.grid.render();
   }
 
   /**

--- a/frameworks/slickgrid-react/docs/grid-functionalities/dynamic-item-metadata.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/dynamic-item-metadata.md
@@ -25,7 +25,6 @@ const Example: React.FC = () => {
 
     // also re-render the grid for the styling to be applied right away
     reactGridRef.current?.slickGrid.invalidate();
-    reactGridRef.current?.slickGrid.render();
   }
 
   /**
@@ -86,7 +85,6 @@ const Example: React.FC = () => {
     // you would put the code here, also make sure to re-render the grid for the styling to be applied right away
     reactGrid.dataView.getItemMetadata = updateItemMetadataForDurationOver50(reactGrid.dataView.getItemMetadata);
     reactGrid.slickGrid.invalidate();
-    reactGrid.slickGrid.render();
   }
 
   /**

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/dynamic-item-metadata.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/dynamic-item-metadata.md
@@ -35,7 +35,6 @@ function changeDurationBackgroundColor() {
 
   // also re-render the grid for the styling to be applied right away
   vueGrid.grid.invalidate();
-  vueGrid.grid.render();
 }
 
 /**
@@ -106,7 +105,6 @@ function vueGridReady(vGrid: SlickgridVueInstance) {
   // you would put the code here, also make sure to re-render the grid for the styling to be applied right away
   vueGrid.dataView.getItemMetadata = updateItemMetadataForDurationOver50(dataView.getItemMetadata);
   vueGrid.grid.invalidate();
-  vueGrid.grid.render();
 }
 
 /**


### PR DESCRIPTION
`grid.invalidate()` is already calling `grid.render()` internally so there's no need to call `render()` a second time.

https://github.com/ghiscoding/slickgrid-universal/blob/170c18f1039ff1479b7393b34f716e7228bc945c/packages/common/src/core/slickGrid.ts#L4221-L4225