### PR TITLE
fix: complex object not copyable from cell context menu

### DIFF
--- a/demos/vanilla/src/examples/example12.ts
+++ b/demos/vanilla/src/examples/example12.ts
@@ -243,28 +243,39 @@ export default class Example12 {
         customTooltip: { position: 'center' },
       },
       // {
-      //   id: 'percentComplete2', name: '% Complete', field: 'analysis.percentComplete', minWidth: 100,
+      //   id: 'percentComplete2',
+      //   name: '% Complete (complex)',
+      //   field: 'analysis.percentComplete',
+      //   minWidth: 100,
       //   type: 'number',
-      //   sortable: true, filterable: true, columnGroup: 'Analysis',
+      //   sortable: true,
+      //   filterable: true,
+      //   columnGroup: 'Analysis',
       //   // filter: { model: Filters.compoundSlider, operator: '>=' },
-      //   formatter: Formatters.complex,
+      //   // formatter: Formatters.complex,
+      //   formatter: Formatters.multiple,
+      //   params: {
+      //     formatters: [Formatters.complex, (_row, _cell, value) => value],
+      //   },
       //   exportCustomFormatter: Formatters.complex, // without the Editing cell Formatter
       //   editor: {
       //     model: Editors.singleSelect,
       //     serializeComplexValueFormat: 'flat', // if we keep "object" as the default it will apply { value: 2, label: 2 } which is not what we want in this case
-      //     collection: Array.from(Array(101).keys()).map(k => ({ value: k, label: k })),
+      //     collection: Array.from(Array(101).keys()).map((k) => ({ value: k, label: k })),
       //     collectionOptions: {
-      //       addCustomFirstEntry: { value: '', label: '--none--' }
+      //       addCustomFirstEntry: { value: '', label: '--none--' },
       //     },
       //     collectionOverride: (_collectionInput, args) => {
       //       const originalCollection = args.originalCollections || [];
       //       const duration = args?.dataContext?.duration ?? args?.compositeEditorOptions?.formValues?.duration;
       //       if (duration === 10) {
-      //         return originalCollection.filter(itemCollection => +itemCollection.value !== 1);
+      //         return originalCollection.filter((itemCollection) => +itemCollection.value !== 1);
       //       }
       //       return originalCollection;
       //     },
