### PR TITLE
fix: allow single row selection via click without checkbox column

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example48.ts
+++ b/demos/aurelia/src/examples/slickgrid/example48.ts
@@ -118,8 +118,6 @@ export class Example48 {
       // enable new hybrid selection model (rows & cells)
       enableHybridSelection: true,
       rowSelectionOptions: {
-        // True (Single Selection), False (Multiple Selections)
-        selectActiveRow: true,
         rowSelectColumnIds: ['id'],
       },
 

--- a/demos/aurelia/src/examples/slickgrid/example50.ts
+++ b/demos/aurelia/src/examples/slickgrid/example50.ts
@@ -60,8 +60,7 @@ export class Example50 {
       rowHeight: 33,
       enableHybridSelection: true,
       rowSelectionOptions: {
-        selectionType: 'row',
-        selectActiveRow: true,
+        selectionType: 'row-click',
       },
     };
 

--- a/demos/react/src/examples/slickgrid/Example48.tsx
+++ b/demos/react/src/examples/slickgrid/Example48.tsx
@@ -93,8 +93,6 @@ const Example48: React.FC = () => {
       // enable new hybrid selection model (rows & cells)
       enableHybridSelection: true,
       rowSelectionOptions: {
-        // True (Single Selection), False (Multiple Selections)
-        selectActiveRow: true,
         rowSelectColumnIds: ['id'],
       },
 

--- a/demos/react/src/examples/slickgrid/Example50.tsx
+++ b/demos/react/src/examples/slickgrid/Example50.tsx
@@ -56,8 +56,7 @@ const Example50: React.FC = () => {
     rowHeight: 33,
     enableHybridSelection: true,
     rowSelectionOptions: {
-      selectionType: 'row',
-      selectActiveRow: true,
+      selectionType: 'row-click',
     },
   };
 

--- a/demos/vanilla/src/examples/example37.ts
+++ b/demos/vanilla/src/examples/example37.ts
@@ -138,8 +138,6 @@ export default class Example37 {
       // enable new hybrid selection model (rows & cells)
       enableHybridSelection: true,
       rowSelectionOptions: {
-        // True (Single Selection), False (Multiple Selections)
-        selectActiveRow: true,
         rowSelectColumnIds: ['id'],
       },
 
@@ -151,6 +149,7 @@ export default class Example37 {
         replaceNewlinesWith: ' ',
       },
     };
+
     this.gridOptions2 = {
       ...this.gridOptions1,
       // you can also enable checkbox selection & row selection, make sure to use `rowSelectColumnIds: ['id', '_checkbox_selector']`

--- a/demos/vanilla/src/examples/example39.ts
+++ b/demos/vanilla/src/examples/example39.ts
@@ -69,6 +69,7 @@ export default class Example01 {
   dispose() {
     this.sgb1?.dispose();
     this.sgb2?.dispose();
+    document.body.classList.remove('material-theme');
   }
 
   /* Define grid Options and Columns */
@@ -87,8 +88,7 @@ export default class Example01 {
       rowHeight: 33,
       enableHybridSelection: true,
       rowSelectionOptions: {
-        selectionType: 'row',
-        selectActiveRow: true,
+        selectionType: 'row-click',
       },
     };
 

--- a/demos/vue/src/components/Example48.vue
+++ b/demos/vue/src/components/Example48.vue
@@ -112,8 +112,6 @@ function defineGrids() {
     // enable new hybrid selection model (rows & cells)
     enableHybridSelection: true,
     rowSelectionOptions: {
-      // True (Single Selection), False (Multiple Selections)
-      selectActiveRow: true,
       rowSelectColumnIds: ['id'],
     },
 

--- a/demos/vue/src/components/Example50.vue
+++ b/demos/vue/src/components/Example50.vue
@@ -54,8 +54,7 @@ function defineGrids() {
     rowHeight: 33,
     enableHybridSelection: true,
     rowSelectionOptions: {
-      selectionType: 'row',
-      selectActiveRow: true,
+      selectionType: 'row-click',
     },
   };
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example48.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example48.component.ts
@@ -126,8 +126,6 @@ export class Example48Component implements OnInit {
       // enable new hybrid selection model (rows & cells)
       enableHybridSelection: true,
       rowSelectionOptions: {
-        // True (Single Selection), False (Multiple Selections)
-        selectActiveRow: true,
         rowSelectColumnIds: ['id'],
       },
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example50.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example50.component.ts
@@ -66,8 +66,7 @@ export class Example50Component implements OnInit {
       rowHeight: 33,
       enableHybridSelection: true,
       rowSelectionOptions: {
-        selectionType: 'row',
-        selectActiveRow: true,
+        selectionType: 'row-click',
       },
     };
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1080,7 +1080,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this._bindingEventService.bind(element, 'mouseout', this.handleCellMouseOut.bind(this) as EventListener);
       });
 
-      if (Draggable) {
+      const isDraggable = this.selectionModel?.getOptions()?.selectionType !== 'row-click';
+      if (Draggable && isDraggable) {
         this.slickDraggableInstance = Draggable({
           containerElement: this._container,
           allowDragFrom: `div.slick-cell, div.slick-cell *, div.${this.dragReplaceEl.cssClass}`,

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -22,13 +22,14 @@ export interface RowLookup {
 
 const CHECK_ICON = 'mdi-icon-check';
 const UNCHECK_ICON = 'mdi-icon-uncheck';
+const DEFAULT_COLUMN_ID = '_checkbox_selector';
 
 export class SlickCheckboxSelectColumn<T = any> {
   pluginName = 'CheckboxSelectColumn' as const;
   protected _defaults = {
-    columnId: '_checkbox_selector',
+    columnId: DEFAULT_COLUMN_ID,
     cssClass: null,
-    field: '_checkbox_selector',
+    field: DEFAULT_COLUMN_ID,
     hideSelectAllCheckbox: false,
     name: '',
     toolTip: 'Select/Deselect All',
@@ -338,7 +339,7 @@ export class SlickCheckboxSelectColumn<T = any> {
 
   protected addCheckboxToFilterHeaderRow(grid: SlickGrid): void {
     this._eventHandler.subscribe(grid.onHeaderRowCellRendered, (_e, args) => {
-      if (args.column.field === (this._addonOptions.field || '_checkbox_selector')) {
+      if (args.column.field === (this._addonOptions.field || DEFAULT_COLUMN_ID)) {
         emptyElement(args.node);
 
         const inputId = `header-filter-selector${this._selectAll_UID}`;

--- a/packages/common/src/interfaces/selectionModelOption.interface.ts
+++ b/packages/common/src/interfaces/selectionModelOption.interface.ts
@@ -3,6 +3,16 @@ import type { OnActiveCellChangedEventArgs, SelectionModel, SlickGrid } from '..
 
 export declare type RowSelectOverride = (data: OnActiveCellChangedEventArgs, selectionModel: SelectionModel, grid: SlickGrid) => boolean;
 
+export type SelectionType =
+  /** multiple cell selection */
+  | 'cell'
+  /** multiple row selection */
+  | 'row'
+  /** single row selection through row click */
+  | 'row-click'
+  /** mixed cell/row selection */
+  | 'mixed';
+
 export interface HybridSelectionModelOption {
   /** defaults to True, do we want to select the active cell? */
   selectActiveCell?: boolean;
@@ -29,7 +39,7 @@ export interface HybridSelectionModelOption {
   rowSelectOverride?: RowSelectOverride | undefined;
 
   /** Defaults to 'mixed', use a specifc selection type */
-  selectionType?: 'cell' | 'row' | 'mixed';
+  selectionType?: SelectionType;
 }
 
 export interface RowSelectionModelOption {


### PR DESCRIPTION
add a new `selectionType: 'row-click'` so that we can use single row click (useful for Master/Detail grids feature). Without this code change, clicking a row was working only half the time because it would sometime do a row selection but other time it was doing a row click and so it wasn't very reliable. This code change is now very robust and completely discard row selection and makes the row clicking the only possible action.

#### before fix
making a selection with the mouse dragging makes a row selection and was discarding any row click making it unreliable

![brave_cQJ1QRbQFy](https://github.com/user-attachments/assets/a881cc05-27fe-4b18-8959-577e634927e8)


#### after fix
making a mouse selection now makes a text selection (expected) and clicking a row works 100% of the time which makes it more reliable

![brave_pcoXk2Zk0I](https://github.com/user-attachments/assets/74cf7a05-7fca-4dad-968a-7c6635f9c9af)
