### PR TITLE
fix(core): column resize auto-scroll should work outside browser webview

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4769,6 +4769,44 @@ describe('SlickGrid core file', () => {
       document.body.dispatchEvent(upEvt);
     });
 
+    it('should trigger accelerated auto-scroll when resizing column inside grid (non-browser-edge)', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        forceFitColumns: false,
+        autoScrollOnColumnResize: true,
+      });
+      grid.init();
+
+      const onColumnsDragSpy = vi.spyOn(grid.onColumnsDrag, 'notify');
+      const viewportX = (grid as any)._viewportScrollContainerX as HTMLDivElement;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 1200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 800 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      const columnElms = container.querySelectorAll('.slick-header-column');
+      const lastColumnElm = columnElms[3];
+      const resizeHandleElm = lastColumnElm.querySelector('.slick-resizable-handle') as HTMLDivElement;
+
+      const cMouseDownEvent = new CustomEvent('mousedown');
+      const bodyMouseMoveEvent = new CustomEvent('mousemove');
+      Object.defineProperty(bodyMouseMoveEvent, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(cMouseDownEvent, 'pageX', { writable: true, value: 80 });
+      Object.defineProperty(cMouseDownEvent, 'pageY', { writable: true, value: 12 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageY', { writable: true, value: 13 });
+      // Simulate pointer inside grid, not at browser edge
+      Object.defineProperty(bodyMouseMoveEvent, 'clientX', { writable: true, value: 400 });
+
+      resizeHandleElm.dispatchEvent(cMouseDownEvent);
+      container.dispatchEvent(cMouseDownEvent);
+      document.body.dispatchEvent(bodyMouseMoveEvent);
+
+      // Advance timers to trigger the accelerated auto-scroll branch
+      vi.advanceTimersByTime(200);
+      expect(onColumnsDragSpy).toHaveBeenCalled();
+      document.body.dispatchEvent(new CustomEvent('mouseup'));
+    });
+
     it('should trigger onViewportChanged and return true when resizing last column and only horizontal scroll occurs', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: false });
       grid.init();

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4637,6 +4637,138 @@ describe('SlickGrid core file', () => {
       expect(scrollToXSpy).toHaveBeenCalledWith(400);
     });
 
