### PR TITLE
feat!: migrate `SlickCompositeEditor` modal from `<div>` to `<dialog>`

### DIFF
--- a/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
+++ b/packages/common/src/interfaces/compositeEditorOpenDetailOption.interface.ts
@@ -114,7 +114,7 @@ export interface CompositeEditorOpenDetailOption {
   onError?: (error: OnErrorOption) => void;
 
   /** onRendered callback allows the user to optionally execute something after the modal is created and rendered in the DOM (for example add Bootstrap `bs-data-theme="dark"` attribute to the modal element) */
-  onRendered?: (modalElm: HTMLDivElement) => void;
+  onRendered?: (modalElm: HTMLDialogElement) => void;
 
   /**
    * onSave callback will be triggered (when defined) after user clicked the save/apply button,

--- a/packages/common/src/styles/slick-editors.scss
+++ b/packages/common/src/styles/slick-editors.scss
@@ -161,6 +161,9 @@
 .slick-editor-modal {
   position: fixed;
   overflow-y: auto;
+  height: auto;
+  width: auto;
+  border: 0;
   top: 0;
   right: 0;
   bottom: 0;

--- a/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.spec.ts
@@ -373,7 +373,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
@@ -389,7 +389,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
       const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
@@ -406,6 +406,7 @@ describe('CompositeEditorService', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(compositeContainerElm).toBeTruthy();
+      expect(compositeContainerElm.hasAttribute('open')).toBeTruthy();
       expect(compositeHeaderElm).toBeTruthy();
       expect(productNameLabelElm.textContent).toBe('Product'); // regular, without column group
       expect(field3LabelElm.innerHTML).toBe('Group Name - <span class="mdi mdi-alert-circle" title="tooltip text"></span> Field 3'); // with column group
@@ -450,7 +451,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
       const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
@@ -487,7 +488,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeContentElm = compositeContainerElm.querySelector('.slick-editor-modal-content.split-view') as HTMLSelectElement;
       const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -498,6 +499,7 @@ describe('CompositeEditorService', () => {
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(compositeContainerElm).toBeTruthy();
+      expect(compositeContainerElm.hasAttribute('open')).toBeTruthy();
       expect(compositeContentElm).toBeTruthy();
       expect(compositeHeaderElm).toBeTruthy();
       expect(compositeTitleElm).toBeTruthy();
@@ -517,7 +519,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', viewColumnLayout: 'auto' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeContentElm = compositeContainerElm.querySelector('.slick-editor-modal-content.triple-split-view') as HTMLSelectElement;
       const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -549,7 +551,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', viewColumnLayout: 'auto' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeContentElm = compositeContainerElm.querySelector('.slick-editor-modal-content') as HTMLSelectElement;
 
       expect(component).toBeTruthy();
@@ -567,7 +569,7 @@ describe('CompositeEditorService', () => {
       component = new SlickCompositeEditorComponent();
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
       expect(setActiveSpy).toHaveBeenCalledTimes(2);
       expect(setActiveSpy).toHaveBeenCalledWith(4, 0, false);
@@ -583,7 +585,7 @@ describe('CompositeEditorService', () => {
       component = new SlickCompositeEditorComponent();
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
@@ -591,7 +593,7 @@ describe('CompositeEditorService', () => {
 
       component.dispose();
 
-      const compositeContainerElm2 = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm2 = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       expect(compositeContainerElm2).toBeFalsy();
     });
 
@@ -602,14 +604,14 @@ describe('CompositeEditorService', () => {
       component = new SlickCompositeEditorComponent();
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', backdrop: null });
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(compositeContainerElm).toBeTruthy();
       compositeContainerElm.click();
 
-      const compositeContainerElm2 = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm2 = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       expect(compositeContainerElm2).toBeFalsy();
     });
 
@@ -621,7 +623,7 @@ describe('CompositeEditorService', () => {
       component = new SlickCompositeEditorComponent();
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', onBeforeOpen: mockOnBeforeCallback });
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
       expect(mockOnBeforeCallback).toHaveBeenCalled();
       expect(component).toBeTruthy();
@@ -637,9 +639,9 @@ describe('CompositeEditorService', () => {
       component = new SlickCompositeEditorComponent();
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details', onRendered: mockOnRenderedCallback });
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
-      expect(mockOnRenderedCallback).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+      expect(mockOnRenderedCallback).toHaveBeenCalledWith(expect.any(HTMLDialogElement));
       expect(component).toBeTruthy();
       expect(component.constructor).toBeDefined();
       expect(compositeContainerElm).toBeTruthy();
@@ -669,7 +671,7 @@ describe('CompositeEditorService', () => {
         grid: gridStub,
       });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
       const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
@@ -720,7 +722,7 @@ describe('CompositeEditorService', () => {
         grid: gridStub,
       });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
       const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
@@ -760,7 +762,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
       const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
       compositeFooterCancelBtnElm.click();
@@ -781,7 +783,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Editing ({{id}}) - {{product.name}}' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeTitleElm = compositeContainerElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
 
       expect(component).toBeTruthy();
@@ -790,7 +792,7 @@ describe('CompositeEditorService', () => {
 
       component.dispose();
 
-      const compositeContainerElm2 = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm2 = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       expect(compositeContainerElm2).toBeFalsy();
       expect(compositeTitleElm.textContent).toBe('Editing (222) - Product ABC');
     });
@@ -803,7 +805,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       compositeContainerElm.dispatchEvent(
         new (window.window as any).KeyboardEvent('keydown', {
           code: 'Escape',
@@ -819,7 +821,7 @@ describe('CompositeEditorService', () => {
     });
 
     it('should execute "validate" on current Editor when the "Tab" key is typed', () => {
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       const getEditCellSpy = vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       const validateSpy = vi.spyOn(currentEditorMock, 'validate');
 
@@ -827,7 +829,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       compositeContainerElm.dispatchEvent(
         new (window.window as any).KeyboardEvent('keydown', {
           code: 'Tab',
@@ -850,7 +852,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterCancelBtnElm = compositeContainerElm.querySelector('.btn-cancel') as HTMLSelectElement;
       const compositeFooterCloseBtnElm = compositeContainerElm.querySelector('.close') as HTMLSelectElement;
       compositeFooterCancelBtnElm.click();
@@ -873,7 +875,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Some Details', showCloseButtonOutside: true });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterCloseBtnElm = compositeContainerElm.querySelector('.close') as HTMLSelectElement;
       compositeFooterCloseBtnElm.click();
 
@@ -893,7 +895,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails({ headerTitle: 'Details' });
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
       compositeFooterSaveBtnElm.click();
 
@@ -919,7 +921,7 @@ describe('CompositeEditorService', () => {
         const mockProduct1 = { id: 222, productName: 'Product 1', address: { zip: 123456 }, price: 12.55 };
         const mockProduct2 = { id: 333, productName: 'Product 2', address: { zip: 456789 }, price: 33.44 };
         const newGridOptions = { ...gridOptionsMock, enableAddRow: true };
-        const currentEditorMock = { validate: vi.fn() };
+        const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
         vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct2);
         vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1]);
         vi.spyOn(dataViewStub, 'getItemById').mockReturnValue(null);
@@ -945,7 +947,7 @@ describe('CompositeEditorService', () => {
         });
         const disposeSpy = vi.spyOn(component, 'dispose');
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
@@ -979,7 +981,7 @@ describe('CompositeEditorService', () => {
         const mockProduct1 = { id: 222, productName: 'Product 1', address: { zip: 123456 }, price: 12.55 };
         const mockProduct2 = { id: 333, productName: 'Product 2', address: { zip: 456789 }, price: 33.44 };
         const newGridOptions = { ...gridOptionsMock, enableAddRow: true };
-        const currentEditorMock = { validate: vi.fn() };
+        const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
         vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct2);
         vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1]);
         vi.spyOn(dataViewStub, 'getItemById').mockReturnValue(mockProduct1); // find existing item
@@ -1013,7 +1015,7 @@ describe('CompositeEditorService', () => {
         });
         const disposeSpy = vi.spyOn(component, 'dispose');
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
@@ -1050,7 +1052,7 @@ describe('CompositeEditorService', () => {
         const mockProduct1 = { id: 222, productName: 'Product 1', address: { zip: 123456 }, price: 12.55 };
         const mockProduct2 = { id: 333, productName: 'Product 2', address: { zip: 456789 }, price: 33.44 };
         const newGridOptions = { ...gridOptionsMock, enableAddRow: true };
-        const currentEditorMock = { validate: vi.fn() };
+        const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
         vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct2);
         vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1]);
         vi.spyOn(dataViewStub, 'getItemById').mockReturnValue(null);
@@ -1078,7 +1080,7 @@ describe('CompositeEditorService', () => {
         });
         const disposeSpy = vi.spyOn(component, 'dispose');
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
@@ -1123,7 +1125,7 @@ describe('CompositeEditorService', () => {
         const mockProduct1 = { id: 222, productName: 'Product 1', address: { zip: 123456 }, price: 12.55 };
         const mockProduct2 = { id: 333, productName: 'Product 2', address: { zip: 456789 }, price: 33.44 };
         const newGridOptions = { ...gridOptionsMock, enableAddRow: true };
-        const currentEditorMock = { validate: vi.fn() };
+        const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
         vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct2);
         vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1]);
         vi.spyOn(dataViewStub, 'getItemById').mockReturnValue(null);
@@ -1151,7 +1153,7 @@ describe('CompositeEditorService', () => {
         });
         const disposeSpy = vi.spyOn(component, 'dispose');
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterCancelBtnElm = compositeFooterElm.querySelector('.btn-cancel') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
@@ -1212,7 +1214,7 @@ describe('CompositeEditorService', () => {
         component.openDetails(mockModalOptions);
         component.editors = { productName: { setValue: vi.fn(), isValueChanged: () => true } as unknown as Editor }; // return True for value changed
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeFooterElm.querySelector('.btn-save') as HTMLSelectElement;
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
@@ -1272,7 +1274,7 @@ describe('CompositeEditorService', () => {
           field3: { setValue: vi.fn(), reset: mockReset2, isValueTouched: () => true } as unknown as Editor,
         }; // return True for value changed
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const input1ResetButtonElm = compositeContainerElm.querySelectorAll<HTMLButtonElement>('button.btn-editor-reset')[0];
         const input2ResetButtonElm = compositeContainerElm.querySelectorAll<HTMLButtonElement>('button.btn-editor-reset')[1];
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
@@ -1332,7 +1334,7 @@ describe('CompositeEditorService', () => {
           field3: { setValue: vi.fn(), reset: mockReset2, isValueTouched: () => true } as unknown as Editor,
         }; // return True for value changed
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const formResetButtonElm = compositeContainerElm.querySelector('.reset-container button') as HTMLButtonElement;
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -1391,7 +1393,7 @@ describe('CompositeEditorService', () => {
         component.openDetails(mockModalOptions);
         component.editors = { productName: { setValue: vi.fn(), isValueChanged: () => true } as unknown as Editor }; // return True for value changed
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeFooterElm.querySelector('.btn-save') as HTMLSelectElement;
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
@@ -1455,7 +1457,7 @@ describe('CompositeEditorService', () => {
         component.openDetails(mockModalOptions);
         component.editors = { productName: { setValue: vi.fn(), isValueChanged: () => true } as unknown as Editor }; // return True for value changed
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterElm = compositeContainerElm.querySelector('.slick-editor-modal-footer') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeFooterElm.querySelector('.btn-save') as HTMLSelectElement;
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
@@ -1509,7 +1511,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
         const productNameDetailContainerElm = compositeBodyElm.querySelector(
           '.item-details-container.editor-productName.slick-col-medium-12'
@@ -1565,7 +1567,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
         const productNameDetailContainerElm = compositeBodyElm.querySelector(
           '.item-details-container.editor-productName.slick-col-medium-12'
@@ -1599,7 +1601,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
         const productNameDetailContainerElm = compositeBodyElm.querySelector(
           '.item-details-container.editor-productName.slick-col-medium-12'
@@ -1675,7 +1677,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
         const productNameDetailContainerElm = compositeBodyElm.querySelector(
           '.item-details-container.editor-productName.slick-col-medium-12'
@@ -1710,7 +1712,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
         const productNameDetailContainerElm = compositeBodyElm.querySelector(
           '.item-details-container.editor-productName.slick-col-medium-12'
@@ -1762,7 +1764,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: 'Details' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeBodyElm = compositeContainerElm.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
         const productNameDetailContainerElm = compositeBodyElm.querySelector(
           '.item-details-container.editor-productName.slick-col-medium-12'
@@ -1838,7 +1840,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: '', modalType: 'auto-mass', headerTitleMassUpdate: 'Mass Update', headerTitleMassSelection: 'Mass Selection' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
@@ -1859,7 +1861,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails({ headerTitle: '', modalType: 'auto-mass', headerTitleMassUpdate: 'Mass Update', headerTitleMassSelection: 'Mass Selection' });
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeHeaderElm = compositeContainerElm.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
@@ -1881,7 +1883,7 @@ describe('CompositeEditorService', () => {
         component = new SlickCompositeEditorComponent();
         component.init(gridStub, container);
         component.openDetails({ headerTitle: '', modalType: 'auto-mass', headerTitleMassUpdate: 'Mass Update', headerTitleMassSelection: 'Mass Selection' });
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
 
         expect(setActiveSpy).toHaveBeenCalledTimes(2);
         expect(setActiveSpy).toHaveBeenCalledWith(4, 2, false);
@@ -1892,7 +1894,7 @@ describe('CompositeEditorService', () => {
 
       it('should throw an error when no rows are selected', async () => {
         const mockProduct = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
-        const currentEditorMock = { validate: vi.fn() };
+        const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
         vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
         vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
         vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -1911,7 +1913,7 @@ describe('CompositeEditorService', () => {
         component.init(gridStub, container);
         component.openDetails(mockModalOptions);
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -1946,7 +1948,7 @@ describe('CompositeEditorService', () => {
 
       it('should handle saving and grid changes when "Mass Selection" save button is clicked', () => {
         const mockProduct = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
-        const currentEditorMock = { validate: vi.fn() };
+        const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
         vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
         vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
         vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -1965,7 +1967,7 @@ describe('CompositeEditorService', () => {
         component.openDetails(mockModalOptions);
         const disposeSpy = vi.spyOn(component, 'dispose');
 
-        const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+        const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
         const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
         const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
         const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -2022,7 +2024,7 @@ describe('CompositeEditorService', () => {
     it('should handle saving and grid changes when "Mass Update" save button is clicked', () => {
       const mockProduct1 = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
       const mockProduct2 = { id: 333, field3: 'else', address: { zip: 789123 }, product: { name: 'Product XYZ', price: 33.44 } };
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1, mockProduct2]);
       vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -2040,7 +2042,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -2088,7 +2090,7 @@ describe('CompositeEditorService', () => {
     it('should handle saving and grid changes when "Mass Update" save button is clicked and user provides a custom "onSave" async function', async () => {
       const mockProduct1 = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
       const mockProduct2 = { id: 333, field3: 'else', address: { zip: 789123 }, product: { name: 'Product XYZ', price: 33.44 } };
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1, mockProduct2]);
       vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -2112,7 +2114,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -2155,7 +2157,7 @@ describe('CompositeEditorService', () => {
     it('should handle saving and expect a dataset preview of the change when "shouldPreviewMassChangeDataset" is enabled and grid changes when "Mass Update" save button is clicked and user provides a custom "onSave" async function', async () => {
       const mockProduct1 = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
       const mockProduct2 = { id: 333, field3: 'else', address: { zip: 789123 }, product: { name: 'Product XYZ', price: 33.44 } };
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1, mockProduct2]);
       vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -2180,7 +2182,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -2226,7 +2228,7 @@ describe('CompositeEditorService', () => {
     it('should show a validation summary when clicking "Mass Update" save button and the custom "onSave" async function throws an error', async () => {
       const mockProduct1 = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
       const mockProduct2 = { id: 333, field3: 'else', address: { zip: 789123 }, product: { name: 'Product XYZ', price: 33.44 } };
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1, mockProduct2]);
       vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -2241,7 +2243,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeFooterSaveBtnElm = compositeContainerElm.querySelector('.btn-save') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
@@ -2310,7 +2312,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
       const compositeBodyElm = document.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
@@ -2346,7 +2348,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
       const compositeBodyElm = document.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
@@ -2372,7 +2374,7 @@ describe('CompositeEditorService', () => {
 
     it('should have translated text when handling a saving of grid changes when "Mass Selection" save button is clicked', () => {
       const mockProduct = { id: 222, field3: 'something', address: { zip: 123456 }, productName: 'Product ABC', price: 12.55 };
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockProduct);
       vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -2389,7 +2391,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
       const compositeBodyElm = document.querySelector('.slick-editor-modal-body') as HTMLSelectElement;
@@ -2433,7 +2435,7 @@ describe('CompositeEditorService', () => {
     it('should have translated text when handling a saving of grid changes when "Mass Update" save button is clicked', () => {
       const mockProduct1 = { id: 222, field3: 'something', address: { zip: 123456 }, product: { name: 'Product ABC', price: 12.55 } };
       const mockProduct2 = { id: 333, field3: 'else', address: { zip: 789123 }, product: { name: 'Product XYZ', price: 33.44 } };
-      const currentEditorMock = { validate: vi.fn() };
+      const currentEditorMock = { validate: vi.fn() } as unknown as Editor;
       vi.spyOn(dataViewStub, 'getItems').mockReturnValue([mockProduct1, mockProduct2]);
       vi.spyOn(gridStub, 'getCellEditor').mockReturnValue(currentEditorMock as any);
       vi.spyOn(currentEditorMock, 'validate').mockReturnValue({ valid: true, msg: null });
@@ -2445,7 +2447,7 @@ describe('CompositeEditorService', () => {
       component.init(gridStub, container);
       component.openDetails(mockModalOptions);
 
-      const compositeContainerElm = document.querySelector('div.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
+      const compositeContainerElm = document.querySelector('dialog.slick-editor-modal.slickgrid_123456') as HTMLSelectElement;
       const compositeHeaderElm = document.querySelector('.slick-editor-modal-header') as HTMLSelectElement;
       const compositeTitleElm = compositeHeaderElm.querySelector('.slick-editor-modal-title') as HTMLSelectElement;
       const compositeBodyElm = document.querySelector('.slick-editor-modal-body') as HTMLSelectElement;

--- a/packages/composite-editor-component/src/slick-composite-editor.component.ts
+++ b/packages/composite-editor-component/src/slick-composite-editor.component.ts
@@ -53,7 +53,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
   protected _compositeOptions!: CompositeEditorOption;
   protected _eventHandler: SlickEventHandler;
   protected _itemDataContext: any;
-  protected _modalElm!: HTMLDivElement;
+  protected _modalElm!: HTMLDialogElement;
   protected _originalDataContext: any;
   protected _options!: CompositeEditorOpenDetailOption;
   protected _lastActiveRowNumber = -1;
@@ -407,7 +407,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
         const parsedHeaderTitle = headerTitle.replace(/\{\{(.*?)\}\}/g, (_match, group) => getDescendantProperty(dataContext, group));
         const layoutColCount = viewColumnLayout === 'auto' ? this.autoCalculateLayoutColumnCount(modalColumns.length) : viewColumnLayout;
 
-        this._modalElm = createDomElement('div', { className: `slick-editor-modal ${gridUid}` });
+        this._modalElm = createDomElement('dialog', { className: `slick-editor-modal ${gridUid}` });
         const modalContentElm = createDomElement('div', { className: 'slick-editor-modal-content' });
 
         // add dark mode CSS class when enabled
@@ -541,6 +541,7 @@ export class SlickCompositeEditorComponent implements ExternalResource {
           modalBodyElm.appendChild(resetButtonContainerElm);
         }
 
+        this._modalElm.open = true;
         document.body.appendChild(this._modalElm);
         document.body.classList.add('slick-modal-open'); // add backdrop to body
         this._bindEventService.bind(document.body, 'click', this.handleBodyClicked.bind(this));


### PR DESCRIPTION
_This is a breaking change and will be scheduled for the next major version, Q1 of 2026_

migrate `SlickCompositeEditor` modal from a `<div>` to a `<dialog>`, it is safe to go ahead since the baseline on MDN is showing as widely available 
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog

The other reason to use a `<dialog>` is related to better accessibility (aria) since it uses native code with native aria support