### PR TITLE
feat: add `autoScrollOnColumnResize` grid option (default true)

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4641,8 +4641,8 @@ describe('SlickGrid core file', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: false });
       grid.init();
 
-      // Simulate state for the branch: _isResizingLastColumn && hScrollDist && !vScrollDist
-      (grid as any)._isResizingLastColumn = true;
+      // Simulate state for the branch: _isResizingColumn && hScrollDist && !vScrollDist
+      (grid as any)._isResizingColumn = true;
       (grid as any).lastRenderedScrollLeft = 0;
       (grid as any).lastRenderedScrollTop = 0;
       (grid as any).prevScrollTop = 0;

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4536,6 +4536,107 @@ describe('SlickGrid core file', () => {
       expect(columns[4].width).toBe(199);
     });
 
+    it('should auto-scroll while resizing the last visible column when option is enabled', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: false });
+      grid.init();
+
+      const scrollToXSpy = vi.spyOn(grid, 'scrollToX');
+      const viewportX = (grid as any)._viewportScrollContainerX as HTMLDivElement;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 1200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 800 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      const columnElms = container.querySelectorAll('.slick-header-column');
+      const lastColumnElm = columnElms[3];
+      const resizeHandleElm = lastColumnElm.querySelector('.slick-resizable-handle') as HTMLDivElement;
+
+      const cMouseDownEvent = new CustomEvent('mousedown');
+      const bodyMouseMoveEvent = new CustomEvent('mousemove');
+      const bodyMouseUpEvent = new CustomEvent('mouseup');
+      Object.defineProperty(bodyMouseMoveEvent, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(cMouseDownEvent, 'pageX', { writable: true, value: 80 });
+      Object.defineProperty(cMouseDownEvent, 'pageY', { writable: true, value: 12 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageY', { writable: true, value: 13 });
+
+      resizeHandleElm.dispatchEvent(cMouseDownEvent);
+      container.dispatchEvent(cMouseDownEvent);
+      document.body.dispatchEvent(bodyMouseMoveEvent);
+      document.body.dispatchEvent(bodyMouseUpEvent);
+
+      expect(scrollToXSpy).toHaveBeenCalledWith(400);
+    });
+
+    it('should not auto-scroll while resizing the last visible column when option is disabled', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        forceFitColumns: false,
+        autoScrollOnColumnResize: false,
+      });
+      grid.init();
+
+      const scrollToXSpy = vi.spyOn(grid, 'scrollToX');
+      const viewportX = (grid as any)._viewportScrollContainerX as HTMLDivElement;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 1200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 800 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      const columnElms = container.querySelectorAll('.slick-header-column');
+      const lastColumnElm = columnElms[3];
+      const resizeHandleElm = lastColumnElm.querySelector('.slick-resizable-handle') as HTMLDivElement;
+
+      const cMouseDownEvent = new CustomEvent('mousedown');
+      const bodyMouseMoveEvent = new CustomEvent('mousemove');
+      const bodyMouseUpEvent = new CustomEvent('mouseup');
+      Object.defineProperty(bodyMouseMoveEvent, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(cMouseDownEvent, 'pageX', { writable: true, value: 80 });
+      Object.defineProperty(cMouseDownEvent, 'pageY', { writable: true, value: 12 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageY', { writable: true, value: 13 });
+
+      resizeHandleElm.dispatchEvent(cMouseDownEvent);
+      container.dispatchEvent(cMouseDownEvent);
+      document.body.dispatchEvent(bodyMouseMoveEvent);
+      document.body.dispatchEvent(bodyMouseUpEvent);
+
+      expect(scrollToXSpy).not.toHaveBeenCalledWith(400);
+    });
+
+    it('should auto-scroll while resizing the last visible column when frozenColumn is enabled', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        forceFitColumns: false,
+        frozenColumn: 0,
+      });
+      grid.init();
+
+      const scrollToXSpy = vi.spyOn(grid, 'scrollToX');
+      const viewportX = (grid as any)._viewportScrollContainerX as HTMLDivElement;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 1200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 800 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      const columnElms = container.querySelectorAll('.slick-header-column');
+      const lastColumnElm = columnElms[3];
+      const resizeHandleElm = lastColumnElm.querySelector('.slick-resizable-handle') as HTMLDivElement;
+
+      const cMouseDownEvent = new CustomEvent('mousedown');
+      const bodyMouseMoveEvent = new CustomEvent('mousemove');
+      const bodyMouseUpEvent = new CustomEvent('mouseup');
+      Object.defineProperty(bodyMouseMoveEvent, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(cMouseDownEvent, 'pageX', { writable: true, value: 80 });
+      Object.defineProperty(cMouseDownEvent, 'pageY', { writable: true, value: 12 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageY', { writable: true, value: 13 });
+
+      resizeHandleElm.dispatchEvent(cMouseDownEvent);
+      container.dispatchEvent(cMouseDownEvent);
+      document.body.dispatchEvent(bodyMouseMoveEvent);
+      document.body.dispatchEvent(bodyMouseUpEvent);
+
+      expect(scrollToXSpy).toHaveBeenCalledWith(400);
+    });
+
     it('should expect the last column to never be resizable', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: true });
       grid.init();

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4637,6 +4637,48 @@ describe('SlickGrid core file', () => {
       expect(scrollToXSpy).toHaveBeenCalledWith(400);
     });
 