+    it('should use autoScrollResizeRightDelay when resize continues from browser right edge', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        forceFitColumns: false,
+        autoScrollResizeRightDelay: 120,
+      });
+      grid.init();
+
+      const onColumnsDragSpy = vi.spyOn(grid.onColumnsDrag, 'notify');
+      const viewportX = (grid as any)._viewportScrollContainerX as HTMLDivElement;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 1200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 800 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      const columnElms = container.querySelectorAll('.slick-header-column');
+      const lastColumnElm = columnElms[3];
+      const resizeHandleElm = lastColumnElm.querySelector('.slick-resizable-handle') as HTMLDivElement;
+
+      const cMouseDownEvent = new CustomEvent('mousedown');
+      const bodyMouseMoveEvent = new CustomEvent('mousemove');
+      const bodyMouseUpEvent = new CustomEvent('mouseup');
+      Object.defineProperty(bodyMouseMoveEvent, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(cMouseDownEvent, 'pageX', { writable: true, value: 80 });
+      Object.defineProperty(cMouseDownEvent, 'pageY', { writable: true, value: 12 });
+      Object.defineProperty(cMouseDownEvent, 'clientX', { writable: true, value: 120 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(bodyMouseMoveEvent, 'pageY', { writable: true, value: 13 });
+      Object.defineProperty(bodyMouseMoveEvent, 'clientX', {
+        writable: true,
+        value: (window.innerWidth || document.documentElement.clientWidth || 1024) - 1,
+      });
+
+      resizeHandleElm.dispatchEvent(cMouseDownEvent);
+      container.dispatchEvent(cMouseDownEvent);
+      document.body.dispatchEvent(bodyMouseMoveEvent);
+
+      const dragCallCountAfterMove = onColumnsDragSpy.mock.calls.length;
+
+      // The minimal auto-scroll logic triggers the callback every 30ms (RESIZE_AUTOSCROLL_MIN_INTERVAL_MS),
+      // so after 90ms, we expect 4 calls (initial + 3 intervals)
+      vi.advanceTimersByTime(90);
+      expect(onColumnsDragSpy.mock.calls.length).toBe(4);
+
+      vi.advanceTimersByTime(40);
+      expect(onColumnsDragSpy.mock.calls.length).toBeGreaterThan(dragCallCountAfterMove);
+
+      document.body.dispatchEvent(bodyMouseUpEvent);
+    });
+
+    it('should clear any existing resize auto-scroll timer when setting up column resize and when clearing all timers', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: false });
+      grid.init();
+
+      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+      const timerId = setInterval(() => {}, 1000);
+      (grid as any)._columnResizeAutoScrollTimer = timerId;
+
+      (grid as any).setupColumnResize();
+      expect(clearIntervalSpy).toHaveBeenCalledWith(timerId);
+      expect((grid as any)._columnResizeAutoScrollTimer).toBeUndefined();
+
+      const timerId2 = setInterval(() => {}, 1000);
+      (grid as any)._columnResizeAutoScrollTimer = timerId2;
+      (grid as any).clearAllTimers();
+      expect(clearIntervalSpy).toHaveBeenCalledWith(timerId2);
+      expect((grid as any)._columnResizeAutoScrollTimer).toBeUndefined();
+
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('should keep resize auto-scroll timer idle when offset becomes zero and stop it when pointer returns inside viewport', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        forceFitColumns: false,
+        autoScrollResizeRightDelay: 60,
+      });
+      grid.init();
+
+      const onColumnsDragSpy = vi.spyOn(grid.onColumnsDrag, 'notify');
+      const viewportX = (grid as any)._viewportScrollContainerX as HTMLDivElement;
+      Object.defineProperty(viewportX, 'scrollWidth', { configurable: true, writable: true, value: 1200 });
+      Object.defineProperty(viewportX, 'clientWidth', { configurable: true, writable: true, value: 800 });
+      Object.defineProperty(viewportX, 'scrollLeft', { configurable: true, writable: true, value: 0 });
+
+      const columnElms = container.querySelectorAll('.slick-header-column');
+      const lastColumnElm = columnElms[3];
+      const resizeHandleElm = lastColumnElm.querySelector('.slick-resizable-handle') as HTMLDivElement;
+
+      const downEvt = new CustomEvent('mousedown');
+      Object.defineProperty(downEvt, 'pageX', { writable: true, value: 80 });
+      Object.defineProperty(downEvt, 'pageY', { writable: true, value: 12 });
+      Object.defineProperty(downEvt, 'clientX', { writable: true, value: 100 });
+
+      const moveRightEdgeEvt = new CustomEvent('mousemove');
+      Object.defineProperty(moveRightEdgeEvt, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(moveRightEdgeEvt, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(moveRightEdgeEvt, 'pageY', { writable: true, value: 13 });
+      Object.defineProperty(moveRightEdgeEvt, 'clientX', {
+        writable: true,
+        value: (window.innerWidth || document.documentElement.clientWidth || 1024) - 1,
+      });
+
+      const moveZeroOffsetEvt = new CustomEvent('mousemove');
+      Object.defineProperty(moveZeroOffsetEvt, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(moveZeroOffsetEvt, 'pageX', { writable: true, value: 0 });
+      Object.defineProperty(moveZeroOffsetEvt, 'pageY', { writable: true, value: 13 });
+      Object.defineProperty(moveZeroOffsetEvt, 'clientX', { writable: true, value: 200 });
+
+      const moveInsideEvt = new CustomEvent('mousemove');
+      Object.defineProperty(moveInsideEvt, 'target', { writable: true, value: resizeHandleElm });
+      Object.defineProperty(moveInsideEvt, 'pageX', { writable: true, value: 140 });
+      Object.defineProperty(moveInsideEvt, 'pageY', { writable: true, value: 13 });
+      Object.defineProperty(moveInsideEvt, 'clientX', { writable: true, value: 200 });
+
+      const upEvt = new CustomEvent('mouseup');
+
+      resizeHandleElm.dispatchEvent(downEvt);
+      container.dispatchEvent(downEvt);
+      document.body.dispatchEvent(moveRightEdgeEvt);
+      expect((grid as any)._columnResizeAutoScrollTimer).toBeDefined();
+
+      document.body.dispatchEvent(moveZeroOffsetEvt);
+      const dragCountBeforeIdleTick = onColumnsDragSpy.mock.calls.length;
+      vi.advanceTimersByTime(30);
+      expect(onColumnsDragSpy.mock.calls.length).toBe(dragCountBeforeIdleTick);
+
+      document.body.dispatchEvent(moveInsideEvt);
+      expect((grid as any)._columnResizeAutoScrollTimer).toBeUndefined();
+
+      document.body.dispatchEvent(upEvt);
+    });
+
     it('should trigger onViewportChanged and return true when resizing last column and only horizontal scroll occurs', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, forceFitColumns: false });
       grid.init();

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -235,14 +235,21 @@ describe('MouseWheel class', () => {
 describe('Resizable class', () => {
   let rsz: any;
   let containerElement: HTMLDivElement;
+  let previousPointerEvent: typeof window.PointerEvent | undefined;
 
   beforeEach(() => {
+    previousPointerEvent = (window as any).PointerEvent;
     containerElement = document.createElement('div');
     containerElement.className = 'slick-container';
   });
 
   afterEach(() => {
     rsz?.destroy();
+    if (previousPointerEvent) {
+      (window as any).PointerEvent = previousPointerEvent;
+    } else {
+      delete (window as any).PointerEvent;
+    }
   });
 
   it('should be able to instantiate the class', () => {
@@ -258,7 +265,7 @@ describe('Resizable class', () => {
     expect(() => Resizable({} as any)).toThrow('[SlickResizable] You did not provide a valid html element that will be used for the handle to resize.');
   });
 
-  it('should trigger mousedown and expect a dragInit and a dragStart and drag to all happen since it was triggered by an allowed element and we did move afterward', () => {
+  it('should trigger resize callbacks on start, move and end interactions', () => {
     const resizeSpy = vi.fn();
     const resizeStartSpy = vi.fn();
     const resizeEndSpy = vi.fn();
@@ -272,23 +279,221 @@ describe('Resizable class', () => {
       onResizeEnd: resizeEndSpy,
     });
 
-    const mdEvt = new MouseEvent('mousedown');
-    Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
-    Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
-    containerElement.dispatchEvent(mdEvt);
+    const hasPointerEvents = typeof window !== 'undefined' && 'PointerEvent' in window;
 
-    const mmEvt = new MouseEvent('mousemove');
-    const muEvt = new MouseEvent('mouseup');
-    Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
-    Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
-    Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });
-    Object.defineProperty(muEvt, 'clientY', { writable: true, configurable: true, value: 10 });
-    document.body.dispatchEvent(mmEvt);
-    document.body.dispatchEvent(muEvt);
+    if (hasPointerEvents) {
+      const pointerDownEvt = new Event('pointerdown');
+      Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+      Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 0 });
+      Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 1 });
+
+      const pointerMoveEvt = new Event('pointermove');
+      Object.defineProperty(pointerMoveEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+      Object.defineProperty(pointerMoveEvt, 'pointerId', { writable: true, configurable: true, value: 1 });
+
+      const pointerUpEvt = new Event('pointerup');
+      Object.defineProperty(pointerUpEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+      Object.defineProperty(pointerUpEvt, 'pointerId', { writable: true, configurable: true, value: 1 });
+
+      containerElement.dispatchEvent(pointerDownEvt);
+      containerElement.dispatchEvent(pointerMoveEvt);
+      containerElement.dispatchEvent(pointerUpEvt);
+    } else {
+      const mdEvt = new MouseEvent('mousedown');
+      Object.defineProperty(mdEvt, 'clientX', { writable: true, configurable: true, value: 10 });
+      Object.defineProperty(mdEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+      containerElement.dispatchEvent(mdEvt);
+
+      const mmEvt = new MouseEvent('mousemove');
+      const muEvt = new MouseEvent('mouseup');
+      Object.defineProperty(mmEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+      Object.defineProperty(mmEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+      Object.defineProperty(muEvt, 'clientX', { writable: true, configurable: true, value: 12 });
+      Object.defineProperty(muEvt, 'clientY', { writable: true, configurable: true, value: 10 });
+      document.body.dispatchEvent(mmEvt);
+      document.body.dispatchEvent(muEvt);
+    }
 
     expect(rsz).toBeTruthy();
-    expect(resizeStartSpy).toHaveBeenCalledWith(mdEvt, { resizeableElement: containerElement, resizeableHandleElement: containerElement });
+    expect(resizeStartSpy).toHaveBeenCalledTimes(1);
     expect(resizeSpy).toHaveBeenCalled();
     expect(resizeEndSpy).toHaveBeenCalled();
+  });
+
+  it('should use pointer events and call resize callbacks with pointer capture', () => {
+    const resizeSpy = vi.fn();
+    const resizeStartSpy = vi.fn();
+    const resizeEndSpy = vi.fn();
+    const setPointerCaptureSpy = vi.fn();
+    const releasePointerCaptureSpy = vi.fn();
+    const hasPointerCaptureSpy = vi.fn().mockReturnValue(true);
+
+    (window as any).PointerEvent = class PointerEventMock extends Event {};
+    (containerElement as any).setPointerCapture = setPointerCaptureSpy;
+    (containerElement as any).releasePointerCapture = releasePointerCaptureSpy;
+    (containerElement as any).hasPointerCapture = hasPointerCaptureSpy;
+
+    rsz = Resizable({
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+      onResize: resizeSpy,
+      onResizeStart: resizeStartSpy,
+      onResizeEnd: resizeEndSpy,
+    });
+
+    const pointerDownEvt = new Event('pointerdown');
+    Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 1 });
+
+    const pointerMoveEvt = new Event('pointermove');
+    Object.defineProperty(pointerMoveEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerMoveEvt, 'pointerId', { writable: true, configurable: true, value: 1 });
+
+    const pointerUpEvt = new Event('pointerup');
+    Object.defineProperty(pointerUpEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerUpEvt, 'pointerId', { writable: true, configurable: true, value: 1 });
+
+    containerElement.dispatchEvent(pointerDownEvt);
+    containerElement.dispatchEvent(pointerMoveEvt);
+    containerElement.dispatchEvent(pointerUpEvt);
+
+    expect(setPointerCaptureSpy).toHaveBeenCalledWith(1);
+    expect(resizeStartSpy).toHaveBeenCalledWith(pointerDownEvt, {
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+    });
+    expect(resizeSpy).toHaveBeenCalled();
+    expect(resizeEndSpy).toHaveBeenCalled();
+    expect(hasPointerCaptureSpy).toHaveBeenCalledWith(1);
+    expect(releasePointerCaptureSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should ignore non-left mouse button with pointer events', () => {
+    const resizeStartSpy = vi.fn();
+
+    (window as any).PointerEvent = class PointerEventMock extends Event {};
+
+    rsz = Resizable({
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+      onResizeStart: resizeStartSpy,
+    });
+
+    const pointerDownEvt = new Event('pointerdown');
+    Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 1 });
+    Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 11 });
+
+    containerElement.dispatchEvent(pointerDownEvt);
+
+    expect(resizeStartSpy).not.toHaveBeenCalled();
+  });
+
+  it('should release pointer capture when pointer resize start is cancelled', () => {
+    const resizeStartSpy = vi.fn().mockReturnValue(false);
+    const releasePointerCaptureSpy = vi.fn();
+
+    (window as any).PointerEvent = class PointerEventMock extends Event {};
+    (containerElement as any).releasePointerCapture = releasePointerCaptureSpy;
+
+    rsz = Resizable({
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+      onResizeStart: resizeStartSpy,
+    });
+
+    const pointerDownEvt = new Event('pointerdown');
+    Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 3 });
+
+    containerElement.dispatchEvent(pointerDownEvt);
+
+    expect(resizeStartSpy).toHaveBeenCalledTimes(1);
+    expect(releasePointerCaptureSpy).toHaveBeenCalledWith(3);
+  });
+
+  it('should ignore mousedown fallback while a pointer interaction is active', () => {
+    const resizeStartSpy = vi.fn();
+
+    (window as any).PointerEvent = class PointerEventMock extends Event {};
+
+    rsz = Resizable({
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+      onResizeStart: resizeStartSpy,
+    });
+
+    const pointerDownEvt = new Event('pointerdown');
+    Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 5 });
+    containerElement.dispatchEvent(pointerDownEvt);
+
+    containerElement.dispatchEvent(new MouseEvent('mousedown'));
+
+    expect(resizeStartSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore pointer move/up events from a different pointer id', () => {
+    const resizeSpy = vi.fn();
+    const resizeEndSpy = vi.fn();
+
+    (window as any).PointerEvent = class PointerEventMock extends Event {};
+
+    rsz = Resizable({
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+      onResize: resizeSpy,
+      onResizeEnd: resizeEndSpy,
+    });
+
+    const pointerDownEvt = new Event('pointerdown');
+    Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 7 });
+    containerElement.dispatchEvent(pointerDownEvt);
+
+    const wrongPointerMoveEvt = new Event('pointermove');
+    Object.defineProperty(wrongPointerMoveEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(wrongPointerMoveEvt, 'pointerId', { writable: true, configurable: true, value: 8 });
+    containerElement.dispatchEvent(wrongPointerMoveEvt);
+
+    const wrongPointerUpEvt = new Event('pointerup');
+    Object.defineProperty(wrongPointerUpEvt, 'pointerType', { writable: true, configurable: true, value: 'mouse' });
+    Object.defineProperty(wrongPointerUpEvt, 'pointerId', { writable: true, configurable: true, value: 8 });
+    containerElement.dispatchEvent(wrongPointerUpEvt);
+
+    expect(resizeSpy).not.toHaveBeenCalled();
+    expect(resizeEndSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle touch pointer move without preventing default', () => {
+    const resizeSpy = vi.fn();
+
+    (window as any).PointerEvent = class PointerEventMock extends Event {};
+
+    rsz = Resizable({
+      resizeableElement: containerElement,
+      resizeableHandleElement: containerElement,
+      onResize: resizeSpy,
+    });
+
+    const pointerDownEvt = new Event('pointerdown');
+    Object.defineProperty(pointerDownEvt, 'pointerType', { writable: true, configurable: true, value: 'touch' });
+    Object.defineProperty(pointerDownEvt, 'button', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(pointerDownEvt, 'pointerId', { writable: true, configurable: true, value: 9 });
+    containerElement.dispatchEvent(pointerDownEvt);
+
+    const pointerMoveEvt = new Event('pointermove');
+    Object.defineProperty(pointerMoveEvt, 'pointerType', { writable: true, configurable: true, value: 'touch' });
+    Object.defineProperty(pointerMoveEvt, 'pointerId', { writable: true, configurable: true, value: 9 });
+    const preventDefaultSpy = vi.fn();
+    Object.defineProperty(pointerMoveEvt, 'preventDefault', { writable: true, configurable: true, value: preventDefaultSpy });
+    containerElement.dispatchEvent(pointerMoveEvt);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    expect(resizeSpy).toHaveBeenCalled();
   });
 });

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -106,6 +106,13 @@ import type { SlickDataView } from './slickDataview.js';
 import { Draggable, MouseWheel, Resizable } from './slickInteractions.js';
 import { applyHtmlToElement, runOptionalHtmlSanitizer } from './utils.js';
 
