### PR TITLE
fix(regression): excelcopybuffer columnvisibility behavior changed in v10

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -6986,14 +6986,14 @@ describe('SlickGrid core file', () => {
         expect(result5).toEqual({ cell: -1, row: -1 });
       });
 
-      it('should return hidden cells as well since skipping them would add an unwanted offset', () => {
+      it('should skip hidden columns and return last visible column cell when x coordinate falls beyond visible canvas', () => {
         grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, enableCellNavigation: true });
 
         const result1 = grid.getCellFromPoint(DEFAULT_COLUMN_WIDTH * 5 + 5, DEFAULT_COLUMN_HEIGHT * 5 + 5);
         const result2 = grid.getCellFromPoint(DEFAULT_COLUMN_WIDTH * 6 + 5, DEFAULT_COLUMN_HEIGHT * 6 + 5);
 
-        expect(result1).toEqual({ cell: 5, row: 5 });
-        expect(result2).toEqual({ cell: 6, row: 6 });
+        expect(result1).toEqual({ cell: 4, row: 5 });
+        expect(result2).toEqual({ cell: 4, row: 6 });
       });
     });
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6380,10 +6380,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     let w = 0;
     for (let i = 0; i < this.columns.length && w <= x; i++) {
-      if (this.columns[i]) {
-        w += this.columns[i].width as number;
-        cell++;
+      if (!this.columns[i] || this.columns[i].hidden) {
+        continue;
       }
+      w += this.columns[i].width as number;
+      cell++;
     }
     cell -= 1;
 

--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -857,6 +857,86 @@ describe('CellExternalCopyManager', () => {
           });
         }));
 
