### PR TITLE
fix: pre-set value for editor validation on paste

### DIFF
--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -217,7 +217,8 @@ describe('CellExternalCopyManager', () => {
       plugin.init(gridStub);
       plugin.setDataItemValueForColumn(mockItem, mockColumns[0], 'some value');
 
-      expect(loadValSpy).toHaveBeenCalledWith(mockItem);
+      const expectedItem = { ...mockItem, firstName: 'some value' };
+      expect(loadValSpy).toHaveBeenCalledWith(expectedItem);
       expect(applyValSpy).toHaveBeenCalledWith(mockItem, 'some value');
     });
 
@@ -232,7 +233,8 @@ describe('CellExternalCopyManager', () => {
       plugin.init(gridStub);
       plugin.setDataItemValueForColumn(mockItem, mockColumns[0], 'some value');
 
-      expect(loadValSpy).toHaveBeenCalledWith(mockItem);
+      const expectedItem = { ...mockItem, firstName: 'some value' };
+      expect(loadValSpy).toHaveBeenCalledWith(expectedItem);
       expect(applyValSpy).toHaveBeenCalledWith(mockItem, 'some value');
       expect(validationSpy).toHaveBeenCalled();
       expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({ validationResults }));

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -197,7 +197,7 @@ export class SlickCellExternalCopyManager {
           cancelChanges: noop,
           commitChanges: noop,
         }) as Editor;
-        editor.loadValue(item);
+        editor.loadValue({ ...item, [columnDef.field]: value });
         const validationResults = editor.validate(undefined, value);
         if (!validationResults.valid) {
           const activeCell = this._grid.getActiveCell()!;


### PR DESCRIPTION
this fixes the issue that the new value is not present on the item when pasting, thus failing certain validations like required