### PR TITLE
refactor(presets): merge duplicate column preset loading logic

### DIFF
--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -161,6 +161,12 @@ const gridServiceStub = {
 const gridStateServiceStub = {
   init: vi.fn(),
   dispose: vi.fn(),
+  changeColumnsArrangement: vi.fn((columns) => {
+    const gridColumns = gridStateServiceStub.getAssociatedGridColumns(mockGrid, columns);
+    if (gridColumns && Array.isArray(gridColumns)) {
+      mockGrid.setColumns(gridColumns);
+    }
+  }),
   getAssociatedGridColumns: vi.fn(),
   getCurrentGridState: vi.fn(),
   needToPreserveRowSelection: vi.fn(),
@@ -1748,15 +1754,12 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
 
       it('should reflect columns in the grid', () => {
         const mockColsPresets = [{ columnId: 'firstName', width: 100 }];
-        const mockCols = [{ id: 'firstName', field: 'firstName', editorClass: undefined, hidden: false }];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue(mockCols);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.options = { presets: { columns: mockColsPresets } } as unknown as GridOption;
         component.initialization(slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect columns with an extra checkbox selection column in the grid when "enableCheckboxSelector" is set', () => {
@@ -1766,15 +1769,14 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           { id: '_checkbox_selector', field: '_checkbox_selector', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columns = mockCols;
         component.options = { ...gridOptions, enableCheckboxSelector: true, presets: { columns: mockColsPresets } } as unknown as GridOption;
         component.initialization(slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect columns with an extra row detail column in the grid when "enableRowDetailView" is set', () => {
@@ -1784,8 +1786,8 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           { id: '_detail_selector', field: '_detail_selector', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columns = mockCols;
         component.options = {
@@ -1796,8 +1798,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         } as GridOption;
         component.initialization(slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect columns with an extra row move column in the grid when "enableRowMoveManager" is set', () => {
@@ -1807,15 +1808,14 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           { id: '_move', field: '_move', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columns = mockCols;
         component.options = { ...gridOptions, enableRowMoveManager: true, presets: { columns: mockColsPresets } } as unknown as GridOption;
         component.initialization(slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect 3 dynamic columns (1-RowMove, 2-RowSelection, 3-RowDetail) when all associated extension flags are enabled', () => {
@@ -1827,8 +1827,8 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           { id: '_detail_selector', field: '_detail_selector', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columns = mockCols;
         component.options = {
@@ -1841,8 +1841,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         } as unknown as GridOption;
         component.initialization(slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should execute backend service "init" method when set', () => {

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -40,7 +40,6 @@ import {
   SlickGrid,
   SlickgridConfig,
   SlickGroupItemMetadataProvider,
-  sortPresetColumns,
   SortService,
   TreeDataService,
   type Observable,
@@ -1306,46 +1305,13 @@ export class AureliaSlickgridCustomElement {
     }
   }
 
-  protected insertDynamicPresetColumns(columnId: string, gridPresetColumns: Column[]) {
-    if (this._columns) {
-      const columnPosition = this._columns.findIndex((c) => c.id === columnId);
-      if (columnPosition >= 0) {
-        const dynColumn = this._columns[columnPosition];
-        if (dynColumn?.id === columnId && !gridPresetColumns.some((c) => c.id === columnId)) {
-          columnPosition > 0 ? gridPresetColumns.splice(columnPosition, 0, dynColumn) : gridPresetColumns.unshift(dynColumn);
-        }
-      }
-    }
-  }
-
   /** Load any possible Columns Grid Presets */
   protected loadColumnPresetsWhenDatasetInitialized() {
     // if user entered some Columns "presets", we need to reflect them all in the grid
     if (this.options.presets && Array.isArray(this.options.presets.columns) && this.options.presets.columns.length > 0) {
-      const gridPresetColumns: Column[] = this.gridStateService.getAssociatedGridColumns(this.grid, this.options.presets.columns);
-      if (gridPresetColumns && Array.isArray(gridPresetColumns) && gridPresetColumns.length > 0 && Array.isArray(this._columns)) {
-        // make sure that the dynamic columns are included in presets (1.Row Move, 2. Row Selection, 3. Row Detail)
-        if (this.options.enableRowMoveManager) {
-          const rmmColId = this.options?.rowMoveManager?.columnId ?? '_move';
-          this.insertDynamicPresetColumns(rmmColId, gridPresetColumns);
-        }
-        if (this.options.enableCheckboxSelector) {
-          const chkColId = this.options?.checkboxSelector?.columnId ?? '_checkbox_selector';
-          this.insertDynamicPresetColumns(chkColId, gridPresetColumns);
-        }
-        if (this.options.enableRowDetailView) {
-          const rdvColId = this.options?.rowDetailView?.columnId ?? '_detail_selector';
-          this.insertDynamicPresetColumns(rdvColId, gridPresetColumns);
-        }
-
-        // keep copy the original optional `width` properties optionally provided by the user.
-        // We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
-        gridPresetColumns.forEach((col) => (col.originalWidth = col.width));
-
-        // finally sort and set the new presets columns (including checkbox selector if need be)
-        const orderedColumns = sortPresetColumns(this._columns, gridPresetColumns);
-        this.grid.setColumns(orderedColumns);
-      }
+      // delegate to GridStateService for centralized column arrangement logic
+      // we pass `false` for triggerAutoSizeColumns to maintain original behavior on preset load
+      this.gridStateService.changeColumnsArrangement(this.options.presets.columns, false);
     }
   }
 

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -22,7 +22,6 @@ import {
   SlickGrid,
   SlickgridConfig,
   SlickGroupItemMetadataProvider,
-  sortPresetColumns,
   SortService,
   TreeDataService,
   type AutocompleterEditor,
@@ -1410,46 +1409,13 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
     }
   }
 
-  protected insertDynamicPresetColumns(columnId: string, gridPresetColumns: Column<TData>[]) {
-    if (this._columns) {
-      const columnPosition = this._columns.findIndex((c) => c.id === columnId);
-      if (columnPosition >= 0) {
-        const dynColumn = this._columns[columnPosition];
-        if (dynColumn?.id === columnId && !gridPresetColumns.some((c) => c.id === columnId)) {
-          columnPosition > 0 ? gridPresetColumns.splice(columnPosition, 0, dynColumn) : gridPresetColumns.unshift(dynColumn);
-        }
-      }
-    }
-  }
-
   /** Load any possible Columns Grid Presets */
   protected loadColumnPresetsWhenDatasetInitialized() {
     // if user entered some Columns "presets", we need to reflect them all in the grid
     if (this.grid && this.options.presets && Array.isArray(this.options.presets.columns) && this.options.presets.columns.length > 0) {
-      const gridPresetColumns: Column<TData>[] = this.gridStateService.getAssociatedGridColumns(this.grid, this.options.presets.columns);
-      if (gridPresetColumns && Array.isArray(gridPresetColumns) && gridPresetColumns.length > 0 && Array.isArray(this._columns)) {
-        // make sure that the dynamic columns are included in presets (1.Row Move, 2. Row Selection, 3. Row Detail)
-        if (this.options.enableRowMoveManager) {
-          const rmmColId = this.options?.rowMoveManager?.columnId ?? '_move';
-          this.insertDynamicPresetColumns(rmmColId, gridPresetColumns);
-        }
-        if (this.options.enableCheckboxSelector) {
-          const chkColId = this.options?.checkboxSelector?.columnId ?? '_checkbox_selector';
-          this.insertDynamicPresetColumns(chkColId, gridPresetColumns);
-        }
-        if (this.options.enableRowDetailView) {
-          const rdvColId = this.options?.rowDetailView?.columnId ?? '_detail_selector';
-          this.insertDynamicPresetColumns(rdvColId, gridPresetColumns);
-        }
-
-        // keep copy the original optional `width` properties optionally provided by the user.
-        // We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
-        gridPresetColumns.forEach((col) => (col.originalWidth = col.width));
-
-        // finally sort and set the new presets columns (including checkbox selector if need be)
-        const orderedColumns = sortPresetColumns(this._columns, gridPresetColumns);
-        this.grid.setColumns(orderedColumns);
-      }
+      // delegate to GridStateService for centralized column arrangement logic
+      // we pass `false` for triggerAutoSizeColumns to maintain original behavior on preset load
+      this.gridStateService.changeColumnsArrangement(this.options.presets.columns, false);
     }
   }
 

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -23,7 +23,6 @@ import {
   SlickGrid,
   SlickgridConfig,
   SlickGroupItemMetadataProvider,
-  sortPresetColumns,
   SortService,
   TreeDataService,
   type AutocompleterEditor,
@@ -1276,46 +1275,13 @@ function loadEditorCollectionAsync(column: Column) {
   }
 }
 
-function insertDynamicPresetColumns(columnId: string, gridPresetColumns: Column<any>[]) {
-  if (_columnDefinitions.value) {
-    const columnPosition = _columnDefinitions.value.findIndex((c) => c.id === columnId);
-    if (columnPosition >= 0) {
-      const dynColumn = _columnDefinitions.value[columnPosition] as Column;
-      if (dynColumn?.id === columnId && !gridPresetColumns.some((c) => c.id === columnId)) {
-        columnPosition > 0 ? gridPresetColumns.splice(columnPosition, 0, dynColumn) : gridPresetColumns.unshift(dynColumn);
-      }
-    }
-  }
-}
-
 /** Load any possible Columns Grid Presets */
 function loadColumnPresetsWhenDatasetInitialized() {
   // if user entered some Columns "presets", we need to reflect them all in the grid
   if (_gridOptions.value.presets && Array.isArray(_gridOptions.value.presets.columns) && _gridOptions.value.presets.columns.length > 0) {
-    const gridPresetColumns: Column<any>[] = gridStateService.getAssociatedGridColumns(grid!, _gridOptions.value.presets.columns);
-    if (gridPresetColumns && Array.isArray(gridPresetColumns) && gridPresetColumns.length > 0 && Array.isArray(_columnDefinitions.value)) {
-      // make sure that the dynamic columns are included in presets (1.Row Move, 2. Row Selection, 3. Row Detail)
-      if (_gridOptions.value.enableRowMoveManager) {
-        const rmmColId = _gridOptions.value?.rowMoveManager?.columnId ?? '_move';
-        insertDynamicPresetColumns(rmmColId, gridPresetColumns);
-      }
-      if (_gridOptions.value.enableCheckboxSelector) {
-        const chkColId = _gridOptions.value?.checkboxSelector?.columnId ?? '_checkbox_selector';
-        insertDynamicPresetColumns(chkColId, gridPresetColumns);
-      }
-      if (_gridOptions.value.enableRowDetailView) {
-        const rdvColId = _gridOptions.value?.rowDetailView?.columnId ?? '_detail_selector';
-        insertDynamicPresetColumns(rdvColId, gridPresetColumns);
-      }
-
-      // keep copy the original optional `width` properties optionally provided by the user.
-      // We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
-      gridPresetColumns.forEach((col) => (col.originalWidth = col.width));
-
-      // finally sort and set the new presets columns (including checkbox selector if need be)
-      const orderedColumns = sortPresetColumns(_columnDefinitions.value, gridPresetColumns);
-      grid?.setColumns(orderedColumns);
-    }
+    // delegate to GridStateService for centralized column arrangement logic
+    // we pass `false` for triggerAutoSizeColumns to maintain original behavior on preset load
+    gridStateService.changeColumnsArrangement(_gridOptions.value.presets.columns, false);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clean": "remove --glob {demos,frameworks,frameworks-plugins,packages}/*/dist --glob=packages/*/tsconfig.tsbuildinfo --stat",
     "cypress": "cypress open --config-file test/cypress.config.ts",
     "cypress:ci": "cypress run --config-file test/cypress.config.ts",
+    "cypress:install": "pnpm exec cypress install",
     "sass:bundle": "pnpm -r --stream --filter=./packages/common run sass:bundle",
     "build:universal": "tsc --build ./tsconfig.packages.json && pnpm sass:bundle",
     "build:frameworks": "pnpm -r --stream --filter=\"./{demos,frameworks,frameworks-plugins}/**\" run build",

--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -398,6 +398,114 @@ describe('GridStateService', () => {
         ]);
         expect(autoSizeSpy).not.toHaveBeenCalled();
       });
+
+      it('should insert checkbox selector column at the correct position when "enableCheckboxSelector" is enabled', () => {
+        gridOptionMock.enableCheckboxSelector = true;
+        gridOptionMock.checkboxSelector = { columnIndexPosition: 0 } as unknown as CheckboxSelectorOption;
+
+        vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(allColumnsMock);
+        vi.spyOn(gridStub, 'getColumns').mockReturnValue(allColumnsMock);
+        const setColsSpy = vi.spyOn(gridStub, 'setColumns');
+
+        service.changeColumnsArrangement(presetColumnsMock, false);
+
+        const setColumnsArg = setColsSpy.mock.calls[0][0];
+        expect(setColumnsArg).toEqual(expect.arrayContaining([expect.objectContaining({ id: '_checkbox_selector', field: '_checkbox_selector' })]));
+        // checkbox selector should be present in the output
+        const checkboxIndex = setColumnsArg.findIndex((col: Column) => col.id === '_checkbox_selector');
+        expect(checkboxIndex).toBeGreaterThanOrEqual(0);
+      });
+
+      it('should insert row detail view column at the correct position when "enableRowDetailView" is enabled', () => {
+        gridOptionMock.enableRowDetailView = true;
+        gridOptionMock.rowDetailView = { columnIndexPosition: 0 } as unknown as RowDetailView;
+
+        vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(allColumnsMock);
+        vi.spyOn(gridStub, 'getColumns').mockReturnValue(allColumnsMock);
+        const setColsSpy = vi.spyOn(gridStub, 'setColumns');
+
+        service.changeColumnsArrangement(presetColumnsMock, false);
+
+        const setColumnsArg = setColsSpy.mock.calls[0][0];
+        expect(setColumnsArg).toEqual(expect.arrayContaining([expect.objectContaining({ id: '_detail_selector', field: '_detail_selector' })]));
+        // row detail should be present in the output
+        const detailIndex = setColumnsArg.findIndex((col: Column) => col.id === '_detail_selector');
+        expect(detailIndex).toBeGreaterThanOrEqual(0);
+      });
+
+      it('should insert row move manager column at the correct position when "enableRowMoveManager" is enabled', () => {
+        gridOptionMock.enableRowMoveManager = true;
+        gridOptionMock.rowMoveManager = { columnIndexPosition: 0 } as unknown as RowMoveManager;
+
+        vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(allColumnsMock);
+        vi.spyOn(gridStub, 'getColumns').mockReturnValue(allColumnsMock);
+        const setColsSpy = vi.spyOn(gridStub, 'setColumns');
+
+        service.changeColumnsArrangement(presetColumnsMock, false);
+
+        const setColumnsArg = setColsSpy.mock.calls[0][0];
+        expect(setColumnsArg).toEqual(expect.arrayContaining([expect.objectContaining({ id: '_move', field: '_move' })]));
+        // row move should be present in the output
+        const moveIndex = setColumnsArg.findIndex((col: Column) => col.id === '_move');
+        expect(moveIndex).toBeGreaterThanOrEqual(0);
+      });
+
+      it('should insert both checkbox selector and row detail columns when both features are enabled', () => {
+        gridOptionMock.enableCheckboxSelector = true;
+        gridOptionMock.enableRowDetailView = true;
+        gridOptionMock.checkboxSelector = { columnIndexPosition: 0 } as unknown as CheckboxSelectorOption;
+        gridOptionMock.rowDetailView = { columnIndexPosition: 1 } as unknown as RowDetailView;
+
+        vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(allColumnsMock);
+        vi.spyOn(gridStub, 'getColumns').mockReturnValue(allColumnsMock);
+        const setColsSpy = vi.spyOn(gridStub, 'setColumns');
+
+        service.changeColumnsArrangement(presetColumnsMock, false);
+
+        const setColumnsArg = setColsSpy.mock.calls[0][0];
+        expect(setColumnsArg).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: '_checkbox_selector', field: '_checkbox_selector' }),
+            expect.objectContaining({ id: '_detail_selector', field: '_detail_selector' }),
+          ])
+        );
+        // both dynamic columns should be present in the output
+        const checkboxIndex = setColumnsArg.findIndex((col: Column) => col.id === '_checkbox_selector');
+        const detailIndex = setColumnsArg.findIndex((col: Column) => col.id === '_detail_selector');
+        expect(checkboxIndex).toBeGreaterThanOrEqual(0);
+        expect(detailIndex).toBeGreaterThanOrEqual(0);
+      });
+
+      it('should insert all three dynamic columns (checkbox selector, row detail, and row move) when all features are enabled', () => {
+        gridOptionMock.enableCheckboxSelector = true;
+        gridOptionMock.enableRowDetailView = true;
+        gridOptionMock.enableRowMoveManager = true;
+        gridOptionMock.checkboxSelector = { columnIndexPosition: 0 } as unknown as CheckboxSelectorOption;
+        gridOptionMock.rowDetailView = { columnIndexPosition: 1 } as unknown as RowDetailView;
+        gridOptionMock.rowMoveManager = { columnIndexPosition: 2 } as unknown as RowMoveManager;
+
+        vi.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(allColumnsMock);
+        vi.spyOn(gridStub, 'getColumns').mockReturnValue(allColumnsMock);
+        const setColsSpy = vi.spyOn(gridStub, 'setColumns');
+
+        service.changeColumnsArrangement(presetColumnsMock, false);
+
+        const setColumnsArg = setColsSpy.mock.calls[0][0];
+        expect(setColumnsArg).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: '_checkbox_selector', field: '_checkbox_selector' }),
+            expect.objectContaining({ id: '_detail_selector', field: '_detail_selector' }),
+            expect.objectContaining({ id: '_move', field: '_move' }),
+          ])
+        );
+        // all three dynamic columns should be present in the output
+        const checkboxIndex = setColumnsArg.findIndex((col: Column) => col.id === '_checkbox_selector');
+        const detailIndex = setColumnsArg.findIndex((col: Column) => col.id === '_detail_selector');
+        const moveIndex = setColumnsArg.findIndex((col: Column) => col.id === '_move');
+        expect(checkboxIndex).toBeGreaterThanOrEqual(0);
+        expect(detailIndex).toBeGreaterThanOrEqual(0);
+        expect(moveIndex).toBeGreaterThanOrEqual(0);
+      });
     });
 
     describe('bindExtensionAddonEventToGridStateChange tests', () => {

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -99,26 +99,29 @@ export class GridStateService {
     if (Array.isArray(definedColumns) && definedColumns.length > 0) {
       const newArrangedColumns: Column[] = this.getAssociatedGridColumns(this._grid, definedColumns);
 
-      if (newArrangedColumns && Array.isArray(newArrangedColumns) && newArrangedColumns.length > 0) {
+      if (Array.isArray(newArrangedColumns) && newArrangedColumns.length > 0) {
         // make sure that the checkbox selector is still visible in the list when it is enabled
         if (Array.isArray(this.sharedService.allColumns)) {
           const dynamicAddonColumnByIndexPositionList: { columnId: string; columnIndexPosition: number }[] = [];
 
           // make sure that the dynamic columns are included in presets (1.Row Move, 2. Row Selection, 3. Row Detail)
           if (this._gridOptions.enableRowMoveManager) {
-            const rmmColId = this._gridOptions?.rowMoveManager?.columnId ?? '_move';
-            const columnIndexPosition = this._gridOptions?.rowMoveManager?.columnIndexPosition ?? 0;
-            dynamicAddonColumnByIndexPositionList.push({ columnId: rmmColId, columnIndexPosition });
+            dynamicAddonColumnByIndexPositionList.push({
+              columnId: this._gridOptions?.rowMoveManager?.columnId ?? '_move',
+              columnIndexPosition: this._gridOptions?.rowMoveManager?.columnIndexPosition ?? 0,
+            });
           }
           if (this._gridOptions.enableCheckboxSelector) {
-            const chkColId = this._gridOptions?.checkboxSelector?.columnId ?? '_checkbox_selector';
-            const columnIndexPosition = this._gridOptions?.checkboxSelector?.columnIndexPosition ?? 0;
-            dynamicAddonColumnByIndexPositionList.push({ columnId: chkColId, columnIndexPosition });
+            dynamicAddonColumnByIndexPositionList.push({
+              columnId: this._gridOptions?.checkboxSelector?.columnId ?? '_checkbox_selector',
+              columnIndexPosition: this._gridOptions?.checkboxSelector?.columnIndexPosition ?? 0,
+            });
           }
           if (this._gridOptions.enableRowDetailView) {
-            const rdvColId = this._gridOptions?.rowDetailView?.columnId ?? '_detail_selector';
-            const columnIndexPosition = this._gridOptions?.rowDetailView?.columnIndexPosition ?? 0;
-            dynamicAddonColumnByIndexPositionList.push({ columnId: rdvColId, columnIndexPosition });
+            dynamicAddonColumnByIndexPositionList.push({
+              columnId: this._gridOptions?.rowDetailView?.columnId ?? '_detail_selector',
+              columnIndexPosition: this._gridOptions?.rowDetailView?.columnIndexPosition ?? 0,
+            });
           }
 
           // since some features could have a `columnIndexPosition`, we need to make sure these indexes are respected in the column definitions

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -1,7 +1,6 @@
 import {
   autoAddEditorFormatterToColumnsWithEditor,
   Editors,
-  FieldType,
   Filters,
   SharedService,
   SlickDataView,
@@ -153,6 +152,12 @@ const gridServiceStub = {
 const gridStateServiceStub = {
   init: vi.fn(),
   dispose: vi.fn(),
+  changeColumnsArrangement: vi.fn((columns) => {
+    const gridColumns = gridStateServiceStub.getAssociatedGridColumns(mockGrid, columns);
+    if (gridColumns && Array.isArray(gridColumns)) {
+      mockGrid.setColumns(gridColumns);
+    }
+  }),
   getAssociatedGridColumns: vi.fn(),
   getCurrentGridState: vi.fn(),
   needToPreserveRowSelection: vi.fn(),
@@ -1707,15 +1712,12 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
 
       it('should reflect columns in the grid', () => {
         const mockColsPresets = [{ columnId: 'firstName', width: 100 }];
-        const mockCols = [{ id: 'firstName', field: 'firstName', editorClass: undefined, hidden: false }];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue(mockCols);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.gridOptions = { presets: { columns: mockColsPresets } } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect columns with an extra checkbox selection column in the grid when "enableCheckboxSelector" is set', () => {
@@ -1725,15 +1727,14 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           { id: '_checkbox_selector', field: '_checkbox_selector', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columnDefinitions = mockCols;
         component.gridOptions = { enableCheckboxSelector: true, presets: { columns: mockColsPresets } } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect columns with an extra row detail column in the grid when "enableRowDetailView" is set', () => {
@@ -1743,8 +1744,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           { id: '_detail_selector', field: '_detail_selector', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columnDefinitions = mockCols;
         component.gridOptions = {
@@ -1754,8 +1755,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect columns with an extra row move column in the grid when "enableRowMoveManager" is set', () => {
@@ -1765,15 +1765,14 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           { id: '_move', field: '_move', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columnDefinitions = mockCols;
         component.gridOptions = { ...gridOptions, enableRowMoveManager: true, presets: { columns: mockColsPresets } } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should reflect 3 dynamic columns (1-RowMove, 2-RowSelection, 3-RowDetail) when all associated extension flags are enabled', () => {
@@ -1785,8 +1784,8 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
           { id: '_detail_selector', field: '_detail_selector', editor: undefined, editorClass: undefined, hidden: false },
           { ...mockCol, editorClass: undefined, hidden: false },
         ];
-        const getAssocColSpy = vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
-        const setColSpy = vi.spyOn(mockGrid, 'setColumns');
+        vi.spyOn(gridStateServiceStub, 'getAssociatedGridColumns').mockReturnValue([mockCol]);
+        const changeColsSpy = vi.spyOn(gridStateServiceStub, 'changeColumnsArrangement');
 
         component.columnDefinitions = mockCols;
         component.gridOptions = {
@@ -1798,8 +1797,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         } as unknown as GridOption;
         component.initialization(divContainer, slickEventHandler);
 
-        expect(getAssocColSpy).toHaveBeenCalledWith(mockGrid, mockColsPresets);
-        expect(setColSpy).toHaveBeenCalledWith(mockCols);
+        expect(changeColsSpy).toHaveBeenCalledWith(mockColsPresets, false);
       });
 
       it('should execute backend service "init" method when set', () => {


### PR DESCRIPTION
duplicate/similar code can be found in [`changeColumnsArrangement()`](https://github.com/ghiscoding/slickgrid-universal/blob/625e688be1bcd823612d67b1ed0190d312bfc7b2/packages/common/src/services/gridState.service.ts#L92-L96) and in each framework wrappers [`loadColumnPresetsWhenDatasetInitialized()`](https://github.com/ghiscoding/slickgrid-universal/blob/625e688be1bcd823612d67b1ed0190d312bfc7b2/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts#L1390-L1392), this PR is removing this duplication by keeping only `changeColumnsArrangement()` from GridStateService which help removing duplicate code and stay DRY while decreasing build code size. 

The other great advantage was that the previous code `loadColumnPresetsWhenDatasetInitialized()` was replicated in every framework wrappers, so centralizing the code in the GridStateService is helping removing so much duplicate code