+      it('should set correct bRange toCell (lastDestX) when hidden column sits between pasted columns on execute', () =>
+        new Promise((done: any) => {
+          const hiddenColsMockColumns = [
+            { id: 'firstName', field: 'firstName', name: 'First Name' },
+            { id: 'lastName', field: 'lastName', name: 'Last Name', hidden: true },
+            { id: 'age', field: 'age', name: 'Age' },
+            { id: 'gender', field: 'gender', name: 'Gender' },
+          ] as Column[];
+          vi.spyOn(gridStub, 'getColumns').mockReturnValue(hiddenColsMockColumns);
+          vi.spyOn(gridStub, 'getDataLength').mockReturnValue(2);
+          vi.spyOn(gridStub, 'getDataItem').mockReturnValue({ firstName: 'John', age: 30 });
+          vi.spyOn(gridStub.getSelectionModel() as SelectionModel, 'getSelectedRanges').mockReturnValueOnce(null as any);
+
+          const clipboardCommandHandler = (cmd: any) => cmd.execute();
+          const setSelectedRangesSpy = vi.spyOn(mockHybridSelectionModel, 'setSelectedRanges');
+          vi.spyOn(gridStub, 'getSelectionModel').mockReturnValue(mockHybridSelectionModel as any);
+
+          plugin.init(gridStub, { clipboardPasteDelay: 1, clearCopySelectionDelay: 1, clipboardCommandHandler });
+
+          vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 0, row: 0 });
+          const keyDownCtrlPasteEvent = new Event('keydown');
+          Object.defineProperty(keyDownCtrlPasteEvent, 'ctrlKey', { writable: true, configurable: true, value: true });
+          Object.defineProperty(keyDownCtrlPasteEvent, 'key', { writable: true, configurable: true, value: 'v' });
+          Object.defineProperty(keyDownCtrlPasteEvent, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+          Object.defineProperty(keyDownCtrlPasteEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+
+          (navigator.clipboard.readText as Mock).mockResolvedValueOnce('John\t30');
+          gridStub.onKeyDown.notify({ cell: 0, row: 0, grid: gridStub }, keyDownCtrlPasteEvent, gridStub);
+
+          setTimeout(() => {
+            expect(setSelectedRangesSpy).toHaveBeenCalledWith([new SlickRange(0, 0, 0, 2)]);
+            done();
+          });
+        }));
+
+      it('should set correct bRange toCell (lastDestX) on undo when hidden column sits between pasted columns', () =>
+        new Promise((done: any) => {
+          const hiddenColsMockColumns = [
+            { id: 'firstName', field: 'firstName', name: 'First Name' },
+            { id: 'lastName', field: 'lastName', name: 'Last Name', hidden: true },
+            { id: 'age', field: 'age', name: 'Age' },
+          ] as Column[];
+          vi.spyOn(gridStub, 'getColumns').mockReturnValue(hiddenColsMockColumns);
+          vi.spyOn(gridStub, 'getDataLength').mockReturnValue(2);
+          vi.spyOn(gridStub, 'getDataItem').mockReturnValue({ firstName: 'John', age: 30 });
+          vi.spyOn(gridStub.getSelectionModel() as SelectionModel, 'getSelectedRanges').mockReturnValueOnce(null as any);
+
+          let clipCommand: any;
+          const clipboardCommandHandler = (cmd: any) => {
+            clipCommand = cmd;
+            cmd.execute();
+          };
+          const setSelectedRangesSpy = vi.spyOn(mockHybridSelectionModel, 'setSelectedRanges');
+          vi.spyOn(gridStub, 'getSelectionModel').mockReturnValue(mockHybridSelectionModel as any);
+          const onPasteCellsSpy = vi.fn();
+
+          plugin.init(gridStub, { clipboardPasteDelay: 1, clearCopySelectionDelay: 1, clipboardCommandHandler, onPasteCells: onPasteCellsSpy });
+
+          vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 0, row: 0 });
+          const keyDownCtrlPasteEvent = new Event('keydown');
+          Object.defineProperty(keyDownCtrlPasteEvent, 'ctrlKey', { writable: true, configurable: true, value: true });
+          Object.defineProperty(keyDownCtrlPasteEvent, 'key', { writable: true, configurable: true, value: 'v' });
+          Object.defineProperty(keyDownCtrlPasteEvent, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+          Object.defineProperty(keyDownCtrlPasteEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+          (navigator.clipboard.readText as Mock).mockResolvedValueOnce('John\t30');
+          gridStub.onKeyDown.notify({ cell: 0, row: 0, grid: gridStub }, keyDownCtrlPasteEvent, gridStub);
+
+          setTimeout(() => {
+            setSelectedRangesSpy.mockClear();
+            onPasteCellsSpy.mockClear();
+
+            clipCommand.undo();
+
+            const expectedRange = new SlickRange(0, 0, 0, 2);
+            expect(setSelectedRangesSpy).toHaveBeenCalledWith([expectedRange]);
+            expect(onPasteCellsSpy).toHaveBeenCalledWith(expect.any(Object), { ranges: [expectedRange] });
+            done();
+          });
+        }));
+
       it('should show a console error when navigator.clipboard fails', () =>
         new Promise((done: any) => {
           const consoleSpy = vi.spyOn(console, 'error').mockReturnValue();

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -300,6 +300,7 @@ export class SlickCellExternalCopyManager {
       this._addonOptions.newRowCreator(newRowsNeeded);
     }
 
+    let lastDestX = activeCell;
     const clipCommand: ExternalCopyClipCommand = {
       isClipboardCommand: true,
       clippedRange,
@@ -319,6 +320,7 @@ export class SlickCellExternalCopyManager {
       w: 0,
       execute: () => {
         clipCommand.h = 0;
+        lastDestX = activeCell;
         for (let y = 0; y < clipCommand.destH; y++) {
           clipCommand.oldValues[y] = [];
           clipCommand.w = 0;
@@ -338,6 +340,7 @@ export class SlickCellExternalCopyManager {
               continue;
             }
             clipCommand.w++;
+            lastDestX = destx;
 
             if (desty < clipCommand.maxDestY && destx < clipCommand.maxDestX) {
               const dt = this._dataWrapper.getDataItem(desty);
@@ -368,7 +371,7 @@ export class SlickCellExternalCopyManager {
           }
         }
 
-        const bRange = new SlickRange(activeRow, activeCell, activeRow + clipCommand.h - 1, activeCell + clipCommand.w - 1);
+        const bRange = new SlickRange(activeRow, activeCell, activeRow + clipCommand.h - 1, lastDestX);
         this.markCopySelection([bRange]);
         this._grid.getSelectionModel()?.setSelectedRanges([bRange]);
         this.onPasteCells.notify({ ranges: [bRange] });
@@ -399,7 +402,7 @@ export class SlickCellExternalCopyManager {
           }
         }
 
-        const bRange = new SlickRange(activeRow, activeCell, activeRow + clipCommand.h - 1, activeCell + clipCommand.w - 1);
+        const bRange = new SlickRange(activeRow, activeCell, activeRow + clipCommand.h - 1, lastDestX);
 
         this.markCopySelection([bRange]);
         this._grid.getSelectionModel()?.setSelectedRanges([bRange]);


### PR DESCRIPTION
fixes both the copy/paste behavior and the cell selection not respecting the new hidden columns

fixes https://github.com/ghiscoding/slickgrid-universal/issues/2541