### PR TITLE
fix: column reorder requires  SortableJS fallback for Firefox/Linux

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2138,7 +2138,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       ghostClass: 'slick-sortable-placeholder',
       draggable: '.slick-header-column',
       dragoverBubble: false,
-      preventOnFilter: false, // allow column to be resized even when they are not orderable
+      // Fixes broken Firefox-Linux dragging
+      forceFallback: /firefox/i.test(navigator.userAgent) && /linux/i.test(navigator.userAgent),
+      // allow column to be resized even when they are not orderable
+      preventOnFilter: false,
       revertClone: true,
       scroll: !this.hasFrozenColumns(), // enable auto-scroll
       // lock unorderable columns by using a combo of filter + onMove

--- a/packages/common/src/extensions/slickDraggableGrouping.ts
+++ b/packages/common/src/extensions/slickDraggableGrouping.ts
@@ -323,6 +323,8 @@ export class SlickDraggableGrouping {
         pull: 'clone',
         put: false,
       },
+      // Fixes broken Firefox-Linux dragging
+      forceFallback: /firefox/i.test(navigator.userAgent) && /linux/i.test(navigator.userAgent),
       revertClone: true,
       // filter: function (_e, target) {
       //   // block column from being able to be dragged if it's already a grouped column


### PR DESCRIPTION
found that SortableJS column reorder didn't work in Firefox Linux and requires a `forceFallback` 