### PR TITLE
feat: deprecate `rowSelectionOptions` and rename to `selectionOptions`

### DIFF
--- a/docs/grid-functionalities/row-detail.md
+++ b/docs/grid-functionalities/row-detail.md
@@ -60,6 +60,7 @@ export default class Example21 {
 
     this.gridOptions = {
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },

--- a/docs/grid-functionalities/row-selection.md
+++ b/docs/grid-functionalities/row-selection.md
@@ -107,6 +107,7 @@ export class Example1 {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -132,6 +133,7 @@ export class Example1 {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -195,6 +197,7 @@ export class Example1 implements OnInit {
         selectableOverride: (row: number, dataContext: any, grid: any) => (dataContext.id % 2 === 1)
       },
       multiSelect: false,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: true,
@@ -276,6 +279,7 @@ For example, we could use the Excel Copy Buffer (Cell Selection) and use `rowSel
 this.gridOptions = {
   // enable new hybrid selection model (rows & cells)
   enableHybridSelection: true,
+  // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
   rowSelectionOptions: {
     selectActiveRow: true,
     rowSelectColumnIds: ['selector'],

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-detail.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-detail.md
@@ -58,6 +58,7 @@ export class GridRowDetailComponent implements OnInit, OnDestroy {
 
     this.gridOptions = {
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },
@@ -425,6 +426,7 @@ export class MainGridComponent implements OnInit {
     this.columnDefinitions = [ /*...*/ ];
     this.gridOptions = {
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
@@ -75,6 +75,7 @@ export class Example1 implements OnInit {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -140,6 +141,7 @@ export class Example1 implements OnInit {
         selectableOverride: (row: number, dataContext: any, grid: any) => (dataContext.id % 2 === 1)
       },
       multiSelect: false,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: true,
@@ -231,6 +233,7 @@ For example, we could use the Excel Copy Buffer (Cell Selection) and use `rowSel
 this.gridOptions = {
   // enable new hybrid selection model (rows & cells)
   enableHybridSelection: true,
+  // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
   rowSelectionOptions: {
     selectActiveRow: true,
     rowSelectColumnIds: ['selector'],

--- a/frameworks/angular-slickgrid/src/library/extensions/slickRowDetailView.ts
+++ b/frameworks/angular-slickgrid/src/library/extensions/slickRowDetailView.ts
@@ -128,7 +128,9 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
       // this also requires the Row Selection Model to be registered as well
       if (!rowSelectionPlugin || !this._grid.getSelectionModel()) {
         const SelectionModelClass = this.gridOptions.enableHybridSelection ? SlickHybridSelectionModel : SlickRowSelectionModel;
-        rowSelectionPlugin = new SelectionModelClass(this.gridOptions.rowSelectionOptions || { selectActiveRow: true });
+        rowSelectionPlugin = new SelectionModelClass(
+          this.gridOptions.selectionOptions ?? this.gridOptions.rowSelectionOptions ?? { selectActiveRow: true }
+        );
         this._grid.setSelectionModel(rowSelectionPlugin);
       }
 

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-detail.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-detail.md
@@ -57,6 +57,7 @@ export class GridExample {
 
     this.gridOptions = {
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },
@@ -407,6 +408,7 @@ export class MainGrid implements OnInit {
     this.columnDefinitions = [ /*...*/ ];
     this.gridOptions = {
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
@@ -81,6 +81,7 @@ export class Example1 {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -108,6 +109,7 @@ export class Example1 {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -144,6 +146,7 @@ export class Example1 implements OnInit {
         selectableOverride: (row: number, dataContext: any, grid: any) => (dataContext.id % 2 === 1)
       },
       multiSelect: false,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: true,
@@ -235,6 +238,7 @@ For example, we could use the Excel Copy Buffer (Cell Selection) and use `rowSel
 this.gridOptions = {
   // enable new hybrid selection model (rows & cells)
   enableHybridSelection: true,
+  // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
   rowSelectionOptions: {
     selectActiveRow: true,
     rowSelectColumnIds: ['selector'],

--- a/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
+++ b/frameworks/aurelia-slickgrid/src/extensions/slickRowDetailView.ts
@@ -113,7 +113,9 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         // this also requires the Row Selection Model to be registered as well
         if (!rowSelectionPlugin || !this._grid.getSelectionModel()) {
           const SelectionModelClass = this.gridOptions.enableHybridSelection ? SlickHybridSelectionModel : SlickRowSelectionModel;
-          rowSelectionPlugin = new SelectionModelClass(this.gridOptions.rowSelectionOptions || { selectActiveRow: true });
+          rowSelectionPlugin = new SelectionModelClass(
+            this.gridOptions.selectionOptions ?? this.gridOptions.rowSelectionOptions ?? { selectActiveRow: true }
+          );
           this._grid.setSelectionModel(rowSelectionPlugin);
         }
 

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-detail.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-detail.md
@@ -49,6 +49,7 @@ const Example: React.FC = () => {
     setColumns([ /*...*/ ]);
     setOptions({
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },
@@ -486,6 +487,7 @@ const Example: React.FC = () => {
     setColumns([ /*...*/]);
     setOptions({
       enableRowDetailView: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         selectActiveRow: true
       },

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -104,6 +104,7 @@ const Example: React.FC = () => {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -138,6 +139,7 @@ const Example: React.FC = () => {
       enableCellNavigation: true,
       enableCheckboxSelector: true,
       enableRowSelection: true,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
@@ -212,6 +214,7 @@ const Example: React.FC = () => {
         // selectableOverride: (row: number, dataContext: any, grid: any) => (dataContext.id % 2 === 1)
       },
       multiSelect: false,
+      // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: true,
@@ -316,6 +319,7 @@ For example, we could use the Excel Copy Buffer (Cell Selection) and use `rowSel
 setGridOptions({
   // enable new hybrid selection model (rows & cells)
   enableHybridSelection: true,
+  // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
   rowSelectionOptions: {
     selectActiveRow: true,
     rowSelectColumnIds: ['selector'],

--- a/frameworks/slickgrid-react/src/extensions/slickRowDetailView.ts
+++ b/frameworks/slickgrid-react/src/extensions/slickRowDetailView.ts
@@ -118,7 +118,9 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         // this also requires the Row Selection Model to be registered as well
         if (!rowSelectionPlugin || !this._grid.getSelectionModel()) {
           const SelectionModelClass = this.gridOptions.enableHybridSelection ? SlickHybridSelectionModel : SlickRowSelectionModel;
-          rowSelectionPlugin = new SelectionModelClass(this.gridOptions.rowSelectionOptions || { selectActiveRow: true });
+          rowSelectionPlugin = new SelectionModelClass(
+            this.gridOptions.selectionOptions ?? this.gridOptions.rowSelectionOptions ?? { selectActiveRow: true }
+          );
           this._grid.setSelectionModel(rowSelectionPlugin);
         }
 

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-detail.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-detail.md
@@ -44,6 +44,7 @@ function defineGrid() {
   const columnDefinitions = [/*...*/];
   gridOptions.value = {
     enableRowDetailView: true,
+    // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
     rowSelectionOptions: {
       selectActiveRow: true
     },
@@ -449,6 +450,7 @@ function defineGrid() {
   const columnDefinitions = [/*...*/];
   gridOptions.value = {
     enableRowDetailView: true,
+    // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
     rowSelectionOptions: {
       selectActiveRow: true
     },

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
@@ -125,6 +125,7 @@ function defineGrid() {
     enableCellNavigation: true,
     enableCheckboxSelector: true,
     enableRowSelection: true,
+    // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
     rowSelectionOptions: {
       // True (Single Selection), False (Multiple Selections)
       selectActiveRow: false
@@ -171,6 +172,7 @@ function defineGrid() {
     enableCellNavigation: true,
     enableCheckboxSelector: true,
     enableRowSelection: true,
+    // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
     rowSelectionOptions: {
       // True (Single Selection), False (Multiple Selections)
       selectActiveRow: false
@@ -268,6 +270,7 @@ function defineGrid() {
       // selectableOverride: (row: number, dataContext: any, grid: any) => (dataContext.id % 2 === 1)
     },
     multiSelect: false,
+    // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
     rowSelectionOptions: {
       // True (Single Selection), False (Multiple Selections)
       selectActiveRow: true,
@@ -386,6 +389,7 @@ For example, we could use the Excel Copy Buffer (Cell Selection) and use `rowSel
 gridOptions.value = {
   // enable new hybrid selection model (rows & cells)
   enableHybridSelection: true,
+  // `rowSelectionOptions` in <=9.x OR `selectionOptions` in >=10.x
   rowSelectionOptions: {
     selectActiveRow: true,
     rowSelectColumnIds: ['selector'],

--- a/frameworks/slickgrid-vue/src/extensions/slickRowDetailView.ts
+++ b/frameworks/slickgrid-vue/src/extensions/slickRowDetailView.ts
@@ -127,7 +127,9 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
         // this also requires the Row Selection Model to be registered as well
         if (!rowSelectionPlugin || !this._grid.getSelectionModel()) {
           const SelectionModelClass = this.gridOptions.enableHybridSelection ? SlickHybridSelectionModel : SlickRowSelectionModel;
-          rowSelectionPlugin = new SelectionModelClass(this.gridOptions.rowSelectionOptions || { selectActiveRow: true });
+          rowSelectionPlugin = new SelectionModelClass(
+            this.gridOptions.selectionOptions ?? this.gridOptions.rowSelectionOptions ?? { selectActiveRow: true }
+          );
           this._grid.setSelectionModel(rowSelectionPlugin);
         }
 

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -121,7 +121,7 @@ export class SlickCheckboxSelectColumn<T = any> {
     // this also requires the Row Selection Model to be registered as well
     if (!this._rowSelectionModel || !this._grid.getSelectionModel()) {
       const SelectionModelClass = this.gridOptions.enableHybridSelection ? SlickHybridSelectionModel : SlickRowSelectionModel;
-      this._rowSelectionModel = new SelectionModelClass(this.gridOptions.rowSelectionOptions);
+      this._rowSelectionModel = new SelectionModelClass(this.gridOptions.selectionOptions ?? this.gridOptions.rowSelectionOptions);
       this._grid.setSelectionModel(this._rowSelectionModel);
     }
 

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -781,7 +781,10 @@ export interface GridOption<C extends Column = Column> {
   /** Row Move Manager Plugin options & events */
   rowMoveManager?: RowMoveManager;
 
-  /** Row selection options */
+  /** Cell/Row/Hybrid Selection options */
+  selectionOptions?: HybridSelectionModelOption | RowSelectionModelOption;
+
+  /** @deprecated @use `selectionOptions` */
   rowSelectionOptions?: HybridSelectionModelOption | RowSelectionModelOption;
 
   /**

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -224,7 +224,7 @@ export class ExtensionService {
           this.gridOptions.enableRowMoveManager)
       ) {
         if (!this._rowSelectionModel || !this.sharedService.slickGrid.getSelectionModel()) {
-          const rowSelectionOptions = this.gridOptions.rowSelectionOptions ?? {};
+          const rowSelectionOptions = this.gridOptions.selectionOptions ?? this.gridOptions.rowSelectionOptions ?? {};
           if (this.gridOptions.enableRowMoveManager && this.gridOptions.rowMoveManager?.dragToSelect !== false) {
             rowSelectionOptions.dragToSelect = true;
           }

--- a/packages/common/src/services/grid.service.ts
+++ b/packages/common/src/services/grid.service.ts
@@ -328,7 +328,7 @@ export class GridService {
     // create a SelectionModel if there's not one yet
     if (!this._grid.getSelectionModel()) {
       const SelectionModelClass = this._gridOptions.enableHybridSelection ? SlickHybridSelectionModel : SlickRowSelectionModel;
-      this._rowSelectionPlugin = new SelectionModelClass(this._gridOptions.rowSelectionOptions);
+      this._rowSelectionPlugin = new SelectionModelClass(this._gridOptions.selectionOptions ?? this._gridOptions.rowSelectionOptions);
       this._grid.setSelectionModel(this._rowSelectionPlugin);
     }
 


### PR DESCRIPTION
deprecating `rowSelectionOptions` in favor of a rename to `selectionOptions` for the upcoming v10, I decided to do this change mostly because of the new Hybrid Selection Model since it now accepts options for different selection types (cell/row/mixed).

```diff
gridOptions = {
  enableRowSelection: true,
- rowSelectionOptions: {
+ selectionOptions: {
    selectActiveRow: false,
  }
};
```

in v10 (not before though), I will also replace rename and merge both `enableHybridSelection` and `enableRowSelection` into a single new `enableSelection` option and the user will then be able to define a `selectionType` (cell/row/mixed) if needed

```diff
gridOptions = {
- enableHybridSelection: true,
- enableRowSelection: true,
+  enableSelection: true,

- rowSelectionOptions: {
+ selectionOptions: {
    selectActiveRow: false,
+   selectionType: 'mixed', // type can be: ('cell','row','mixed')
  }
};
```