### PR TITLE
fix: only show Cell Selection drag handle w/using mixed/cell selection

### DIFF
--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -444,7 +444,7 @@ export class SlickDragExtendHandle {
   cssClass = 'slick-drag-replace-handle';
 
   constructor(gridUid: string) {
-    this.id = gridUid + '_drag_replace_handle';
+    this.id = `${gridUid}_drag_replace_handle`;
   }
 
   removeEl(): void {
@@ -455,7 +455,7 @@ export class SlickDragExtendHandle {
     if (activeCellNode) {
       const dragReplaceEl = document.createElement('div');
       dragReplaceEl.classList.add('slick-drag-replace-handle');
-      dragReplaceEl.setAttribute('id', this.id);
+      dragReplaceEl.id = this.id;
       activeCellNode.appendChild(dragReplaceEl);
     }
   }

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -3271,7 +3271,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected handleSelectedRangesChanged(e: SlickEventData, ranges: SlickRange[]): void {
     const ne = e.getNativeEvent<CustomEvent>();
     const selectionMode: CellSelectionMode = ne?.detail?.selectionMode ?? '';
-    const addDragHandle = !!ne?.detail?.addDragHandle;
+    let addDragHandle = !!ne?.detail?.addDragHandle;
+
+    const selectionType = this.getSelectionModel()?.getOptions()?.selectionType;
+    addDragHandle = selectionType === 'cell' || selectionType === 'mixed';
 
     // drag and replace functionality
     const prevSelectedRanges = this.selectedRanges.slice(0);
@@ -4052,7 +4055,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       applyHtmlToElement(cellDiv, cellResult as string | HTMLElement, this._options);
 
       // add drag-to-replace handle
-      if (row === this.selectionBottomRow && cell === this.selectionRightCell && this._options.showCellSelection) {
+      const selectionType = this.getSelectionModel()?.getOptions()?.selectionType;
+      const addDragHandle = selectionType === 'cell' || selectionType === 'mixed';
+      if (row === this.selectionBottomRow && cell === this.selectionRightCell && this._options.showCellSelection && addDragHandle) {
         this.dragReplaceEl.createEl(cellDiv);
       }
     }

--- a/packages/common/src/enums/selectionModel.type.ts
+++ b/packages/common/src/enums/selectionModel.type.ts
@@ -1,9 +1,10 @@
 import type { SlickEvent, SlickRange } from '../core/slickCore.js';
 import type { SlickPlugin } from '../interfaces/index.js';
 
-export type SelectionModel = SlickPlugin & {
+export type SelectionModel<T = any> = SlickPlugin & {
   refreshSelections: () => void;
   onSelectedRangesChanged: SlickEvent<SlickRange[]>;
+  getOptions: () => T;
   getSelectedRanges: () => SlickRange[];
   setSelectedRanges: (ranges: SlickRange[], caller?: string, selectionMode?: string) => void;
 };

--- a/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellSelectionModel.spec.ts
@@ -141,7 +141,7 @@ describe('CellSelectionModel Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.addonOptions).toEqual({ selectActiveCell: true });
+    expect(plugin.getOptions()).toEqual({ selectActiveCell: true });
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
   });
 
@@ -152,7 +152,7 @@ describe('CellSelectionModel Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.addonOptions).toEqual({ selectActiveCell: false });
+    expect(plugin.getOptions()).toEqual({ selectActiveCell: false });
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
   });
 
@@ -164,7 +164,7 @@ describe('CellSelectionModel Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.cellRangeSelector).toBeTruthy();
-    expect(plugin.addonOptions).toEqual({ selectActiveCell: true, cellRangeSelector: mockCellRangeSelector });
+    expect(plugin.getOptions()).toEqual({ selectActiveCell: true, cellRangeSelector: mockCellRangeSelector });
     expect(registerSpy).toHaveBeenCalledWith(plugin.cellRangeSelector);
   });
 

--- a/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
@@ -148,7 +148,7 @@ describe('Row Selection Model Plugin', () => {
   it('should create the plugin and initialize it', () => {
     plugin.init(gridStub);
 
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: expect.any(SlickCellRangeSelector),
       dragToSelect: false,
@@ -179,7 +179,7 @@ describe('Row Selection Model Plugin', () => {
     plugin = new SlickHybridSelectionModel({ selectActiveRow: false });
     plugin.init(gridStub);
 
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: expect.any(SlickCellRangeSelector),
       dragToSelect: false,
@@ -196,7 +196,7 @@ describe('Row Selection Model Plugin', () => {
     plugin = new SlickHybridSelectionModel({ selectActiveRow: true });
     plugin.init(gridStub);
 
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: expect.any(SlickCellRangeSelector),
       dragToSelect: false,
@@ -636,7 +636,7 @@ describe('Row Selection Model Plugin', () => {
   describe('with Selector', () => {
     beforeEach(() => {
       plugin.activeSelectionIsRow = true;
-      plugin.addonOptions.dragToSelect = true;
+      plugin.getOptions().dragToSelect = true;
     });
 
     afterEach(() => {
@@ -669,7 +669,7 @@ describe('Row Selection Model Plugin', () => {
       vi.spyOn(gridStub, 'getColumns').mockReturnValueOnce(mockColumns);
       const setSelectedRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
 
-      plugin.addonOptions.cellRangeSelector = new SlickCellRangeSelector({
+      plugin.getOptions().cellRangeSelector = new SlickCellRangeSelector({
         selectionCss: {
           border: 'none',
         } as CSSStyleDeclaration,
@@ -808,7 +808,7 @@ describe('Cell Selection Model Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.getCellRangeSelector()).toBeTruthy();
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: expect.any(SlickCellRangeSelector),
       dragToSelect: false,
@@ -829,7 +829,7 @@ describe('Cell Selection Model Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.getCellRangeSelector()).toBeTruthy();
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: expect.any(SlickCellRangeSelector),
       dragToSelect: false,
@@ -854,7 +854,7 @@ describe('Cell Selection Model Plugin', () => {
     plugin.init(gridStub);
 
     expect(plugin.getCellRangeSelector()).toBeTruthy();
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: mockCellRangeSelector,
       dragToSelect: false,

--- a/packages/common/src/extensions/__tests__/slickRowSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickRowSelectionModel.spec.ts
@@ -123,7 +123,7 @@ describe('SlickRowSelectionModel Plugin', () => {
   it('should create the plugin and initialize it', () => {
     plugin.init(gridStub);
 
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: undefined,
       dragToSelect: false,
@@ -135,7 +135,7 @@ describe('SlickRowSelectionModel Plugin', () => {
     plugin = new SlickRowSelectionModel({ selectActiveRow: false });
     plugin.init(gridStub);
 
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: undefined,
       dragToSelect: false,
@@ -147,7 +147,7 @@ describe('SlickRowSelectionModel Plugin', () => {
     plugin = new SlickRowSelectionModel({ selectActiveRow: true });
     plugin.init(gridStub);
 
-    expect(plugin.addonOptions).toEqual({
+    expect(plugin.getOptions()).toEqual({
       autoScrollWhenDrag: true,
       cellRangeSelector: undefined,
       dragToSelect: false,
@@ -418,7 +418,7 @@ describe('SlickRowSelectionModel Plugin', () => {
 
   describe('with Selector', () => {
     beforeEach(() => {
-      plugin.addonOptions.dragToSelect = true;
+      plugin.getOptions().dragToSelect = true;
     });
 
     afterEach(() => {
@@ -450,7 +450,7 @@ describe('SlickRowSelectionModel Plugin', () => {
       vi.spyOn(gridStub, 'getColumns').mockReturnValueOnce(mockColumns);
       const setSelectedRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
 
-      plugin.addonOptions.cellRangeSelector = new SlickCellRangeSelector({
+      plugin.getOptions().cellRangeSelector = new SlickCellRangeSelector({
         selectionCss: {
           border: 'none',
         } as CSSStyleDeclaration,

--- a/packages/common/src/extensions/slickCellSelectionModel.ts
+++ b/packages/common/src/extensions/slickCellSelectionModel.ts
@@ -11,15 +11,15 @@ export interface CellSelectionModelOption {
 
 export type CellSelectionMode = 'SEL' | 'REP';
 
-export class SlickCellSelectionModel implements SelectionModel {
+export class SlickCellSelectionModel implements SelectionModel<CellSelectionModelOption | undefined> {
   onSelectedRangesChanged: SlickEvent<SlickRange[]>;
   pluginName: 'CellSelectionModel' = 'CellSelectionModel' as const;
 
-  protected _addonOptions?: CellSelectionModelOption;
   protected _cachedPageRowCount = 0;
   protected _eventHandler: SlickEventHandler;
   protected _dataView?: CustomDataView | SlickDataView;
   protected _grid!: SlickGrid;
+  protected _options?: CellSelectionModelOption;
   protected _prevSelectedRow?: number;
   protected _prevKeyDown = '';
   protected _ranges: SlickRange[] = [];
@@ -37,11 +37,7 @@ export class SlickCellSelectionModel implements SelectionModel {
         ? new SlickCellRangeSelector({ selectionCss: { border: '2px solid black' } as CSSStyleDeclaration })
         : options.cellRangeSelector;
 
-    this._addonOptions = options;
-  }
-
-  get addonOptions(): CellSelectionModelOption | undefined {
-    return this._addonOptions;
+    this._options = options;
   }
 
   get cellRangeSelector(): SlickCellRangeSelector {
@@ -54,7 +50,7 @@ export class SlickCellSelectionModel implements SelectionModel {
 
   init(grid: SlickGrid): void {
     this._grid = grid;
-    if (this._addonOptions === undefined || this._addonOptions.cellRangeSelector === undefined) {
+    if (this._options === undefined || this._options.cellRangeSelector === undefined) {
       this._selector = new SlickCellRangeSelector({
         selectionCss: { border: `2px solid ${this._grid.getOptions().darkMode ? 'white' : 'black'}` } as CSSStyleDeclaration,
       });
@@ -63,7 +59,7 @@ export class SlickCellSelectionModel implements SelectionModel {
     if (grid.hasDataView()) {
       this._dataView = grid.getData<CustomDataView | SlickDataView>();
     }
-    this._addonOptions = { ...this._defaults, ...this._addonOptions } as CellSelectionModelOption;
+    this._options = { ...this._defaults, ...this._options } as CellSelectionModelOption;
 
     // add PubSub instance to all SlickEvent
     const pubSub = grid.getPubSubService();
@@ -93,6 +89,10 @@ export class SlickCellSelectionModel implements SelectionModel {
     }
     this._eventHandler.unsubscribeAll();
     this._selector?.dispose();
+  }
+
+  getOptions(): CellSelectionModelOption | undefined {
+    return this._options;
   }
 
   getSelectedRanges(): SlickRange[] {
@@ -164,9 +164,9 @@ export class SlickCellSelectionModel implements SelectionModel {
     const isCellDefined = isDefined(args.cell);
     const isRowDefined = isDefined(args.row);
 
-    if (this._addonOptions?.selectActiveCell && isRowDefined && isCellDefined) {
+    if (this._options?.selectActiveCell && isRowDefined && isCellDefined) {
       this.setSelectedRanges([new SlickRange(args.row, args.cell)]);
-    } else if (!this._addonOptions?.selectActiveCell || (!isRowDefined && !isCellDefined)) {
+    } else if (!this._options?.selectActiveCell || (!isRowDefined && !isCellDefined)) {
       // clear the previous selection once the cell changes
       this.setSelectedRanges([]);
     }

--- a/packages/common/src/extensions/slickHybridSelectionModel.ts
+++ b/packages/common/src/extensions/slickHybridSelectionModel.ts
@@ -6,7 +6,7 @@ import type { GridOption, HybridSelectionModelOption, SelectionModel } from '../
 import type { CustomDataView, OnActiveCellChangedEventArgs } from '../interfaces/index.js';
 import { SlickCellRangeSelector } from './slickCellRangeSelector.js';
 
-export class SlickHybridSelectionModel implements SelectionModel {
+export class SlickHybridSelectionModel implements SelectionModel<HybridSelectionModelOption> {
   // hybrid selection model is CellSelectionModel except when selecting
   // specific columns, which behave as RowSelectionModel
 
@@ -46,10 +46,6 @@ export class SlickHybridSelectionModel implements SelectionModel {
     this._options = { ...this._defaults, ...options };
   }
 
-  get addonOptions(): HybridSelectionModelOption {
-    return this._options;
-  }
-
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
   }
@@ -68,7 +64,7 @@ export class SlickHybridSelectionModel implements SelectionModel {
   init(grid: SlickGrid): void {
     this._grid = grid;
     this._options = { ...this._defaults, ...this._options };
-    this._selector = this.addonOptions.cellRangeSelector;
+    this._selector = this._options.cellRangeSelector;
 
     if (this._options.selectionType === 'cell') {
       this._activeSelectionIsRow = false;
@@ -94,7 +90,7 @@ export class SlickHybridSelectionModel implements SelectionModel {
               copyToSelectionCss: { border: '2px solid purple' } as CSSStyleDeclaration,
             }
       );
-      this.addonOptions.cellRangeSelector = this._selector;
+      this._options.cellRangeSelector = this._selector;
     }
 
     if (grid.hasDataView()) {
@@ -133,6 +129,10 @@ export class SlickHybridSelectionModel implements SelectionModel {
     }
     this._selector?.destroy();
     this._selector?.dispose();
+  }
+
+  getOptions(): HybridSelectionModelOption {
+    return this._options;
   }
 
   // Region: CellSelectionModel Members
@@ -570,7 +570,7 @@ export class SlickHybridSelectionModel implements SelectionModel {
     args: { range: SlickRange; selectionMode: string; allowAutoEdit?: boolean; caller: 'onCellRangeSelecting' | 'onCellRangeSelected' }
   ): boolean {
     if (this._activeSelectionIsRow) {
-      if (!this.gridOptions.multiSelect || (!this.addonOptions?.selectActiveRow && this._options.selectionType !== 'row')) {
+      if (!this.gridOptions.multiSelect || (!this._options?.selectActiveRow && this._options.selectionType !== 'row')) {
         return false;
       }
       this.setSelectedRanges(

--- a/packages/common/src/extensions/slickRowSelectionModel.ts
+++ b/packages/common/src/extensions/slickRowSelectionModel.ts
@@ -3,7 +3,7 @@ import { type SelectionModel } from '../enums/index.js';
 import { SlickCellRangeSelector } from '../extensions/slickCellRangeSelector.js';
 import type { GridOption, OnActiveCellChangedEventArgs, RowSelectionModelOption } from '../interfaces/index.js';
 
-export class SlickRowSelectionModel implements SelectionModel {
+export class SlickRowSelectionModel implements SelectionModel<RowSelectionModelOption> {
   pluginName: 'RowSelectionModel' = 'RowSelectionModel' as const;
 
   /** triggered when selected ranges changes */
@@ -28,10 +28,6 @@ export class SlickRowSelectionModel implements SelectionModel {
     this._options = { ...this._defaults, ...options };
   }
 
-  get addonOptions(): RowSelectionModelOption {
-    return this._options;
-  }
-
   get eventHandler(): SlickEventHandler {
     return this._eventHandler;
   }
@@ -43,7 +39,7 @@ export class SlickRowSelectionModel implements SelectionModel {
   init(grid: SlickGrid): void {
     this._grid = grid;
     this._options = { ...this._defaults, ...this._options };
-    this._selector = this.addonOptions.cellRangeSelector;
+    this._selector = this._options.cellRangeSelector;
 
     // add PubSub instance to all SlickEvent
     const pubSub = grid.getPubSubService();
@@ -56,7 +52,7 @@ export class SlickRowSelectionModel implements SelectionModel {
         selectionCss: { border: 'none' } as CSSStyleDeclaration,
         autoScroll: this._options.autoScrollWhenDrag,
       });
-      this.addonOptions.cellRangeSelector = this._selector;
+      this._options.cellRangeSelector = this._selector;
     }
 
     this._eventHandler
@@ -90,6 +86,10 @@ export class SlickRowSelectionModel implements SelectionModel {
       this._selector?.destroy();
       this._selector?.dispose();
     }
+  }
+
+  getOptions(): RowSelectionModelOption {
+    return this._options;
   }
 
   getCellRangeSelector(): SlickCellRangeSelector | undefined {
@@ -154,7 +154,7 @@ export class SlickRowSelectionModel implements SelectionModel {
   }
 
   protected handleCellRangeSelected(_e: SlickEventData, args: { range: SlickRange; selectionMode: string }): boolean | void {
-    if (!this.gridOptions.multiSelect || !this.addonOptions.selectActiveRow) {
+    if (!this.gridOptions.multiSelect || !this._options.selectActiveRow) {
       return false;
     }
     this.setSelectedRanges(


### PR DESCRIPTION
we shouldn't show the Cell Selection drag handle, unless we are using the new Hybrid Selection Model ("mixed" or "cell", but not "row"), it's also unusable unless we are in the hybrid mode, so no reason to show it if it ain't usable

<img width="3003" height="876" alt="image" src="https://github.com/user-attachments/assets/9d4b597d-caa9-4056-a714-238f3e0d8e62" />
