### PR TITLE
fix(a11y): align submenu arrow keys and Escape behavior with ARIA

### DIFF
--- a/packages/common/src/extensions/__tests__/keyboardNavigation.spec.ts
+++ b/packages/common/src/extensions/__tests__/keyboardNavigation.spec.ts
@@ -145,6 +145,29 @@ describe('bindKeyboardNavigation', () => {
     expect(document.activeElement).toBe(items[0]);
   });
 
+  it('should call onActivate and not onOpenSubMenu when Enter is pressed on non-submenu item', () => {
+    const onActivate = vi.fn();
+    const onOpenSubMenu = vi.fn();
+    const service = {
+      bind: (el: HTMLElement, event: string, handler: EventListener) => {
+        el.addEventListener(event, handler);
+      },
+    };
+
+    bindKeyboardNavigation(container, service as any, {
+      focusedItemSelector: '[role="menuitem"]:focus',
+      allItemsSelector: '[role="menuitem"]',
+      onActivate,
+      onOpenSubMenu,
+    });
+
+    items[0].focus();
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(onActivate).toHaveBeenCalledWith(items[0]);
+    expect(onOpenSubMenu).not.toHaveBeenCalled();
+  });
+
   it('should apply filterFn when hovering over items', () => {
     const menuItems = container.querySelectorAll('[role="menuitem"]');
     const filterFn = (item: HTMLElement) => item !== menuItems[2];
@@ -527,6 +550,20 @@ describe('Sub-menu keyboard navigation', () => {
     expect(onOpenSubMenu).toHaveBeenCalledWith(parentItem);
   });
 
+  it('should call onOpenSubMenu when ArrowRight is pressed on dropleft submenu trigger', () => {
+    document.body.appendChild(container);
+    parentItem.classList.remove('dropright');
+    parentItem.classList.add('dropleft');
+    parentItem.tabIndex = 0;
+    parentItem.focus();
+    if (document.activeElement !== parentItem) {
+      Object.defineProperty(document, 'activeElement', { value: parentItem, configurable: true });
+    }
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+    container.dispatchEvent(event);
+    expect(onOpenSubMenu).toHaveBeenCalledWith(parentItem);
+  });
+
   it('should call onOpenSubMenu when Enter is pressed on submenu trigger', () => {
     document.body.appendChild(container);
     parentItem.tabIndex = 0;
@@ -593,5 +630,55 @@ describe('Sub-menu keyboard navigation', () => {
     const event = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
     container.dispatchEvent(event);
     expect(onCloseSubMenu).not.toHaveBeenCalled();
+  });
+
+  it('should call onCloseSubMenu and not onEscape when Escape is pressed in submenu', () => {
+    const localOnCloseSubMenu = vi.fn();
+    const localOnEscape = vi.fn();
+
+    bindKeyboardNavigation(subMenu, bindService, {
+      focusedItemSelector: '[role="menuitem"]:focus',
+      allItemsSelector: '[role="menuitem"]',
+      onCloseSubMenu: localOnCloseSubMenu,
+      onEscape: localOnEscape,
+    });
+
+    subMenuItem.tabIndex = 0;
+    subMenuItem.focus();
+    if (document.activeElement !== subMenuItem) {
+      Object.defineProperty(document, 'activeElement', { value: subMenuItem, configurable: true });
+    }
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    subMenu.dispatchEvent(event);
+
+    expect(localOnCloseSubMenu).toHaveBeenCalledWith(subMenuItem);
+    expect(localOnEscape).not.toHaveBeenCalled();
+  });
+
+  it('should call onEscape and not onCloseSubMenu when Escape is pressed in root menu', () => {
+    const localOnCloseSubMenu = vi.fn();
+    const localOnEscape = vi.fn();
+
+    document.body.appendChild(container);
+
+    bindKeyboardNavigation(container, bindService, {
+      focusedItemSelector: '[role="menuitem"]:focus',
+      allItemsSelector: '[role="menuitem"]',
+      onCloseSubMenu: localOnCloseSubMenu,
+      onEscape: localOnEscape,
+    });
+
+    parentItem.tabIndex = 0;
+    parentItem.focus();
+    if (document.activeElement !== parentItem) {
+      Object.defineProperty(document, 'activeElement', { value: parentItem, configurable: true });
+    }
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    container.dispatchEvent(event);
+
+    expect(localOnEscape).toHaveBeenCalled();
+    expect(localOnCloseSubMenu).not.toHaveBeenCalled();
   });
 });

--- a/packages/common/src/extensions/keyboardNavigation.ts
+++ b/packages/common/src/extensions/keyboardNavigation.ts
@@ -1,7 +1,8 @@
 import type { BindingEventService } from '@slickgrid-universal/binding';
 
 /**
- * Configuration options for keyboard navigation
+ * Configuration options for keyboard navigation,
+ * some ARIA practices can be found here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role
  */
 export interface KeyboardNavigationOptions {
   /** CSS selector to find currently focused item (e.g., '[role="menuitem"]:focus' or '.list-item:focus') */
@@ -16,9 +17,9 @@ export interface KeyboardNavigationOptions {
   onEscape?: () => void;
   /** Callback when Tab or Shift+Tab is pressed */
   onTab?: (evt: KeyboardEvent, focusedItem: HTMLElement) => void;
-  /** Callback when ArrowRight is pressed on a submenu item (for dropright submenus) */
+  /** Callback when ArrowRight is pressed on a submenu item to open the submenu */
   onOpenSubMenu?: (focusedItem: HTMLElement) => void;
-  /** Callback when ArrowLeft is pressed in a submenu (for dropleft submenus or to close dropright) */
+  /** Callback when ArrowLeft is pressed in a submenu to close it and return to parent */
   onCloseSubMenu?: (focusedItem: HTMLElement) => void;
   /** Key for binding event service (default: 'keyboard-navigation') */
   eventServiceKey?: string;
@@ -78,8 +79,6 @@ export function bindKeyboardNavigation(
 
         // Precompute context for arrow events
         const isInSubMenu = focusedItem.closest('.slick-submenu');
-        const isDropRight = focusedItem.closest('.dropright');
-        const isDropLeft = focusedItem.closest('.dropleft');
 
         switch (evt.key) {
           case 'Tab':
@@ -100,17 +99,17 @@ export function bindKeyboardNavigation(
             break;
           }
           case 'ArrowRight': {
-            // Only handle if focusedItem is a submenu trigger and submenu is dropright
+            // Open submenu on ArrowRight if focused item is a submenu trigger (standard a11y pattern)
             const isSubMenuTrigger = focusedItem.classList.contains('slick-submenu-item');
-            if (isSubMenuTrigger && isDropRight && typeof options.onOpenSubMenu === 'function') {
+            if (isSubMenuTrigger && typeof options.onOpenSubMenu === 'function') {
               stopBubbling();
               options.onOpenSubMenu(focusedItem);
             }
             break;
           }
           case 'ArrowLeft': {
-            // Only handle if in a submenu and submenu is dropright or dropleft
-            if (isInSubMenu && (isDropRight || isDropLeft) && typeof options.onCloseSubMenu === 'function') {
+            // Close submenu on ArrowLeft if in a submenu, return focus to parent menu item (standard a11y pattern)
+            if (isInSubMenu && typeof options.onCloseSubMenu === 'function') {
               stopBubbling();
               options.onCloseSubMenu(focusedItem);
             }
@@ -119,7 +118,7 @@ export function bindKeyboardNavigation(
           case 'Enter':
           case ' ': {
             const isSubMenuTrigger = focusedItem.classList.contains('slick-submenu-item');
-            if (isSubMenuTrigger && isDropRight && typeof options.onOpenSubMenu === 'function') {
+            if (isSubMenuTrigger && typeof options.onOpenSubMenu === 'function') {
               stopBubbling();
               options.onOpenSubMenu(focusedItem);
             } else {
@@ -132,7 +131,11 @@ export function bindKeyboardNavigation(
           }
           case 'Escape':
             stopBubbling();
-            if (onEscape) {
+            // WAI-ARIA standard: In a submenu, Escape closes the submenu and returns to parent
+            // In the root menu, Escape closes everything
+            if (isInSubMenu && typeof options.onCloseSubMenu === 'function') {
+              options.onCloseSubMenu(focusedItem);
+            } else if (onEscape) {
               onEscape();
             }
             break;

--- a/packages/common/src/extensions/menuBaseClass.ts
+++ b/packages/common/src/extensions/menuBaseClass.ts
@@ -542,7 +542,7 @@ export class MenuBaseClass<M extends MenuPlugin | HeaderButton> {
         }
       },
       onCloseSubMenu: (focusedItem: HTMLElement) => {
-        // Close the current sub-menu and focus the trigger in the previous menu
+        // Close the current sub-menu, then focus the trigger in the previous menu
         const currentSubMenu = focusedItem.closest('.slick-submenu');
         if (currentSubMenu) {
           // Remove the current sub-menu from the DOM


### PR DESCRIPTION
fixes an issue with sub-menu that didn't open when sub-menu is expected to open on the left (e.g. if we open our menu from the right far side of the grid) and we use the arrow right key, it should always open sub-menu with arrow right (even if menu opens on the left side). Also left arrow key is always considered as a key to close current sub-menu. 

This follows ARIA patterns described in this article:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role