### PR TITLE
fix: use dataItemColumnValueExtractor for grouping with nested objects

### DIFF
--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -1424,6 +1424,58 @@ describe('SlickDatView core file', () => {
       });
       expect(dv.getItem(2)).toBeUndefined();
     });
+
+    it('should apply grouping correctly when using dataItemColumnValueExtractor for nested object properties', () => {
+      const mockData = [
+        { id: 1, security: { fullName: 'John Doe' }, role: { name: 'admin' } },
+        { id: 2, security: { fullName: 'Jane Doe' }, role: { name: 'user' } },
+        { id: 3, security: { fullName: 'John Smith' }, role: { name: 'admin' } },
+      ];
+
+      dv = new SlickDataView({});
+      dv.setItems(mockData);
+
+      // Mock grid with dataItemColumnValueExtractor
+      const mockGrid = {
+        getOptions: () => ({
+          dataItemColumnValueExtractor: (item: any, col: any) => {
+            if (col.field === 'role' && item.role) {
+              return item.role.name;
+            }
+            if (col.field === 'fullName' && item.security) {
+              return item.security.fullName;
+            }
+            return item[col.field];
+          },
+        }),
+        getColumns: () => [
+          { id: 'security', field: 'fullName', name: 'Full Name' },
+          { id: 'role', field: 'role', name: 'Role' },
+        ],
+      } as any;
+
+      // Set grid on dataview to enable extractor usage
+      (dv as any)._grid = mockGrid;
+
+      // Group by role using the extractor
+      dv.setGrouping({
+        getter: 'role',
+        formatter: (g) => `Role: ${g.value} <span class="text-green">(${g.count} items)</span>`,
+      } as Grouping);
+
+      // Check that grouping works correctly with extractor
+      expect(dv.getGroups().length).toBe(2); // 'admin' and 'user' groups
+      expect(dv.getGroups()[0].value).toBe('admin');
+      expect(dv.getGroups()[0].count).toBe(2);
+      expect(dv.getGroups()[1].value).toBe('user');
+      expect(dv.getGroups()[1].count).toBe(1);
+
+      // Verify items are grouped correctly
+      const adminGroup = dv.getGroups()[0];
+      expect(adminGroup.rows.length).toBe(2);
+      expect(adminGroup.rows[0].id).toBe(1);
+      expect(adminGroup.rows[1].id).toBe(3);
+    });
   });
 
   describe('Sorting', () => {

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -3,6 +3,7 @@ import { SlickGroupItemMetadataProvider } from '../extensions/slickGroupItemMeta
 import type { CssStyleHash, CustomDataView } from '../interfaces/gridOption.interface.js';
 import type {
   Aggregator,
+  Column,
   DataViewHints,
   Grouping,
   GroupingFormatterItem,
@@ -881,6 +882,32 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     return this.groups;
   }
 
+  /**
+   * Get the grouping value for an item, respecting dataItemColumnValueExtractor if available.
+   * This allows grouping to work correctly with custom extractors for nested object properties.
+   */
+  protected getGroupingValue(item: TData, fieldName: string | number): any {
+    // Check if grid is available and has dataItemColumnValueExtractor
+    if (this._grid) {
+      const extractor = this._grid.getOptions?.().dataItemColumnValueExtractor;
+      if (extractor) {
+        const columns = this._grid.getColumns?.();
+        if (columns) {
+          // Find the column matching the grouping field
+          const column = columns.find((col: Column) => col.field === fieldName || col.id === fieldName);
+          if (column) {
+            const extractedValue = extractor(item, column);
+            if (extractedValue !== undefined && extractedValue !== null) {
+              return extractedValue;
+            }
+          }
+        }
+      }
+    }
+    // Fallback to direct field access
+    return item[fieldName as keyof TData];
+  }
+
   protected extractGroups(rows: any[], parentGroup?: SlickGroup): SlickGroup[] {
     let group: SlickGroup;
     let val: any;
@@ -905,7 +932,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
     for (let i = 0, l = rows.length; i < l; i++) {
       r = rows[i];
-      val = gi.getterIsAFn ? (gi.getter as GroupGetterFn)(r) : r[gi.getter as keyof TData];
+      val = gi.getterIsAFn ? (gi.getter as GroupGetterFn)(r) : this.getGroupingValue(r, gi.getter as string);
       group = groupsByVal[val];
       if (!group) {
         group = new SlickGroup();


### PR DESCRIPTION
## PR Description: Fix Grouping with dataItemColumnValueExtractor for Nested Objects

**fixes an old issue opened in SlickGrid (6pac) project: https://github.com/6pac/SlickGrid/issues/227**

_vibe coded a fix with Copilot_

### Description

Fixes issue where grouping does not work with `dataItemColumnValueExtractor` for accessing nested object properties. When a column uses a custom `dataItemColumnValueExtractor` to access nested objects and grouping is applied to that column, the DataView's grouping logic ignored the extractor and tried to access the field directly, resulting in `undefined` values for grouping.

### Root Cause

The DataView's `extractGroups()` method only performed direct field access (`r[gi.getter]`) without checking if a custom `dataItemColumnValueExtractor` was available. This caused nested object properties to fail grouping since the field wouldn't exist at the top level of the data item.

### Solution

- Added `Column` import to slickDataview.ts
- Added `getGroupingValue()` helper method that:
  - Checks if a grid reference is available with `dataItemColumnValueExtractor`
  - Finds the column definition matching the grouping field
  - Uses the extractor to get the value if available
  - Falls back to direct field access if no extractor or grid reference
- Modified `extractGroups()` to use this helper for string field getters instead of direct field access

### Step-by-Step Reproduction in UI

#### Setup Phase

1. **Create a sample grid HTML:**
   ```html
   <div id="grid" style="width: 100%; height: 500px;"></div>
   ```

2. **Define nested object data:**
   ```javascript
   const data = [
     { 
       id: 1, 
       security: { fullName: 'John Doe' }, 
       role: { name: 'Admin' },
       department: { name: 'Engineering' }
     },
     { 
       id: 2, 
       security: { fullName: 'Jane Smith' }, 
       role: { name: 'User' },
       department: { name: 'Marketing' }
     },
     { 
       id: 3, 
       security: { fullName: 'Bob Johnson' }, 
       role: { name: 'Admin' },
       department: { name: 'Engineering' }
     },
     { 
       id: 4, 
       security: { fullName: 'Alice Williams' }, 
       role: { name: 'User' },
       department: { name: 'Sales' }
     },
   ];
   ```

3. **Define columns:**
   ```javascript
   const columns = [
     { id: 'security', field: 'fullName', name: 'Full Name', width: 150 },
     { id: 'role', field: 'role', name: 'Role', width: 100 },
     { id: 'department', field: 'department', name: 'Department', width: 150 },
   ];
   ```

4. **Initialize grid with dataItemColumnValueExtractor:**
   ```javascript
   const grid = new SlickGrid(
     document.getElementById('grid'),
     data,
     columns,
     {
       enableGrouping: true,
       dataItemColumnValueExtractor: (item, col) => {
         // Extract nested property values
         if (col.field === 'fullName' && item.security) {
           return item.security.fullName;
         }
         if (col.field === 'role' && item.role) {
           return item.role.name;
         }
         if (col.field === 'department' && item.department) {
           return item.department.name;
         }
         return item[col.field];
       },
     }
   );
   ```

#### Testing the Fix

5. **Apply grouping by "Role" column:**
   - Right-click on the "Role" column header
   - Select "Group by Role" from the context menu
   - **Before Fix:** Groups display as "undefined" (because extractor wasn't being used)
   - **After Fix:** Groups display correctly as "Admin" and "User"

6. **Verify group contents:**
   - Expand the "Admin" group:
     - Should show: John Doe (id: 1) and Bob Johnson (id: 3)
     - Count should display "(2 items)"
   - Collapse and expand the "User" group:
     - Should show: Jane Smith (id: 2) and Alice Williams (id: 4)
     - Count should display "(2 items)"

7. **Test multi-level grouping:**
   - While "Role" grouping is active, right-click on "Department" column
   - Select "Group by Department"
   - **Result:** Should now have two grouping levels:
     - Level 1: Admin / User
     - Level 2: Engineering / Marketing / Sales (nested under each role)
   - **Before Fix:** Second level shows "undefined"
   - **After Fix:** Second level shows correct department names

8. **Verify sorting works correctly:**
   - Click on the "Role" group header to sort
   - Groups should reorder (Admin first or User first depending on sort direction)
   - All items remain correctly grouped under their parent group

9. **Test collapsing/expanding:**
   - Click the arrow next to "Admin" to collapse the group
   - Click again to expand
   - Verify items appear/disappear correctly
   - All operations work smoothly with nested property grouping

### Expected Behavior After Fix

✅ Grouping by columns with nested object properties works correctly  
✅ Groups display proper values instead of "undefined"  
✅ Multi-level grouping respects extractors at all levels  
✅ Sorting and collapsing/expanding groups work as expected  
✅ No performance degradation  

### Testing

✅ Added unit test in slickDataView.spec.ts:
- Test: "should apply grouping correctly when using dataItemColumnValueExtractor for nested object properties"
- Verifies grouping creates correct groups based on extracted nested property values
- Ensures items are properly distributed across groups
- **Test Result:** PASSING ✅

### Impact

- ✅ Fixes grouping with custom extractors
- ✅ No breaking changes
- ✅ Grid reference must be available (set via `syncGridSelection()` or used by plugins like draggable grouping)
- ✅ Fallback to direct field access for DataView-only usage without grid reference
- ✅ Maintains backward compatibility with existing grouping implementations

### Files Changed

- slickDataview.ts - Added Column import and `getGroupingValue()` helper method, modified `extractGroups()`
- slickDataView.spec.ts - Added test for grouping with dataItemColumnValueExtractor
