### PR TITLE
fix(styling): Draggable Grouping dropzone should be full width

### DIFF
--- a/packages/common/src/styles/slick-plugins.scss
+++ b/packages/common/src/styles/slick-plugins.scss
@@ -936,6 +936,8 @@ li.hidden {
 
 .slick-preheader-panel,
 .slick-topheader-panel {
+  width: 100%;
+
   .slick-dropzone,
   .slick-dropzone-hover {
     display: flex;


### PR DESCRIPTION
just add a `width: 100%` to preheader, this problem only showed up in my demos using Bootstrap


<img width="3158" height="839" alt="image" src="https://github.com/user-attachments/assets/c4df7504-2228-478b-bec8-c150127b6898" />
