### PR TITLE
chore: rename `queueMicrotaskPolyfill` for Salesforce locker service

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -11,7 +11,7 @@ import {
   isDefined,
   isDefinedNumber,
   isPrimitiveOrHTML,
-  queueMicrotaskOrSetTimeout,
+  queueMicrotaskPolyfill,
 } from '@slickgrid-universal/utils';
 import type { SortableEvent, Options as SortableOptions } from 'sortablejs';
 import Sortable from 'sortablejs/modular/sortable.core.esm.js';
@@ -3445,7 +3445,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.updateColumns();
       this.triggerEvent(this.onAfterSetColumns, { newColumns, grid: this });
     };
-    waitNextCycle ? queueMicrotaskOrSetTimeout(() => updateCols()) : updateCols();
+    waitNextCycle ? queueMicrotaskPolyfill(() => updateCols()) : updateCols();
   }
 
   /** Update columns for when a hidden property has changed but the column list itself has not changed. */

--- a/packages/common/src/editors/dateEditor.ts
+++ b/packages/common/src/editors/dateEditor.ts
@@ -1,6 +1,6 @@
 import { parse } from '@formkit/tempo';
 import { BindingEventService } from '@slickgrid-universal/binding';
-import { createDomElement, emptyElement, extend, queueMicrotaskOrSetTimeout, setDeepValue } from '@slickgrid-universal/utils';
+import { createDomElement, emptyElement, extend, queueMicrotaskPolyfill, setDeepValue } from '@slickgrid-universal/utils';
 import { Calendar, type FormatDateString, type Options } from 'vanilla-calendar-pro';
 import { resetDatePicker, setPickerDates, setPickerFocus } from '../commonEditorFilter/commonEditorFilterUtils.js';
 import { SlickEventData, type SlickGrid } from '../core/index.js';
@@ -208,7 +208,7 @@ export class DateEditor implements Editor {
         }
       }) as EventListener);
 