+const RESIZE_AUTOSCROLL_MIN_INTERVAL_MS = 30;
+const RESIZE_AUTOSCROLL_MAX_INTERVAL_MS = 600;
+const RESIZE_AUTOSCROLL_ACCELERATE_INTERVAL = 5;
+const RESIZE_AUTOSCROLL_BROWSER_EDGE_PX = 1;
+const RESIZE_AUTOSCROLL_BROWSER_EDGE_LEFT_DELAY_MS = 300;
+const RESIZE_AUTOSCROLL_BROWSER_EDGE_RIGHT_DELAY_MS = 1200;
+
 /**
  * @license
  * (c) 2009-present Michael Leibman
@@ -211,6 +218,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected canvas: HTMLCanvasElement | null = null;
   protected canvas_context: CanvasRenderingContext2D | null = null;
   protected _isResizingColumn = false;
+  protected _columnResizeAutoScrollTimer?: any;
   protected _lastColumnGridMenuCompensation = 2; // when Grid Menu is enabled, we need to compensate the last column width by 2px to give room for the column resize handle between the last column and the grid menu button
 
   // settings
@@ -246,6 +254,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     asyncEditorLoadDelay: 100,
     forceFitColumns: false,
     autoScrollOnColumnResize: true,
+    autoScrollResizeLeftDelay: RESIZE_AUTOSCROLL_BROWSER_EDGE_LEFT_DELAY_MS,
+    autoScrollResizeRightDelay: RESIZE_AUTOSCROLL_BROWSER_EDGE_RIGHT_DELAY_MS,
     enableAsyncPostRender: false,
     asyncPostRenderDelay: 50,
     enableAsyncPostRenderCleanup: false,
@@ -2236,17 +2246,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   protected setupColumnResize(): void {
-    let j: number;
-    let k: number;
-    let c: C;
-    let pageX: number;
-    let minPageX: number;
-    let maxPageX: number;
-    let firstResizable: number | undefined;
-    let lastResizable = -1;
+    let j: number, k: number, c: C;
+    let pageX: number, minPageX: number, maxPageX: number;
+    let firstResizable: number | undefined,
+      lastResizable = -1;
     let frozenLeftColMaxWidth = 0;
+    let resizeAutoScrollDeltaX = 0;
+    // Only these two are needed for auto-scroll state
+    let autoScrollClientX: number | undefined;
+    let autoScrollOffsetX = 0;
 
     this._bindingEventService.unbindAll('colresizes');
+    this.clearAutoScrollTimer();
     const children: HTMLElement[] = this.getHeaderChildren();
     const vc = this.getVisibleColumns();
     for (let i = 0; i < children.length; i++) {
@@ -2265,6 +2276,68 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (firstResizable === undefined) {
       return;
     }
+
+    // --- Minimal auto-scroll logic for browser edge ---
+    const stopColumnResizeAutoScroll = () => {
+      this.clearAutoScrollTimer();
+      autoScrollOffsetX = 0;
+    };
+
+    const scheduleColumnResizeAutoScroll = (resizeCallback: (targetPageX: number) => void) => {
+      if (this._columnResizeAutoScrollTimer || !autoScrollOffsetX) return;
+      let elapsed = 0;
+      this._columnResizeAutoScrollTimer = setInterval(() => {
+        if (!autoScrollOffsetX) {
+          elapsed = 0;
+          return;
+        }
+        const isBrowserEdge = Math.abs(autoScrollOffsetX) === 1;
+        const viewportOffset = getOffset(this._viewportScrollContainerX);
+        const moveDistance = isBrowserEdge ? 4 * autoScrollOffsetX : (this.getAbsoluteColumnMinWidth() / 2) * Math.sign(autoScrollOffsetX);
+        if (!isBrowserEdge) {
+          const delay = RESIZE_AUTOSCROLL_MAX_INTERVAL_MS - Math.abs(autoScrollOffsetX) * RESIZE_AUTOSCROLL_ACCELERATE_INTERVAL;
+          elapsed += RESIZE_AUTOSCROLL_MIN_INTERVAL_MS;
+          if (elapsed < delay) return;
+          elapsed = 0;
+        }
+        const targetPageX =
+          autoScrollOffsetX > 0
+            ? viewportOffset.left + this._viewportScrollContainerX.clientWidth + moveDistance
+            : viewportOffset.left - moveDistance;
+        resizeCallback(targetPageX + resizeAutoScrollDeltaX);
+      }, RESIZE_AUTOSCROLL_MIN_INTERVAL_MS);
+    };
+
+    const updateColumnResizeAutoScroll = (
+      clientX: number | undefined,
+      targetPageX: number,
+      resizeCallback: (targetPageX: number) => void
+    ) => {
+      autoScrollClientX = isDefinedNumber(clientX) ? clientX : autoScrollClientX;
+      const viewportOffset = getOffset(this._viewportScrollContainerX);
+      const left = viewportOffset.left;
+      const right = left + this._viewportScrollContainerX.clientWidth;
+      const browserW = window.innerWidth || document.documentElement.clientWidth || 0;
+      if (targetPageX <= left) {
+        autoScrollOffsetX = targetPageX - left;
+      } else if (targetPageX >= right) {
+        autoScrollOffsetX = targetPageX - right;
+      } else if (isDefinedNumber(autoScrollClientX) && browserW > 0) {
+        /* v8 ignore if */
+        if (autoScrollClientX <= RESIZE_AUTOSCROLL_BROWSER_EDGE_PX) {
+          autoScrollOffsetX = -1;
+        } else if (autoScrollClientX >= browserW - RESIZE_AUTOSCROLL_BROWSER_EDGE_PX) {
+          autoScrollOffsetX = 1;
+        } else {
+          stopColumnResizeAutoScroll();
+          return;
+        }
+      } else {
+        stopColumnResizeAutoScroll();
+        return;
+      }
+      scheduleColumnResizeAutoScroll(resizeCallback);
+    };
 
     for (let i = 0; i < children.length; i++) {
       const colElm = children[i];
@@ -2289,6 +2362,213 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         {},
         'colresizes'
       );
