### PR TITLE
fix: add row/column counts ARIA attributes for grid accessibility

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2882,6 +2882,15 @@ describe('SlickGrid core file', () => {
       expect(result).toBeTruthy();
     });
 
+    it('should expect the grid container to have aria attributes set', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, defaultOptions);
+
+      expect(grid).toBeTruthy();
+      expect(grid._container.getAttribute('role')).toBe('grid');
+      expect(grid._container.getAttribute('aria-colcount')).toBe('1');
+      expect(grid._container.getAttribute('aria-rowcount')).toBe('11');
+    });
+
     it('should return undefined editor when getDataItem() did not find any associated cell item', () => {
       const columns = [
         { id: 'name', field: 'name', name: 'Name' },

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -661,6 +661,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this._container.classList.add(this.uid);
     this._container.classList.add('slick-widget');
     this._container.setAttribute('role', 'grid');
+    this._container.setAttribute('aria-colcount', this.columns.length.toString());
+    this._container.setAttribute('aria-rowcount', Array.isArray(this.data) ? this.data.length.toString() : '0');
 
     const containerStyles = getComputedStyle(this._container);
     if (!/relative|absolute|fixed/.test(containerStyles.position)) {
@@ -3438,6 +3440,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return; // exit early if freeze is invalid
     }
     this.columns = newColumns;
+    this._container.setAttribute('aria-colcount', this.columns.length.toString());
     const updateCols = () => {
       this.updateColumns();
       this.triggerEvent(this.onAfterSetColumns, { newColumns, grid: this });
@@ -4751,6 +4754,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   updateRowCount(): void {
     if (this.initialized) {
       const dataLength = this.getDataLength();
+      this._container.setAttribute('aria-rowcount', dataLength.toString());
 
       // remap all rowspan cache when necessary
       if (dataLength > 0 && dataLength !== this._prevDataLength) {


### PR DESCRIPTION
add more ARIA attributes as identified in this external project for better accessibility
https://github.com/microsoft/vscode-cosmosdb/pull/2934

adding these extra aria attributes
- `aria-colcount` (also updated when `setColumns()` is called)
- `aria-rowcount` (also updated when `updateRowCount()` is called, which is also called by the DataView)

the `role=grid` was already in place, the only attribute I won't add is `aria-label` on the grid container because that text could be any text and/or any locale, user can define that one themselves. 