-      queueMicrotaskOrSetTimeout(() => {
+      queueMicrotaskPolyfill(() => {
         this.calendarInstance = new Calendar(this._inputElm, this._pickerMergedOptions);
         this.calendarInstance.init();
         if (!this.args.isCompositeEditor) {
@@ -229,7 +229,7 @@ export class DateEditor implements Editor {
 
   destroy(): void {
     clearTimeout(this._timer);
-    queueMicrotaskOrSetTimeout(() => {
+    queueMicrotaskPolyfill(() => {
       this.hide();
       this.calendarInstance?.destroy();
       emptyElement(this._editorInputGroupElm);

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -1,5 +1,5 @@
 import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import { deepCopy, extend, queueMicrotaskOrSetTimeout, stripTags } from '@slickgrid-universal/utils';
+import { deepCopy, extend, queueMicrotaskPolyfill, stripTags } from '@slickgrid-universal/utils';
 import { dequal } from 'dequal/lite';
 import { Constants } from '../constants.js';
 import { SlickEvent, SlickEventData, SlickEventHandler, type SlickDataView, type SlickGrid } from '../core/index.js';
@@ -858,7 +858,7 @@ export class FilterService {
       // and we did not have time to convert it to a flat dataset yet (for SlickGrid to use),
       // we would end up calling the pre-filter too early because these pre-filter works only a flat dataset
       // for that use case (like Example 6), we can queue a microtask to be executed at the end of current task
-      queueMicrotaskOrSetTimeout(() => this.refreshTreeDataFilters());
+      queueMicrotaskPolyfill(() => this.refreshTreeDataFilters());
     }
   }
 

--- a/packages/common/src/services/pagination.service.ts
+++ b/packages/common/src/services/pagination.service.ts
@@ -1,5 +1,5 @@
 import type { BasePubSubService, EventSubscription } from '@slickgrid-universal/event-pub-sub';
-import { queueMicrotaskOrSetTimeout } from '@slickgrid-universal/utils';
+import { queueMicrotaskPolyfill } from '@slickgrid-universal/utils';
 import { dequal } from 'dequal/lite';
 import { SlickEventHandler, type SlickDataView, type SlickGrid } from '../core/index.js';
 import type {
@@ -143,7 +143,7 @@ export class PaginationService {
           };
         }
       });
-      queueMicrotaskOrSetTimeout(() => {
+      queueMicrotaskPolyfill(() => {
         if (this.dataView) {
           this.dataView.setRefreshHints({ isFilterUnchanged: true });
           this.dataView.setPagingOptions({ pageSize: this.paginationOptions.pageSize, pageNum: this._pageNumber - 1 }); // dataView page starts at 0 instead of 1

--- a/packages/utils/src/__tests__/utils.spec.ts
+++ b/packages/utils/src/__tests__/utils.spec.ts
@@ -16,7 +16,7 @@ import {
   isPrimitiveOrHTML,
   isPrimitiveValue,
   parseBoolean,
-  queueMicrotaskOrSetTimeout,
+  queueMicrotaskPolyfill,
   removeAccentFromText,
   setDeepValue,
   titleCase,
@@ -661,18 +661,12 @@ describe('Service/Utilies', () => {
     });
   });
 
-  describe('queueMicrotaskOrSetTimeout() method', () => {
-    it('use queueMicrotask() when available', () =>
+  describe('queueMicrotaskPolyfill() method', () => {
+    it('uses queueMicrotask() when available', () =>
       new Promise((done: any) => {
         const callback = vi.fn();
-
-        // Mock queueMicrotask
         const queueMicrotaskSpy = vi.spyOn(global, 'queueMicrotask');
-
-        // Call the function being tested
-        queueMicrotaskOrSetTimeout(callback);
-
-        // Wait for the callback to be executed
+        queueMicrotaskPolyfill(callback);
         setTimeout(() => {
           expect(queueMicrotaskSpy).toHaveBeenCalledWith(callback);
           expect(callback).toHaveBeenCalledTimes(1);
@@ -681,32 +675,22 @@ describe('Service/Utilies', () => {
         }, 10);
       }));
 
-    it('use setTimeout() fallback when queueMicrotask() is not available', () =>
+    it('uses Promise.resolve().then() fallback when queueMicrotask is not available', () =>
       new Promise((done: any) => {
         const callback = vi.fn();
-
-        // Mock queueMicrotask
-        const queueMicrotaskSpy = vi.spyOn(global, 'queueMicrotask');
-        queueMicrotaskSpy.mockImplementation(() => {
-          // Simulate queueMicrotask throwing an error
-          throw new Error('queueMicrotask not available');
-        });
-
-        // Mock setTimeout
-        const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
-
-        // Call the function being tested
-        queueMicrotaskOrSetTimeout(callback);
-
-        // Assertions
-        expect(queueMicrotaskSpy).toHaveBeenCalledWith(callback);
-        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
-
-        // Wait for the callback to be executed
+        // Remove queueMicrotask
+        const originalQueueMicrotask = global.queueMicrotask;
+        // @ts-ignore
+        delete global.queueMicrotask;
+        // Spy on Promise.resolve().then
+        const promiseThenSpy = vi.spyOn(Promise, 'resolve');
+        queueMicrotaskPolyfill(callback);
         setTimeout(() => {
+          expect(promiseThenSpy).toHaveBeenCalled();
           expect(callback).toHaveBeenCalledTimes(1);
-          queueMicrotaskSpy.mockRestore();
-          setTimeoutSpy.mockRestore();
+          promiseThenSpy.mockRestore();
+          // Restore queueMicrotask
+          global.queueMicrotask = originalQueueMicrotask;
           done();
         }, 10);
       }));

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -269,12 +269,12 @@ export function parseBoolean(input: any): boolean {
   return /(true|1)/i.test(input + '');
 }
 
-/** use `queueMicrotask()` when available, otherwise fallback to `setTimeout` for Salesforce LWC locker service */
-export function queueMicrotaskOrSetTimeout(callback: () => void): void {
-  try {
+/** Use `queueMicrotask()` when available, otherwise fallback to `Promise.resolve().then(callback)` for Salesforce LWC locker service */
+export function queueMicrotaskPolyfill(callback: () => void): void {
+  if (typeof queueMicrotask === 'function') {
     queueMicrotask(callback);
-  } catch {
-    setTimeout(callback, 0);
+  } else {
+    Promise.resolve().then(callback);
   }
 }
 

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -53,7 +53,7 @@ import { SlickFooterComponent } from '@slickgrid-universal/custom-footer-compone
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickPaginationComponent } from '@slickgrid-universal/pagination-component';
-import { deepCopy, extend, queueMicrotaskOrSetTimeout } from '@slickgrid-universal/utils';
+import { deepCopy, extend, queueMicrotaskPolyfill } from '@slickgrid-universal/utils';
 import { dequal } from 'dequal/lite';
 import { type SlickerGridInstance } from '../interfaces/slickerGridInstance.interface.js';
 import { UniversalContainerService } from '../services/universalContainer.service.js';
@@ -193,7 +193,7 @@ export class SlickVanillaGridBundle<TData = any> {
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
       // however we need to queue our process until the flat dataset is ready, so we can queue a microtask to execute the DataView refresh only after everything is ready
-      queueMicrotaskOrSetTimeout(() => {
+      queueMicrotaskPolyfill(() => {
         const flatDatasetLn = this.dataView?.getItemCount() ?? 0;
         if (flatDatasetLn > 0 && (flatDatasetLn !== prevFlatDatasetLn || !isDatasetEqual)) {
           this.filterService.refreshTreeDataFilters();
@@ -957,7 +957,7 @@ export class SlickVanillaGridBundle<TData = any> {
         const process = isExecuteCommandOnInit ? (backendApi.process?.(query) ?? null) : (backendApi.onInit?.(query) ?? null);
 
         // wrap this inside a microtask to be executed at the end of the task and avoid timing issue since the gridOptions needs to be ready before running this onInit
-        queueMicrotaskOrSetTimeout(() => {
+        queueMicrotaskPolyfill(() => {
           const backendUtilityService = this.backendUtilityService as BackendUtilityService;
           // keep start time & end timestamps & return it after process execution
           const startTime = new Date();


### PR DESCRIPTION
`queueMicrotask` isn't supported in Salesforce LWC (because of the locker service, though it should work in LWS). I previously had a try/catch and fallback to `setTimeout` but after looking at some LWC code, I found out that using `Promise.resolve().then(callback);` is better than `setTimeout(callback, 0)`, I also renamed the function from `queueMicrotaskOrSetTimeout` to `queueMicrotaskPolyfill` which is shorter and better represent the fact that it's indeed a polyfill for Salesforce LWC (hopefully this can be removed when we switch to Salesforce LWS in the near future)