### PR TITLE
fix: Excel/Text Exports display top/preheader titles w/DraggableGrouping

### DIFF
--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -1571,6 +1571,48 @@ describe('ExcelExportService', () => {
         );
       });
 
+      it('should export with grouped header titles and "Group by" text prepended and showing up on first row', async () => {
+        mockCollection2 = [{ id: 0, userId: '1E06', firstName: 'John', lastName: 'X', position: 'SALES_REP', order: 10 }];
+        vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([{ getter: 'id' }] as any);
+        vi.spyOn(dataViewStub, 'getLength').mockReturnValue(mockCollection2.length);
+        vi.spyOn(dataViewStub, 'getItem').mockReturnValue(null).mockReturnValueOnce(mockCollection2[0]);
+        const pubSubSpy = vi.spyOn(pubSubServiceStub, 'publish');
+
+        service.init(gridStub, container);
+        await service.exportToExcel({ ...mockExportExcelOptions, useStreamingExport: false });
+
+        expect(pubSubSpy).toHaveBeenCalledWith('onAfterExportToExcel', { filename: 'export.xlsx', mimeType: mimeTypeXLSX });
+        expect(downloadExcelFile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            worksheets: [
+              expect.objectContaining({
+                data: [
+                  [
+                    { value: '' },
+                    { metadata: { style: 4 }, value: 'User Profile' },
+                    { metadata: { style: 4 }, value: 'User Profile' },
+                    { metadata: { style: 4 }, value: 'Company Profile' },
+                    { metadata: { style: 4 }, value: 'Company Profile' },
+                    { metadata: { style: 4 }, value: 'Sales' },
+                  ],
+                  [
+                    { metadata: { style: 1 }, value: 'Grouped By' },
+                    { metadata: { style: 1 }, value: 'FirstName' },
+                    { metadata: { style: 1 }, value: 'LastName' },
+                    { metadata: { style: 1 }, value: 'User Id' },
+                    { metadata: { style: 1 }, value: 'Position' },
+                    { metadata: { style: 1 }, value: 'Order' },
+                  ],
+                  ['', 'John', 'X', '1E06', 'SALES_REP', '10'],
+                ],
+              }),
+            ],
+          }),
+          'export.xlsx',
+          { mimeType: mimeTypeXLSX }
+        );
+      });
+
       describe('with Translation', () => {
         let mockTranslateCollection: any[];
 

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -283,7 +283,11 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
     }
 
     // get all Grouped Column Header Titles when defined (from pre-header row)
-    if (this._gridOptions.createPreHeaderPanel && this._gridOptions.showPreHeaderPanel && !this._gridOptions.enableDraggableGrouping) {
+    if (
+      this._gridOptions.createPreHeaderPanel &&
+      this._gridOptions.showPreHeaderPanel &&
+      (!this._gridOptions.enableDraggableGrouping || (this._gridOptions.enableDraggableGrouping && this._gridOptions.createTopHeaderPanel))
+    ) {
       // when having Grouped Header Titles (in the pre-header), then make the cell Bold & Aligned Center
       const boldCenterAlign = this._stylesheet.createFormat({ alignment: { horizontal: 'center' }, font: { bold: true } });
       outputData.push(this.getColumnGroupedHeaderTitlesData(columns, { style: boldCenterAlign?.id }));
@@ -331,25 +335,31 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
    * @returns {Object} array of Excel cell format
    */
   protected getColumnGroupedHeaderTitlesData(columns: Column[], metadata: ExcelMetadata): Array<ExcelColumnMetadata> {
+    let colspanStartIndex = 0;
+    let headerOffset = 0; // increases when "Group by" is provided in the next header row
     let outputGroupedHeaderTitles: Array<ExcelColumnMetadata> = [];
+
+    if (this.getGroupColumnTitle()) {
+      outputGroupedHeaderTitles.push({ value: '' });
+      headerOffset = 1;
+    }
 
     // get all Column Header Titles
     this._groupedColumnHeaders = this.getColumnGroupedHeaderTitles(columns) || [];
-    if (this._groupedColumnHeaders && Array.isArray(this._groupedColumnHeaders) && this._groupedColumnHeaders.length > 0) {
+    if (Array.isArray(this._groupedColumnHeaders) && this._groupedColumnHeaders.length > 0) {
       // add the header row + add a new line at the end of the row
-      outputGroupedHeaderTitles = this._groupedColumnHeaders.map((header) => ({ value: header.title, metadata }));
+      outputGroupedHeaderTitles.push(...this._groupedColumnHeaders.map((header) => ({ value: header.title, metadata })));
     }
 
     // merge necessary cells (any grouped header titles)
-    let colspanStartIndex = 0;
     const headersLn = this._groupedColumnHeaders.length;
     for (let cellIndex = 0; cellIndex < headersLn; cellIndex++) {
       if (
         cellIndex + 1 === headersLn ||
         (cellIndex + 1 < headersLn && this._groupedColumnHeaders[cellIndex].title !== this._groupedColumnHeaders[cellIndex + 1].title)
       ) {
-        const leftExcelColumnChar = this.getExcelColumnNameByIndex(colspanStartIndex + 1);
-        const rightExcelColumnChar = this.getExcelColumnNameByIndex(cellIndex + 1);
+        const leftExcelColumnChar = this.getExcelColumnNameByIndex(colspanStartIndex + 1 + headerOffset);
+        const rightExcelColumnChar = this.getExcelColumnNameByIndex(cellIndex + 1 + headerOffset);
         this._sheet.mergeCells(`${leftExcelColumnChar}1`, `${rightExcelColumnChar}1`);
 
         // next group starts 1 column index away
@@ -382,7 +392,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
   protected getGroupColumnTitle(): string | null {
     // Group By text, it could be set in the export options or from translation or if nothing is found then use the English constant text
-    let groupByColumnHeader = this._excelExportOptions.groupingColumnHeaderTitle;
+    let groupByColumnHeader = this._excelExportOptions?.groupingColumnHeaderTitle ?? '';
     if (!groupByColumnHeader && this._gridOptions.enableTranslate && this._translaterService?.translate) {
       groupByColumnHeader = this._translaterService.translate(`${getTranslationPrefix(this._gridOptions)}GROUP_BY`);
     } else if (!groupByColumnHeader) {

--- a/packages/text-export/src/textExport.service.ts
+++ b/packages/text-export/src/textExport.service.ts
@@ -215,7 +215,11 @@ export class TextExportService implements ExternalResource, BaseTextExportServic
     }
 
     // get all Grouped Column Header Titles when defined (from pre-header row)
-    if (this._gridOptions.createPreHeaderPanel && this._gridOptions.showPreHeaderPanel && !this._gridOptions.enableDraggableGrouping) {
+    if (
+      this._gridOptions.createPreHeaderPanel &&
+      this._gridOptions.showPreHeaderPanel &&
+      (!this._gridOptions.enableDraggableGrouping || (this._gridOptions.enableDraggableGrouping && this._gridOptions.createTopHeaderPanel))
+    ) {
       this._groupedColumnHeaders = this.getColumnGroupedHeaderTitles(columns) || [];
       if (Array.isArray(this._groupedColumnHeaders) && this._groupedColumnHeaders.length > 0) {
         // add the header row + add a new line at the end of the row


### PR DESCRIPTION
Export Services have a condition to ignore pre-header when Draggable Grouping is defined, however that is incorrect when both `createPreHeaderPanel` and `createTopHeaderPanel` are provided (like [Example 3](https://ghiscoding.github.io/slickgrid-universal/#/example03), shown below), when that happens it means that the Draggable Grouping is inserted in the Top Header, which mean that we do need to export the Pre-Header which then contain the Header Grouped Titles

Basically the pre-header titles ("Common Factor", "Period", ...) were missing in the Export

Also fixes a second problem in the Excel Export, when the first column has a "Group by" shown as the first cell, then other Header Grouped Titles should be offset by 1 cell

<img width="2584" height="1013" alt="image" src="https://github.com/user-attachments/assets/153ed896-5e62-4823-9291-5d9c66a32d79" />
