### PR TITLE
feat: add Grouping/TreeData option to `toggleOnNodeTitle`

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -32,4 +32,14 @@ jobs:
         run: pnpm build
 
       - name: Publish
-        run: pnpm dlx pkg-pr-new publish --no-template --pnpm './packages/*' './frameworks/*' './frameworks-plugins/*'
+        run: |
+          # Create tarballs in the correct location for pkg-pr-new
+          for dir in ./packages/* ./frameworks/* ./frameworks-plugins/*; do
+            if [ -d "$dir" ] && [ -f "$dir/package.json" ]; then
+              echo "Packing $dir"
+              cd "$dir"
+              npm pack ./dist
+              cd - > /dev/null
+            fi
+          done
+          pnpm dlx pkg-pr-new publish --no-template --pnpm './packages/*' './frameworks/*' './frameworks-plugins/*'

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -38,7 +38,12 @@ jobs:
             if [ -d "$dir" ] && [ -f "$dir/package.json" ]; then
               echo "Packing $dir"
               cd "$dir"
-              npm pack ./dist
+              # Check if package has publishConfig.directory set to dist
+              if grep -q '"directory":\s*"dist"' package.json; then
+                npm pack ./dist
+              else
+                npm pack
+              fi
               cd - > /dev/null
             fi
           done

--- a/demos/aurelia/src/examples/slickgrid/example13.ts
+++ b/demos/aurelia/src/examples/slickgrid/example13.ts
@@ -217,7 +217,7 @@ export class Example13 {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableExcelExport: true,
       enableTextExport: true,

--- a/demos/aurelia/src/examples/slickgrid/example13.ts
+++ b/demos/aurelia/src/examples/slickgrid/example13.ts
@@ -216,6 +216,9 @@ export class Example13 {
       // you could debounce/throttle the input text filter if you have lots of data
       // filterTypingDebounce: 250,
       enableGrouping: true,
+      groupItemMetadataOption: {
+        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      },
       enableExcelExport: true,
       enableTextExport: true,
       excelExportOptions: { sanitizeDataExport: true },

--- a/demos/aurelia/src/examples/slickgrid/example13.ts
+++ b/demos/aurelia/src/examples/slickgrid/example13.ts
@@ -217,7 +217,7 @@ export class Example13 {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableExcelExport: true,
       enableTextExport: true,

--- a/demos/aurelia/src/examples/slickgrid/example13.ts
+++ b/demos/aurelia/src/examples/slickgrid/example13.ts
@@ -217,7 +217,7 @@ export class Example13 {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon)
       },
       enableExcelExport: true,
       enableTextExport: true,

--- a/demos/aurelia/src/examples/slickgrid/example27.ts
+++ b/demos/aurelia/src/examples/slickgrid/example27.ts
@@ -114,7 +114,7 @@ export class Example27 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/aurelia/src/examples/slickgrid/example27.ts
+++ b/demos/aurelia/src/examples/slickgrid/example27.ts
@@ -114,6 +114,7 @@ export class Example27 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
+        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/aurelia/src/examples/slickgrid/example27.ts
+++ b/demos/aurelia/src/examples/slickgrid/example27.ts
@@ -114,7 +114,7 @@ export class Example27 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/aurelia/src/examples/slickgrid/example27.ts
+++ b/demos/aurelia/src/examples/slickgrid/example27.ts
@@ -114,7 +114,7 @@ export class Example27 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/aurelia/src/examples/slickgrid/example28.ts
+++ b/demos/aurelia/src/examples/slickgrid/example28.ts
@@ -228,7 +228,7 @@ export class Example28 {
 
   treeFormatter: Formatter = (_row, _cell, value, _columnDef, dataContext, grid) => {
     const gridOptions = grid.getOptions();
-    const treeLevelPropName = (gridOptions.treeDataOptions && gridOptions.treeDataOptions.levelPropName) || '__treeLevel';
+    const treeLevelPropName = gridOptions?.treeDataOptions?.levelPropName || '__treeLevel';
     if (value === null || value === undefined || dataContext === undefined) {
       return '';
     }
@@ -241,18 +241,19 @@ export class Example28 {
     const exportIndentationLeadingChar = '.';
 
     value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const spacer = `<span style="display:inline-block; width:${15 * treeLevel}px;"></span>`;
+    const spacer = `<span class="display-inline-block width-${15 * treeLevel}px"></span>`;
     const indentSpacer = addWhiteSpaces(5 * treeLevel);
+    const spanValue = `<span class="slick-tree-title">${value}</span>`;
 
     if (data[idx + 1]?.[treeLevelPropName] > data[idx][treeLevelPropName] || data[idx]['__hasChildren']) {
-      const folderPrefix = `<span class="mdi icon ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></span>`;
+      const folderPrefix = `<i class="mdi font-22px ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></i>`;
       if (dataContext.__collapsed) {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       } else {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       }
     } else {
-      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${value}`;
+      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${spanValue}`;
     }
   };
 

--- a/demos/aurelia/test/cypress/e2e/example01.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example01.cy.ts
@@ -16,11 +16,15 @@ describe('Example 1 - Basic Grids', () => {
   it('should have 2 grids of size 800 by 225px', () => {
     cy.get('#slickGridContainer-grid1-1').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
 
     cy.get('#slickGridContainer-grid1-2').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
   });
 
   it('should have exact column titles on 1st grid', () => {
@@ -108,7 +112,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -166,7 +170,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-1')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -209,7 +213,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -320,7 +324,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -354,7 +358,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-1')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {

--- a/demos/aurelia/test/cypress/e2e/example13.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example13.cy.ts
@@ -276,7 +276,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-test="clear-filter-btn"]').click();
       cy.get('[data-test="group-duration-sort-value-btn"]').click();
       cy.get('[data-test="collapse-all-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 1');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 2');
@@ -296,7 +296,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
 
     it('should Group by "Duration & Effort-Driven", then focus on first cell group "Duration: 0" then type ArrowRight and expect sub-group to expand', () => {
       cy.get('[data-test="group-duration-effort-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
@@ -320,6 +320,16 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.press(Cypress.Keyboard.Keys.LEFT);
 
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+      cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+    });
+
+    it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+      cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
+      cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
+
+      cy.get('[data-row="0"] > .slick-cell.l0').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/demos/aurelia/test/cypress/e2e/example13.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example13.cy.ts
@@ -329,7 +329,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
 
-      cy.get('[data-row="0"] > .slick-cell.l0').click();
+      cy.get('[data-row="0"] > .slick-cell.l0 .slick-group-title').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/demos/aurelia/test/cypress/e2e/example27.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example27.cy.ts
@@ -1,7 +1,7 @@
 /* eslint-disable n/file-extension-in-import */
 import { changeTimezone, zeroPadding } from '../plugins/utilities';
 