+    it('should trigger onViewportChanged and return true when resizing last column and only horizontal scroll occurs', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: false });
+      grid.init();
+
+      // Simulate state for the branch: _isResizingLastColumn && hScrollDist && !vScrollDist
+      (grid as any)._isResizingLastColumn = true;
+      (grid as any).lastRenderedScrollLeft = 0;
+      (grid as any).lastRenderedScrollTop = 0;
+      (grid as any).prevScrollTop = 0;
+      (grid as any).scrollTop = 0;
+
+      // Ensure scroll bounds allow scrollLeft = 100
+      (grid as any).canvasWidth = 200;
+      if (!(grid as any)._viewportScrollContainerX) {
+        (grid as any)._viewportScrollContainerX = document.createElement('div');
+      }
+      const viewportX = (grid as any)._viewportScrollContainerX;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 50 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      // Set prevScrollLeft and scrollLeft right before dispatching scroll event
+      (grid as any).prevScrollLeft = 0;
+      viewportX.scrollLeft = 100;
+      (grid as any).scrollLeft = 100;
+
+      // Stub scrollToX to avoid side effects
+      vi.spyOn(grid as any, 'scrollToX').mockImplementation(() => {});
+
+      const onViewportChangedSpy = vi.spyOn(grid, 'triggerEvent');
+
+      // Dispatch a real scroll event on the viewport element
+      const scrollEvent = new Event('scroll');
+      viewportX.dispatchEvent(scrollEvent);
+      // Call handleScroll to simulate the grid's scroll handler
+      (grid as any).handleScroll(scrollEvent);
+
+      // Should update lastRenderedScrollLeft, trigger onViewportChanged
+      expect((grid as any).lastRenderedScrollLeft).toBe(100);
+      expect(onViewportChangedSpy).toHaveBeenCalledWith(grid.onViewportChanged, expect.anything());
+    });
+
     it('should expect the last column to never be resizable', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: true });
       grid.init();

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -210,6 +210,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected canvas: HTMLCanvasElement | null = null;
   protected canvas_context: CanvasRenderingContext2D | null = null;
+  protected _isResizingLastColumn = false;
   protected _lastColumnGridMenuCompensation = 2; // when Grid Menu is enabled, we need to compensate the last column width by 2px to give room for the column resize handle between the last column and the grid menu button
 
   // settings
@@ -244,6 +245,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     asyncEditorLoading: false,
     asyncEditorLoadDelay: 100,
     forceFitColumns: false,
+    autoScrollOnColumnResize: true,
     enableAsyncPostRender: false,
     asyncPostRenderDelay: 50,
     enableAsyncPostRenderCleanup: false,
@@ -1391,8 +1393,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const oldCanvasWidthR = this.canvasWidthR;
     this.canvasWidth = this.getCanvasWidth();
 
-    if (this._options.createTopHeaderPanel) {
-      Utils.width(this._topHeaderPanel, this._options.topHeaderPanelWidth ?? this.canvasWidth);
+    if (this._options.createTopHeaderPanel && !this._isResizingLastColumn) {
+      const panelWidth = this._options.topHeaderPanelWidth ?? this.canvasWidth;
+      this._topHeaderPanel.style.width = typeof panelWidth === 'string' ? panelWidth : `${panelWidth}px`;
     }
     const widthChanged =
       this.canvasWidth !== oldCanvasWidth || this.canvasWidthL !== oldCanvasWidthL || this.canvasWidthR !== oldCanvasWidthR;
@@ -1429,8 +1432,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           Utils.width(this._footerRowL, this.canvasWidthL);
           Utils.width(this._footerRowR, this.canvasWidthR);
         }
-        if (this._options.createPreHeaderPanel) {
-          Utils.width(this._preHeaderPanel, this._options.preHeaderPanelWidth ?? this.canvasWidth);
+        if (this._options.createPreHeaderPanel && !this._isResizingLastColumn) {
+          const panelWidth = this._options.preHeaderPanelWidth ?? this.canvasWidth;
+          this._preHeaderPanel.style.width = typeof panelWidth === 'string' ? panelWidth : `${panelWidth}px`;
         }
         Utils.width(this._viewportTopL, this.canvasWidthL);
         Utils.width(this._viewportTopR, this.viewportW - this.canvasWidthL);
@@ -1456,8 +1460,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           Utils.width(this._footerRowL, this.canvasWidth);
         }
 