+
+      const applyColumnResize = (
+        targetPageX: number,
+        resizeElms: { resizeableElement: HTMLElement; resizeableHandleElement: HTMLElement }
+      ) => {
+        this.columnResizeDragging = true;
+        let actualMinWidth;
+        const d = Math.min(maxPageX, Math.max(minPageX, targetPageX)) - pageX;
+        let x;
+        let newCanvasWidthL = 0;
+        // oxlint-disable-next-line no-unused-vars
+        let newCanvasWidthR = 0;
+        const viewportWidth = this.getViewportInnerWidth();
+
+        if (d < 0) {
+          x = d;
+
+          for (j = i; j >= 0; j--) {
+            c = vc[j];
+            if (c && c.resizable && !c.hidden) {
+              actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
+              /* v8 ignore if */
+              if (x && (c.previousWidth || 0) + x < actualMinWidth) {
+                x += (c.previousWidth || 0) - actualMinWidth;
+                c.width = actualMinWidth;
+              } else {
+                c.width = (c.previousWidth || 0) + x;
+                x = 0;
+              }
+            }
+          }
+
+          for (k = 0; k <= i; k++) {
+            c = vc[k];
+            if (c && !c.hidden) {
+              if (this.hasFrozenColumns() && k > this._options.frozenColumn!) {
+                newCanvasWidthR += c.width || 0;
+              } else {
+                newCanvasWidthL += c.width || 0;
+              }
+            }
+          }
+
+          if (this._options.forceFitColumns) {
+            x = -d;
+            for (j = i + 1; j < vc.length; j++) {
+              c = vc[j];
+              if (c && !c.hidden) {
+                if (c.resizable) {
+                  if (x && c.maxWidth && c.maxWidth - (c.previousWidth || 0) < x) {
+                    x -= c.maxWidth - (c.previousWidth || 0);
+                    c.width = c.maxWidth;
+                  } else {
+                    c.width = (c.previousWidth || 0) + x;
+                    x = 0;
+                  }
+
+                  if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
+                    newCanvasWidthR += c.width || 0;
+                  } else {
+                    newCanvasWidthL += c.width || 0;
+                  }
+                }
+              }
+            }
+          } else {
+            for (j = i + 1; j < vc.length; j++) {
+              c = vc[j];
+              if (c && !c.hidden) {
+                if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
+                  newCanvasWidthR += c.width || 0;
+                } else {
+                  newCanvasWidthL += c.width || 0;
+                }
+              }
+            }
+          }
+
+          if (this._options.forceFitColumns) {
+            x = -d;
+            for (j = i + 1; j < vc.length; j++) {
+              c = vc[j];
+              if (c && !c.hidden && c.resizable) {
+                /* v8 ignore if */
+                if (x && c.maxWidth && c.maxWidth - (c.previousWidth || 0) < x) {
+                  x -= c.maxWidth - (c.previousWidth || 0);
+                  c.width = c.maxWidth;
+                } else {
+                  c.width = (c.previousWidth || 0) + x;
+                  x = 0;
+                }
+              }
+            }
+          }
+        } else {
+          x = d;
+
+          newCanvasWidthL = 0;
+          newCanvasWidthR = 0;
+
+          for (j = i; j >= 0; j--) {
+            c = vc[j];
+            if (c && !c.hidden && c.resizable) {
+              if (x && c.maxWidth && c.maxWidth - (c.previousWidth || 0) < x) {
+                x -= c.maxWidth - (c.previousWidth || 0);
+                c.width = c.maxWidth;
+              } else {
+                const newWidth = (c.previousWidth || 0) + x;
+                const resizedCanvasWidthL = this.canvasWidthL + x;
+
+                if (this.hasFrozenColumns() && j <= this._options.frozenColumn!) {
+                  // if we're on the left frozen side, we need to make sure that our left section width never goes over the total viewport width
+                  // prettier-ignore
+                  if (newWidth > frozenLeftColMaxWidth && resizedCanvasWidthL < viewportWidth - this._options.frozenRightViewportMinWidth!) {
+                    frozenLeftColMaxWidth = newWidth;
+                  }
+                  // prettier-ignore
+                  c.width = resizedCanvasWidthL + this._options.frozenRightViewportMinWidth! > viewportWidth ? frozenLeftColMaxWidth : newWidth;
+                } else {
+                  c.width = newWidth;
+                }
+                x = 0;
+              }
+            }
+          }
+
+          for (k = 0; k <= i; k++) {
+            c = vc[k];
+            if (c && !c.hidden) {
+              if (this.hasFrozenColumns() && k > this._options.frozenColumn!) {
+                newCanvasWidthR += c.width || 0;
+              } else {
+                newCanvasWidthL += c.width || 0;
+              }
+            }
+          }
+
+          if (this._options.forceFitColumns) {
+            x = -d;
+            for (j = i + 1; j < vc.length; j++) {
+              c = vc[j];
+              if (c && !c.hidden && c.resizable) {
+                actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
+                /* v8 ignore if */
+                if (x && (c.previousWidth || 0) + x < actualMinWidth) {
+                  x += (c.previousWidth || 0) - actualMinWidth;
+                  c.width = actualMinWidth;
+                } else {
+                  c.width = (c.previousWidth || 0) + x;
+                  x = 0;
+                }
+
+                if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
+                  newCanvasWidthR += c.width || 0;
+                } else {
+                  newCanvasWidthL += c.width || 0;
+                }
+              }
+            }
+          } else {
+            for (j = i + 1; j < vc.length; j++) {
+              c = vc[j];
+              if (c && !c.hidden) {
+                if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
+                  // eslint-disable-next-line
+                  newCanvasWidthR += c.width || 0;
+                } else {
+                  newCanvasWidthL += c.width || 0;
+                }
+              }
+            }
+          }
+        }
+
+        if (this.hasFrozenColumns() && newCanvasWidthL !== this.canvasWidthL) {
+          Utils.width(this._headerL, newCanvasWidthL + 1000);
+          Utils.setStyleSize(this._paneHeaderR, 'left', newCanvasWidthL);
+        }
+
+        this.applyColumnHeaderWidths();
+        if (this._options.syncColumnCellResize) {
+          this.applyColumnWidths();
+        }
+
+        this.updateCanvasWidth();
+        if (this._options.autoScrollOnColumnResize && !this._options.forceFitColumns) {
+          const columnRight = this.columnPosRight[i];
+          const scrollLeft = this._viewportScrollContainerX.scrollLeft;
+          const viewportWidth = this._viewportScrollContainerX.clientWidth;
+          const isLastVisibleColumn = i === vc.length - 1;
+          const previousScrollLeft = this._viewportScrollContainerX.scrollLeft;
+          if (isLastVisibleColumn) {
+            this._isResizingColumn = true;
+            const maxScrollLeft = Math.max(0, this._viewportScrollContainerX.scrollWidth - this._viewportScrollContainerX.clientWidth);
+            this.scrollToX(maxScrollLeft);
+          } else if (columnRight > scrollLeft + viewportWidth) {
+            this._isResizingColumn = true;
+            this.scrollToX(columnRight - viewportWidth);
+          }
+          resizeAutoScrollDeltaX += this._viewportScrollContainerX.scrollLeft - previousScrollLeft;
+        }
+
+        this.triggerEvent(this.onColumnsDrag, {
+          triggeredByColumn: resizeElms.resizeableElement,
+          resizeHandle: resizeElms.resizeableHandleElement,
+        });
+      };
 
       this.slickResizableInstances.push(
         Resizable({
@@ -2347,217 +2627,24 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             }
             maxPageX = pageX + Math.min(shrinkLeewayOnRight ?? 100000, stretchLeewayOnLeft ?? 100000);
             minPageX = pageX - Math.min(shrinkLeewayOnLeft ?? 100000, stretchLeewayOnRight ?? 100000);
+            resizeAutoScrollDeltaX = 0;
+            autoScrollClientX = isDefinedNumber((targetEvent as MouseEvent).clientX) ? (targetEvent as MouseEvent).clientX : undefined;
+            stopColumnResizeAutoScroll();
           },
           onResize: (e, resizeElms) => {
             const targetEvent = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
-            this.columnResizeDragging = true;
-            let actualMinWidth;
             const targetPageX = (targetEvent as MouseEvent).pageX;
-            const d = Math.min(maxPageX, Math.max(minPageX, targetPageX)) - pageX;
-            let x;
-            let newCanvasWidthL = 0;
-            // oxlint-disable-next-line no-unused-vars
-            let newCanvasWidthR = 0;
-            const viewportWidth = this.getViewportInnerWidth();
-
-            if (d < 0) {
-              // shrink column
-              x = d;
-
-              for (j = i; j >= 0; j--) {
-                c = vc[j];
-                if (c && c.resizable && !c.hidden) {
-                  actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
-                  /* v8 ignore if */
-                  if (x && (c.previousWidth || 0) + x < actualMinWidth) {
-                    x += (c.previousWidth || 0) - actualMinWidth;
-                    c.width = actualMinWidth;
-                  } else {
-                    c.width = (c.previousWidth || 0) + x;
-                    x = 0;
-                  }
-                }
-              }
-
-              for (k = 0; k <= i; k++) {
-                c = vc[k];
-                if (c && !c.hidden) {
-                  if (this.hasFrozenColumns() && k > this._options.frozenColumn!) {
-                    newCanvasWidthR += c.width || 0;
-                  } else {
-                    newCanvasWidthL += c.width || 0;
-                  }
-                }
-              }
-
-              if (this._options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (c && !c.hidden) {
-                    if (c.resizable) {
-                      if (x && c.maxWidth && c.maxWidth - (c.previousWidth || 0) < x) {
-                        x -= c.maxWidth - (c.previousWidth || 0);
-                        c.width = c.maxWidth;
-                      } else {
-                        c.width = (c.previousWidth || 0) + x;
-                        x = 0;
-                      }
-
-                      if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
-                        newCanvasWidthR += c.width || 0;
-                      } else {
-                        newCanvasWidthL += c.width || 0;
-                      }
-                    }
-                  }
-                }
-              } else {
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (c && !c.hidden) {
-                    if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
-                      newCanvasWidthR += c.width || 0;
-                    } else {
-                      newCanvasWidthL += c.width || 0;
-                    }
-                  }
-                }
-              }
-
-              if (this._options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (c && !c.hidden && c.resizable) {
-                    /* v8 ignore if */
-                    if (x && c.maxWidth && c.maxWidth - (c.previousWidth || 0) < x) {
-                      x -= c.maxWidth - (c.previousWidth || 0);
-                      c.width = c.maxWidth;
-                    } else {
-                      c.width = (c.previousWidth || 0) + x;
-                      x = 0;
-                    }
-                  }
-                }
-              }
-            } else {
-              // stretch column
-              x = d;
-
-              newCanvasWidthL = 0;
-              newCanvasWidthR = 0;
-
-              for (j = i; j >= 0; j--) {
-                c = vc[j];
-                if (c && !c.hidden && c.resizable) {
-                  if (x && c.maxWidth && c.maxWidth - (c.previousWidth || 0) < x) {
-                    x -= c.maxWidth - (c.previousWidth || 0);
-                    c.width = c.maxWidth;
-                  } else {
-                    const newWidth = (c.previousWidth || 0) + x;
-                    const resizedCanvasWidthL = this.canvasWidthL + x;
-
-                    if (this.hasFrozenColumns() && j <= this._options.frozenColumn!) {
-                      // if we're on the left frozen side, we need to make sure that our left section width never goes over the total viewport width
-                      // prettier-ignore
-                      if (newWidth > frozenLeftColMaxWidth && resizedCanvasWidthL < viewportWidth - this._options.frozenRightViewportMinWidth!) {
-                        frozenLeftColMaxWidth = newWidth; // keep max column width ref, if we go over the limit this number will stop increasing
-                      }
-                      // prettier-ignore
-                      c.width = resizedCanvasWidthL + this._options.frozenRightViewportMinWidth! > viewportWidth ? frozenLeftColMaxWidth : newWidth;
-                    } else {
-                      c.width = newWidth;
-                    }
-                    x = 0;
-                  }
-                }
-              }
-
-              for (k = 0; k <= i; k++) {
-                c = vc[k];
-                if (c && !c.hidden) {
-                  if (this.hasFrozenColumns() && k > this._options.frozenColumn!) {
-                    newCanvasWidthR += c.width || 0;
-                  } else {
-                    newCanvasWidthL += c.width || 0;
-                  }
-                }
-              }
-
-              if (this._options.forceFitColumns) {
-                x = -d;
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (c && !c.hidden && c.resizable) {
-                    actualMinWidth = Math.max(c.minWidth || 0, this.absoluteColumnMinWidth);
-                    /* v8 ignore if */
-                    if (x && (c.previousWidth || 0) + x < actualMinWidth) {
-                      x += (c.previousWidth || 0) - actualMinWidth;
-                      c.width = actualMinWidth;
-                    } else {
-                      c.width = (c.previousWidth || 0) + x;
-                      x = 0;
-                    }
-
-                    if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
-                      newCanvasWidthR += c.width || 0;
-                    } else {
-                      newCanvasWidthL += c.width || 0;
-                    }
-                  }
-                }
-              } else {
-                for (j = i + 1; j < vc.length; j++) {
-                  c = vc[j];
-                  if (c && !c.hidden) {
-                    if (this.hasFrozenColumns() && j > this._options.frozenColumn!) {
-                      // eslint-disable-next-line
-                      newCanvasWidthR += c.width || 0;
-                    } else {
-                      newCanvasWidthL += c.width || 0;
-                    }
-                  }
-                }
-              }
-            }
-
-            if (this.hasFrozenColumns() && newCanvasWidthL !== this.canvasWidthL) {
-              Utils.width(this._headerL, newCanvasWidthL + 1000);
-              Utils.setStyleSize(this._paneHeaderR, 'left', newCanvasWidthL);
-            }
-
-            this.applyColumnHeaderWidths();
-            if (this._options.syncColumnCellResize) {
-              this.applyColumnWidths();
-            }
-
-            // Always update canvas width during column resize (restores previous behavior for fixed grid widths)
-            this.updateCanvasWidth();
-            // Hybrid auto-scroll logic:
-            // - For last visible column, always scroll to maxScrollLeft (legacy behavior, fixes test)
-            // - For other columns, scroll just enough to bring right edge into view
-            if (this._options.autoScrollOnColumnResize && !this._options.forceFitColumns) {
-              const columnRight = this.columnPosRight[i];
-              const scrollLeft = this._viewportScrollContainerX.scrollLeft;
-              const viewportWidth = this._viewportScrollContainerX.clientWidth;
-              const isLastVisibleColumn = i === vc.length - 1;
-              if (isLastVisibleColumn) {
-                this._isResizingColumn = true;
-                const maxScrollLeft = Math.max(0, this._viewportScrollContainerX.scrollWidth - this._viewportScrollContainerX.clientWidth);
-                this.scrollToX(maxScrollLeft);
-              } else if (columnRight > scrollLeft + viewportWidth) {
-                this._isResizingColumn = true;
-                this.scrollToX(columnRight - viewportWidth);
-              }
-            }
-
-            this.triggerEvent(this.onColumnsDrag, {
-              triggeredByColumn: resizeElms.resizeableElement,
-              resizeHandle: resizeElms.resizeableHandleElement,
+            updateColumnResizeAutoScroll((targetEvent as MouseEvent).clientX, targetPageX, (resizePageX: number) => {
+              applyColumnResize(resizePageX, {
+                resizeableElement: resizeElms.resizeableElement,
+                resizeableHandleElement: resizeableHandle,
+              });
             });
+            applyColumnResize(targetPageX + resizeAutoScrollDeltaX, resizeElms);
           },
           onResizeEnd: (_e, resizeElms) => {
+            stopColumnResizeAutoScroll();
+            resizeAutoScrollDeltaX = 0;
             this._isResizingColumn = false;
             resizeElms.resizeableElement.classList.remove('slick-header-column-active');
 
@@ -2911,6 +2998,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Clear all highlight timers that might have been left opened */
   protected clearAllTimers(): void {
+    this.clearAutoScrollTimer();
     [
       this._columnResizeTimer,
       this._executionBlockTimer,
@@ -2924,6 +3012,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         clearTimeout(timer);
       }
     });
+  }
+
+  protected clearAutoScrollTimer(): void {
+    if (this._columnResizeAutoScrollTimer) {
+      clearInterval(this._columnResizeAutoScrollTimer);
+      this._columnResizeAutoScrollTimer = undefined;
+    }
   }
 
   /**

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2248,8 +2248,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected setupColumnResize(): void {
     let j: number, k: number, c: C;
     let pageX: number, minPageX: number, maxPageX: number;
-    let firstResizable: number | undefined,
-      lastResizable = -1;
+    let firstResizable: number | undefined;
+    let lastResizable = -1;
     let frozenLeftColMaxWidth = 0;
     let resizeAutoScrollDeltaX = 0;
     // Only these two are needed for auto-scroll state
@@ -2380,7 +2380,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
         if (d < 0) {
           x = d;
-
           for (j = i; j >= 0; j--) {
             c = vc[j];
             if (c && c.resizable && !c.hidden) {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2294,12 +2294,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         const isBrowserEdge = Math.abs(autoScrollOffsetX) === 1;
         const viewportOffset = getOffset(this._viewportScrollContainerX);
         const moveDistance = isBrowserEdge ? 4 * autoScrollOffsetX : (this.getAbsoluteColumnMinWidth() / 2) * Math.sign(autoScrollOffsetX);
+        /* v8 ignore next 5 */
         if (!isBrowserEdge) {
           const delay = RESIZE_AUTOSCROLL_MAX_INTERVAL_MS - Math.abs(autoScrollOffsetX) * RESIZE_AUTOSCROLL_ACCELERATE_INTERVAL;
           elapsed += RESIZE_AUTOSCROLL_MIN_INTERVAL_MS;
           if (elapsed < delay) return;
           elapsed = 0;
         }