-function removeExtraSpaces(text) {
+function removeExtraSpaces(text: string) {
   return `${text}`.replace(/\s+/g, ' ').trim();
 }
 
@@ -259,7 +259,14 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
 
   it('should be able to click on "Dynamically Toggle First Parent" expect only the first parent item to get collapsed', () => {
     cy.get('[data-test=dynamically-toggle-first-parent-btn]').contains('Dynamically Toggle First Parent').click();
-
     cy.get(`#grid27 .slick-group-toggle.expanded`).should('have.length', 0);
+  });
+
+  it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
+
+    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/demos/aurelia/test/cypress/e2e/example27.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example27.cy.ts
@@ -266,7 +266,7 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
 
-    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell.l0 .slick-tree-title').click();
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/demos/react/src/examples/slickgrid/Example13.tsx
+++ b/demos/react/src/examples/slickgrid/Example13.tsx
@@ -207,7 +207,7 @@ const Example13: React.FC = () => {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableExcelExport: true,
       enableTextExport: true,

--- a/demos/react/src/examples/slickgrid/Example13.tsx
+++ b/demos/react/src/examples/slickgrid/Example13.tsx
@@ -207,7 +207,7 @@ const Example13: React.FC = () => {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableExcelExport: true,
       enableTextExport: true,

--- a/demos/react/src/examples/slickgrid/Example13.tsx
+++ b/demos/react/src/examples/slickgrid/Example13.tsx
@@ -207,7 +207,7 @@ const Example13: React.FC = () => {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon)
       },
       enableExcelExport: true,
       enableTextExport: true,

--- a/demos/react/src/examples/slickgrid/Example13.tsx
+++ b/demos/react/src/examples/slickgrid/Example13.tsx
@@ -206,6 +206,9 @@ const Example13: React.FC = () => {
       // you could debounce/throttle the input text filter if you have lots of data
       // filterTypingDebounce: 250,
       enableGrouping: true,
+      groupItemMetadataOption: {
+        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      },
       enableExcelExport: true,
       enableTextExport: true,
       excelExportOptions: { sanitizeDataExport: true },

--- a/demos/react/src/examples/slickgrid/Example27.tsx
+++ b/demos/react/src/examples/slickgrid/Example27.tsx
@@ -119,7 +119,7 @@ const Example27: React.FC = () => {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/react/src/examples/slickgrid/Example27.tsx
+++ b/demos/react/src/examples/slickgrid/Example27.tsx
@@ -119,7 +119,7 @@ const Example27: React.FC = () => {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/react/src/examples/slickgrid/Example27.tsx
+++ b/demos/react/src/examples/slickgrid/Example27.tsx
@@ -119,6 +119,7 @@ const Example27: React.FC = () => {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
+        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/react/src/examples/slickgrid/Example27.tsx
+++ b/demos/react/src/examples/slickgrid/Example27.tsx
@@ -119,7 +119,7 @@ const Example27: React.FC = () => {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/react/src/examples/slickgrid/Example28.tsx
+++ b/demos/react/src/examples/slickgrid/Example28.tsx
@@ -238,7 +238,7 @@ const Example28: React.FC = () => {
 
   const treeFormatter: Formatter = (_row, _cell, value, _columnDef, dataContext, grid) => {
     const gridOptions = grid.getOptions();
-    const treeLevelPropName = (gridOptions.treeDataOptions && gridOptions.treeDataOptions.levelPropName) || '__treeLevel';
+    const treeLevelPropName = gridOptions?.treeDataOptions?.levelPropName || '__treeLevel';
     if (value === null || value === undefined || dataContext === undefined) {
       return '';
     }
@@ -251,18 +251,19 @@ const Example28: React.FC = () => {
     const exportIndentationLeadingChar = '.';
 
     value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const spacer = `<span style="display:inline-block; width:${15 * treeLevel}px;"></span>`;
+    const spacer = `<span class="display-inline-block width-${15 * treeLevel}px"></span>`;
     const indentSpacer = addWhiteSpaces(5 * treeLevel);
+    const spanValue = `<span class="slick-tree-title">${value}</span>`;
 
     if (data[idx + 1]?.[treeLevelPropName] > data[idx][treeLevelPropName] || data[idx]['__hasChildren']) {
-      const folderPrefix = `<span class="mdi icon color-alt-warning ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></span>`;
+      const folderPrefix = `<i class="mdi font-22px ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></i>`;
       if (dataContext.__collapsed) {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       } else {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       }
     } else {
-      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${value}`;
+      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${spanValue}`;
     }
   };
 

--- a/demos/react/test/cypress/e2e/example01.cy.ts
+++ b/demos/react/test/cypress/e2e/example01.cy.ts
@@ -16,11 +16,15 @@ describe('Example 1 - Basic Grids', () => {
   it('should have 2 grids of size 800 by 225px', () => {
     cy.get('#slickGridContainer-grid1-1').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
 
     cy.get('#slickGridContainer-grid1-2').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
   });
 
   it('should have exact column titles on 1st grid', () => {
@@ -108,7 +112,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -166,7 +170,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-1')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -209,7 +213,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -320,7 +324,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -354,7 +358,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-1')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {

--- a/demos/react/test/cypress/e2e/example13.cy.ts
+++ b/demos/react/test/cypress/e2e/example13.cy.ts
@@ -276,7 +276,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-test="clear-filter-btn"]').click();
       cy.get('[data-test="group-duration-sort-value-btn"]').click();
       cy.get('[data-test="collapse-all-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 1');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 2');
@@ -296,7 +296,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
 
     it('should Group by "Duration & Effort-Driven", then focus on first cell group "Duration: 0" then type ArrowRight and expect sub-group to expand', () => {
       cy.get('[data-test="group-duration-effort-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
@@ -320,6 +320,16 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.press(Cypress.Keyboard.Keys.LEFT);
 
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+      cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+    });
+
+    it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+      cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
+      cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
+
+      cy.get('[data-row="0"] > .slick-cell.l0').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/demos/react/test/cypress/e2e/example13.cy.ts
+++ b/demos/react/test/cypress/e2e/example13.cy.ts
@@ -329,7 +329,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
 
-      cy.get('[data-row="0"] > .slick-cell.l0').click();
+      cy.get('[data-row="0"] > .slick-cell.l0 .slick-group-title').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/demos/react/test/cypress/e2e/example27.cy.ts
+++ b/demos/react/test/cypress/e2e/example27.cy.ts
@@ -263,7 +263,7 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
 
-    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell.l0 .slick-tree-title').click();
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/demos/react/test/cypress/e2e/example27.cy.ts
+++ b/demos/react/test/cypress/e2e/example27.cy.ts
@@ -256,7 +256,14 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
 
   it('should be able to click on "Dynamically Toggle First Parent" expect only the first parent item to get collapsed', () => {
     cy.get('[data-test=dynamically-toggle-first-parent-btn]').contains('Dynamically Toggle First Parent').click();
-
     cy.get(`#grid27 .slick-group-toggle.expanded`).should('have.length', 0);
+  });
+
+  it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
+
+    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/demos/vanilla/src/examples/example02.ts
+++ b/demos/vanilla/src/examples/example02.ts
@@ -274,7 +274,7 @@ export default class Example02 {
         onColumnsChanged: (e, args) => console.log(e, args),
       },
       groupItemMetadataOption: {
-        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableExcelExport: true,
       excelExportOptions: {

--- a/demos/vanilla/src/examples/example02.ts
+++ b/demos/vanilla/src/examples/example02.ts
@@ -273,6 +273,9 @@ export default class Example02 {
       columnPicker: {
         onColumnsChanged: (e, args) => console.log(e, args),
       },
+      groupItemMetadataOption: {
+        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      },
       enableExcelExport: true,
       excelExportOptions: {
         filename: 'my-export',

--- a/demos/vanilla/src/examples/example02.ts
+++ b/demos/vanilla/src/examples/example02.ts
@@ -274,7 +274,7 @@ export default class Example02 {
         onColumnsChanged: (e, args) => console.log(e, args),
       },
       groupItemMetadataOption: {
-        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableExcelExport: true,
       excelExportOptions: {

--- a/demos/vanilla/src/examples/example02.ts
+++ b/demos/vanilla/src/examples/example02.ts
@@ -274,7 +274,7 @@ export default class Example02 {
         onColumnsChanged: (e, args) => console.log(e, args),
       },
       groupItemMetadataOption: {
-        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon)
       },
       enableExcelExport: true,
       excelExportOptions: {

--- a/demos/vanilla/src/examples/example05.ts
+++ b/demos/vanilla/src/examples/example05.ts
@@ -273,7 +273,7 @@ export default class Example05 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/vanilla/src/examples/example05.ts
+++ b/demos/vanilla/src/examples/example05.ts
@@ -273,7 +273,7 @@ export default class Example05 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/vanilla/src/examples/example05.ts
+++ b/demos/vanilla/src/examples/example05.ts
@@ -273,7 +273,7 @@ export default class Example05 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/vanilla/src/examples/example05.ts
+++ b/demos/vanilla/src/examples/example05.ts
@@ -273,6 +273,7 @@ export default class Example05 {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
+        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/demos/vanilla/src/examples/example06.ts
+++ b/demos/vanilla/src/examples/example06.ts
@@ -262,16 +262,17 @@ export default class Example06 {
     value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     const spacer = `<span class="display-inline-block width-${15 * treeLevel}px"></span>`;
     const indentSpacer = addWhiteSpaces(5 * treeLevel);
+    const spanValue = `<span class="slick-tree-title">${value}</span>`;
 
     if (data[idx + 1]?.[treeLevelPropName] > data[idx][treeLevelPropName] || data[idx]['__hasChildren']) {
       const folderPrefix = `<i class="mdi font-22px ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></i>`;
       if (dataContext.__collapsed) {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       } else {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       }
     } else {
-      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${value}`;
+      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${spanValue}`;
     }
   };
 

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -202,7 +202,7 @@ function defineGrid() {
     // filterTypingDebounce: 250,
     enableGrouping: true,
     groupItemMetadataOption: {
-      toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
     },
     enableExcelExport: true,
     enableTextExport: true,

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -202,7 +202,7 @@ function defineGrid() {
     // filterTypingDebounce: 250,
     enableGrouping: true,
     groupItemMetadataOption: {
-      toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
     },
     enableExcelExport: true,
     enableTextExport: true,

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -201,6 +201,9 @@ function defineGrid() {
     // you could debounce/throttle the input text filter if you have lots of data
     // filterTypingDebounce: 250,
     enableGrouping: true,
+    groupItemMetadataOption: {
+      toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+    },
     enableExcelExport: true,
     enableTextExport: true,
     excelExportOptions: { sanitizeDataExport: true },

--- a/demos/vue/src/components/Example13.vue
+++ b/demos/vue/src/components/Example13.vue
@@ -202,7 +202,7 @@ function defineGrid() {
     // filterTypingDebounce: 250,
     enableGrouping: true,
     groupItemMetadataOption: {
-      toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      toggleOnNodeTitle: true, // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon)
     },
     enableExcelExport: true,
     enableTextExport: true,

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -116,7 +116,7 @@ function defineGrid() {
     enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
     treeDataOptions: {
       columnId: 'title',
-      toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+      toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
       parentPropName: 'parentId',
       // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
       levelPropName: 'treeLevel',

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -116,6 +116,7 @@ function defineGrid() {
     enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
     treeDataOptions: {
       columnId: 'title',
+      toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
       parentPropName: 'parentId',
       // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
       levelPropName: 'treeLevel',

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -116,7 +116,7 @@ function defineGrid() {
     enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
     treeDataOptions: {
       columnId: 'title',
-      toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+      toggleOnNodeTitle: true, // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
       parentPropName: 'parentId',
       // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
       levelPropName: 'treeLevel',

--- a/demos/vue/src/components/Example27.vue
+++ b/demos/vue/src/components/Example27.vue
@@ -116,7 +116,7 @@ function defineGrid() {
     enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
     treeDataOptions: {
       columnId: 'title',
-      toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+      toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
       parentPropName: 'parentId',
       // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
       levelPropName: 'treeLevel',

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -31,7 +31,7 @@ let vueGrid!: SlickgridVueInstance;
 
 const treeFormatter: Formatter = (_row, _cell, value, _columnDef, dataContext, grid) => {
   const gridOptions = grid.getOptions();
-  const treeLevelPropName = (gridOptions.treeDataOptions && gridOptions.treeDataOptions.levelPropName) || '__treeLevel';
+  const treeLevelPropName = gridOptions?.treeDataOptions?.levelPropName || '__treeLevel';
   if (value === null || value === undefined || dataContext === undefined) {
     return '';
   }
@@ -39,23 +39,24 @@ const treeFormatter: Formatter = (_row, _cell, value, _columnDef, dataContext, g
   const data = dataView.getItems();
   const identifierPropName = dataView.getIdPropertyName() || 'id';
   const idx = dataView.getIdxById(dataContext[identifierPropName]) as number;
-  const prefix = getFileIcon(value);
+  const prefix = this.getFileIcon(value);
   const treeLevel = dataContext[treeLevelPropName];
   const exportIndentationLeadingChar = '.';
 
   value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  const spacer = `<span style="display:inline-block; width:${15 * treeLevel}px;"></span>`;
+  const spacer = `<span class="display-inline-block width-${15 * treeLevel}px"></span>`;
   const indentSpacer = addWhiteSpaces(5 * treeLevel);
+  const spanValue = `<span class="slick-tree-title">${value}</span>`;
 
   if (data[idx + 1]?.[treeLevelPropName] > data[idx][treeLevelPropName] || data[idx]['__hasChildren']) {
-    const folderPrefix = `<span class="mdi icon ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></span>`;
+    const folderPrefix = `<i class="mdi font-22px ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></i>`;
     if (dataContext.__collapsed) {
-      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
     } else {
-      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
     }
   } else {
-    return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${value}`;
+    return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${spanValue}`;
   }
 };
 

--- a/demos/vue/src/components/Example28.vue
+++ b/demos/vue/src/components/Example28.vue
@@ -39,7 +39,7 @@ const treeFormatter: Formatter = (_row, _cell, value, _columnDef, dataContext, g
   const data = dataView.getItems();
   const identifierPropName = dataView.getIdPropertyName() || 'id';
   const idx = dataView.getIdxById(dataContext[identifierPropName]) as number;
-  const prefix = this.getFileIcon(value);
+  const prefix = getFileIcon(value);
   const treeLevel = dataContext[treeLevelPropName];
   const exportIndentationLeadingChar = '.';
 

--- a/demos/vue/test/cypress/e2e/example01.cy.ts
+++ b/demos/vue/test/cypress/e2e/example01.cy.ts
@@ -16,11 +16,15 @@ describe('Example 1 - Basic Grids', () => {
   it('should have 2 grids of size 800 by 225px', () => {
     cy.get('#slickGridContainer-grid1-1').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
 
     cy.get('#slickGridContainer-grid1-2').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
   });
 
   it('should have exact column titles on 1st grid', () => {
@@ -108,7 +112,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -166,7 +170,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-1')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -209,7 +213,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -320,7 +324,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-2')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -354,7 +358,7 @@ describe('Example 1 - Basic Grids', () => {
     cy.get('#grid1-1')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {

--- a/demos/vue/test/cypress/e2e/example13.cy.ts
+++ b/demos/vue/test/cypress/e2e/example13.cy.ts
@@ -276,7 +276,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-test="clear-filter-btn"]').click();
       cy.get('[data-test="group-duration-sort-value-btn"]').click();
       cy.get('[data-test="collapse-all-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 1');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 2');
@@ -296,7 +296,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
 
     it('should Group by "Duration & Effort-Driven", then focus on first cell group "Duration: 0" then type ArrowRight and expect sub-group to expand', () => {
       cy.get('[data-test="group-duration-effort-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
@@ -320,6 +320,16 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.press(Cypress.Keyboard.Keys.LEFT);
 
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+      cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+    });
+
+    it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+      cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
+      cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
+
+      cy.get('[data-row="0"] > .slick-cell.l0').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/demos/vue/test/cypress/e2e/example13.cy.ts
+++ b/demos/vue/test/cypress/e2e/example13.cy.ts
@@ -329,7 +329,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
 
-      cy.get('[data-row="0"] > .slick-cell.l0').click();
+      cy.get('[data-row="0"] > .slick-cell.l0 .slick-group-title').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/demos/vue/test/cypress/e2e/example27.cy.ts
+++ b/demos/vue/test/cypress/e2e/example27.cy.ts
@@ -1,7 +1,7 @@
 /* eslint-disable n/file-extension-in-import */
 import { changeTimezone, zeroPadding } from '../plugins/utilities';
 
-function removeExtraSpaces(text) {
+function removeExtraSpaces(text: string) {
   return `${text}`.replace(/\s+/g, ' ').trim();
 }
 
@@ -259,7 +259,14 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
 
   it('should be able to click on "Dynamically Toggle First Parent" expect only the first parent item to get collapsed', () => {
     cy.get('[data-test=dynamically-toggle-first-parent-btn]').contains('Dynamically Toggle First Parent').click();
-
     cy.get(`#grid27 .slick-group-toggle.expanded`).should('have.length', 0);
+  });
+
+  it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
+
+    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/demos/vue/test/cypress/e2e/example27.cy.ts
+++ b/demos/vue/test/cypress/e2e/example27.cy.ts
@@ -266,7 +266,7 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
 
-    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell.l0 .slick-tree-title').click();
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/docs/grid-functionalities/grouping-aggregators.md
+++ b/docs/grid-functionalities/grouping-aggregators.md
@@ -33,7 +33,7 @@ The important thing to understand while working with `SlickGrid` is that Groupin
 
 The Draggable Grouping can be located in either the Top-Header or the Pre-Header as described below.
 
-#### Pre-Heaader
+#### Pre-Header
 Draggable Grouping can be located in either the Pre-Header of the Top-Header, however when it is located in the Pre-Header then the Header Grouping will not be available (because both of them would conflict with each other). Note that prior to the version 5.1 of Slickgrid-Universal, the Pre-Header was the default and only available option.
 
 ```ts
@@ -44,10 +44,14 @@ this.gridOptions = {
   draggableGrouping: {
     // ... any draggable plugin option
   },
+  groupItemMetadataOption: { 
+    // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+    toggleOnNodeTitle: true, 
+  }
 }
 ```
 
-#### Top-Heaader
+#### Top-Header
 ##### requires v5.1 and higher
 This is the preferred section since the Top-Header is on top of all headers (including pre-header) and it will always be the full grid width. Using the Top-Header also frees up the Pre-Header section for the potential use of Header Grouping.
 
@@ -106,30 +110,34 @@ Note: the Group Total Formatters named as currency will have these extra `params
 ```typescript
 initializeGrid() {
   this.columns = [
-      {
-        id: 'title', name: 'Title', field: 'title'
-      },
-      {
-        id: 'duration', name: 'Duration', field: 'duration',
-        type: 'number',
-        groupTotalsFormatter: GroupTotalFormatters.sumTotals,
-        params: { groupFormatterPrefix: 'Total: ' }
-      },
-      {
-        id: 'cost', name: 'Cost', field: 'cost',
-        exportWithFormatter: true,    // for a Dollar Formatter, we also want it to be displayed in the export to file
-        formatter: Formatters.dollar,
-        groupTotalsFormatter: GroupTotalFormatters.sumTotalsDollar,
-        params: { groupFormatterPrefix: '<b>Total</b>: ' /*, groupFormatterSuffix: ' USD'*/ }
-      }
+    {
+      id: 'title', name: 'Title', field: 'title'
+    },
+    {
+      id: 'duration', name: 'Duration', field: 'duration',
+      type: 'number',
+      groupTotalsFormatter: GroupTotalFormatters.sumTotals,
+      params: { groupFormatterPrefix: 'Total: ' }
+    },
+    {
+      id: 'cost', name: 'Cost', field: 'cost',
+      exportWithFormatter: true,    // for a Dollar Formatter, we also want it to be displayed in the export to file
+      formatter: Formatters.dollar,
+      groupTotalsFormatter: GroupTotalFormatters.sumTotalsDollar,
+      params: { groupFormatterPrefix: '<b>Total</b>: ' /*, groupFormatterSuffix: ' USD'*/ }
+    }
   ];
 
-    this.gridOptions = {
-      enableGrouping: true,        // don't forget to enable the grouping
-      exportOptions: {
-        sanitizeDataExport: true   // you can also sanitize the exported data (it will remove any HTML tags)
-      }
-    };
+  this.gridOptions = {
+    enableGrouping: true,        // don't forget to enable the grouping
+    exportOptions: {
+      sanitizeDataExport: true   // you can also sanitize the exported data (it will remove any HTML tags)
+    },
+    groupItemMetadataOption: { 
+      // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+      toggleOnNodeTitle: true, 
+    }
+  };
 }
 ```
 
@@ -218,7 +226,7 @@ To "Clear all Grouping", "Collapse all Groups" and "Expand all Groups", we can s
 
 ### Styling (change icons)
 The current icons are chevron (right/down), however if you wish to use +/- icons. You can simply update the SASS variables to use whichever SVG icon paths. The SASS variables you can change are
-```css
+```scss
 $slick-icon-group-color:                    $slick-primary-color;
 $slick-icon-group-expanded-svg-path:        "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M11,7H13V11H17V13H13V17H11V13H7V11H11V7Z";
 $slick-icon-group-collapsed-svg-path:       "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M17,11V13H7V11H17Z";

--- a/docs/grid-functionalities/tree-data-grid.md
+++ b/docs/grid-functionalities/tree-data-grid.md
@@ -61,7 +61,7 @@ initializeGrid() {
       formatter: Formatters.tree, exportCustomFormatter: Formatters.treeExport
     },
     // ...
-  };
+  ];
 
   this.gridOptions = {
     enableFiltering: true,  // <<-- REQUIRED, it won't work without filtering enabled
@@ -80,6 +80,7 @@ initializeGrid() {
         columnId: 'title',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'ASC'
       },
+      toggleOnNodeTitle: true,     // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
     },
   };
 }
@@ -118,7 +119,7 @@ initializeGrid() {
       filterable: true, sortable: true,
     },
     // ...
-  };
+  ];
 
   this.gridOptions = {
     enableFiltering: true,  // <<-- REQUIRED, it won't work without filtering enabled
@@ -126,8 +127,8 @@ initializeGrid() {
 
     treeDataOptions: {
       columnId: 'file',           // the column where you will have the Tree with collapse/expand icons
-      parentPropName: 'files',  // the parent/child key relation in your dataset
-      levelPropName: 'treeLevel',  // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
+      parentPropName: 'files',    // the parent/child key relation in your dataset
+      levelPropName: 'treeLevel', // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
 
       // you can optionally sort by a different column and/or sort direction
       // this is the RECOMMENDED approach, unless you are 100% that your original array is already sorted (in most cases it's not)
@@ -135,6 +136,7 @@ initializeGrid() {
         columnId: 'size',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'DESC'
       },
+      toggleOnNodeTitle: true,    // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
     },
   };
 }
@@ -150,7 +152,8 @@ this.gridOptions = {
   multiColumnSort: false, // <<-- REQUIRED to be Disabled since multi-column sorting is not currently supported with Tree Data
 
   treeDataOptions: {
-    columnId: 'title',           // the column where you will have the Tree with collapse/expand icons
+    columnId: 'title',        // the column where you will have the Tree with collapse/expand icons
+    toggleOnNodeTitle: true,  // enable toggle of tree by clicking on the toggle icon or its title (requires `.slick-tree-title` CSS class)
     // ...
 
     // we can also add a Custom Formatter just for the title text portion

--- a/frameworks/angular-slickgrid/docs/TOC.md
+++ b/frameworks/angular-slickgrid/docs/TOC.md
@@ -67,7 +67,7 @@
 * [Load Global Grid Options](grid-functionalities/global-options.md)
 * [Grid Menu](grid-functionalities/grid-menu.md)
 * [Grid State & Presets](grid-functionalities/grid-state-preset.md)
-* [Grouping & Aggregators](grid-functionalities/grouping-and-aggregators.md)
+* [Grouping & Aggregators](grid-functionalities/grouping-aggregators.md)
 * [Header & Footer Slots](grid-functionalities/header-footer-slots.md)
 * [Custom Menu Slots](grid-functionalities/menu-slots.md)
 * [Header Menu & Header Buttons](grid-functionalities/header-menu-header-buttons.md)

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/grouping-aggregators.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/grouping-aggregators.md
@@ -67,7 +67,7 @@ export class GridGroupingComponent implements OnInit, OnDestroy {
 
 The Draggable Grouping can be located in either the Top-Header or the Pre-Header as described below.
 
-#### Pre-Heaader
+#### Pre-Header
 Draggable Grouping can be located in either the Pre-Header of the Top-Header, however when it is located in the Pre-Header then the Header Grouping will not be available (because both of them would conflict with each other). Note that prior to the version 8.1 of Angular-Slickgrid, the Pre-Header was the default and only available option.
 
 ```ts
@@ -78,10 +78,14 @@ this.gridOptions = {
   draggableGrouping: {
     // ... any draggable plugin option
   },
+  groupItemMetadataOption: { 
+    // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+    toggleOnNodeTitle: true, 
+  }
 }
 ```
 
-#### Top-Heaader
+#### Top-Header
 ##### requires v8.1 and higher
 This is the preferred section since the Top-Header is on top of all headers (including pre-header) and it will always be the full grid width. Using the Top-Header also frees up the Pre-Header section for the potential use of Header Grouping.
 
@@ -140,30 +144,34 @@ Note: the Group Total Formatters named as currency will have these extra `params
 ```typescript
 export class GridGroupingComponent implements OnInit, OnDestroy {
   this.columns = [
-      {
-        id: 'title', name: 'Title', field: 'title'
-      },
-      {
-        id: 'duration', name: 'Duration', field: 'duration',
-        type: 'number',
-        groupTotalsFormatter: GroupTotalFormatters.sumTotals,
-        params: { groupFormatterPrefix: 'Total: ' }
-      },
-      {
-        id: 'cost', name: 'Cost', field: 'cost',
-        exportWithFormatter: true,    // for a Dollar Formatter, we also want it to be displayed in the export to file
-        formatter: Formatters.dollar,
-        groupTotalsFormatter: GroupTotalFormatters.sumTotalsDollar,
-        params: { groupFormatterPrefix: '<b>Total</b>: ' /*, groupFormatterSuffix: ' USD'*/ }
-      }
+    {
+      id: 'title', name: 'Title', field: 'title'
+    },
+    {
+      id: 'duration', name: 'Duration', field: 'duration',
+      type: 'number',
+      groupTotalsFormatter: GroupTotalFormatters.sumTotals,
+      params: { groupFormatterPrefix: 'Total: ' }
+    },
+    {
+      id: 'cost', name: 'Cost', field: 'cost',
+      exportWithFormatter: true,    // for a Dollar Formatter, we also want it to be displayed in the export to file
+      formatter: Formatters.dollar,
+      groupTotalsFormatter: GroupTotalFormatters.sumTotalsDollar,
+      params: { groupFormatterPrefix: '<b>Total</b>: ' /*, groupFormatterSuffix: ' USD'*/ }
+    }
   ];
 
-    this.gridOptions = {
-      enableGrouping: true,        // don't forget to enable the grouping
-      exportOptions: {
-        sanitizeDataExport: true   // you can also sanitize the exported data (it will remove any HTML tags)
-      }
-    };
+  this.gridOptions = {
+    enableGrouping: true,        // don't forget to enable the grouping
+    exportOptions: {
+      sanitizeDataExport: true   // you can also sanitize the exported data (it will remove any HTML tags)
+    },
+    groupItemMetadataOption: { 
+      // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+      toggleOnNodeTitle: true, 
+    }
+  };
 }
 ```
 
@@ -188,10 +196,10 @@ You can also create a custom `groupTotalsFormatter` similarly to a Formatter, ju
 ```typescript
 defineGrid() {
   this.columns = [
-      {
-        id: 'cost', name: 'Cost', field: 'cost',
-        groupTotalsFormatter: this.sumTotalsFormatter
-      }
+    {
+      id: 'cost', name: 'Cost', field: 'cost',
+      groupTotalsFormatter: this.sumTotalsFormatter
+    }
   ];
 }
 
@@ -210,26 +218,26 @@ Once you have added a `groupTotalsFormatter` and defined which aggregate you wan
 ##### ViewModel
 ```ts
 groupByDuration() {
-    this.dataviewObj.setGrouping({
-      getter: 'duration',  // the column `field` to group by
-      formatter: (g) => {
-        // (required) what will be displayed on top of each group
-        return `Duration:  ${g.value} <span style="color:green">(${g.count} items)</span>`;
-      },
-      comparer: (a, b) => {
-        // (optional) comparer is helpful to sort the grouped data
-        // code below will sort the grouped value in ascending order
-        return SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc);
-      },
-      aggregators: [
-        // (optional), what aggregators (accumulator) to use and on which field to do so
-        new Aggregators.Avg('percentComplete'),
-        new Aggregators.Sum('cost')
-      ],
-      aggregateCollapsed: false,  // (optional), do we want our aggregator to be collapsed?
-      lazyTotalsCalculation: true // (optional), do we want to lazily calculate the totals? True is commonly used
-    });
-  }
+  this.dataviewObj.setGrouping({
+    getter: 'duration',  // the column `field` to group by
+    formatter: (g) => {
+      // (required) what will be displayed on top of each group
+      return `Duration:  ${g.value} <span style="color:green">(${g.count} items)</span>`;
+    },
+    comparer: (a, b) => {
+      // (optional) comparer is helpful to sort the grouped data
+      // code below will sort the grouped value in ascending order
+      return SortComparers.numeric(a.value, b.value, SortDirectionNumber.asc);
+    },
+    aggregators: [
+      // (optional), what aggregators (accumulator) to use and on which field to do so
+      new Aggregators.Avg('percentComplete'),
+      new Aggregators.Sum('cost')
+    ],
+    aggregateCollapsed: false,  // (optional), do we want our aggregator to be collapsed?
+    lazyTotalsCalculation: true // (optional), do we want to lazily calculate the totals? True is commonly used
+  });
+}
 ```
 
 ### Clear Grouping / Collapse All / Expand All
@@ -252,7 +260,7 @@ To "Clear all Grouping", "Collapse all Groups" and "Expand all Groups", we can s
 
 ### Styling (change icons)
 The current icons are chevron (right/down), however if you wish to use +/- icons. You can simply update the SASS variables to use whichever SVG icon paths. The SASS variables you can change are
-```css
+```scss
 $slick-icon-group-color:                    $primary-color;
 $slick-icon-group-expanded-svg-path:        "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M11,7H13V11H17V13H13V17H11V13H7V11H11V7Z";
 $slick-icon-group-collapsed-svg-path:       "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M17,11V13H7V11H17Z";

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/tree-data-grid.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/tree-data-grid.md
@@ -91,6 +91,7 @@ defineGrid() {
         columnId: 'title',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'ASC'
       },
+      toggleOnNodeTitle: true,     // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
     },
   };
 }
@@ -147,8 +148,8 @@ initializeGrid() {
 
     treeDataOptions: {
       columnId: 'file',           // the column where you will have the Tree with collapse/expand icons
-      parentPropName: 'files',  // the parent/child key relation in your dataset
-      levelPropName: 'treeLevel',  // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
+      parentPropName: 'files',    // the parent/child key relation in your dataset
+      levelPropName: 'treeLevel', // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
 
       // you can optionally sort by a different column and/or sort direction
       // this is the RECOMMENDED approach, unless you are 100% that your original array is already sorted (in most cases it's not)
@@ -156,6 +157,7 @@ initializeGrid() {
         columnId: 'size',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'DESC'
       },
+      toggleOnNodeTitle: true,    // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
     },
   };
 }
@@ -171,7 +173,8 @@ this.gridOptions = {
   multiColumnSort: false, // <<-- REQUIRED to be Disabled since multi-column sorting is not currently supported with Tree Data
 
   treeDataOptions: {
-    columnId: 'title',           // the column where you will have the Tree with collapse/expand icons
+    columnId: 'title',        // the column where you will have the Tree with collapse/expand icons
+    toggleOnNodeTitle: true,  // enable toggle of tree by clicking on the toggle icon or its title (requires `.slick-tree-title` CSS class)
     // ...
 
     // we can also add a Custom Formatter just for the title text portion

--- a/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
@@ -206,7 +206,7 @@ export class Example13Component implements OnInit {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon)
       },
       enableTextExport: true,
       gridMenu: {

--- a/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
@@ -206,7 +206,7 @@ export class Example13Component implements OnInit {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableTextExport: true,
       gridMenu: {

--- a/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
@@ -205,6 +205,9 @@ export class Example13Component implements OnInit {
       // you could debounce/throttle the input text filter if you have lots of data
       // filterTypingDebounce: 250,
       enableGrouping: true,
+      groupItemMetadataOption: {
+        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+      },
       enableTextExport: true,
       gridMenu: {
         hideExportTextDelimitedCommand: false,

--- a/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example13.component.ts
@@ -206,7 +206,7 @@ export class Example13Component implements OnInit {
       // filterTypingDebounce: 250,
       enableGrouping: true,
       groupItemMetadataOption: {
-        toggleByCellClick: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of group by clicking anywhere on the cell (not just the toggle icon)
       },
       enableTextExport: true,
       gridMenu: {

--- a/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
@@ -131,6 +131,7 @@ export class Example27Component implements OnInit {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
+        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
@@ -131,7 +131,7 @@ export class Example27Component implements OnInit {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
@@ -131,7 +131,7 @@ export class Example27Component implements OnInit {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleByCellClick: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example27.component.ts
@@ -131,7 +131,7 @@ export class Example27Component implements OnInit {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        toggleOnNodeTitle: true, // enable toggle of tree by clicking anywhere on the cell (not just the toggle icon)
+        toggleOnNodeTitle: true, // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
         parentPropName: 'parentId',
         // this is optional, you can define the tree level property name that will be used for the sorting/indentation, internally it will use "__treeLevel"
         levelPropName: 'treeLevel',

--- a/frameworks/angular-slickgrid/src/demos/examples/example28.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example28.component.ts
@@ -269,7 +269,7 @@ export class Example28Component implements OnInit {
 
   treeFormatter: Formatter = (_row, _cell, value, _columnDef, dataContext, grid) => {
     const gridOptions = grid.getOptions();
-    const treeLevelPropName = (gridOptions.treeDataOptions && gridOptions.treeDataOptions.levelPropName) || '__treeLevel';
+    const treeLevelPropName = gridOptions?.treeDataOptions?.levelPropName || '__treeLevel';
     if (value === null || value === undefined || dataContext === undefined) {
       return '';
     }
@@ -282,18 +282,19 @@ export class Example28Component implements OnInit {
     const exportIndentationLeadingChar = '.';
 
     value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const spacer = `<span style="display:inline-block; width:${15 * treeLevel}px;"></span>`;
+    const spacer = `<span class="display-inline-block width-${15 * treeLevel}px"></span>`;
     const indentSpacer = addWhiteSpaces(5 * treeLevel);
+    const spanValue = `<span class="slick-tree-title">${value}</span>`;
 
     if (data[idx + 1]?.[treeLevelPropName] > data[idx][treeLevelPropName] || data[idx]['__hasChildren']) {
-      const folderPrefix = `<span class="mdi icon ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></span>`;
+      const folderPrefix = `<i class="mdi font-22px ${dataContext.__collapsed ? 'mdi-folder' : 'mdi-folder-open'}"></i>`;
       if (dataContext.__collapsed) {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle collapsed" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       } else {
-        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${value}`;
+        return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle expanded" level="${treeLevel}"></span>${folderPrefix} ${prefix} ${spanValue}`;
       }
     } else {
-      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${value}`;
+      return `<span class="hidden">${exportIndentationLeadingChar}</span>${spacer}${indentSpacer} <span class="slick-group-toggle" level="${treeLevel}"></span>${prefix} ${spanValue}`;
     }
   };
 

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -697,7 +697,7 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
       let dataViewOptions: Partial<DataViewOption> = { ...this.options.dataView, inlineFilters: dataviewInlineFilters };
 
       if (this.options.draggableGrouping || this.options.enableGrouping) {
-        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
+        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider(this.options.groupItemMetadataOption);
         this.sharedService.groupItemMetadataProvider = this.groupItemMetadataProvider;
         dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: this.groupItemMetadataProvider };
       }

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example01.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example01.cy.ts
@@ -9,11 +9,15 @@ describe('Example 1 - Basic Grids', () => {
   it('should have 2 grids of size 800 by 225px', () => {
     cy.get('#slickGridContainer-grid1-1').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-1 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
 
     cy.get('#slickGridContainer-grid1-2').should('have.css', 'width', '800px');
 
-    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('#slickGridContainer-grid1-2 > .slickgrid-container').should(($el) =>
+      expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1)
+    );
   });
 
   it('should have exact column titles on 1st grid', () => {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example13.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example13.cy.ts
@@ -276,7 +276,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-test="clear-filter-btn"]').click();
       cy.get('[data-test="group-duration-sort-value-btn"]').click();
       cy.get('[data-test="collapse-all-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 1');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 2');
@@ -296,7 +296,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
 
     it('should Group by "Duration & Effort-Driven", then focus on first cell group "Duration: 0" then type ArrowRight and expect sub-group to expand', () => {
       cy.get('[data-test="group-duration-effort-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
@@ -320,6 +320,16 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.press(Cypress.Keyboard.Keys.LEFT);
 
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+      cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+    });
+
+    it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+      cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
+      cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
+
+      cy.get('[data-row="0"] > .slick-cell.l0').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example13.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example13.cy.ts
@@ -329,7 +329,7 @@ describe('Example 13 - Grouping & Aggregators', () => {
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
 
-      cy.get('[data-row="0"] > .slick-cell.l0').click();
+      cy.get('[data-row="0"] > .slick-cell.l0 .slick-group-title').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example27.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example27.cy.ts
@@ -254,7 +254,14 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
 
   it('should be able to click on "Dynamically Toggle First Parent" expect only the first parent item to get collapsed', () => {
     cy.get('[data-test=dynamically-toggle-first-parent-btn]').contains('Dynamically Toggle First Parent').click();
-
     cy.get(`#grid27 .slick-group-toggle.expanded`).should('have.length', 0);
+  });
+
+  it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
+
+    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example27.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example27.cy.ts
@@ -261,7 +261,7 @@ describe('Example 27 - Tree Data (from a flat dataset with parentId references)'
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
 
-    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell.l0 .slick-tree-title').click();
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/grouping-aggregators.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/grouping-aggregators.md
@@ -59,6 +59,12 @@ export class Example {
 
   attached() {
     // populate the grid
+    this.gridOptions = {
+      groupItemMetadataOption: { 
+        // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+        toggleOnNodeTitle: true, 
+      }
+    }
   }
 }
 ```
@@ -67,7 +73,7 @@ export class Example {
 
 The Draggable Grouping can be located in either the Top-Header or the Pre-Header as described below.
 
-#### Pre-Heaader
+#### Pre-Header
 Draggable Grouping can be located in either the Pre-Header of the Top-Header, however when it is located in the Pre-Header then the Header Grouping will not be available (because both of them would conflict with each other). Note that prior to the version 8.1 of Aurelia-Slickgrid, the Pre-Header was the default and only available option.
 
 ```ts
@@ -78,10 +84,14 @@ this.gridOptions = {
   draggableGrouping: {
     // ... any draggable plugin option
   },
+  groupItemMetadataOption: { 
+    // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+    toggleOnNodeTitle: true, 
+  }
 }
 ```
 
-#### Top-Heaader
+#### Top-Header
 ##### requires v8.1 and higher
 This is the preferred section since the Top-Header is on top of all headers (including pre-header) and it will always be the full grid width. Using the Top-Header also frees up the Pre-Header section for the potential use of Header Grouping.
 
@@ -252,7 +262,7 @@ To "Clear all Grouping", "Collapse all Groups" and "Expand all Groups", we can s
 
 ### Styling (change icons)
 The current icons are chevron (right/down), however if you wish to use +/- icons. You can simply update the SASS variables to use whichever SVG icon paths. The SASS variables you can change are
-```css
+```scss
 $slick-icon-group-color:                    $primary-color;
 $slick-icon-group-expanded-svg-path:        "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M11,7H13V11H17V13H13V17H11V13H7V11H11V7Z";
 $slick-icon-group-collapsed-svg-path:       "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M17,11V13H7V11H17Z";

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/tree-data-grid.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/tree-data-grid.md
@@ -91,6 +91,7 @@ defineGrid() {
         columnId: 'title',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'ASC'
       },
+      toggleOnNodeTitle: true,     // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
     },
   };
 }
@@ -147,8 +148,8 @@ initializeGrid() {
 
     treeDataOptions: {
       columnId: 'file',           // the column where you will have the Tree with collapse/expand icons
-      parentPropName: 'files',  // the parent/child key relation in your dataset
-      levelPropName: 'treeLevel',  // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
+      parentPropName: 'files',    // the parent/child key relation in your dataset
+      levelPropName: 'treeLevel', // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
 
       // you can optionally sort by a different column and/or sort direction
       // this is the RECOMMENDED approach, unless you are 100% that your original array is already sorted (in most cases it's not)
@@ -156,6 +157,7 @@ initializeGrid() {
         columnId: 'size',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'DESC'
       },
+      toggleOnNodeTitle: true,    // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
     },
   };
 }
@@ -171,7 +173,8 @@ this.gridOptions = {
   multiColumnSort: false, // <<-- REQUIRED to be Disabled since multi-column sorting is not currently supported with Tree Data
 
   treeDataOptions: {
-    columnId: 'title',           // the column where you will have the Tree with collapse/expand icons
+    columnId: 'title',        // the column where you will have the Tree with collapse/expand icons
+    toggleOnNodeTitle: true,  // enable toggle of tree by clicking on the toggle icon or its title (requires `.slick-tree-title` CSS class)
     // ...
 
     // we can also add a Custom Formatter just for the title text portion

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -342,7 +342,7 @@ export class AureliaSlickgridCustomElement {
       let dataViewOptions: Partial<DataViewOption> = { ...this.options.dataView, inlineFilters: dataviewInlineFilters };
 
       if (this.options.draggableGrouping || this.options.enableGrouping) {
-        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
+        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider(this.options.groupItemMetadataOption);
         this.sharedService.groupItemMetadataProvider = this.groupItemMetadataProvider;
         dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: this.groupItemMetadataProvider };
       }

--- a/frameworks/slickgrid-react/docs/grid-functionalities/grouping-aggregators.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/grouping-aggregators.md
@@ -48,7 +48,13 @@ const Example: React.FC = () => {
   }
 
   function defineGrid() {
-    // populate the grid
+    setColumns([ /* ... */ ]);
+    setOptions({
+      groupItemMetadataOption: { 
+        // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+        toggleOnNodeTitle: true, 
+      }
+    });
   }
 
   return !options ? null : (
@@ -66,7 +72,7 @@ const Example: React.FC = () => {
 
 The Draggable Grouping can be located in either the Top-Header or the Pre-Header as described below.
 
-#### Pre-Heaader
+#### Pre-Header
 Draggable Grouping can be located in either the Pre-Header of the Top-Header, however when it is located in the Pre-Header then the Header Grouping will not be available (because both of them would conflict with each other). Note that prior to the version 5.1 of Slickgrid-React, the Pre-Header was the default and only available option.
 
 ```ts
@@ -80,7 +86,7 @@ const gridOptions = {
 }
 ```
 
-#### Top-Heaader
+#### Top-Header
 ##### requires v5.1 and higher
 This is the preferred section since the Top-Header is on top of all headers (including pre-header) and it will always be the full grid width. Using the Top-Header also frees up the Pre-Header section for the potential use of Header Grouping.
 
@@ -259,7 +265,7 @@ To "Clear all Grouping", "Collapse all Groups" and "Expand all Groups", we can s
 
 ### Styling (change icons)
 The current icons are chevron (right/down), however if you wish to use +/- icons. You can simply update the SASS variables to use whichever SVG icon paths. The SASS variables you can change are
-```css
+```scss
 $slick-icon-group-color:                    $primary-color;
 $slick-icon-group-expanded-svg-path:        "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M11,7H13V11H17V13H13V17H11V13H7V11H11V7Z";
 $slick-icon-group-collapsed-svg-path:       "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M17,11V13H7V11H17Z";

--- a/frameworks/slickgrid-react/docs/grid-functionalities/tree-data-grid.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/tree-data-grid.md
@@ -81,6 +81,7 @@ function defineGrid() {
         columnId: 'title',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'ASC'
       },
+      toggleOnNodeTitle: true,     // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
     },
   };
 }
@@ -120,8 +121,8 @@ const Example: React.FC = () => {
 
       treeDataOptions: {
         columnId: 'file',           // the column where you will have the Tree with collapse/expand icons
-        parentPropName: 'files',  // the parent/child key relation in your dataset
-        levelPropName: 'treeLevel',  // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
+        parentPropName: 'files',    // the parent/child key relation in your dataset
+        levelPropName: 'treeLevel', // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
 
         // you can optionally sort by a different column and/or sort direction
         // this is the RECOMMENDED approach, unless you are 100% that your original array is already sorted (in most cases it's not)
@@ -129,6 +130,7 @@ const Example: React.FC = () => {
           columnId: 'size',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
           direction: 'DESC'
         },
+        toggleOnNodeTitle: true,    // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
       },
     };
 
@@ -173,7 +175,8 @@ const gridOptions: GridOption = {
   multiColumnSort: false, // <<-- REQUIRED to be Disabled since multi-column sorting is not currently supported with Tree Data
 
   treeDataOptions: {
-    columnId: 'title',           // the column where you will have the Tree with collapse/expand icons
+    columnId: 'title',        // the column where you will have the Tree with collapse/expand icons
+    toggleOnNodeTitle: true,  // enable toggle of tree by clicking on the toggle icon or its title (requires `.slick-tree-title` CSS class)
     // ...
 
     // we can also add a Custom Formatter just for the title text portion

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -488,7 +488,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
       let dataViewOptions: Partial<DataViewOption> = { ...this._options.dataView, inlineFilters: dataviewInlineFilters };
 
       if (this._options.draggableGrouping || this._options.enableGrouping) {
-        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
+        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider(this._options.groupItemMetadataOption);
         this.sharedService.groupItemMetadataProvider = this.groupItemMetadataProvider;
         dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: this.groupItemMetadataProvider };
       }

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/grouping-aggregators.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/grouping-aggregators.md
@@ -49,6 +49,12 @@ onBeforeMount(() => {
 });
 
 function defineGrid() {
+  gridOptions.value = { 
+    groupItemMetadataOption: { 
+      // enable toggle of group by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
+      toggleOnNodeTitle: true, 
+    }
+  }
 }
 
 function vueGridReady(vueGrid: SlickgridVueInstance) {
@@ -74,7 +80,7 @@ function vueGridReady(vueGrid: SlickgridVueInstance) {
 
 The Draggable Grouping can be located in either the Top-Header or the Pre-Header as described below.
 
-#### Pre-Heaader
+#### Pre-Header
 Draggable Grouping can be located in either the Pre-Header of the Top-Header, however when it is located in the Pre-Header then the Header Grouping will not be available (because both of them would conflict with each other). Note that prior to the version 5.1 of Slickgrid-Vue, the Pre-Header was the default and only available option.
 
 ```ts
@@ -88,7 +94,7 @@ gridOptions.value = {
 }
 ```
 
-#### Top-Heaader
+#### Top-Header
 ##### requires v5.1 and higher
 This is the preferred section since the Top-Header is on top of all headers (including pre-header) and it will always be the full grid width. Using the Top-Header also frees up the Pre-Header section for the potential use of Header Grouping.
 
@@ -276,7 +282,8 @@ function expandAllGroups() {
 
 ### Styling (change icons)
 The current icons are chevron (right/down), however if you wish to use +/- icons. You can simply update the SASS variables to use whichever SVG icon paths. The SASS variables you can change are
-```css
+
+```scss
 $slick-icon-group-color:                    $primary-color;
 $slick-icon-group-expanded-svg-path:        "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M11,7H13V11H17V13H13V17H11V13H7V11H11V7Z";
 $slick-icon-group-collapsed-svg-path:       "M19,19V5H5V19H19M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5C3,3.89 3.9,3 5,3H19M17,11V13H7V11H17Z";

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/tree-data-grid.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/tree-data-grid.md
@@ -83,6 +83,7 @@ function defineGrid() {
         columnId: 'title',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'ASC'
       },
+      toggleOnNodeTitle: true, // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon)
     },
   };
 }
@@ -125,8 +126,8 @@ function defineGrid() {
 
     treeDataOptions: {
       columnId: 'file',           // the column where you will have the Tree with collapse/expand icons
-      parentPropName: 'files',  // the parent/child key relation in your dataset
-      levelPropName: 'treeLevel',  // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
+      parentPropName: 'files',    // the parent/child key relation in your dataset
+      levelPropName: 'treeLevel', // optionally, you can define the tree level property name, it nothing is provided it will use "__treeLevel"
 
       // you can optionally sort by a different column and/or sort direction
       // this is the RECOMMENDED approach, unless you are 100% that your original array is already sorted (in most cases it's not)
@@ -134,6 +135,7 @@ function defineGrid() {
         columnId: 'size',         // which column are we using to do the initial sort? it doesn't have to be the tree column, it could be any column
         direction: 'DESC'
       },
+      toggleOnNodeTitle: true,    // enable toggle of tree by clicking on the toggle icon or its title (not just the toggle icon), defaults to false
     },
   };
 
@@ -177,7 +179,8 @@ gridOptions.value = {
   multiColumnSort: false, // <<-- REQUIRED to be Disabled since multi-column sorting is not currently supported with Tree Data
 
   treeDataOptions: {
-    columnId: 'title',           // the column where you will have the Tree with collapse/expand icons
+    columnId: 'title',        // the column where you will have the Tree with collapse/expand icons
+    toggleOnNodeTitle: true,  // enable toggle of tree by clicking on the toggle icon or its title (requires `.slick-tree-title` CSS class)
     // ...
 
     // we can also add a Custom Formatter just for the title text portion

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -36,6 +36,7 @@ import {
   type ExtensionList,
   type ExternalResource,
   type ExternalResourceConstructor,
+  type GroupItemMetadataProviderOption,
   type Metrics,
   type Observable,
   type Pagination,
@@ -420,7 +421,9 @@ function initialization() {
   } as Partial<DataViewOption>;
 
   if (_gridOptions.value.draggableGrouping || _gridOptions.value.enableGrouping) {
-    groupItemMetadataProvider = new SlickGroupItemMetadataProvider(_gridOptions.value.groupItemMetadataOption);
+    groupItemMetadataProvider = new SlickGroupItemMetadataProvider(
+      _gridOptions.value.groupItemMetadataOption as GroupItemMetadataProviderOption | undefined
+    );
     sharedService.groupItemMetadataProvider = groupItemMetadataProvider;
     dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: groupItemMetadataProvider };
   }

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -385,19 +385,19 @@ function initialization() {
     _gridOptions.value.enableMouseWheelScrollHandler = true;
   }
 
-  eventPubSubService.eventNamingStyle = _gridOptions.value?.eventNamingStyle ?? 'camelCaseWithExtraOnPrefix';
+  eventPubSubService.eventNamingStyle = _gridOptions.value.eventNamingStyle ?? 'camelCaseWithExtraOnPrefix';
   eventPubSubService.publish('onBeforeGridCreate', true);
 
   // make sure the dataset is initialized (if not it will throw an error that it cannot getLength of null)
   // dataset.value = dataset.value || dataModel.value || [];
   currentDatasetLength = dataModel.value?.length || 0;
   _gridOptions.value = mergeGridOptions(_gridOptions.value as GridOption);
-  _paginationOptions.value = _gridOptions.value?.pagination;
-  backendServiceApi = _gridOptions.value?.backendServiceApi;
+  _paginationOptions.value = _gridOptions.value.pagination;
+  backendServiceApi = _gridOptions.value.backendServiceApi;
   isLocalGrid = !backendServiceApi; // considered a local grid if it doesn't have a backend service set
 
   // inject the I18Next instance when translation is enabled
-  if (_gridOptions.value?.enableTranslate || _gridOptions.value?.i18n) {
+  if (_gridOptions.value.enableTranslate || _gridOptions.value.i18n) {
     i18next = inject<I18Next | null>('i18next', null);
     if (i18next) {
       translaterService.i18nInstance = i18next;
@@ -409,18 +409,18 @@ function initialization() {
   }
 
   // unless specified, we'll create an internal postProcess callback (currently only available for GraphQL)
-  if (_gridOptions.value?.backendServiceApi && !_gridOptions.value.backendServiceApi?.disableInternalPostProcess) {
+  if (_gridOptions.value.backendServiceApi && !_gridOptions.value.backendServiceApi?.disableInternalPostProcess) {
     createBackendApiInternalPostProcessCallback(_gridOptions.value as GridOption);
   }
 
-  const dataviewInlineFilters = (_gridOptions.value?.dataView && _gridOptions.value.dataView.inlineFilters) || false;
+  const dataviewInlineFilters = (_gridOptions.value.dataView && _gridOptions.value.dataView.inlineFilters) || false;
   let dataViewOptions: Partial<DataViewOption> = {
     ..._gridOptions.value.dataView,
     inlineFilters: dataviewInlineFilters,
   } as Partial<DataViewOption>;
 
-  if (_gridOptions.value?.draggableGrouping || _gridOptions.value?.enableGrouping) {
-    groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
+  if (_gridOptions.value.draggableGrouping || _gridOptions.value.enableGrouping) {
+    groupItemMetadataProvider = new SlickGroupItemMetadataProvider(_gridOptions.value.groupItemMetadataOption);
     sharedService.groupItemMetadataProvider = groupItemMetadataProvider;
     dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: groupItemMetadataProvider };
   }
@@ -438,8 +438,8 @@ function initialization() {
   _columns.value = loadSlickGridEditors(columnsModel.value || []);
 
   // if the user wants to automatically add a Custom Editor Formatter, we need to call the auto add function again
-  if (_gridOptions.value?.autoAddCustomEditorFormatter) {
-    autoAddEditorFormatterToColumnsWithEditor(_columns.value as Column[], _gridOptions.value?.autoAddCustomEditorFormatter);
+  if (_gridOptions.value.autoAddCustomEditorFormatter) {
+    autoAddEditorFormatterToColumnsWithEditor(_columns.value as Column[], _gridOptions.value.autoAddCustomEditorFormatter);
   }
 
   // save reference for all columns before they optionally become hidden/visible
@@ -460,7 +460,7 @@ function initialization() {
   extensionService.createExtensionsBeforeGridCreation(_columns.value as Column[], _gridOptions.value as GridOption);
 
   // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options
-  if (_gridOptions.value?.presets?.pinning) {
+  if (_gridOptions.value.presets?.pinning) {
     _gridOptions.value = { ..._gridOptions.value, ..._gridOptions.value.presets.pinning };
   }
 
@@ -500,25 +500,25 @@ function initialization() {
 
   // user could show a custom footer with the data metrics (dataset length and last updated timestamp)
   if (
-    !_gridOptions.value?.enablePagination &&
-    _gridOptions.value?.showCustomFooter &&
-    _gridOptions.value?.customFooterOptions &&
+    !_gridOptions.value.enablePagination &&
+    _gridOptions.value.showCustomFooter &&
+    _gridOptions.value.customFooterOptions &&
     gridContainerElm
   ) {
-    slickFooter = new SlickFooterComponent(grid, _gridOptions.value?.customFooterOptions, eventPubSubService, translaterService);
+    slickFooter = new SlickFooterComponent(grid, _gridOptions.value.customFooterOptions, eventPubSubService, translaterService);
     slickFooter.renderFooter(gridContainerElm as HTMLDivElement);
   }
 
   if (dataview) {
     // load the data in the DataView (unless it's a hierarchical dataset, if so it will be loaded after the initial tree sort)
-    const initialDataset = _gridOptions.value?.enableTreeData ? sortTreeDataset(dataModel.value || []) : dataModel.value;
+    const initialDataset = _gridOptions.value.enableTreeData ? sortTreeDataset(dataModel.value || []) : dataModel.value;
     if (Array.isArray(initialDataset)) {
       dataview.setItems(initialDataset, _gridOptions.value.datasetIdPropertyName ?? 'id');
     }
 
     // if you don't want the items that are not visible (due to being filtered out or being on a different page)
     // to stay selected, pass 'false' to the second arg
-    if (grid?.getSelectionModel() && _gridOptions.value?.dataView && 'syncGridSelection' in _gridOptions.value.dataView) {
+    if (grid?.getSelectionModel() && _gridOptions.value.dataView && 'syncGridSelection' in _gridOptions.value.dataView) {
       // if we are using a Backend Service, we will do an extra flag check, the reason is because it might have some unintended behaviors
       // with the BackendServiceApi because technically the data in the page changes the DataView on every page change.
       let preservedRowSelectionWithBackend = false;
@@ -567,7 +567,7 @@ function initialization() {
 
   // bind the Backend Service API callback functions only after the grid is initialized
   // because the preProcess() and onInit() might get triggered
-  if (_gridOptions.value?.backendServiceApi) {
+  if (_gridOptions.value.backendServiceApi) {
     bindBackendCallbackFunctions(_gridOptions.value as GridOption);
   }
 

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -399,7 +399,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   /** Set some Grouping */
   setGrouping(groupingInfo: Grouping | Grouping[]): void {
     if (!this._options.groupItemMetadataProvider) {
-      this._options.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
+      this._options.groupItemMetadataProvider = new SlickGroupItemMetadataProvider(this._grid?.getOptions().groupItemMetadataOption);
     }
 
     this.groups = [];

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -139,6 +139,28 @@ describe('GroupItemMetadataProvider Service', () => {
       );
     });
 
+    it('should add pointer class to group title when toggleOnTitle is enabled', () => {
+      service.init(gridStub);
+      service.setOptions({ enableExpandCollapse: true, toggleOnTitle: true });
+      const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: 'Some Title' }, gridStub) as DocumentFragment;
+      const htmlContent = getHtmlStringOutput(output, 'outerHTML');
+
+      expect(htmlContent).toBe(
+        '<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title pointer" level="0">Some Title</span>'
+      );
+    });
+
+    it('should not add pointer class to group title when toggleOnTitle is disabled', () => {
+      service.init(gridStub);
+      service.setOptions({ enableExpandCollapse: true, toggleOnTitle: false });
+      const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: 'Some Title' }, gridStub) as DocumentFragment;
+      const htmlContent = getHtmlStringOutput(output, 'outerHTML');
+
+      expect(htmlContent).toBe(
+        '<span class="slick-group-toggle expanded" aria-expanded="true" style="margin-left: 0px;"></span><span class="slick-group-title" level="0">Some Title</span>'
+      );
+    });
+
     it('should provide HTMLElement and return same Grouping info formatted with a group level 0 without indentation when calling "defaultGroupCellFormatter" with option "enableExpandCollapse" set to True', () => {
       service.init(gridStub);
       service.setOptions({ enableExpandCollapse: true });

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -95,6 +95,7 @@ describe('GroupItemMetadataProvider Service', () => {
       toggleCssClass: 'slick-group-toggle',
       toggleExpandedCssClass: 'expanded',
       toggleCollapsedCssClass: 'collapsed',
+      toggleByCellClick: false,
       enableExpandCollapse: true,
       groupFormatter: expect.any(Function),
       totalsFormatter: expect.any(Function),
@@ -467,6 +468,153 @@ describe('GroupItemMetadataProvider Service', () => {
       expect(collapseGroupSpy).not.toHaveBeenCalled();
       expect(preventDefaultSpy).not.toHaveBeenCalled();
       expect(stopPropagationSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleByCellClick option via constructor', () => {
+    let collapseGroupSpy: any;
+    let expandGroupSpy: any;
+    let clickEvent: Event;
+    const group = new SlickGroup();
+    const mockRange = { top: 10, bottom: 25 } as any;
+
+    beforeEach(() => {
+      vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue(mockRange);
+      collapseGroupSpy = vi.spyOn(dataViewStub, 'collapseGroup');
+      expandGroupSpy = vi.spyOn(dataViewStub, 'expandGroup');
+
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(group);
+      clickEvent = new Event('click');
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: document.createElement('div') });
+      Object.defineProperty(clickEvent, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+      Object.defineProperty(clickEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should expand Group when toggleByCellClick is true and clicking on cell with group title', () => {
+      group.groupingKey = 'age';
+      group.collapsed = true;
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: true });
+
+      serviceWithToggle.init(gridStub);
+
+      // Create a cell structure with group title
+      const cellElm = document.createElement('div');
+      cellElm.className = 'slick-cell';
+      const toggleIcon = document.createElement('span');
+      toggleIcon.className = 'slick-group-toggle';
+      cellElm.appendChild(toggleIcon);
+      const titleElm = document.createElement('span');
+      titleElm.className = 'slick-group-title';
+      titleElm.textContent = 'Group Title';
+      cellElm.appendChild(titleElm);
+      document.body.appendChild(cellElm);
+
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: titleElm });
+      gridStub.onClick.notify({ row: 0, cell: 2, grid: gridStub }, clickEvent);
+
+      expect(expandGroupSpy).toHaveBeenCalledWith('age');
+      expect(collapseGroupSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(cellElm);
+      serviceWithToggle.dispose();
+    });
+
+    it('should collapse Group when toggleByCellClick is true and clicking on cell content', () => {
+      group.groupingKey = 'age';
+      group.collapsed = false;
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: true });
+
+      serviceWithToggle.init(gridStub);
+
+      // Create a cell structure with group title
+      const cellElm = document.createElement('div');
+      cellElm.className = 'slick-cell';
+      const toggleIcon = document.createElement('span');
+      toggleIcon.className = 'slick-group-toggle';
+      cellElm.appendChild(toggleIcon);
+      const titleElm = document.createElement('span');
+      titleElm.className = 'slick-group-title';
+      titleElm.textContent = 'Group Title';
+      cellElm.appendChild(titleElm);
+      document.body.appendChild(cellElm);
+
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: titleElm });
+      gridStub.onClick.notify({ row: 0, cell: 2, grid: gridStub }, clickEvent);
+
+      expect(collapseGroupSpy).toHaveBeenCalledWith('age');
+      expect(expandGroupSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(cellElm);
+      serviceWithToggle.dispose();
+    });
+
+    it('should NOT expand Group when toggleByCellClick is false and clicking on cell title', () => {
+      group.groupingKey = 'age';
+      group.collapsed = true;
+      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: false });
+
+      serviceWithoutToggle.init(gridStub);
+
+      // Create a cell structure with group title
+      const cellElm = document.createElement('div');
+      cellElm.className = 'slick-cell';
+      const toggleIcon = document.createElement('span');
+      toggleIcon.className = 'slick-group-toggle';
+      cellElm.appendChild(toggleIcon);
+      const titleElm = document.createElement('span');
+      titleElm.className = 'slick-group-title';
+      titleElm.textContent = 'Group Title';
+      cellElm.appendChild(titleElm);
+      document.body.appendChild(cellElm);
+
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: titleElm });
+      gridStub.onClick.notify({ row: 0, cell: 2, grid: gridStub }, clickEvent);
+
+      expect(expandGroupSpy).not.toHaveBeenCalled();
+      expect(collapseGroupSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(cellElm);
+      serviceWithoutToggle.dispose();
+    });
+
+    it('should expand Group when toggleByCellClick is false and clicking directly on toggle icon', () => {
+      group.groupingKey = 'age';
+      group.collapsed = true;
+      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: false });
+
+      serviceWithoutToggle.init(gridStub);
+
+      const toggleIcon = document.createElement('span');
+      toggleIcon.className = 'slick-group-toggle';
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: toggleIcon });
+      gridStub.onClick.notify({ row: 0, cell: 2, grid: gridStub }, clickEvent);
+
+      expect(expandGroupSpy).toHaveBeenCalledWith('age');
+      expect(collapseGroupSpy).not.toHaveBeenCalled();
+
+      serviceWithoutToggle.dispose();
+    });
+
+    it('should expand Group when toggleByCellClick is true and clicking directly on toggle icon', () => {
+      group.groupingKey = 'age';
+      group.collapsed = true;
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: true });
+
+      serviceWithToggle.init(gridStub);
+
+      const toggleIcon = document.createElement('span');
+      toggleIcon.className = 'slick-group-toggle';
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: toggleIcon });
+      gridStub.onClick.notify({ row: 0, cell: 2, grid: gridStub }, clickEvent);
+
+      expect(expandGroupSpy).toHaveBeenCalledWith('age');
+      expect(collapseGroupSpy).not.toHaveBeenCalled();
+
+      serviceWithToggle.dispose();
     });
   });
 });

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -95,7 +95,7 @@ describe('GroupItemMetadataProvider Service', () => {
       toggleCssClass: 'slick-group-toggle',
       toggleExpandedCssClass: 'expanded',
       toggleCollapsedCssClass: 'collapsed',
-      toggleOnTitle: false,
+      toggleOnNodeTitle: false,
       enableExpandCollapse: true,
       groupFormatter: expect.any(Function),
       totalsFormatter: expect.any(Function),
@@ -139,9 +139,9 @@ describe('GroupItemMetadataProvider Service', () => {
       );
     });
 
-    it('should add pointer class to group title when toggleOnTitle is enabled', () => {
+    it('should add pointer class to group title when toggleOnNodeTitle is enabled', () => {
       service.init(gridStub);
-      service.setOptions({ enableExpandCollapse: true, toggleOnTitle: true });
+      service.setOptions({ enableExpandCollapse: true, toggleOnNodeTitle: true });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: 'Some Title' }, gridStub) as DocumentFragment;
       const htmlContent = getHtmlStringOutput(output, 'outerHTML');
 
@@ -150,9 +150,9 @@ describe('GroupItemMetadataProvider Service', () => {
       );
     });
 
-    it('should not add pointer class to group title when toggleOnTitle is disabled', () => {
+    it('should not add pointer class to group title when toggleOnNodeTitle is disabled', () => {
       service.init(gridStub);
-      service.setOptions({ enableExpandCollapse: true, toggleOnTitle: false });
+      service.setOptions({ enableExpandCollapse: true, toggleOnNodeTitle: false });
       const output = service.getOptions().groupFormatter!(0, 0, 'test', mockColumns[0], { title: 'Some Title' }, gridStub) as DocumentFragment;
       const htmlContent = getHtmlStringOutput(output, 'outerHTML');
 
@@ -493,7 +493,7 @@ describe('GroupItemMetadataProvider Service', () => {
     });
   });
 
-  describe('toggleOnTitle option via constructor', () => {
+  describe('toggleOnNodeTitle option via constructor', () => {
     let collapseGroupSpy: any;
     let expandGroupSpy: any;
     let clickEvent: Event;
@@ -516,10 +516,10 @@ describe('GroupItemMetadataProvider Service', () => {
       vi.clearAllMocks();
     });
 
-    it('should expand Group when toggleOnTitle is true and clicking on .slick-group-title', () => {
+    it('should expand Group when toggleOnNodeTitle is true and clicking on .slick-group-title', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnNodeTitle: true });
 
       serviceWithToggle.init(gridStub);
 
@@ -545,10 +545,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithToggle.dispose();
     });
 
-    it('should collapse Group when toggleOnTitle is true and clicking on .slick-group-title', () => {
+    it('should collapse Group when toggleOnNodeTitle is true and clicking on .slick-group-title', () => {
       group.groupingKey = 'age';
       group.collapsed = false;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnNodeTitle: true });
 
       serviceWithToggle.init(gridStub);
 
@@ -574,10 +574,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithToggle.dispose();
     });
 
-    it('should NOT toggle Group when toggleOnTitle is true and clicking on non-title cell content', () => {
+    it('should NOT toggle Group when toggleOnNodeTitle is true and clicking on non-title cell content', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnNodeTitle: true });
 
       serviceWithToggle.init(gridStub);
 
@@ -608,10 +608,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithToggle.dispose();
     });
 
-    it('should NOT toggle when toggleOnTitle is false and clicking on .slick-group-title', () => {
+    it('should NOT toggle when toggleOnNodeTitle is false and clicking on .slick-group-title', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: false });
+      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleOnNodeTitle: false });
 
       serviceWithoutToggle.init(gridStub);
 
@@ -637,10 +637,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithoutToggle.dispose();
     });
 
-    it('should expand Group when toggleOnTitle is false and clicking on .slick-group-toggle', () => {
+    it('should expand Group when toggleOnNodeTitle is false and clicking on .slick-group-toggle', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: false });
+      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleOnNodeTitle: false });
 
       serviceWithoutToggle.init(gridStub);
 
@@ -655,10 +655,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithoutToggle.dispose();
     });
 
-    it('should expand Group when toggleOnTitle is true and clicking on .slick-group-toggle', () => {
+    it('should expand Group when toggleOnNodeTitle is true and clicking on .slick-group-toggle', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnNodeTitle: true });
 
       serviceWithToggle.init(gridStub);
 

--- a/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickGroupItemMetadataProvider.spec.ts
@@ -95,7 +95,7 @@ describe('GroupItemMetadataProvider Service', () => {
       toggleCssClass: 'slick-group-toggle',
       toggleExpandedCssClass: 'expanded',
       toggleCollapsedCssClass: 'collapsed',
-      toggleByCellClick: false,
+      toggleOnTitle: false,
       enableExpandCollapse: true,
       groupFormatter: expect.any(Function),
       totalsFormatter: expect.any(Function),
@@ -471,7 +471,7 @@ describe('GroupItemMetadataProvider Service', () => {
     });
   });
 
-  describe('toggleByCellClick option via constructor', () => {
+  describe('toggleOnTitle option via constructor', () => {
     let collapseGroupSpy: any;
     let expandGroupSpy: any;
     let clickEvent: Event;
@@ -494,10 +494,10 @@ describe('GroupItemMetadataProvider Service', () => {
       vi.clearAllMocks();
     });
 
-    it('should expand Group when toggleByCellClick is true and clicking on cell with group title', () => {
+    it('should expand Group when toggleOnTitle is true and clicking on .slick-group-title', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
 
       serviceWithToggle.init(gridStub);
 
@@ -523,10 +523,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithToggle.dispose();
     });
 
-    it('should collapse Group when toggleByCellClick is true and clicking on cell content', () => {
+    it('should collapse Group when toggleOnTitle is true and clicking on .slick-group-title', () => {
       group.groupingKey = 'age';
       group.collapsed = false;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
 
       serviceWithToggle.init(gridStub);
 
@@ -552,10 +552,44 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithToggle.dispose();
     });
 
-    it('should NOT expand Group when toggleByCellClick is false and clicking on cell title', () => {
+    it('should NOT toggle Group when toggleOnTitle is true and clicking on non-title cell content', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: false });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
+
+      serviceWithToggle.init(gridStub);
+
+      // Create a cell structure with group title
+      const cellElm = document.createElement('div');
+      cellElm.className = 'slick-cell';
+      const toggleIcon = document.createElement('span');
+      toggleIcon.className = 'slick-group-toggle';
+      cellElm.appendChild(toggleIcon);
+      const titleElm = document.createElement('span');
+      titleElm.className = 'slick-group-title';
+      titleElm.textContent = 'Group Title';
+      cellElm.appendChild(titleElm);
+      const contentElm = document.createElement('span');
+      contentElm.className = 'other-content';
+      contentElm.textContent = 'Other Content';
+      cellElm.appendChild(contentElm);
+      document.body.appendChild(cellElm);
+
+      // Click on non-title content
+      Object.defineProperty(clickEvent, 'target', { writable: true, configurable: true, value: contentElm });
+      gridStub.onClick.notify({ row: 0, cell: 2, grid: gridStub }, clickEvent);
+
+      expect(expandGroupSpy).not.toHaveBeenCalled();
+      expect(collapseGroupSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(cellElm);
+      serviceWithToggle.dispose();
+    });
+
+    it('should NOT toggle when toggleOnTitle is false and clicking on .slick-group-title', () => {
+      group.groupingKey = 'age';
+      group.collapsed = true;
+      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: false });
 
       serviceWithoutToggle.init(gridStub);
 
@@ -581,10 +615,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithoutToggle.dispose();
     });
 
-    it('should expand Group when toggleByCellClick is false and clicking directly on toggle icon', () => {
+    it('should expand Group when toggleOnTitle is false and clicking on .slick-group-toggle', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: false });
+      const serviceWithoutToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: false });
 
       serviceWithoutToggle.init(gridStub);
 
@@ -599,10 +633,10 @@ describe('GroupItemMetadataProvider Service', () => {
       serviceWithoutToggle.dispose();
     });
 
-    it('should expand Group when toggleByCellClick is true and clicking directly on toggle icon', () => {
+    it('should expand Group when toggleOnTitle is true and clicking on .slick-group-toggle', () => {
       group.groupingKey = 'age';
       group.collapsed = true;
-      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleByCellClick: true });
+      const serviceWithToggle = new SlickGroupItemMetadataProvider({ toggleOnTitle: true });
 
       serviceWithToggle.init(gridStub);
 

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -42,7 +42,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     toggleCssClass: 'slick-group-toggle',
     toggleExpandedCssClass: 'expanded',
     toggleCollapsedCssClass: 'collapsed',
-    toggleOnTitle: false,
+    toggleOnNodeTitle: false,
     enableExpandCollapse: true,
     groupFormatter: this.defaultGroupCellFormatter.bind(this),
     totalsFormatter: this.defaultTotalsCellFormatter.bind(this),
@@ -153,7 +153,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     // 2. group title span
     const groupTitleElm = createDomElement('span', { className: this._options.groupTitleCssClass || '' });
     groupTitleElm.setAttribute('level', groupLevel);
-    if (this._options?.toggleOnTitle) {
+    if (this._options?.toggleOnNodeTitle) {
       groupTitleElm.classList.add('pointer');
     }
     item.title instanceof HTMLElement || item.title instanceof DocumentFragment
@@ -182,7 +182,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     const toggleCssClass = this._options.toggleCssClass || '';
     const groupTitleCssClass = this._options.groupTitleCssClass || '';
     const isIconClicked = target?.classList.contains(toggleCssClass);
-    const isElmToggled = this._options?.toggleOnTitle
+    const isElmToggled = this._options?.toggleOnNodeTitle
       ? isIconClicked || target?.closest(`.${toggleCssClass},.${groupTitleCssClass}`)
       : isIconClicked;
 

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -42,7 +42,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     toggleCssClass: 'slick-group-toggle',
     toggleExpandedCssClass: 'expanded',
     toggleCollapsedCssClass: 'collapsed',
-    toggleByCellClick: false,
+    toggleOnTitle: false,
     enableExpandCollapse: true,
     groupFormatter: this.defaultGroupCellFormatter.bind(this),
     totalsFormatter: this.defaultTotalsCellFormatter.bind(this),
@@ -153,6 +153,9 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     // 2. group title span
     const groupTitleElm = createDomElement('span', { className: this._options.groupTitleCssClass || '' });
     groupTitleElm.setAttribute('level', groupLevel);
+    if (this._options?.toggleOnTitle) {
+      groupTitleElm.classList.add('pointer');
+    }
     item.title instanceof HTMLElement || item.title instanceof DocumentFragment
       ? groupTitleElm.appendChild(item.title)
       : applyHtmlToElement(groupTitleElm, item.title ?? '', this.gridOptions);
@@ -178,10 +181,10 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     const item = this._grid?.getDataItem(args.row);
     const toggleCssClass = this._options.toggleCssClass || '';
     const groupTitleCssClass = this._options.groupTitleCssClass || '';
-    const isElmToggled = this._options?.toggleByCellClick
-      ? target?.classList.contains(toggleCssClass) ||
-        target?.closest('.slick-cell')?.querySelector(`.slick-cell > .${toggleCssClass},.${groupTitleCssClass}`)
-      : target?.classList.contains(toggleCssClass);
+    const isIconClicked = target?.classList.contains(toggleCssClass);
+    const isElmToggled = this._options?.toggleOnTitle
+      ? isIconClicked || target?.closest(`.${toggleCssClass},.${groupTitleCssClass}`)
+      : isIconClicked;
 
     if (item instanceof SlickGroup && isElmToggled) {
       this.handleDataViewExpandOrCollapse(item);

--- a/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
+++ b/packages/common/src/extensions/slickGroupItemMetadataProvider.ts
@@ -42,6 +42,7 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     toggleCssClass: 'slick-group-toggle',
     toggleExpandedCssClass: 'expanded',
     toggleCollapsedCssClass: 'collapsed',
+    toggleByCellClick: false,
     enableExpandCollapse: true,
     groupFormatter: this.defaultGroupCellFormatter.bind(this),
     totalsFormatter: this.defaultTotalsCellFormatter.bind(this),
@@ -67,10 +68,8 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
     return this._grid?.getOptions() || {};
   }
 
-  init(grid: SlickGrid, inputOptions?: GroupItemMetadataProviderOption): void {
+  init(grid: SlickGrid): void {
     this._grid = grid;
-    this._options = { ...this._defaults, ...inputOptions };
-
     this._eventHandler.subscribe(grid.onClick, this.handleGridClick.bind(this));
     this._eventHandler.subscribe(grid.onKeyDown, this.handleGridKeyDown.bind(this));
   }
@@ -177,7 +176,14 @@ export class SlickGroupItemMetadataProvider implements SlickPlugin {
   protected handleGridClick(e: SlickEventData, args: OnClickEventArgs): void {
     const target = e.target as HTMLElement;
     const item = this._grid?.getDataItem(args.row);
-    if (item instanceof SlickGroup && target.classList.contains(this._options.toggleCssClass || '')) {
+    const toggleCssClass = this._options.toggleCssClass || '';
+    const groupTitleCssClass = this._options.groupTitleCssClass || '';
+    const isElmToggled = this._options?.toggleByCellClick
+      ? target?.classList.contains(toggleCssClass) ||
+        target?.closest('.slick-cell')?.querySelector(`.slick-cell > .${toggleCssClass},.${groupTitleCssClass}`)
+      : target?.classList.contains(toggleCssClass);
+
+    if (item instanceof SlickGroup && isElmToggled) {
       this.handleDataViewExpandOrCollapse(item);
       e.stopImmediatePropagation();
       e.preventDefault();

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -137,8 +137,8 @@ describe('Tree Formatter', () => {
     );
   });
 
-  it('should add pointer class to tree title when toggleOnTitle is enabled', () => {
-    mockGridOptions.treeDataOptions!.toggleOnTitle = true;
+  it('should add pointer class to tree title when toggleOnNodeTitle is enabled', () => {
+    mockGridOptions.treeDataOptions!.toggleOnNodeTitle = true;
     const output = treeFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');
@@ -147,8 +147,8 @@ describe('Tree Formatter', () => {
     );
   });
 
-  it('should not add pointer class to tree title when toggleOnTitle is not enabled', () => {
-    mockGridOptions.treeDataOptions!.toggleOnTitle = false;
+  it('should not add pointer class to tree title when toggleOnNodeTitle is not enabled', () => {
+    mockGridOptions.treeDataOptions!.toggleOnNodeTitle = false;
     const output = treeFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub) as FormatterResultWithHtml;
 
     expect(output.addClasses).toBe('slick-tree-level-0');

--- a/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
+++ b/packages/common/src/formatters/__tests__/treeFormatter.spec.ts
@@ -133,7 +133,27 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span>`
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span>`
+    );
+  });
+
+  it('should add pointer class to tree title when toggleOnTitle is enabled', () => {
+    mockGridOptions.treeDataOptions!.toggleOnTitle = true;
+    const output = treeFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub) as FormatterResultWithHtml;
+
+    expect(output.addClasses).toBe('slick-tree-level-0');
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title pointer" level="0">Barbara</span>`
+    );
+  });
+
+  it('should not add pointer class to tree title when toggleOnTitle is not enabled', () => {
+    mockGridOptions.treeDataOptions!.toggleOnTitle = false;
+    const output = treeFormatter(1, 1, dataset[3]['firstName'], {} as Column, dataset[3], gridStub) as FormatterResultWithHtml;
+
+    expect(output.addClasses).toBe('slick-tree-level-0');
+    expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span>`
     );
   });
 
@@ -143,7 +163,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect((output.html as HTMLElement).outerHTML).toEqual(
-      `<span><span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span></span>`
+      `<span><span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara</span></span>`
     );
   });
 
@@ -152,7 +172,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-1');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="1">Bobby</span>`
+      `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="1">Bobby</span>`
     );
   });
 
@@ -161,7 +181,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-3');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 45px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="3">Sponge</span>`
+      `<span style="display: inline-block; width: 45px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="3">Sponge</span>`
     );
   });
 
@@ -170,7 +190,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-1');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1">Jane</span>`
+      `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle slick-tree-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1">Jane</span>`
     );
   });
 
@@ -179,7 +199,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous</span>`
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous</span>`
     );
   });
 
@@ -203,7 +223,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-1');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1"><span class="mdi mdi-subdirectory-arrow-right"></span>Jane</span>`
+      `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle slick-tree-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1"><span class="mdi mdi-subdirectory-arrow-right"></span>Jane</span>`
     );
   });
 
@@ -213,7 +233,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara Cane</span>`
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">Barbara Cane</span>`
     );
   });
 
@@ -223,7 +243,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous &lt; Doe</span>`
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle collapsed" aria-expanded="false"></div><span class="slick-tree-title" level="0">Anonymous &lt; Doe</span>`
     );
   });
 
@@ -233,7 +253,7 @@ describe('Tree Formatter', () => {
 
     expect(output.addClasses).toBe('slick-tree-level-0');
     expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">444444</span>`
+      `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle" aria-expanded="false"></div><span class="slick-tree-title" level="0">444444</span>`
     );
   });
 
@@ -289,7 +309,7 @@ describe('Tree Formatter', () => {
 
       expect(output.addClasses).toBe('slick-tree-level-0');
       expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-        `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle load-fail" aria-expanded="false"></div><span class="slick-tree-load-fail"></span><span class="slick-tree-title" level="0">John</span>`
+        `<span style="display: inline-block; width: 0px;"></span><div class="slick-group-toggle slick-tree-toggle load-fail" aria-expanded="false"></div><span class="slick-tree-load-fail"></span><span class="slick-tree-title" level="0">John</span>`
       );
     });
 
@@ -298,7 +318,7 @@ describe('Tree Formatter', () => {
 
       expect(output.addClasses).toBe('slick-tree-level-1');
       expect(getHtmlStringOutput(output.html as DocumentFragment, 'outerHTML')).toEqual(
-        `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1">Jane</span>`
+        `<span style="display: inline-block; width: 15px;"></span><div class="slick-group-toggle slick-tree-toggle expanded" aria-expanded="true"></div><span class="slick-tree-title" level="1">Jane</span>`
       );
     });
   });

--- a/packages/common/src/formatters/treeFormatter.ts
+++ b/packages/common/src/formatters/treeFormatter.ts
@@ -52,7 +52,7 @@ export const treeFormatter: Formatter = (row, cell, value, columnDef, dataContex
     outputValue = parseFormatterWhenExist(treeDataOptions.titleFormatter, row, cell, columnDef, dataContext, grid);
   }
   const treeTitleElm = createDomElement('span', { className: 'slick-tree-title' });
-  if (gridOptions.treeDataOptions?.toggleOnTitle) {
+  if (gridOptions.treeDataOptions?.toggleOnNodeTitle) {
     treeTitleElm.classList.add('pointer');
   }
   applyHtmlToElement(treeTitleElm, outputValue, gridOptions);

--- a/packages/common/src/formatters/treeFormatter.ts
+++ b/packages/common/src/formatters/treeFormatter.ts
@@ -37,7 +37,8 @@ export const treeFormatter: Formatter = (row, cell, value, columnDef, dataContex
   }
 
   const indentSpacerElm = createDomElement('span', { style: { display: 'inline-block', width: `${indentMarginLeft * treeLevel}px` } });
-  const spanToggleClass = `slick-group-toggle ${toggleClass}`.trim();
+  // @deprecated `.slick-group-toggle` class, to remove in next major version
+  const spanToggleClass = `slick-group-toggle slick-tree-toggle ${toggleClass}`.trim();
   const spanIconElm = createDomElement('div', { className: spanToggleClass, ariaExpanded: String(toggleClass === 'expanded') });
 
   const containerElm = createDocumentFragmentOrElement(gridOptions);
@@ -50,10 +51,13 @@ export const treeFormatter: Formatter = (row, cell, value, columnDef, dataContex
   if (treeDataOptions.titleFormatter) {
     outputValue = parseFormatterWhenExist(treeDataOptions.titleFormatter, row, cell, columnDef, dataContext, grid);
   }
-  const spanTitleElm = createDomElement('span', { className: 'slick-tree-title' });
-  applyHtmlToElement(spanTitleElm, outputValue, gridOptions);
-  spanTitleElm.setAttribute('level', treeLevel);
-  containerElm.appendChild(spanTitleElm);
+  const treeTitleElm = createDomElement('span', { className: 'slick-tree-title' });
+  if (gridOptions.treeDataOptions?.toggleOnTitle) {
+    treeTitleElm.classList.add('pointer');
+  }
+  applyHtmlToElement(treeTitleElm, outputValue, gridOptions);
+  treeTitleElm.setAttribute('level', treeLevel);
+  containerElm.appendChild(treeTitleElm);
 
   return { addClasses: slickTreeLevelClass, html: containerElm };
 };

--- a/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
+++ b/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
@@ -43,7 +43,7 @@ export interface GroupItemMetadataProviderOption {
   toggleCollapsedCssClass?: string;
 
   /** Defaults to False, should we toggle the tree node when clicking on the tree node title or toggle icon (tree node must have element with `.slick-tree-title` class name) */
-  toggleOnTitle?: boolean;
+  toggleOnNodeTitle?: boolean;
 
   /** Whether or not we want to enable the group expanding/collapsing */
   enableExpandCollapse?: boolean;

--- a/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
+++ b/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
@@ -42,6 +42,9 @@ export interface GroupItemMetadataProviderOption {
   /** Defaults to "collapsed" */
   toggleCollapsedCssClass?: string;
 
+  /** Defaults to False, should we toggle the tree node when clicking on the cell */
+  toggleByCellClick?: boolean;
+
   /** Whether or not we want to enable the group expanding/collapsing */
   enableExpandCollapse?: boolean;
 

--- a/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
+++ b/packages/common/src/interfaces/groupItemMetadataProviderOption.interface.ts
@@ -42,8 +42,8 @@ export interface GroupItemMetadataProviderOption {
   /** Defaults to "collapsed" */
   toggleCollapsedCssClass?: string;
 
-  /** Defaults to False, should we toggle the tree node when clicking on the cell */
-  toggleByCellClick?: boolean;
+  /** Defaults to False, should we toggle the tree node when clicking on the tree node title or toggle icon (tree node must have element with `.slick-tree-title` class name) */
+  toggleOnTitle?: boolean;
 
   /** Whether or not we want to enable the group expanding/collapsing */
   enableExpandCollapse?: boolean;

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -78,8 +78,8 @@ export interface TreeDataOption extends TreeDataPropNames {
   /** Optional Title Formatter (allows you to format/style the title text differently) */
   titleFormatter?: Formatter;
 
-  /** Defaults to False, should we toggle the tree node when clicking on the cell */
-  toggleByCellClick?: boolean;
+  /** Defaults to False, should we toggle the tree node when clicking on the tree node title or toggle icon (tree node must have element with `.slick-tree-title` class name) */
+  toggleOnTitle?: boolean;
 
   /**
    * Lazy load callback that should resolve the data that you're fetching lazily

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -78,6 +78,9 @@ export interface TreeDataOption extends TreeDataPropNames {
   /** Optional Title Formatter (allows you to format/style the title text differently) */
   titleFormatter?: Formatter;
 
+  /** Defaults to False, should we toggle the tree node when clicking on the cell */
+  toggleByCellClick?: boolean;
+
   /**
    * Lazy load callback that should resolve the data that you're fetching lazily
    * @param {*} node - node item that is being expanded

--- a/packages/common/src/interfaces/treeDataOption.interface.ts
+++ b/packages/common/src/interfaces/treeDataOption.interface.ts
@@ -79,7 +79,7 @@ export interface TreeDataOption extends TreeDataPropNames {
   titleFormatter?: Formatter;
 
   /** Defaults to False, should we toggle the tree node when clicking on the tree node title or toggle icon (tree node must have element with `.slick-tree-title` class name) */
-  toggleOnTitle?: boolean;
+  toggleOnNodeTitle?: boolean;
 
   /**
    * Lazy load callback that should resolve the data that you're fetching lazily

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -567,10 +567,10 @@ describe('TreeData Service', () => {
       expect(pubSubSpy).not.toHaveBeenCalledWith(`onTreeItemToggled`);
     });
 
-    describe('toggleByCellClick option', () => {
-      it('should toggle the "__collapsed" when "toggleByCellClick" is enabled and clicking anywhere on the cell that contains a toggle icon', () => {
+    describe('toggleOnTitle option', () => {
+      it('should toggle the "__collapsed" when "toggleOnTitle" is enabled and clicking on the tree node title', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleByCellClick = true;
+        gridOptionsMock.treeDataOptions!.toggleOnTitle = true;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
@@ -578,18 +578,19 @@ describe('TreeData Service', () => {
 
         service.init(gridStub);
         const eventData = new SlickEventData();
-        // Create a cell with a toggle icon inside
+        // Create a cell with a toggle icon and title inside
         const cellElm = document.createElement('div');
         cellElm.className = 'slick-cell';
         const toggleIcon = document.createElement('span');
         toggleIcon.className = 'slick-group-toggle';
         cellElm.appendChild(toggleIcon);
-        const textElm = document.createElement('span');
-        textElm.textContent = 'Item Text';
-        cellElm.appendChild(textElm);
+        const titleElm = document.createElement('span');
+        titleElm.className = 'slick-tree-title';
+        titleElm.textContent = 'Item Text';
+        cellElm.appendChild(titleElm);
 
-        // Click on the text (not the toggle icon directly)
-        Object.defineProperty(eventData, 'target', { writable: true, value: textElm });
+        // Click on the tree title
+        Object.defineProperty(eventData, 'target', { writable: true, value: titleElm });
         gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, eventData, gridStub);
 
         expect(spyGetItem).toHaveBeenCalled();
@@ -597,9 +598,9 @@ describe('TreeData Service', () => {
         expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
       });
 
-      it('should toggle the "__collapsed" when "toggleByCellClick" is enabled and clicking directly on the toggle icon', () => {
+      it('should toggle the "__collapsed" when "toggleOnTitle" is enabled and clicking directly on the toggle icon', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleByCellClick = true;
+        gridOptionsMock.treeDataOptions!.toggleOnTitle = true;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
@@ -616,9 +617,9 @@ describe('TreeData Service', () => {
         expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
       });
 
-      it('should NOT toggle the "__collapsed" when "toggleByCellClick" is disabled (false) and clicking on cell text', () => {
+      it('should NOT toggle the "__collapsed" when "toggleOnTitle" is disabled (false) and clicking on cell text', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleByCellClick = false;
+        gridOptionsMock.treeDataOptions!.toggleOnTitle = false;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
@@ -645,9 +646,9 @@ describe('TreeData Service', () => {
         expect(spyUptItem).not.toHaveBeenCalled();
       });
 
-      it('should toggle the "__collapsed" when "toggleByCellClick" is disabled (false) and clicking directly on the toggle icon', () => {
+      it('should toggle the "__collapsed" when "toggleOnTitle" is disabled (false) and clicking directly on the toggle icon', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleByCellClick = false;
+        gridOptionsMock.treeDataOptions!.toggleOnTitle = false;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -567,10 +567,10 @@ describe('TreeData Service', () => {
       expect(pubSubSpy).not.toHaveBeenCalledWith(`onTreeItemToggled`);
     });
 
-    describe('toggleOnTitle option', () => {
-      it('should toggle the "__collapsed" when "toggleOnTitle" is enabled and clicking on the tree node title', () => {
+    describe('toggleOnNodeTitle option', () => {
+      it('should toggle the "__collapsed" when "toggleOnNodeTitle" is enabled and clicking on the tree node title', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleOnTitle = true;
+        gridOptionsMock.treeDataOptions!.toggleOnNodeTitle = true;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
@@ -598,9 +598,9 @@ describe('TreeData Service', () => {
         expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
       });
 
-      it('should toggle the "__collapsed" when "toggleOnTitle" is enabled and clicking directly on the toggle icon', () => {
+      it('should toggle the "__collapsed" when "toggleOnNodeTitle" is enabled and clicking directly on the toggle icon', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleOnTitle = true;
+        gridOptionsMock.treeDataOptions!.toggleOnNodeTitle = true;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
@@ -617,9 +617,9 @@ describe('TreeData Service', () => {
         expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
       });
 
-      it('should NOT toggle the "__collapsed" when "toggleOnTitle" is disabled (false) and clicking on cell text', () => {
+      it('should NOT toggle the "__collapsed" when "toggleOnNodeTitle" is disabled (false) and clicking on cell text', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleOnTitle = false;
+        gridOptionsMock.treeDataOptions!.toggleOnNodeTitle = false;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
@@ -646,9 +646,9 @@ describe('TreeData Service', () => {
         expect(spyUptItem).not.toHaveBeenCalled();
       });
 
-      it('should toggle the "__collapsed" when "toggleOnTitle" is disabled (false) and clicking directly on the toggle icon', () => {
+      it('should toggle the "__collapsed" when "toggleOnNodeTitle" is disabled (false) and clicking directly on the toggle icon', () => {
         mockRowData.__collapsed = false;
-        gridOptionsMock.treeDataOptions!.toggleOnTitle = false;
+        gridOptionsMock.treeDataOptions!.toggleOnNodeTitle = false;
         vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
         const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
         const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');

--- a/packages/common/src/services/__tests__/treeData.service.spec.ts
+++ b/packages/common/src/services/__tests__/treeData.service.spec.ts
@@ -566,6 +566,104 @@ describe('TreeData Service', () => {
       expect(SharedService.prototype.hierarchicalDataset![0].file).toBe('myFile.txt');
       expect(pubSubSpy).not.toHaveBeenCalledWith(`onTreeItemToggled`);
     });
+
+    describe('toggleByCellClick option', () => {
+      it('should toggle the "__collapsed" when "toggleByCellClick" is enabled and clicking anywhere on the cell that contains a toggle icon', () => {
+        mockRowData.__collapsed = false;
+        gridOptionsMock.treeDataOptions!.toggleByCellClick = true;
+        vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+        const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
+        const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
+        const spyInvalidate = vi.spyOn(gridStub, 'invalidate');
+
+        service.init(gridStub);
+        const eventData = new SlickEventData();
+        // Create a cell with a toggle icon inside
+        const cellElm = document.createElement('div');
+        cellElm.className = 'slick-cell';
+        const toggleIcon = document.createElement('span');
+        toggleIcon.className = 'slick-group-toggle';
+        cellElm.appendChild(toggleIcon);
+        const textElm = document.createElement('span');
+        textElm.textContent = 'Item Text';
+        cellElm.appendChild(textElm);
+
+        // Click on the text (not the toggle icon directly)
+        Object.defineProperty(eventData, 'target', { writable: true, value: textElm });
+        gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, eventData, gridStub);
+
+        expect(spyGetItem).toHaveBeenCalled();
+        expect(spyInvalidate).toHaveBeenCalled();
+        expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
+      });
+
+      it('should toggle the "__collapsed" when "toggleByCellClick" is enabled and clicking directly on the toggle icon', () => {
+        mockRowData.__collapsed = false;
+        gridOptionsMock.treeDataOptions!.toggleByCellClick = true;
+        vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+        const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
+        const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
+        const spyInvalidate = vi.spyOn(gridStub, 'invalidate');
+
+        service.init(gridStub);
+        const eventData = new SlickEventData();
+        div.className = 'slick-group-toggle';
+        Object.defineProperty(eventData, 'target', { writable: true, value: div });
+        gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, eventData, gridStub);
+
+        expect(spyGetItem).toHaveBeenCalled();
+        expect(spyInvalidate).toHaveBeenCalled();
+        expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
+      });
+
+      it('should NOT toggle the "__collapsed" when "toggleByCellClick" is disabled (false) and clicking on cell text', () => {
+        mockRowData.__collapsed = false;
+        gridOptionsMock.treeDataOptions!.toggleByCellClick = false;
+        vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+        const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
+        const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
+        const spyInvalidate = vi.spyOn(gridStub, 'invalidate');
+
+        service.init(gridStub);
+        const eventData = new SlickEventData();
+        // Create a cell with a toggle icon inside
+        const cellElm = document.createElement('div');
+        cellElm.className = 'slick-cell';
+        const toggleIcon = document.createElement('span');
+        toggleIcon.className = 'slick-group-toggle';
+        cellElm.appendChild(toggleIcon);
+        const textElm = document.createElement('span');
+        textElm.textContent = 'Item Text';
+        cellElm.appendChild(textElm);
+
+        // Click on the text (not the toggle icon directly)
+        Object.defineProperty(eventData, 'target', { writable: true, value: textElm });
+        gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, eventData, gridStub);
+
+        expect(spyGetItem).not.toHaveBeenCalled();
+        expect(spyInvalidate).not.toHaveBeenCalled();
+        expect(spyUptItem).not.toHaveBeenCalled();
+      });
+
+      it('should toggle the "__collapsed" when "toggleByCellClick" is disabled (false) and clicking directly on the toggle icon', () => {
+        mockRowData.__collapsed = false;
+        gridOptionsMock.treeDataOptions!.toggleByCellClick = false;
+        vi.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
+        const spyGetItem = vi.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
+        const spyUptItem = vi.spyOn(dataViewStub, 'updateItem');
+        const spyInvalidate = vi.spyOn(gridStub, 'invalidate');
+
+        service.init(gridStub);
+        const eventData = new SlickEventData();
+        div.className = 'slick-group-toggle';
+        Object.defineProperty(eventData, 'target', { writable: true, value: div });
+        gridStub.onClick.notify({ cell: 0, row: 0, grid: gridStub }, eventData, gridStub);
+
+        expect(spyGetItem).toHaveBeenCalled();
+        expect(spyInvalidate).toHaveBeenCalled();
+        expect(spyUptItem).toHaveBeenCalledWith(123, { ...mockRowData, __collapsed: true });
+      });
+    });
   });
 
   describe('onKeyDown subscription', () => {

--- a/packages/common/src/services/gridState.service.ts
+++ b/packages/common/src/services/gridState.service.ts
@@ -485,7 +485,7 @@ export class GridStateService {
 
     // subscribe to Row Selection changes (when enabled)
     if (this._gridOptions.enableSelection || this._gridOptions.enableCheckboxSelector) {
-      this._eventHandler.subscribe(this._dataView.onSelectedRowIdsChanged, (e, args) => {
+      this._eventHandler.subscribe(this._dataView.onSelectedRowIdsChanged, (_e, args) => {
         const previousSelectedRowIndexes = (this._selectedRowIndexes || []).slice();
         const previousSelectedFilteredRowDataContextIds = (this.selectedRowDataContextIds || []).slice();
         this.selectedRowDataContextIds = args.filteredIds;

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -463,7 +463,9 @@ export class TreeDataService {
 
       if (typeof targetElm?.className === 'string') {
         const isIconClicked = ['slick-group-toggle', 'slick-tree-toggle'].some((cls) => targetElm.classList.contains(cls));
-        const isElmToggled = this.treeDataOptions?.toggleOnTitle ? isIconClicked || targetElm?.closest('.slick-tree-title') : isIconClicked;
+        const isElmToggled = this.treeDataOptions?.toggleOnNodeTitle
+          ? isIconClicked || targetElm?.closest('.slick-tree-title')
+          : isIconClicked;
 
         if (isElmToggled) {
           const item = this.dataView.getItem(args.row);

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -455,14 +455,19 @@ export class TreeDataService {
 
   protected handleOnCellClick(event: Event | SlickEventData, args: OnClickEventArgs): void {
     if (event && args) {
-      const targetElm: any = event.target || {};
+      const targetElm = event.target as HTMLElement | null;
       const collapsedPropName = getTreeDataOptionPropName(this.treeDataOptions, 'collapsedPropName');
       const childrenPropName = getTreeDataOptionPropName(this.treeDataOptions, 'childrenPropName');
       const hasChildrenPropName = getTreeDataOptionPropName(this.treeDataOptions, 'hasChildrenPropName');
       const lazyLoadingPropName = getTreeDataOptionPropName(this.treeDataOptions, 'lazyLoadingPropName');
 
       if (typeof targetElm?.className === 'string') {
-        if (targetElm.classList.contains('slick-group-toggle')) {
+        const isElmToggled = this.treeDataOptions?.toggleByCellClick
+          ? targetElm?.classList.contains('slick-group-toggle') ||
+            targetElm?.closest('.slick-cell')?.querySelector(`.slick-cell > .slick-group-toggle`)
+          : targetElm?.classList.contains('slick-group-toggle');
+
+        if (isElmToggled) {
           const item = this.dataView.getItem(args.row);
           if (item) {
             item[collapsedPropName] = !item[collapsedPropName]; // toggle the collapsed flag

--- a/packages/common/src/services/treeData.service.ts
+++ b/packages/common/src/services/treeData.service.ts
@@ -462,10 +462,8 @@ export class TreeDataService {
       const lazyLoadingPropName = getTreeDataOptionPropName(this.treeDataOptions, 'lazyLoadingPropName');
 
       if (typeof targetElm?.className === 'string') {
-        const isElmToggled = this.treeDataOptions?.toggleByCellClick
-          ? targetElm?.classList.contains('slick-group-toggle') ||
-            targetElm?.closest('.slick-cell')?.querySelector(`.slick-cell > .slick-group-toggle`)
-          : targetElm?.classList.contains('slick-group-toggle');
+        const isIconClicked = ['slick-group-toggle', 'slick-tree-toggle'].some((cls) => targetElm.classList.contains(cls));
+        const isElmToggled = this.treeDataOptions?.toggleOnTitle ? isIconClicked || targetElm?.closest('.slick-tree-title') : isIconClicked;
 
         if (isElmToggled) {
           const item = this.dataView.getItem(args.row);
@@ -600,7 +598,8 @@ export class TreeDataService {
           (e.key === ' ' || (e.key === 'ArrowRight' && isCollapsed) || (e.key === 'ArrowLeft' && !isCollapsed));
 
         if (shouldToggle) {
-          const cellGroupToggleElm = this._grid.getActiveCellNode()?.querySelector<HTMLDivElement>('.slick-group-toggle');
+          const cellGroupClassName = '.slick-group-toggle,.slick-tree-toggle';
+          const cellGroupToggleElm = this._grid.getActiveCellNode()?.querySelector<HTMLDivElement>(cellGroupClassName);
           if (cellGroupToggleElm) {
             e.preventDefault();
             e.stopImmediatePropagation();

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -569,13 +569,15 @@
         vertical-align: var(--slick-draggable-group-title-vertical-align, v.$slick-draggable-group-title-vertical-align);
       }
       .slick-group-toggle,
+      .slick-tree-toggle,
       .slick-tree-load-fail {
         cursor: pointer;
         display: inline-block;
         width: 1em;
         height: 1em;
       }
-      .slick-group-toggle {
+      .slick-group-toggle,
+      .slick-tree-toggle {
         color: var(--slick-icon-group-color, v.$slick-icon-group-color);
         font-size: var(--slick-icon-group-font-size, v.$slick-icon-group-font-size);
         margin-right: var(--slick-icon-group-margin-right, v.$slick-icon-group-margin-right);
@@ -613,6 +615,7 @@
       }
       // fix alignment when slick-cell includes slickgrid icons (align bottom will in fact center the icon & text), for example Tree Data/Grouping
       .slick-group-toggle,
+      .slick-tree-toggle,
       .mdi,
       .sgi {
         vertical-align: var(--slick-icon-with-text-valign, v.$slick-icon-with-text-valign);

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -536,7 +536,7 @@ export class SlickVanillaGridBundle<TData = any> {
       let dataViewOptions: Partial<DataViewOption> = { ...this._gridOptions.dataView, inlineFilters: dataviewInlineFilters };
 
       if (this.gridOptions.draggableGrouping || this.gridOptions.enableGrouping) {
-        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider();
+        this.groupItemMetadataProvider = new SlickGroupItemMetadataProvider(this._gridOptions.groupItemMetadataOption);
         this.sharedService.groupItemMetadataProvider = this.groupItemMetadataProvider;
         dataViewOptions = { ...dataViewOptions, groupItemMetadataProvider: this.groupItemMetadataProvider };
       }

--- a/test/cypress/e2e/example01.cy.ts
+++ b/test/cypress/e2e/example01.cy.ts
@@ -20,10 +20,10 @@ describe('Example 01 - Basic Grids', () => {
 
   it('should have 2 grids of size 800 * 225px and 800 * 255px', () => {
     cy.get('.grid1').should('have.css', 'width', '800px');
-    cy.get('.grid1 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+    cy.get('.grid1 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(225, 1));
 
     cy.get('.grid2').should('have.css', 'width', '800px');
-    cy.get('.grid2 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(255));
+    cy.get('.grid2 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.be.approximately(255, 1));
   });
 
   it('should have exact column titles on 1st grid', () => {

--- a/test/cypress/e2e/example02.cy.ts
+++ b/test/cypress/e2e/example02.cy.ts
@@ -428,7 +428,7 @@ describe('Example 02 - Grouping & Aggregators', () => {
     it('should Group by "Duration" and collapse everything, then focus on first cell group "Duration: 0" then type ArrowRight and expect group to expand', () => {
       cy.get('[data-test="group-duration-sort-value-btn"]').click();
       cy.get('[data-test="collapse-all-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 1');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 2');
@@ -448,7 +448,7 @@ describe('Example 02 - Grouping & Aggregators', () => {
 
     it('should Group by "Duration & Effort-Driven", then focus on first cell group "Duration: 0" then type ArrowRight and expect sub-group to expand', () => {
       cy.get('[data-test="group-duration-effort-btn"]').click();
-      cy.get('[data-row="0"] > .l0').click();
+      cy.get('[data-row="0"] > .l0').focus();
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
@@ -472,6 +472,16 @@ describe('Example 02 - Grouping & Aggregators', () => {
       cy.press(Cypress.Keyboard.Keys.LEFT);
 
       cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+      cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
+    });
+
+    it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+      cy.get('[data-row="0"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Duration: 0');
+      cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
+      cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
+
+      cy.get('[data-row="0"] > .slick-cell.l0').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/test/cypress/e2e/example02.cy.ts
+++ b/test/cypress/e2e/example02.cy.ts
@@ -481,7 +481,7 @@ describe('Example 02 - Grouping & Aggregators', () => {
       cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: False');
       cy.get('[data-row="2"] > .slick-cell:nth(0) .slick-group-title').should('contain', 'Effort-Driven: True');
 
-      cy.get('[data-row="0"] > .slick-cell.l0').click();
+      cy.get('[data-row="0"] > .slick-cell.l0 .slick-group-title').click();
       cy.get('[data-row="1"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
       cy.get('[data-row="2"] > .slick-cell:nth(0)').should('not.have.class', '.slick-group-title');
     });

--- a/test/cypress/e2e/example05.cy.ts
+++ b/test/cypress/e2e/example05.cy.ts
@@ -110,7 +110,7 @@ describe('Example 05 - Tree Data (from a flat dataset with parentId references)'
     cy.get('.grid5 .slickgrid-container')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -157,7 +157,7 @@ describe('Example 05 - Tree Data (from a flat dataset with parentId references)'
     cy.get('.grid5 .slickgrid-container')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -218,7 +218,7 @@ describe('Example 05 - Tree Data (from a flat dataset with parentId references)'
     cy.get('.grid5 .slickgrid-container')
       .should(($grid) => {
         const classes = $grid.prop('className').split(' ');
-        gridUid = classes.find((className) => /slickgrid_.*/.test(className));
+        gridUid = classes.find((className: string) => /slickgrid_.*/.test(className));
         expect(gridUid).to.not.be.null;
       })
       .then(() => {
@@ -283,7 +283,14 @@ describe('Example 05 - Tree Data (from a flat dataset with parentId references)'
 
   it('should be able to click on "Dynamically Toggle First Parent" expect only the first parent item to get collapsed', () => {
     cy.get('[data-test=dynamically-toggle-first-parent-btn]').contains('Dynamically Toggle First Parent').click();
-
     cy.get(`.grid5 .slick-group-toggle.expanded`).should('have.length', 0);
+  });
+
+  it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
+
+    cy.get('[data-row="1"] > .slick-cell.l0').click();
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
   });
 });

--- a/test/cypress/e2e/example05.cy.ts
+++ b/test/cypress/e2e/example05.cy.ts
@@ -288,9 +288,9 @@ describe('Example 05 - Tree Data (from a flat dataset with parentId references)'
 
   it('should toggle group by clicking anywhere on the group row and expect it to collapse/expand', () => {
     cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-title').should('contain', 'Task 1');
-    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'collapsed');
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-toggle').should('have.class', 'collapsed');
 
-    cy.get('[data-row="1"] > .slick-cell.l0').click();
-    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-group-toggle').should('have.class', 'expanded');
+    cy.get('[data-row="1"] > .slick-cell.l0 .slick-tree-title').click();
+    cy.get('[data-row="1"] > .slick-cell:nth(0) .slick-tree-toggle').should('have.class', 'expanded');
   });
 });


### PR DESCRIPTION
add a new option named  ~`toggleByCellClick`~ `toggleOnNodeTitle` that allows clicking on the Tree Data and/or Grouping node title to toggle it. This can be helpful since some user, like me, might find the toggle icon a little too small to click. The new option won't be enabled by default and will keep the same original behavior (not everyone would want this, hence its default disabled state)

- Tree Data: `gridOptions = { treeDataOptions: { toggleOnNodeTitle: true, }}`
- Grouping: `gridOptions = { groupItemMetadataOption: { toggleOnNodeTitle: true, }}`

#### TODO
- [x] Not sure if I should revisit this and maybe change it to `toggleOnNodeTitle` since cell click might interfere with other processes like inline cell editing
  - yup this is better since that won't conflict with inline editing
- [x] forgot to add docs for the new option in both Tree Data and Grouping docs

[Screencast_20260427_222730.webm](https://github.com/user-attachments/assets/29836fc7-1034-4048-b267-9d33046e3abd)