-        if (this._options.createPreHeaderPanel) {
-          Utils.width(this._preHeaderPanel, this._options.preHeaderPanelWidth ?? this.canvasWidth);
+        if (this._options.createPreHeaderPanel && !this._isResizingLastColumn) {
+          const panelWidth = this._options.preHeaderPanelWidth ?? this.canvasWidth;
+          this._preHeaderPanel.style.width = typeof panelWidth === 'string' ? panelWidth : `${panelWidth}px`;
         }
         Utils.width(this._viewportTopL, '100%');
 
@@ -2523,12 +2528,24 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             if (this._options.syncColumnCellResize) {
               this.applyColumnWidths();
             }
+
+            // keep drag experience smooth by auto-scrolling when stretching the last visible column
+            if (this._options.autoScrollOnColumnResize && !this._options.forceFitColumns && i === vc.length - 1 && d > 0) {
+              this._isResizingLastColumn = true;
+              this.updateCanvasWidth();
+              const maxScrollLeft = Math.max(0, this._viewportScrollContainerX.scrollWidth - this._viewportScrollContainerX.clientWidth);
+              if (this._viewportScrollContainerX.scrollLeft < maxScrollLeft) {
+                this.scrollToX(maxScrollLeft);
+              }
+            }
+
             this.triggerEvent(this.onColumnsDrag, {
               triggeredByColumn: resizeElms.resizeableElement,
               resizeHandle: resizeElms.resizeableHandleElement,
             });
           },
           onResizeEnd: (_e, resizeElms) => {
+            this._isResizingLastColumn = false;
             resizeElms.resizeableElement.classList.remove('slick-header-column-active');
 
             const triggeredByColumn = resizeElms.resizeableElement.id.replace(this.uid, '');
@@ -2548,6 +2565,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             }
             this.updateCanvasWidth(true);
             this.render();
+            this.scrollToX(this._viewportScrollContainerX.scrollLeft);
             this.triggerEvent(this.onColumnsResized, { triggeredByColumn });
             clearTimeout(this._columnResizeTimer);
             this._columnResizeTimer = setTimeout(() => (this.columnResizeDragging = false), this._options.columnResizingDelay);