-      //     massUpdate: true, minValue: 0, maxValue: 100,
+      //     massUpdate: true,
+      //     minValue: 0,
+      //     maxValue: 100,
       //   },
       // },
       {

--- a/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickContextMenu.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vite
 import { TranslateServiceStub } from '../../../../../test/translateServiceStub.js';
 import { SlickEvent, SlickEventData, type SlickDataView, type SlickGrid } from '../../core/index.js';
 import { ExtensionUtility } from '../../extensions/extensionUtility.js';
+import { Formatters } from '../../formatters/index.js';
 import type { Column, ContextMenu, ElementPosition, ExternalResource, Formatter, GridOption, MenuCommandItem, MenuOptionItem } from '../../interfaces/index.js';
 import {
   BackendUtilityService,
@@ -1273,6 +1274,68 @@ describe('ContextMenu Plugin', () => {
         } as GridOption;
         const columnMock = { id: 'firstName', name: 'First Name', field: 'firstName' } as Column;
         const dataContextMock = { id: 123, firstName: 'John', lastName: '·\u034f ⮞   Doe', age: 50 };
+        vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        plugin.dispose();
+        plugin.init({ commandItems: [] });
+
+        const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find(
+          (item: MenuCommandItem) => item.command === 'copy'
+        ) as MenuCommandItem;
+        const isCommandUsable = menuItemCommand.itemUsabilityOverride!({
+          cell: 2,
+          row: 2,
+          grid: gridStub,
+          column: columnMock,
+          dataContext: dataContextMock,
+        });
+
+        expect(isCommandUsable).toBe(true);
+      });
+
+      it('should expect "itemUsabilityOverride" callback from the "copy" command to return True when data is a complex object and Formatters.complex is defined in column formatter', () => {
+        const copyGridOptionsMock = {
+          ...gridOptionsMock,
+          enableExcelExport: false,
+          enableTextExport: false,
+          contextMenu: { hideCopyCellValueCommand: false },
+        } as GridOption;
+        const columnMock = { id: 'firstName', name: 'First Name', field: 'user.firstName', formatter: Formatters.complexObject } as Column;
+        const dataContextMock = { id: 123, user: { firstName: 'John', lastName: 'Doe', age: 50 } };
+        vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
+        vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
+        plugin.dispose();
+        plugin.init({ commandItems: [] });
+
+        const menuItemCommand = ((copyGridOptionsMock.contextMenu as ContextMenu).commandItems as MenuCommandItem[]).find(
+          (item: MenuCommandItem) => item.command === 'copy'
+        ) as MenuCommandItem;
+        const isCommandUsable = menuItemCommand.itemUsabilityOverride!({
+          cell: 2,
+          row: 2,
+          grid: gridStub,
+          column: columnMock,
+          dataContext: dataContextMock,
+        });
+
+        expect(isCommandUsable).toBe(true);
+      });
+
+      it('should expect "itemUsabilityOverride" callback from the "copy" command to return True when data is a complex object and Formatters.complex is defined inside params.formatters', () => {
+        const copyGridOptionsMock = {
+          ...gridOptionsMock,
+          enableExcelExport: false,
+          enableTextExport: false,
+          contextMenu: { hideCopyCellValueCommand: false },
+        } as GridOption;
+        const columnMock = {
+          id: 'firstName',
+          name: 'First Name',
+          field: 'user.firstName',
+          formatter: Formatters.multiple,
+          params: { formatters: [Formatters.complexObject] },
+        } as Column;
+        const dataContextMock = { id: 123, user: { firstName: 'John', lastName: 'Doe', age: 50 } };
         vi.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         vi.spyOn(gridStub, 'getOptions').mockReturnValue(copyGridOptionsMock);
         plugin.dispose();

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -1,7 +1,7 @@
 import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { extend, isDefined } from '@slickgrid-universal/utils';
 import type { SlickEventData } from '../core/index.js';
-import { copyCellToClipboard, getParsedCellValue } from '../formatters/formatterUtilities.js';
+import { copyCellToClipboard, getCopyCellValue } from '../formatters/formatterUtilities.js';
 import type {
   Column,
   ContextMenu,
@@ -12,13 +12,7 @@ import type {
   MenuOptionItem,
   OnContextMenuArgs,
 } from '../interfaces/index.js';
-import {
-  getCellValueFromQueryFieldGetter,
-  getTranslationPrefix,
-  type ExcelExportService,
-  type PdfExportService,
-  type TextExportService,
-} from '../services/index.js';
+import { getTranslationPrefix, type ExcelExportService, type PdfExportService, type TextExportService } from '../services/index.js';
 import type { SharedService } from '../services/shared.service.js';
 import type { TreeDataService } from '../services/treeData.service.js';
 import type { ExtensionUtility } from './extensionUtility.js';
@@ -186,20 +180,7 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
           command: 'copy',
           positionOrder: 50,
           action: (_e, args) => copyCellToClipboard(args as MenuCommandItemCallbackArgs),
-          itemUsabilityOverride: (args: MenuCallbackArgs) => {
-            // make sure there's an item to copy before enabling this command
-            const columnDef = args.column;
-            const dataContext = args.dataContext;
-            if (typeof columnDef.queryFieldNameGetterFn === 'function') {
-              return isDefined(getCellValueFromQueryFieldGetter(columnDef, dataContext, ''));
-            } else if (columnDef && dataContext.hasOwnProperty(columnDef.field)) {
-              return isDefined(dataContext[columnDef.field]);
-            } else if (isDefined(getParsedCellValue(args))) {
-              return true;
-            }
-
-            return false;
-          },
+          itemUsabilityOverride: (args: MenuCallbackArgs) => isDefined(getCopyCellValue(args)),
         },
         contextMenu.hideCommands,
         menuCommandItems,

--- a/packages/common/src/extensions/slickContextMenu.ts
+++ b/packages/common/src/extensions/slickContextMenu.ts
@@ -1,7 +1,7 @@
 import type { BasePubSubService } from '@slickgrid-universal/event-pub-sub';
-import { extend } from '@slickgrid-universal/utils';
+import { extend, isDefined } from '@slickgrid-universal/utils';
 import type { SlickEventData } from '../core/index.js';
-import { copyCellToClipboard } from '../formatters/formatterUtilities.js';
+import { copyCellToClipboard, getParsedCellValue } from '../formatters/formatterUtilities.js';
 import type {
   Column,
   ContextMenu,
@@ -191,15 +191,13 @@ export class SlickContextMenu extends MenuFromCellBaseClass<ContextMenu> {
             const columnDef = args.column;
             const dataContext = args.dataContext;
             if (typeof columnDef.queryFieldNameGetterFn === 'function') {
-              const cellValue = getCellValueFromQueryFieldGetter(columnDef, dataContext, '');
-              if (cellValue !== '' && cellValue !== undefined) {
-                return true;
-              }
+              return isDefined(getCellValueFromQueryFieldGetter(columnDef, dataContext, ''));
             } else if (columnDef && dataContext.hasOwnProperty(columnDef.field)) {
-              return (
-                dataContext[columnDef.field] !== '' && dataContext[columnDef.field] !== null && dataContext[columnDef.field] !== undefined
-              );
+              return isDefined(dataContext[columnDef.field]);
+            } else if (isDefined(getParsedCellValue(args))) {
+              return true;
             }
+
             return false;
           },
         },

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -10,6 +10,7 @@ import type {
   FormatterResultWithHtml,
   FormatterResultWithText,
   GridOption,
+  MenuCallbackArgs,
   TextExportOption,
 } from '../interfaces/index.js';
 import { mapTempoDateFormatWithFieldType, toUtcDate, tryParseDate } from '../services/dateUtils.js';
@@ -46,36 +47,38 @@ export function autoAddEditorFormatterToColumnsWithEditor(columns: Column[], cus
   }
 }
 
+/** Get the parsed cell value, which will use the formatter if "exportWithFormatter" is set */
+export function getParsedCellValue(args: MenuCallbackArgs): string {
+  // get the value, if "exportWithFormatter" is set then we'll use the formatter output
+  const grid = args?.grid || ({} as SlickGrid);
+  const gridOptions = grid.getOptions() as GridOption;
+  const cell = args?.cell ?? 0;
+  const row = args?.row ?? 0;
+  const columnDef = args?.column;
+  const dataContext = args?.dataContext;
+  const exportOptions = gridOptions && (gridOptions.excelExportOptions || gridOptions.textExportOptions);
+  let textToCopy = exportWithFormatterWhenDefined(row, cell, columnDef, dataContext, grid, exportOptions);
+  if (typeof columnDef.queryFieldNameGetterFn === 'function') {
+    textToCopy = getCellValueFromQueryFieldGetter(columnDef, dataContext, '');
+  }
+
+  return textToCopy;
+}
+
 /**
  * Copy active cell content to clipboard. The command will first check if the cell has a Formatter (and exportWithFormatter)
  * @param args
  */
-export async function copyCellToClipboard(args: {
-  grid: SlickGrid;
-  cell?: number;
-  row?: number;
-  column: Column;
-  dataContext?: any;
-}): Promise<string | number> {
-  let finalTextToCopy = '';
+export async function copyCellToClipboard(args: MenuCallbackArgs): Promise<string | number> {
+  let textToCopy = '';
   try {
-    // get the value, if "exportWithFormatter" is set then we'll use the formatter output
     const grid = args?.grid || ({} as SlickGrid);
     const gridOptions = grid.getOptions() as GridOption;
-    const cell = args?.cell ?? 0;
-    const row = args?.row ?? 0;
-    const columnDef = args?.column;
-    const dataContext = args?.dataContext;
-    const exportOptions = gridOptions && (gridOptions.excelExportOptions || gridOptions.textExportOptions);
-    let textToCopy = exportWithFormatterWhenDefined(row, cell, columnDef, dataContext, grid, exportOptions);
-    if (typeof columnDef.queryFieldNameGetterFn === 'function') {
-      textToCopy = getCellValueFromQueryFieldGetter(columnDef, dataContext, '');
-    }
 
     // when it's a string, we'll remove any unwanted Tree Data/Grouping symbols from the beginning (if exist) from the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
-    finalTextToCopy = textToCopy;
+    textToCopy = getParsedCellValue(args);
     if (typeof textToCopy === 'string') {
-      finalTextToCopy = textToCopy
+      textToCopy = textToCopy
         .replace(/^([·⮞⮟]\s*)|([·⮞⮟])\s*/gi, '')
         .replace(/[\u00b7\u034f]/gi, '') // remove unwanted Unicode characters (if entered directly)
         .trim();
@@ -83,11 +86,11 @@ export async function copyCellToClipboard(args: {
 
     // copy to clipboard using override or default browser Clipboard API
     const clipboardOverrideFn = gridOptions.clipboardWriteOverride;
-    clipboardOverrideFn ? clipboardOverrideFn(finalTextToCopy) : await navigator.clipboard.writeText(finalTextToCopy);
+    clipboardOverrideFn ? clipboardOverrideFn(textToCopy) : await navigator.clipboard.writeText(textToCopy);
   } catch (err) {
     console.error(`Unable to read/write to clipboard. Please check your browser settings or permissions. Error: ${err}`);
   }
-  return finalTextToCopy;
+  return textToCopy;
 }
 
 export function retrieveFormatterOptions(

--- a/packages/common/src/formatters/formatterUtilities.ts
+++ b/packages/common/src/formatters/formatterUtilities.ts
@@ -48,7 +48,7 @@ export function autoAddEditorFormatterToColumnsWithEditor(columns: Column[], cus
 }
 
 /** Get the parsed cell value, which will use the formatter if "exportWithFormatter" is set */
-export function getParsedCellValue(args: MenuCallbackArgs): string {
+export function getCopyCellValue(args: MenuCallbackArgs): string {
   // get the value, if "exportWithFormatter" is set then we'll use the formatter output
   const grid = args?.grid || ({} as SlickGrid);
   const gridOptions = grid.getOptions() as GridOption;
@@ -60,6 +60,14 @@ export function getParsedCellValue(args: MenuCallbackArgs): string {
   let textToCopy = exportWithFormatterWhenDefined(row, cell, columnDef, dataContext, grid, exportOptions);
   if (typeof columnDef.queryFieldNameGetterFn === 'function') {
     textToCopy = getCellValueFromQueryFieldGetter(columnDef, dataContext, '');
+  }
+
+  // when it's a string, we'll remove any unwanted Tree Data/Grouping symbols from the beginning (if exist) from the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
+  if (typeof textToCopy === 'string') {
+    textToCopy = textToCopy
+      .replace(/^([·⮞⮟]\s*)|([·⮞⮟])\s*/gi, '')
+      .replace(/[\u00b7\u034f]/gi, '') // remove unwanted Unicode characters (if entered directly)
+      .trim();
   }
 
   return textToCopy;
@@ -75,14 +83,8 @@ export async function copyCellToClipboard(args: MenuCallbackArgs): Promise<strin
     const grid = args?.grid || ({} as SlickGrid);
     const gridOptions = grid.getOptions() as GridOption;
 
-    // when it's a string, we'll remove any unwanted Tree Data/Grouping symbols from the beginning (if exist) from the string before copying (e.g.: "⮟  Task 21" or "·   Task 2")
-    textToCopy = getParsedCellValue(args);
-    if (typeof textToCopy === 'string') {
-      textToCopy = textToCopy
-        .replace(/^([·⮞⮟]\s*)|([·⮞⮟])\s*/gi, '')
-        .replace(/[\u00b7\u034f]/gi, '') // remove unwanted Unicode characters (if entered directly)
-        .trim();
-    }
+    // get cell to copy
+    textToCopy = getCopyCellValue(args);
 
     // copy to clipboard using override or default browser Clipboard API
     const clipboardOverrideFn = gridOptions.clipboardWriteOverride;


### PR DESCRIPTION
the "Copy" command wasn't enabled when data was a complex object (dot notation), this PR fixes that by detecting if the `field` had a dot notation and is using `Formatters.complex`, basically it now uses the same code to detect if the command should be enabled & copy the cell value. 

I also assume that it's a bug that was in place since the Copy command was introduced, or in other words it was always a bug and now it's fixed :)