### PR TITLE
fix: should stop Draggable service when setting hybrid 'row-click'

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3233,6 +3233,17 @@ describe('SlickGrid core file', () => {
       expect(onDragInitSpy).not.toHaveBeenCalled();
     });
 
+    it('should stop() the Draggable service when "selectionType" is set "row-click"', () => {
+      const hybridSelectionModel = new SlickHybridSelectionModel({ selectionType: 'row-click' });
+      const setRangeSpy = vi.spyOn(hybridSelectionModel, 'setSelectedRanges');
+
+      grid = new SlickGrid<any, Column>(container, data, columns, defaultOptions);
+      const draggableSpy = vi.spyOn(grid.slickDraggableInstance, 'stop');
+      grid.setSelectionModel(hybridSelectionModel);
+
+      expect(draggableSpy).toHaveBeenCalled();
+    });
+
     it('should not drag when event has cancelled bubbling (immediatePropagationStopped)', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, defaultOptions);
 

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -54,6 +54,23 @@ describe('Draggable class', () => {
     dg.destroy();
   });
 
+  it('should NOT trigger dragInit event when user has stopped the service', () => {
+    const dragInitSpy = vi.fn();
+    const dragSpy = vi.fn();
+    containerElement.className = 'slick-cell';
+
+    dg = Draggable({ containerElement, allowDragFrom: 'div.slick-cell', onDrag: dragSpy, onDragInit: dragInitSpy });
+    dg.stop();
+
+    containerElement.dispatchEvent(new MouseEvent('mousedown', { ctrlKey: true }));
+
+    expect(dg).toBeTruthy();
+    expect(dragInitSpy).not.toHaveBeenCalled();
+    expect(dragSpy).not.toHaveBeenCalled();
+
+    dg.destroy();
+  });
+
   it('should NOT trigger dragInit event when user is pressing mousedown and mousemove + Ctrl key combo that we considered as forbidden via "preventDragFromKeys"', () => {
     const dragInitSpy = vi.fn();
     const dragSpy = vi.fn();

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1177,15 +1177,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   setSelectionModel(model: SelectionModel): void {
     if (this.selectionModel) {
       this.selectionModel.onSelectedRangesChanged.unsubscribe(this.handleSelectedRangesChanged.bind(this));
-      if (this.selectionModel.destroy) {
-        this.selectionModel.destroy();
-      }
+      this.selectionModel?.destroy();
     }
 
     this.selectionModel = model;
     if (this.selectionModel) {
       this.selectionModel.init(this as unknown as SlickGrid);
       this.selectionModel.onSelectedRangesChanged.subscribe(this.handleSelectedRangesChanged.bind(this));
+      if (this.selectionModel.getOptions()?.selectionType === 'row-click' && this.slickDraggableInstance?.stop) {
+        this.slickDraggableInstance.stop(); // don't allow dragging (cell selection) when using row-click
+      }
     }
   }
 

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -36,7 +36,9 @@ import type {
  */
 export function Draggable(options: DraggableOption): {
   destroy: () => void;
+  stop: () => void;
 } {
+  let isStopped = false;
   let { containerElement } = options;
   const { onDragInit, onDragStart, onDrag, onDragEnd, preventDragFromKeys } = options;
   let element: HTMLElement | null;
@@ -82,7 +84,7 @@ export function Draggable(options: DraggableOption): {
 
   /** Do we want to prevent Drag events from happening (for example prevent onDrag when Ctrl key is pressed while dragging) */
   function preventDrag(event: MouseEvent | TouchEvent | KeyboardEvent): boolean {
-    let eventPrevented = false;
+    let eventPrevented = isStopped;
     if (preventDragFromKeys) {
       preventDragFromKeys.forEach((key) => {
         if ((event as KeyboardEvent)[key]) {
@@ -175,11 +177,15 @@ export function Draggable(options: DraggableOption): {
     }
   }
 
+  function stop() {
+    isStopped = true;
+  }
+
   // initialize Slick.MouseWheel by attaching mousewheel event
   init();
 
   // public API
-  return { destroy };
+  return { destroy, stop };
 }
 
 /**

--- a/packages/common/src/interfaces/interactions.interface.ts
+++ b/packages/common/src/interfaces/interactions.interface.ts
@@ -5,6 +5,7 @@ import type { DragPosition } from './drag.interface.js';
 
 export interface InteractionBase {
   destroy: () => void;
+  stop?: () => void;
 }
 
 export interface ClassDetectElement {


### PR DESCRIPTION
follow-up on PR #2311 
after implementing it in SlickGrid I found that it wasn't working as expected when `explicitInitialization` grid option is disabled. I didn't have that issue in my previous PR because my global grid options default is set to `explicitInitialization: true`