### PR TITLE
fix: properly update lastSearchValue to support presetted filter cleanup

### DIFF
--- a/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
+++ b/packages/common/src/filters/__tests__/compoundInputFilter.spec.ts
@@ -251,6 +251,22 @@ describe('CompoundInputFilter', () => {
     expect(callbackSpy).toHaveBeenCalled();
   });
 
+  it('should trigger a backend query when user empties the input after a preset search term was loaded via searchTerms (skipCompoundOperatorFilterWithNullInput=true)', () => {
+    mockColumn.filter!.skipCompoundOperatorFilterWithNullInput = true;
+    mockColumn.type = 'string';
+    filterArguments.searchTerms = ['abc'];
+    const callbackSpy = vi.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    const filterInputElm = divContainer.querySelector('.search-filter.filter-duration input') as HTMLInputElement;
+
+    // simulate truncating the filter (select all + backspace)
+    filterInputElm.value = '';
+    filterInputElm.dispatchEvent(new (window.window as any).Event('keyup', { key: 'Backspace', bubbles: true, cancelable: true }));
+
+    expect(callbackSpy).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: null, shouldTriggerQuery: true });
+  });
+
   it('should call "setValues" with extra spaces at the beginning of the searchTerms and trim value when "enableFilterTrimWhiteSpace" is enabled in grid options', () => {
     gridOptionMock.enableFilterTrimWhiteSpace = true;
     mockColumn.type = 'number';

--- a/packages/common/src/filters/inputFilter.ts
+++ b/packages/common/src/filters/inputFilter.ts
@@ -158,6 +158,8 @@ export class InputFilter implements Filter {
       this._currentValue = this._filterInputElm.value;
     }
 
+    this._lastSearchValue = this._currentValue;
+
     // update "filled" CSS class
     this.updateFilterStyle(this.getValues() !== '');
 
@@ -301,6 +303,7 @@ export class InputFilter implements Filter {
     this.updateFilterStyle(!!searchTerm);
     if (searchTerm !== undefined) {
       this._currentValue = searchVal;
+      this._lastSearchValue = this._currentValue; // sync so clearing a preset triggers a backend query
     }
 
     // create the DOM Select dropdown for the Operator


### PR DESCRIPTION
If the app startsup with presets (e.g from localStorage) and these contain filter presets for CompoundInputs, deleting all of them (CTRL+A; Backspace) won't trigger Backend Service re-fetches due to wrong undefined<>'' checks.