@@ -5436,6 +5454,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const dx = Math.abs(this.lastRenderedScrollLeft - this.scrollLeft);
       const dy = Math.abs(this.lastRenderedScrollTop - this.scrollTop);
       if (dx > 20 || dy > 20) {
+        if (this._isResizingLastColumn && hScrollDist && !vScrollDist) {
+          this.lastRenderedScrollLeft = this.scrollLeft;
+          this.triggerEvent(this.onViewportChanged, {});
+          return true;
+        }
+
         // if rendering is forced or scrolling is small enough to be "easy", just render
         if (this._options.forceSyncScrolling || (dy < this.viewportH && dx < this.viewportW)) {
           this.render();

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -210,7 +210,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   protected canvas: HTMLCanvasElement | null = null;
   protected canvas_context: CanvasRenderingContext2D | null = null;
-  protected _isResizingLastColumn = false;
+  protected _isResizingColumn = false;
   protected _lastColumnGridMenuCompensation = 2; // when Grid Menu is enabled, we need to compensate the last column width by 2px to give room for the column resize handle between the last column and the grid menu button
 
   // settings
@@ -1393,7 +1393,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const oldCanvasWidthR = this.canvasWidthR;
     this.canvasWidth = this.getCanvasWidth();
 
-    if (this._options.createTopHeaderPanel && !this._isResizingLastColumn) {
+    if (this._options.createTopHeaderPanel && !this._isResizingColumn) {
       const panelWidth = this._options.topHeaderPanelWidth ?? this.canvasWidth;
       this._topHeaderPanel.style.width = typeof panelWidth === 'string' ? panelWidth : `${panelWidth}px`;
     }
@@ -1432,7 +1432,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           Utils.width(this._footerRowL, this.canvasWidthL);
           Utils.width(this._footerRowR, this.canvasWidthR);
         }
-        if (this._options.createPreHeaderPanel && !this._isResizingLastColumn) {
+        if (this._options.createPreHeaderPanel && !this._isResizingColumn) {
           const panelWidth = this._options.preHeaderPanelWidth ?? this.canvasWidth;
           this._preHeaderPanel.style.width = typeof panelWidth === 'string' ? panelWidth : `${panelWidth}px`;
         }
@@ -1460,7 +1460,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           Utils.width(this._footerRowL, this.canvasWidth);
         }
 
-        if (this._options.createPreHeaderPanel && !this._isResizingLastColumn) {
+        if (this._options.createPreHeaderPanel && !this._isResizingColumn) {
           const panelWidth = this._options.preHeaderPanelWidth ?? this.canvasWidth;
           this._preHeaderPanel.style.width = typeof panelWidth === 'string' ? panelWidth : `${panelWidth}px`;
         }
@@ -2529,13 +2529,23 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
               this.applyColumnWidths();
             }
 
-            // keep drag experience smooth by auto-scrolling when stretching the last visible column
-            if (this._options.autoScrollOnColumnResize && !this._options.forceFitColumns && i === vc.length - 1 && d > 0) {
-              this._isResizingLastColumn = true;
-              this.updateCanvasWidth();
-              const maxScrollLeft = Math.max(0, this._viewportScrollContainerX.scrollWidth - this._viewportScrollContainerX.clientWidth);
-              if (this._viewportScrollContainerX.scrollLeft < maxScrollLeft) {
+            // Always update canvas width during column resize (restores previous behavior for fixed grid widths)
+            this.updateCanvasWidth();
+            // Hybrid auto-scroll logic:
+            // - For last visible column, always scroll to maxScrollLeft (legacy behavior, fixes test)
+            // - For other columns, scroll just enough to bring right edge into view
+            if (this._options.autoScrollOnColumnResize && !this._options.forceFitColumns) {
+              const columnRight = this.columnPosRight[i];
+              const scrollLeft = this._viewportScrollContainerX.scrollLeft;
+              const viewportWidth = this._viewportScrollContainerX.clientWidth;
+              const isLastVisibleColumn = i === vc.length - 1;
+              if (isLastVisibleColumn) {
+                this._isResizingColumn = true;
+                const maxScrollLeft = Math.max(0, this._viewportScrollContainerX.scrollWidth - this._viewportScrollContainerX.clientWidth);
                 this.scrollToX(maxScrollLeft);
+              } else if (columnRight > scrollLeft + viewportWidth) {
+                this._isResizingColumn = true;
+                this.scrollToX(columnRight - viewportWidth);
               }
             }
 
@@ -2545,7 +2555,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             });
           },
           onResizeEnd: (_e, resizeElms) => {
-            this._isResizingLastColumn = false;
+            this._isResizingColumn = false;
             resizeElms.resizeableElement.classList.remove('slick-header-column-active');
 
             const triggeredByColumn = resizeElms.resizeableElement.id.replace(this.uid, '');
@@ -5454,7 +5464,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const dx = Math.abs(this.lastRenderedScrollLeft - this.scrollLeft);
       const dy = Math.abs(this.lastRenderedScrollTop - this.scrollTop);
       if (dx > 20 || dy > 20) {
-        if (this._isResizingLastColumn && hScrollDist && !vScrollDist) {
+        if (this._isResizingColumn && hScrollDist && !vScrollDist) {
           this.lastRenderedScrollLeft = this.scrollLeft;
           this.triggerEvent(this.onViewportChanged, {});
           return true;

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -162,7 +162,7 @@ export interface GridOption<C extends Column = Column> {
   /** Auto-resize options (bottom padding, minHeight, ...)  */
   autoResize?: AutoResizeOption;
 
-  /** Defaults to true, auto-scroll the grid horizontally while stretching the last visible column resize handle. */
+  /** Defaults to true, auto-scrolls horizontally to keep the resized column visible (last column scrolls to max for legacy compatibility). */
   autoScrollOnColumnResize?: boolean;
 
   /** Auto-tooltip options (enableForCells, enableForHeaderCells, maxToolTipLength) */

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -162,6 +162,9 @@ export interface GridOption<C extends Column = Column> {
   /** Auto-resize options (bottom padding, minHeight, ...)  */
   autoResize?: AutoResizeOption;
 
+  /** Defaults to true, auto-scroll the grid horizontally while stretching the last visible column resize handle. */
+  autoScrollOnColumnResize?: boolean;
+
   /** Auto-tooltip options (enableForCells, enableForHeaderCells, maxToolTipLength) */
   autoTooltipOptions?: AutoTooltipOption;
 


### PR DESCRIPTION
Defaults to true, auto-scrolls horizontally to keep the resized column visible (last column scrolls to max for legacy compatibility).

This was related to a PR opened in MSSQL extension, they added the feature through a SlickGrid plugin but I can do it directly in the core with less than 20 lines.

~**Note** this only applies to the last column resizing.~ actually let's make it auto-scroll for any column that goes outside the viewport on the right (not just on last column)

<img width="1386" height="493" alt="firefox_nkPL3ufTpU" src="https://github.com/user-attachments/assets/250bb409-999a-456e-8551-fc74b5881af5" />