### PR TITLE
chore(deps): update to latest Cypress version that fully supports TS 6

### DIFF
--- a/demos/aurelia/test/cypress.config.ts
+++ b/demos/aurelia/test/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  allowCypressEnv: false,
   projectId: 'gtbpy4',
   video: false,
   viewportWidth: 1200,

--- a/demos/aurelia/test/cypress/tsconfig.json
+++ b/demos/aurelia/test/cypress/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "esModuleInterop": true,
     "lib": ["es2021", "dom"],

--- a/demos/react/test/cypress.config.ts
+++ b/demos/react/test/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  allowCypressEnv: false,
   projectId: 'wmnjof',
   video: false,
   viewportWidth: 1200,

--- a/demos/react/test/cypress/tsconfig.json
+++ b/demos/react/test/cypress/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "esModuleInterop": true,
     "lib": ["es2021", "dom"],

--- a/demos/vue/test/cypress.config.mjs
+++ b/demos/vue/test/cypress.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  allowCypressEnv: false,
   video: false,
   viewportWidth: 1200,
   viewportHeight: 1020,

--- a/demos/vue/test/cypress/tsconfig.json
+++ b/demos/vue/test/cypress/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "esModuleInterop": true,
     "lib": ["es2021", "dom"],

--- a/frameworks/angular-slickgrid/test/cypress.config.ts
+++ b/frameworks/angular-slickgrid/test/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  allowCypressEnv: false,
   projectId: 'hqnfoi',
   video: false,
   viewportWidth: 1200,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,14 +58,17 @@ catalogs:
       specifier: ^10.1.0
       version: 10.1.0
     cypress:
-      specifier: ^15.13.1
-      version: 15.13.1
+      specifier: ^15.14.0
+      version: 15.14.0
     cypress-real-events:
       specifier: ^1.15.0
       version: 1.15.0
     dequal:
       specifier: ^2.0.3
       version: 2.0.3
+    dompurify:
+      specifier: ^3.3.3
+      version: 3.4.0
     globals:
       specifier: ^17.4.0
       version: 17.4.0
@@ -149,7 +152,7 @@ importers:
     devDependencies:
       '@4tw/cypress-drag-drop':
         specifier: 'catalog:'
-        version: 2.3.1(cypress@15.13.1)
+        version: 2.3.1(cypress@15.14.0)
       '@formkit/tempo':
         specifier: 'catalog:'
         version: 1.0.0
@@ -191,10 +194,10 @@ importers:
         version: 10.1.0
       cypress:
         specifier: 'catalog:'
-        version: 15.13.1
+        version: 15.14.0
       cypress-real-events:
         specifier: 'catalog:'
-        version: 1.15.0(cypress@15.13.1)
+        version: 1.15.0(cypress@15.14.0)
       eslint-plugin-cypress:
         specifier: ^6.2.3
         version: 6.3.0(eslint@9.39.2(jiti@2.6.1))
@@ -345,10 +348,10 @@ importers:
         version: 1.3.4
       cypress:
         specifier: 'catalog:'
-        version: 15.13.1
+        version: 15.14.0
       cypress-real-events:
         specifier: 'catalog:'
-        version: 1.15.0(cypress@15.13.1)
+        version: 1.15.0(cypress@15.14.0)
       dompurify:
         specifier: 'catalog:'
         version: 3.4.0
@@ -442,7 +445,7 @@ importers:
     devDependencies:
       '@4tw/cypress-drag-drop':
         specifier: 'catalog:'
-        version: 2.3.1(cypress@15.13.1)
+        version: 2.3.1(cypress@15.14.0)
       '@faker-js/faker':
         specifier: 'catalog:'
         version: 10.4.0
@@ -475,10 +478,10 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.15)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.99.0)(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.99.0)(terser@5.46.0)(yaml@2.8.3))
       cypress:
         specifier: 'catalog:'