+        /* v8 ignore next */
         const targetPageX =
           autoScrollOffsetX > 0
             ? viewportOffset.left + this._viewportScrollContainerX.clientWidth + moveDistance

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -271,21 +271,47 @@ export function Resizable(options: ResizableOption): {
   destroy: () => void;
 } {
   const { resizeableElement, resizeableHandleElement, onResizeStart, onResize, onResizeEnd } = options;
+  const supportsPointerEvents = typeof window !== 'undefined' && 'PointerEvent' in window;
+  let activePointerId: number | undefined;
   if (!resizeableHandleElement || typeof resizeableHandleElement.addEventListener !== 'function') {
     throw new Error('[SlickResizable] You did not provide a valid html element that will be used for the handle to resize.');
   }
 
   function init(): void {
-    // add event listeners on the draggable element
+    if (supportsPointerEvents) {
+      resizeableHandleElement.addEventListener('pointerdown', pointerResizeStartHandler as EventListener);
+    }
+
+    // Keep mouse/touch listeners for backward compatibility and test environments
+    // where interactions are simulated with mousedown/mousemove/mouseup.
     resizeableHandleElement.addEventListener('mousedown', resizeStartHandler);
     resizeableHandleElement.addEventListener('touchstart', resizeStartHandler);
   }
 
   function destroy(): void {
     if (typeof resizeableHandleElement?.removeEventListener === 'function') {
+      if (supportsPointerEvents) {
+        resizeableHandleElement.removeEventListener('pointerdown', pointerResizeStartHandler as EventListener);
+        removePointerListeners();
+      }
+
       resizeableHandleElement.removeEventListener('mousedown', resizeStartHandler);
       resizeableHandleElement.removeEventListener('touchstart', resizeStartHandler);
     }
+  }
+
+  function addPointerListeners(): void {
+    resizeableHandleElement.addEventListener('pointermove', pointerResizingHandler as EventListener);
+    resizeableHandleElement.addEventListener('pointerup', pointerResizeEndHandler as EventListener);
+    resizeableHandleElement.addEventListener('pointercancel', pointerResizeEndHandler as EventListener);
+    resizeableHandleElement.addEventListener('lostpointercapture', pointerResizeEndHandler as EventListener);
+  }
+
+  function removePointerListeners(): void {
+    resizeableHandleElement.removeEventListener('pointermove', pointerResizingHandler as EventListener);
+    resizeableHandleElement.removeEventListener('pointerup', pointerResizeEndHandler as EventListener);
+    resizeableHandleElement.removeEventListener('pointercancel', pointerResizeEndHandler as EventListener);
+    resizeableHandleElement.removeEventListener('lostpointercapture', pointerResizeEndHandler as EventListener);
   }
 
   function executeResizeCallbackWhenDefined(
@@ -301,6 +327,10 @@ export function Resizable(options: ResizableOption): {
   }
 
   function resizeStartHandler(e: MouseEvent | TouchEvent): void {
+    if (supportsPointerEvents && activePointerId !== undefined) {
+      return;
+    }
+
     e.preventDefault();
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
     const result = executeResizeCallbackWhenDefined(onResizeStart, event);
@@ -309,6 +339,26 @@ export function Resizable(options: ResizableOption): {
       document.body.addEventListener('mouseup', resizeEndHandler);
       document.body.addEventListener('touchmove', resizingHandler);
       document.body.addEventListener('touchend', resizeEndHandler);
+    }
+  }
+
+  function pointerResizeStartHandler(e: PointerEvent): void {
+    if (e.pointerType === 'mouse' && e.button !== 0) {
+      return;
+    }
+
+    e.preventDefault();
+    activePointerId = e.pointerId;
+    if (typeof resizeableHandleElement.setPointerCapture === 'function') {
+      resizeableHandleElement.setPointerCapture(e.pointerId);
+    }
+
+    const result = executeResizeCallbackWhenDefined(onResizeStart, e);
+    if (result !== false) {
+      addPointerListeners();
+    } else if (typeof resizeableHandleElement.releasePointerCapture === 'function') {
+      resizeableHandleElement.releasePointerCapture(e.pointerId);
+      activePointerId = undefined;
     }
   }
 
@@ -322,6 +372,19 @@ export function Resizable(options: ResizableOption): {
     }
   }
 
+  function pointerResizingHandler(e: PointerEvent): void {
+    if (activePointerId !== undefined && e.pointerId !== activePointerId) {
+      return;
+    }
+
+    if (e.preventDefault && e.pointerType !== 'touch') {
+      e.preventDefault();
+    }
+    if (typeof onResize === 'function') {
+      onResize(e, { resizeableElement, resizeableHandleElement });
+    }
+  }
+
   /** Remove all mouse/touch handlers */
   function resizeEndHandler(e: MouseEvent | TouchEvent): void {
     const event = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
@@ -330,6 +393,24 @@ export function Resizable(options: ResizableOption): {
     document.body.removeEventListener('mouseup', resizeEndHandler);
     document.body.removeEventListener('touchmove', resizingHandler);
     document.body.removeEventListener('touchend', resizeEndHandler);
+  }
+
+  function pointerResizeEndHandler(e: PointerEvent): void {
+    if (activePointerId !== undefined && e.pointerId !== activePointerId) {
+      return;
+    }
+
+    executeResizeCallbackWhenDefined(onResizeEnd, e);
+    removePointerListeners();
+    if (
+      activePointerId !== undefined &&
+      typeof resizeableHandleElement.hasPointerCapture === 'function' &&
+      resizeableHandleElement.hasPointerCapture(activePointerId) &&
+      typeof resizeableHandleElement.releasePointerCapture === 'function'
+    ) {
+      resizeableHandleElement.releasePointerCapture(activePointerId);
+    }
+    activePointerId = undefined;
   }
 
   // initialize Resizable service by attaching mouse/touch events

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -165,6 +165,12 @@ export interface GridOption<C extends Column = Column> {
   /** Defaults to true, auto-scrolls horizontally to keep the resized column visible (last column scrolls to max for legacy compatibility). */
   autoScrollOnColumnResize?: boolean;
 
+  /** Defaults to 300, delay used when resize auto-scroll continues from the browser/webview left edge after the pointer leaves the page. */
+  autoScrollResizeLeftDelay?: number;
+
+  /** Defaults to 1200, delay used when resize auto-scroll continues from the browser/webview right edge after the pointer leaves the page. */
+  autoScrollResizeRightDelay?: number;
+
   /** Auto-tooltip options (enableForCells, enableForHeaderCells, maxToolTipLength) */
   autoTooltipOptions?: AutoTooltipOption;
 


### PR DESCRIPTION
fixes issue brought up in MSSQL (https://github.com/microsoft/vscode-mssql/pull/21863#issuecomment-4282836278) to have column resize auto-scroll also work when falling outside of the browser viewport/webview

<img width="1912" height="948" alt="msedge_D35i8SAV98" src="https://github.com/user-attachments/assets/31890de5-750a-494e-8a8b-67c1eb7c6d7b" />

<img width="1903" height="786" alt="Code_-_Insiders_vbBlOD1xJo" src="https://github.com/user-attachments/assets/8531f04c-c256-4a74-a1b8-60058a48f2bc" />