### PR TITLE
chore: fix Cypress test failing when running Sunday 1st day of month

### DIFF
--- a/demos/aurelia/test/cypress/e2e/example32.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example32.cy.ts
@@ -181,7 +181,12 @@ describe('Example 32 - Columns Resize by Content', () => {
       const yesterdayDate = format(addDay(new Date(), -1), 'YYYY-MM-DD');
       const todayDate = format(new Date(), 'YYYY-MM-DD');
 
-      cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+      // Check if yesterday's date element exists (may not be visible when 1st day of the month is a Sunday, e.g. 2026-02-01)
+      cy.get(`[data-vc-date=${yesterdayDate}]`).then(($el) => {
+        if ($el.length > 0) {
+          expect($el).to.have.attr('data-vc-date-disabled');
+        }
+      });
       cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
 
       // make grid readonly again
@@ -379,16 +384,21 @@ describe('Example 32 - Columns Resize by Content', () => {
     });
 
     it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
-      cy.get('[data-row="2"] .slick-cell.l2.r2').contains(/[0-9]* days/);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').click();
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+      // Check if yesterday's date element exists (may not be visible when we run the test on the 1st day of the month and it is a Sunday, e.g. 2026-02-01)
+      cy.get('[data-row="2"] .slick-cell.l2.r2').then(($el) => {
+        if ($el.length > 0) {
+          cy.wrap($el).contains(/[0-9]* days/);
+          cy.wrap($el).click();
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+          cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+        }
+      });
     });
 
     it('should click on "Auto-Edit by keyboard OFF" button', () => {

--- a/demos/react/test/cypress/e2e/example32.cy.ts
+++ b/demos/react/test/cypress/e2e/example32.cy.ts
@@ -181,7 +181,12 @@ describe('Example 32 - Columns Resize by Content', () => {
       const yesterdayDate = format(addDay(new Date(), -1), 'YYYY-MM-DD');
       const todayDate = format(new Date(), 'YYYY-MM-DD');
 
-      cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+      // Check if yesterday's date element exists (may not be visible when 1st day of the month is a Sunday, e.g. 2026-02-01)
+      cy.get(`[data-vc-date=${yesterdayDate}]`).then(($el) => {
+        if ($el.length > 0) {
+          expect($el).to.have.attr('data-vc-date-disabled');
+        }
+      });
       cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
 
       // make grid readonly again
@@ -379,16 +384,21 @@ describe('Example 32 - Columns Resize by Content', () => {
     });
 
     it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
-      cy.get('[data-row="2"] .slick-cell.l2.r2').contains(/[0-9]* days/);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').click();
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+      // Check if yesterday's date element exists (may not be visible when we run the test on the 1st day of the month and it is a Sunday, e.g. 2026-02-01)
+      cy.get('[data-row="2"] .slick-cell.l2.r2').then(($el) => {
+        if ($el.length > 0) {
+          cy.wrap($el).contains(/[0-9]* days/);
+          cy.wrap($el).click();
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+          cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+        }
+      });
     });
 
     it('should click on "Auto-Edit by keyboard OFF" button', () => {

--- a/demos/vue/test/cypress/e2e/example32.cy.ts
+++ b/demos/vue/test/cypress/e2e/example32.cy.ts
@@ -181,7 +181,12 @@ describe('Example 32 - Columns Resize by Content', () => {
       const yesterdayDate = format(addDay(new Date(), -1), 'YYYY-MM-DD');
       const todayDate = format(new Date(), 'YYYY-MM-DD');
 
-      cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+      // Check if yesterday's date element exists (may not be visible when 1st day of the month is a Sunday, e.g. 2026-02-01)
+      cy.get(`[data-vc-date=${yesterdayDate}]`).then(($el) => {
+        if ($el.length > 0) {
+          expect($el).to.have.attr('data-vc-date-disabled');
+        }
+      });
       cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
 
       // make grid readonly again
@@ -379,16 +384,21 @@ describe('Example 32 - Columns Resize by Content', () => {
     });
 
     it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
-      cy.get('[data-row="2"] .slick-cell.l2.r2').contains(/[0-9]* days/);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').click();
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+      // Check if yesterday's date element exists (may not be visible when we run the test on the 1st day of the month and it is a Sunday, e.g. 2026-02-01)
+      cy.get('[data-row="2"] .slick-cell.l2.r2').then(($el) => {
+        if ($el.length > 0) {
+          cy.wrap($el).contains(/[0-9]* days/);
+          cy.wrap($el).click();
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+          cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+        }
+      });
     });
 
     it('should click on "Auto-Edit by keyboard OFF" button', () => {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example32.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example32.cy.ts
@@ -181,7 +181,12 @@ describe('Example 32 - Columns Resize by Content', () => {
       const yesterdayDate = format(addDay(new Date(), -1), 'YYYY-MM-DD');
       const todayDate = format(new Date(), 'YYYY-MM-DD');
 
-      cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+      // Check if yesterday's date element exists (may not be visible when we run the test on the 1st day of the month and it is a Sunday, e.g. 2026-02-01)
+      cy.get(`[data-vc-date=${yesterdayDate}]`).then(($el) => {
+        if ($el.length > 0) {
+          expect($el).to.have.attr('data-vc-date-disabled');
+        }
+      });
       cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
 
       // make grid readonly again
@@ -379,16 +384,21 @@ describe('Example 32 - Columns Resize by Content', () => {
     });
 
     it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
-      cy.get('[data-row="2"] .slick-cell.l2.r2').contains(/[0-9]* days/);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').click();
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+      // Check if yesterday's date element exists (may not be visible when we run the test on the 1st day of the month and it is a Sunday, e.g. 2026-02-01)
+      cy.get('[data-row="2"] .slick-cell.l2.r2').then(($el) => {
+        if ($el.length > 0) {
+          cy.wrap($el).contains(/[0-9]* days/);
+          cy.wrap($el).click();
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+          cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+        }
+      });
     });
 
     it('should click on "Auto-Edit by keyboard OFF" button', () => {

--- a/test/cypress/e2e/example14.cy.ts
+++ b/test/cypress/e2e/example14.cy.ts
@@ -191,7 +191,12 @@ describe('Example 14 - Columns Resize by Content', () => {
       const yesterdayDate = format(addDay(new Date(), -1), 'YYYY-MM-DD');
       const todayDate = format(new Date(), 'YYYY-MM-DD');
 
-      cy.get(`[data-vc-date=${yesterdayDate}]`).should('have.attr', 'data-vc-date-disabled');
+      // Check if yesterday's date element exists (may not be visible when 1st day of the month is a Sunday, e.g. 2026-02-01)
+      cy.get(`[data-vc-date=${yesterdayDate}]`).then(($el) => {
+        if ($el.length > 0) {
+          expect($el).to.have.attr('data-vc-date-disabled');
+        }
+      });
       cy.get(`[data-vc-date=${todayDate}]`).should('not.have.attr', 'data-vc-date-disabled');
 
       // make grid readonly again
@@ -402,16 +407,21 @@ describe('Example 14 - Columns Resize by Content', () => {
     });
 
     it('should be able to edit "Duration" when "autoEditByKeypress" is enabled and by clicking once on second row and expect next row to become editable', () => {
-      cy.get('[data-row="2"] .slick-cell.l2.r2').contains(/[0-9]* days/);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').click();
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+      // Check if yesterday's date element exists (may not be visible when we run the test on the 1st day of the month and it is a Sunday, e.g. 2026-02-01)
+      cy.get('[data-row="2"] .slick-cell.l2.r2').then(($el) => {
+        if ($el.length > 0) {
+          cy.wrap($el).contains(/[0-9]* days/);
+          cy.wrap($el).click();
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
-      cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
-      cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('123');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 1);
+          cy.get('[data-row="2"] .slick-cell.l2.r2').type('{enter}');
+          cy.get('[data-row="2"] .slick-cell.l2.r2.active.editable').should('have.length', 0);
 
-      cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+          cy.get('[data-row="2"] .slick-cell.l2.r2').should('contain', '123 days');
+        }
+      });
     });
 
     it('should click on "Auto-Edit by keyboard OFF" button', () => {


### PR DESCRIPTION
fixes some Cypress test failings when run on the 1st day of the month and it happens to be a Sunday (e.g. Feb 1st, 2026). When that happen, we don't see previous month dates and that caused the Cypress test to fail because it was expecting a "yesterday's date" condition but yesterday isn't showing when the calendar starts on a Sunday... so let's just skip these conditions when that happens

For example it failed when I ran the test on February 1st because my yesterday's date was not shown in current calendar month. The test works fine when running on February 2nd

<img width="391" height="316" alt="image" src="https://github.com/user-attachments/assets/97c2ae26-5937-4ee3-9ee5-af6bffe4899f" />