-        version: 15.13.1
+        version: 15.14.0
       cypress-real-events:
         specifier: 'catalog:'
-        version: 1.15.0(cypress@15.13.1)
+        version: 1.15.0(cypress@15.14.0)
       globals:
         specifier: 'catalog:'
         version: 17.4.0
@@ -763,7 +766,7 @@ importers:
     devDependencies:
       '@4tw/cypress-drag-drop':
         specifier: 'catalog:'
-        version: 2.3.1(cypress@15.13.1)
+        version: 2.3.1(cypress@15.14.0)
       '@types/fnando__sparkline':
         specifier: 'catalog:'
         version: 0.3.7
@@ -772,10 +775,10 @@ importers:
         version: 6.0.5(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.99.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
       cypress:
         specifier: 'catalog:'
-        version: 15.13.1
+        version: 15.14.0
       cypress-real-events:
         specifier: 'catalog:'
-        version: 1.15.0(cypress@15.13.1)
+        version: 1.15.0(cypress@15.14.0)
       sass:
         specifier: 'catalog:'
         version: 1.99.0
@@ -937,7 +940,7 @@ importers:
     devDependencies:
       '@4tw/cypress-drag-drop':
         specifier: 'catalog:'
-        version: 2.3.1(cypress@15.13.1)
+        version: 2.3.1(cypress@15.14.0)
       '@angular-eslint/eslint-plugin':
         specifier: 'catalog:'
         version: 21.3.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -1042,10 +1045,10 @@ importers:
         version: 5.3.8(@popperjs/core@2.11.8)
       cypress:
         specifier: 'catalog:'
-        version: 15.13.1
+        version: 15.14.0
       cypress-real-events:
         specifier: 'catalog:'
-        version: 1.15.0(cypress@15.13.1)
+        version: 1.15.0(cypress@15.14.0)
       dompurify:
         specifier: 'catalog:'
         version: 3.4.0
@@ -5169,8 +5172,8 @@ packages:
     peerDependencies:
       cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x || ^15.x
 
-  cypress@15.13.1:
-    resolution: {integrity: sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==}
+  cypress@15.14.0:
+    resolution: {integrity: sha512-AHt9YLKVl6uOFfXsLM3+LSZFwsx36BJRyFv4CjsqcRgr+V9kir0IPVRZUgqZVNudRalx771A1c4yR3DmXvSiBQ==}
     engines: {node: ^20.1.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
 
@@ -8311,9 +8314,9 @@ packages:
 
 snapshots:
 
-  '@4tw/cypress-drag-drop@2.3.1(cypress@15.13.1)':
+  '@4tw/cypress-drag-drop@2.3.1(cypress@15.14.0)':
     dependencies:
-      cypress: 15.13.1
+      cypress: 15.14.0
 
   '@algolia/abtesting@1.14.1':
     dependencies:
@@ -12644,11 +12647,11 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cypress-real-events@1.15.0(cypress@15.13.1):
+  cypress-real-events@1.15.0(cypress@15.14.0):
     dependencies:
-      cypress: 15.13.1
+      cypress: 15.14.0
 
-  cypress@15.13.1:
+  cypress@15.14.0:
     dependencies:
       '@cypress/request': 3.0.10
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   '@vitest/ui': ^4.1.4
   bootstrap: ^5.3.8
   cross-env: ^10.1.0
-  cypress: ^15.13.1
+  cypress: ^15.14.0
   cypress-real-events: ^1.15.0
   dequal: ^2.0.3
   dompurify: ^3.3.3

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  allowCypressEnv: false,
   video: false,
   projectId: 'p5zxx6',
   viewportWidth: 1200,

--- a/test/cypress/tsconfig.json
+++ b/test/cypress/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "esModuleInterop": true,
     "lib": ["es2021", "dom"],


### PR DESCRIPTION
Cypress now officially supports TypeScript v6, so we can get rid of all the `"ignoreDeprecations": "6.0"` flags in Cypress `tsconfig.json` files.