### PR TITLE
chore(angular): remove TranslateModule from unit tests

### DIFF
--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, type ApplicationRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateService } from '@ngx-translate/core';
 import {
   autoAddEditorFormatterToColumnsWithEditor,
   Editors,
@@ -46,7 +46,7 @@ import { type SlickFooterComponent } from '@slickgrid-universal/custom-footer-co
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import type { GraphqlPaginatedResult, GraphqlService, GraphqlServiceApi, GraphqlServiceOption } from '@slickgrid-universal/graphql';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { MockSlickEvent, MockSlickEventHandler } from '../../../../test/mockSlickEvent.js';
 import { RxJsResourceStub } from '../../../../test/rxjsResourceStub.js';
@@ -69,6 +69,27 @@ const angularUtilServiceStub = {
   createAngularComponent: vi.fn(),
   createAngularComponentAppendToDom: vi.fn(),
 } as unknown as AngularUtilService;
+
+class MockTranslateService {
+  private lang = 'en';
+  private translations: Record<string, Record<string, string>> = {};
+  public onLangChange = new Subject<{ lang: string }>();
+
+  setTranslation(lang: string, translations: Record<string, string>) {
+    this.translations[lang] = translations;
+  }
+  use(lang: string) {
+    this.lang = lang;
+    this.onLangChange.next({ lang });
+    return Promise.resolve();
+  }
+  getCurrentLang() {
+    return this.lang;
+  }
+  instant(key: string) {
+    return this.translations[this.lang]?.[key] ?? key;
+  }
+}
 
 class AngularRowDetailView {
   static readonly pluginName = 'AngularRowDetailView';
@@ -373,7 +394,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     sharedService = new SharedService();
     translaterService = new TranslaterServiceStub();
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      providers: [{ provide: TranslateService, useClass: MockTranslateService }],
       teardown: { destroyAfterEach: false },
     });
     translate = TestBed.inject(TranslateService);

--- a/frameworks/angular-slickgrid/src/library/services/__tests__/translater.service.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/services/__tests__/translater.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateService } from '@ngx-translate/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { TranslaterService } from '../translater.service.js';
 
@@ -7,19 +7,37 @@ describe('Translater Service', () => {
   let translate: TranslateService;
   let service: TranslaterService;
 
+  class MockTranslateService {
+    private lang = 'en';
+    private translations: Record<string, Record<string, string>> = {};
+    setTranslation(lang: string, translations: Record<string, string>) {
+      this.translations[lang] = translations;
+    }
+    use(lang: string) {
+      this.lang = lang;
+      return Promise.resolve();
+    }
+    getCurrentLang() {
+      return this.lang;
+    }
+    instant(key: string) {
+      return this.translations[this.lang]?.[key] ?? key;
+    }
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      providers: [{ provide: TranslateService, useClass: MockTranslateService }],
       teardown: { destroyAfterEach: false },
     });
     translate = TestBed.inject(TranslateService);
     service = new TranslaterService(translate);
 
-    translate.setTranslation('fr', {
+    (translate as any).setTranslation('fr', {
       ITEMS: 'éléments',
       OF: 'de',
     });
-    translate.setTranslation('en', {
+    (translate as any).setTranslation('en', {
       ITEMS: 'items',
       OF: 'of',
     });

--- a/frameworks/angular-slickgrid/src/library/services/__tests__/translater.service.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/services/__tests__/translater.service.spec.ts
@@ -33,11 +33,11 @@ describe('Translater Service', () => {
     translate = TestBed.inject(TranslateService);
     service = new TranslaterService(translate);
 
-    (translate as any).setTranslation('fr', {
+    translate.setTranslation('fr', {
       ITEMS: 'éléments',
       OF: 'de',
     });
-    (translate as any).setTranslation('en', {
+    translate.setTranslation('en', {
       ITEMS: 'items',
       OF: 'of',
     });


### PR DESCRIPTION
we don't use the ngx-translate TranslateModule in the component but it was still imported in the unit tests, let's remove it and be closer to the standalone approach that we already have in AngularSlickgridComponent. The other main reason to refactor this is because it's being removed in ngx-translate@18.0.0-RC.1 via this commit https://github.com/ngx-translate/core/commit/d936f975b60ee6518197a15ae01355d4fccc4aea