### PR TITLE
fix(styling): problem to display resizable handle because of Grid Menu

### DIFF
--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -235,7 +235,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
     iconToggleDarkModeCommand: 'mdi mdi-brightness-4',
     iconToggleFilterCommand: 'mdi mdi-flip-vertical',
     iconTogglePreHeaderCommand: 'mdi mdi-flip-vertical',
-    menuWidth: 14,
+    menuWidth: 12,
     resizeOnShowHeaderRow: true,
     showBulletWhenIconMissing: true,
     subItemChevronClass: 'mdi mdi-chevron-down mdi-rotate-270',

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -150,7 +150,7 @@ export interface GridMenuOption extends MenuOption<GridMenuCommandItemCallbackAr
    */
   maxHeight?: number | string;
 
-  /** Defaults to 14 pixels (only the number), which is the width in pixels of the Grid Menu icon container */
+  /** Defaults to 12 pixels (only the number), which is the width in pixels of the Grid Menu icon container */
   menuWidth?: number;
 
   /**

--- a/packages/common/src/styles/_variables.scss
+++ b/packages/common/src/styles/_variables.scss
@@ -160,8 +160,8 @@ $slick-header-padding:                                      $slick-header-paddin
 $slick-header-row-background-color:                         #ffffff !default;
 $slick-header-row-filter-padding:                           4px !default;
 $slick-header-text-color:                                   #333 !default;
-$slick-header-resizable-width:                              7px !default;
-$slick-header-resizable-hover:                              2px solid #606060 !default;
+$slick-header-resizable-width:                              4px !default;
+$slick-header-resizable-hover:                              2px solid #7c7c7c !default;
 $slick-header-resizable-hover-border-bottom:                $slick-header-resizable-hover !default;
 $slick-header-resizable-hover-border-left:                  $slick-header-resizable-hover !default;
 $slick-header-resizable-hover-border-right:                 $slick-header-resizable-hover !default;
@@ -170,8 +170,8 @@ $slick-header-resizable-hover-width:                        4px !default;
 $slick-header-resizable-hover-border-radius:                8px !default;
 $slick-header-resizable-hover-right:                        0 !default;
 $slick-header-resizable-hover-opacity:                      0.4 !default;
-$slick-header-resizable-hover-height:                       100% !default;
-$slick-header-resizable-hover-top:                          0 !default;
+$slick-header-resizable-hover-height:                       80% !default;
+$slick-header-resizable-hover-top:                          10% !default;
 
 /* Frozen pinned rows/columns */
 $slick-frozen-border-bottom:                                1px solid #a5a5a5 !default;
@@ -372,7 +372,7 @@ $slick-column-picker-title-width:                           calc(100% - #{$slick
 $slick-column-picker-z-index:                               9000 !default;
 
 /* Grid Menu - hamburger menu */
-$slick-grid-menu-button-padding:                            4px 2px !default;
+$slick-grid-menu-button-padding:                            4px 0px !default;
 $slick-grid-menu-label-margin:                              4px !default;
 $slick-grid-menu-label-font-weight:                         normal !default;
 $slick-grid-menu-link-background-color:                     #ffffff !default;
@@ -1155,10 +1155,10 @@ $slick-dark-text-color:                                   #d4d4d4 !default;
   --slick-cell-selected-color:                            #474747;
   --slick-row-selected-color:                             #474747;
   --slick-row-highlight-background-color:                 #505050;
-  --slick-header-resizable-hover-border-bottom:           2px solid #aaa;
-  --slick-header-resizable-hover-border-top:              2px solid #aaa;
-  --slick-header-resizable-hover-border-left:             2px solid #aaa;
-  --slick-header-resizable-hover-border-right:            2px solid #aaa;
+  --slick-header-resizable-hover-border-bottom:           2px solid #acacac;
+  --slick-header-resizable-hover-border-top:              2px solid #acacac;
+  --slick-header-resizable-hover-border-left:             2px solid #acacac;
+  --slick-header-resizable-hover-border-right:            2px solid #acacac;
   --slick-scrollbar-color:                                #828282 #424242;
   --slick-sorting-header-color:                           var(--slick-base-dark-text-color);
   --slick-submenu-box-shadow:                             0 1px 3px 1px rgba(146, 152, 163, 0.4);

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -775,9 +775,9 @@
         cursor: col-resize;
         top: 0;
         height: 100%;
-        width: 7px;
+        width: 6px;
         right: 0;
-        z-index: 1;
+        z-index: 4;
 
         &:hover {
           border-bottom: var(--slick-header-resizable-hover-border-bottom, v.$slick-header-resizable-hover-border-bottom);


### PR DESCRIPTION
after switching from `width: calc(100% - 18px)` to CSS flexbox in v10 to align column headers and grid menu (hamburger), the last column resize handle barely shows, this PR makes it much more visible and I also changed the default CSS styling of the column resize handle 

![brave_j7QRyueTe6](https://github.com/user-attachments/assets/1947de97-5657-4eaf-a72b-915e7d7ab95f)
