### PR TITLE
fix(styling): col header resize issue w/collapsable scrollbar Firefox

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2664,6 +2664,52 @@ describe('SlickGrid core file', () => {
       expect(result).toBe(DEFAULT_GRID_WIDTH + (1000 + 80 * 2) * 2 + 1000); // Left + Right => 800 + (1000 + (defaultColumnWidth * 2)) * 2 + 1000
     });
 
+    it('should remove Grid Menu width from the last header when scrollbar width is collapsed', () => {
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name', width: 80 },
+        { id: 'lastName', field: 'lastName', name: 'Last Name', width: 80 },
+      ] as Column[];
+      grid = new SlickGrid<any, Column>(container, [], columns, {
+        ...defaultOptions,
+        enableGridMenu: true,
+        gridMenu: { menuWidth: 18 },
+      });
+      grid.init();
+
+      const headerElms = container.querySelectorAll<HTMLElement>('.slick-header-columns .slick-header-column');
+      const firstHeaderWidth = parseFloat(headerElms[0].style.width || '0');
+      const lastHeaderWidth = parseFloat(headerElms[1].style.width || '0');
+
+      expect(firstHeaderWidth).toBe(80);
+      expect(lastHeaderWidth).toBe(60);
+      expect(firstHeaderWidth - lastHeaderWidth).toBe(20);
+    });
+
+    it('should only remove last column compensation from header width when scrollbar width is visible', () => {
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name', width: 80 },
+        { id: 'lastName', field: 'lastName', name: 'Last Name', width: 80 },
+      ] as Column[];
+      grid = new SlickGrid<any, Column>(container, [], columns, {
+        ...defaultOptions,
+        enableGridMenu: true,
+        gridMenu: { menuWidth: 18 },
+      });
+      grid.init();
+
+      (grid as any).scrollbarDimensions = { width: 12, height: 12 };
+      (grid as any).createColumnHeaders();
+      (grid as any).applyColumnHeaderWidths();
+
+      const headerElms = container.querySelectorAll<HTMLElement>('.slick-header-columns .slick-header-column');
+      const firstHeaderWidth = parseFloat(headerElms[0].style.width || '0');
+      const lastHeaderWidth = parseFloat(headerElms[1].style.width || '0');
+
+      expect(firstHeaderWidth).toBe(80);
+      expect(lastHeaderWidth).toBe(78);
+      expect(firstHeaderWidth - lastHeaderWidth).toBe(2);
+    });
+
     it('should define rowspan and test mandatory rows are always rendered', () => {
       const metadata: any = {
         0: { columns: { 0: { colspan: 2, rowspan: 28 } } },

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2710,6 +2710,31 @@ describe('SlickGrid core file', () => {
       expect(firstHeaderWidth - lastHeaderWidth).toBe(2);
     });
 
+    it('should use default Grid Menu width fallback when scrollbar width is collapsed and menu width is undefined', () => {
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name', width: 80 },
+        { id: 'lastName', field: 'lastName', name: 'Last Name', width: 80 },
+      ] as Column[];
+      grid = new SlickGrid<any, Column>(container, [], columns, {
+        ...defaultOptions,
+        enableGridMenu: true,
+        gridMenu: {},
+      });
+      grid.init();
+
+      (grid as any).scrollbarDimensions = { width: 0, height: 12 };
+      (grid as any).createColumnHeaders();
+      (grid as any).applyColumnHeaderWidths();
+
+      const headerElms = container.querySelectorAll<HTMLElement>('.slick-header-columns .slick-header-column');
+      const firstHeaderWidth = parseFloat(headerElms[0].style.width || '0');
+      const lastHeaderWidth = parseFloat(headerElms[1].style.width || '0');
+
+      expect(firstHeaderWidth).toBe(80);
+      expect(lastHeaderWidth).toBe(60);
+      expect(firstHeaderWidth - lastHeaderWidth).toBe(20);
+    });
+
     it('should define rowspan and test mandatory rows are always rendered', () => {
       const metadata: any = {
         0: { columns: { 0: { colspan: 2, rowspan: 28 } } },

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -210,6 +210,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected canvas: HTMLCanvasElement | null = null;
   protected canvas_context: CanvasRenderingContext2D | null = null;
+  protected _lastColumnGridMenuCompensation = 2; // when Grid Menu is enabled, we need to compensate the last column width by 2px to give room for the column resize handle between the last column and the grid menu button
 
   // settings
   protected _options!: O;
@@ -1827,7 +1828,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       }
     }
 
-    for (let i = 0; i < this.columns.length; i++) {
+    for (let i = 0, ln = this.columns.length; i < ln; i++) {
       const m: C = this.columns[i];
       if (!m || m.hidden) {
         continue;
@@ -1860,7 +1861,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const colNameElm = createDomElement('span', { className: 'slick-column-name' }, header);
       applyHtmlToElement(colNameElm, m.name, this._options);
 
-      Utils.width(header, m.width! - this.headerColumnWidthDiff);
+      let colWidth = m.width! - this.headerColumnWidthDiff;
+      if (this._options.enableGridMenu && i === ln - 1) {
+        // account for 2px border on last column to give room for the column resize handle between the last column and the grid menu button
+        // scrollbar could be hidden or collapsed (e.g. Firefox) but we still have to compensate for the Grid Menu button width
+        colWidth -= this._lastColumnGridMenuCompensation;
+        if (!this.scrollbarDimensions?.width) {
+          colWidth -= this._options.gridMenu?.menuWidth ?? 18;
+        }
+      }
+      Utils.width(header, colWidth);
 
       let classname = m.headerCssClass || null;
       if (classname) {
@@ -3132,7 +3142,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         for (let i = 0, ln = header.children.length; i < ln; i++, columnIndex++) {
           const h = header.children[i] as HTMLElement;
           const col = vc[columnIndex] || {};
-          const width = (col.width || 0) - this.headerColumnWidthDiff;
+          let width = (col.width || 0) - this.headerColumnWidthDiff;
+          if (this._options.enableGridMenu && i === ln - 1) {
+            // account for 2px border on last column to give room for the column resize handle between the last column and the grid menu button
+            // scrollbar could be hidden or collapsed (e.g. Firefox) but we still have to compensate for the Grid Menu button width
+            width -= this._lastColumnGridMenuCompensation;
+            if (!this.scrollbarDimensions?.width) {
+              width -= this._options.gridMenu?.menuWidth ?? 18;
+            }
+          }
           if (Utils.width(h) !== width) {
             Utils.width(h, width);
           }

--- a/packages/common/src/extensions/slickGridMenu.ts
+++ b/packages/common/src/extensions/slickGridMenu.ts
@@ -58,7 +58,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     hideSyncResizeButton: false,
     forceFitTitle: 'Force fit columns',
     marginBottom: 15,
-    menuWidth: 12,
+    menuWidth: 14,
     minHeight: 150,
     contentMinWidth: 0,
     resizeOnShowHeaderRow: false,
@@ -176,11 +176,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
     emptyElement(this._menuElm, true);
     this._gridMenuButtonElm = null as any;
     this._menuElm = null;
-    if (this._headerElm) {
-      // put back grid header original width (fixes width and frozen+gridMenu on left header)
-      this._headerElm.style.width = '100%';
-      this._headerElm.parentElement?.querySelector('.slick-grid-menu-container')?.remove();
-    }
+    this._headerElm?.parentElement?.querySelector('.slick-grid-menu-container')?.remove();
   }
 
   createColumnPickerContainer(): void {
@@ -892,7 +888,7 @@ export class SlickGridMenu extends MenuBaseClass<GridMenu> {
       forceFitTitle: this.extensionUtility.getPickerTitleOutputString('forceFitTitle', 'gridMenu'),
       syncResizeTitle: this.extensionUtility.getPickerTitleOutputString('syncResizeTitle', 'gridMenu'),
       iconCssClass: 'mdi mdi-menu',
-      menuWidth: 12,
+      menuWidth: 16,
       commandItems: [],
       hideClearAllFiltersCommand: false,
       hideRefreshDatasetCommand: false,

--- a/packages/common/src/global-grid-options.ts
+++ b/packages/common/src/global-grid-options.ts
@@ -235,7 +235,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
     iconToggleDarkModeCommand: 'mdi mdi-brightness-4',
     iconToggleFilterCommand: 'mdi mdi-flip-vertical',
     iconTogglePreHeaderCommand: 'mdi mdi-flip-vertical',
-    menuWidth: 12,
+    menuWidth: 16,
     resizeOnShowHeaderRow: true,
     showBulletWhenIconMissing: true,
     subItemChevronClass: 'mdi mdi-chevron-down mdi-rotate-270',

--- a/packages/common/src/interfaces/gridMenuOption.interface.ts
+++ b/packages/common/src/interfaces/gridMenuOption.interface.ts
@@ -156,7 +156,7 @@ export interface GridMenuOption extends MenuOption<GridMenuCommandItemCallbackAr
    */
   maxHeight?: number | string;
 
-  /** Defaults to 12 pixels (only the number), which is the width in pixels of the Grid Menu icon container */
+  /** Defaults to 16 (number in pixels), which is the width in pixels of the Grid Menu icon container */
   menuWidth?: number;
 
   /**


### PR DESCRIPTION
When we enable the Grid Menu (default), we need to compensate its width and remove it from the calculation on the last column header so that we can see the column resize handle properly. We were previously relying on the scrollbar width calculation (which is nearly the same width as the grid menu icon) **but** Firefox recent version changed their behavior and are now showing what we can call collapsible scrollbar which only show its full width when hovering it. So I can't rely on the scrollbar anymore because it's now returns 0px in Firefox and those users can't resize the last column anymore. 

I also decreased last column width on other browsers as well by 2px, which also helps other browsers like Chrome/Edge to more easily resize the last column as well

### without fix

<img width="1075" height="471" alt="firefox_2Ndl9JRdlE" src="https://github.com/user-attachments/assets/f5610d00-e435-4c93-bc56-c2b29d9b1cff" />

### with fix

<img width="1053" height="455" alt="firefox_dovzg9pYRL" src="https://github.com/user-attachments/assets/4f51389b-4806-4421-89a9-2f2ff88d8c63" />
