### PR TITLE
chore: replace validation alert() with showToast() to avoid blocking UI

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example03.ts
+++ b/demos/aurelia/src/examples/slickgrid/example03.ts
@@ -22,6 +22,7 @@ import SAMPLE_COLLECTION_DATA_URL from './data/collection_100_numbers.json?url';
 import COUNTRIES_COLLECTION_URL from './data/countries.json?url';
 import COUNTRY_NAMES_URL from './data/country_names.json?url';
 import fetchJsonp from './jsonp.js';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 100;
 
@@ -567,7 +568,7 @@ export class Example03 {
 
   onCellValidationError(_e: Event, args: any) {
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
   }
 

--- a/demos/aurelia/src/examples/slickgrid/example20.ts
+++ b/demos/aurelia/src/examples/slickgrid/example20.ts
@@ -11,6 +11,7 @@ import {
   type SlickGrid,
 } from 'aurelia-slickgrid';
 import './example20.scss'; // provide custom CSS/SASS styling
+import { showToast } from './utilities.js';
 
 export class Example20 {
   aureliaGrid!: AureliaGridInstance;
@@ -318,7 +319,7 @@ export class Example20 {
   }
 
   onCellValidationError(_e: Event, args: any) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 
   setFrozenColumns(frozenCols: number) {

--- a/demos/aurelia/src/examples/slickgrid/example26.ts
+++ b/demos/aurelia/src/examples/slickgrid/example26.ts
@@ -19,6 +19,7 @@ import { CustomTitleFormatter } from './custom-title-formatter.js';
 import { EditorSelect } from './editor-select.js';
 import { FilterSelect } from './filter-select.js';
 import './example26.scss';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 100;
 
@@ -312,7 +313,7 @@ export class Example26 {
   }
 
   onCellValidation(_e: Event, args: any) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 
   changeAutoCommit() {

--- a/demos/aurelia/src/examples/slickgrid/example30.ts
+++ b/demos/aurelia/src/examples/slickgrid/example30.ts
@@ -27,6 +27,7 @@ import {
 } from 'aurelia-slickgrid';
 import './example30.scss'; // provide custom CSS/SASS styling
 import COUNTRIES_COLLECTION_URL from './data/countries.json?url';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 500;
 
@@ -610,7 +611,7 @@ export class Example30 {
         console.log(errorMsg);
       }
     } else {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     e.preventDefault(); // OR eventData.preventDefault();
     return false;

--- a/demos/aurelia/test/cypress/e2e/example10.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example10.cy.ts
@@ -19,14 +19,14 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
     cy.get('@grid1')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(225, 1));
 
     cy.get('#slickGridContainer-grid2').as('grid2');
     cy.get('@grid2').should('have.css', 'width', '800px');
 
     cy.get('@grid2')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(255));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(255, 1));
   });
 
   it('should have exact Titles on 1st grid', () => {

--- a/demos/react-fluent/src/examples/slickgrid/Example05.tsx
+++ b/demos/react-fluent/src/examples/slickgrid/Example05.tsx
@@ -15,6 +15,7 @@ import './example05.scss'; // provide custom CSS/SASS styling
 
 import { Button } from '@fluentui/react-components';
 import { baseFluentGridOption } from './base-fluent-grid-options.js';
+import { showToast } from './utilities.js';
 
 const Example05: React.FC = () => {
   const [columns, setColumns] = useState<Column[]>([]);
@@ -324,7 +325,7 @@ const Example05: React.FC = () => {
   }
 
   function onCellValidationError(_e: Event, args: any) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 
   function setFrozenColumns(frozenCols: number) {

--- a/demos/react/src/examples/slickgrid/Example03.tsx
+++ b/demos/react/src/examples/slickgrid/Example03.tsx
@@ -24,6 +24,7 @@ import SAMPLE_COLLECTION_DATA_URL from './data/collection_100_numbers.json?url';
 import COUNTRIES_COLLECTION from './data/countries.json';
 import COUNTRY_NAMES from './data/country_names.json';
 import fetchJsonp from './jsonp.js';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 100;
 
@@ -562,7 +563,7 @@ const Example3: React.FC = () => {
 
   function onCellValidationError(_e: Event, args: any) {
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
   }
 

--- a/demos/react/src/examples/slickgrid/Example20.tsx
+++ b/demos/react/src/examples/slickgrid/Example20.tsx
@@ -11,6 +11,7 @@ import {
   type GridOption,
   type SlickgridReactInstance,
 } from 'slickgrid-react';
+import { showToast } from './utilities.js';
 import './example20.scss'; // provide custom CSS/SASS styling
 
 const Example20: React.FC = () => {
@@ -321,7 +322,7 @@ const Example20: React.FC = () => {
   }
 
   function onCellValidationError(_e: Event, args: any) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 
   function setFrozenColumns(frozenCols: number) {

--- a/demos/react/src/examples/slickgrid/Example30.tsx
+++ b/demos/react/src/examples/slickgrid/Example30.tsx
@@ -26,6 +26,7 @@ import {
   type VanillaCalendarOption,
 } from 'slickgrid-react';
 import COUNTRIES_COLLECTION from './data/countries.json';
+import { showToast } from './utilities.js';
 import './example30.scss'; // provide custom CSS/SASS styling
 
 const NB_ITEMS = 500;
@@ -604,7 +605,7 @@ const Example30: React.FC = () => {
         console.log(errorMsg);
       }
     } else {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     return false;
   }

--- a/demos/react/test/cypress/e2e/example10.cy.ts
+++ b/demos/react/test/cypress/e2e/example10.cy.ts
@@ -19,14 +19,14 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
     cy.get('@grid1')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(225, 1));
 
     cy.get('#slickGridContainer-grid2').as('grid2');
     cy.get('@grid2').should('have.css', 'width', '800px');
 
     cy.get('@grid2')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(255));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(255, 1));
   });
 
   it('should have exact Titles on 1st grid', () => {

--- a/demos/vanilla/src/examples/example03.ts
+++ b/demos/vanilla/src/examples/example03.ts
@@ -21,6 +21,7 @@ import { PdfExportService } from '@slickgrid-universal/pdf-export';
 import { TextExportService } from '@slickgrid-universal/text-export';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import { ExampleGridOptions } from './example-grid-options.js';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 10_000;
 
@@ -580,7 +581,7 @@ export default class Example03 {
     console.log('handleValidationError', event.detail);
     const args = event?.detail?.args;
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
   }
 

--- a/demos/vanilla/src/examples/example04.ts
+++ b/demos/vanilla/src/examples/example04.ts
@@ -16,6 +16,7 @@ import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import { ExampleGridOptions } from './example-grid-options.js';
 import fetchJsonp from './jsonp.js';
+import { showToast } from './utilities.js';
 import './example04.scss';
 
 // you can create custom validator to pass to an inline editor
@@ -569,7 +570,7 @@ export default class Example04 {
     console.log('handleOnValidationError', event.detail);
     const args = event?.detail?.args;
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
       return false;
     }
   }

--- a/demos/vanilla/src/examples/example07.ts
+++ b/demos/vanilla/src/examples/example07.ts
@@ -5,6 +5,7 @@ import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanil
 import DOMPurify from 'dompurify';
 import type { TranslateService } from '../translate.service.js';
 import { ExampleGridOptions } from './example-grid-options.js';
+import { showToast } from './utilities.js';
 import './example07.scss';
 import '../material-styles.scss';
 
@@ -631,7 +632,7 @@ export default class Example07 {
     console.log('handleValidationError', event.detail);
     const args = event.detail && event.detail.args;
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
   }
 

--- a/demos/vanilla/src/examples/example11-modal.ts
+++ b/demos/vanilla/src/examples/example11-modal.ts
@@ -2,6 +2,7 @@ import { BindingEventService } from '@slickgrid-universal/binding';
 import { Formatters, type Column, type DOMEvent, type Formatter, type GridOption } from '@slickgrid-universal/common';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import { ExampleGridOptions } from './example-grid-options.js';
+import { showToast } from './utilities.js';
 import './example11-modal.scss';
 
 export default class Example11Modal {
@@ -72,7 +73,7 @@ export default class Example11Modal {
     console.log('handleValidationError', event.detail);
     const args = event.detail && event.detail.args;
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     return false;
   }

--- a/demos/vanilla/src/examples/example11.ts
+++ b/demos/vanilla/src/examples/example11.ts
@@ -29,7 +29,7 @@ import countriesJson from './data/countries.json?raw';
 import { ExampleGridOptions } from './example-grid-options.js';
 import exampleModal from './example11-modal.html?raw';
 import Example11Modal from './example11-modal.js';
-import { loadComponent } from './utilities.js';
+import { loadComponent, showToast } from './utilities.js';
 import './example11.scss';
 
 const LOCAL_STORAGE_KEY = 'gridViewPreset';
@@ -519,7 +519,7 @@ export default class Example11 {
     console.log('handleValidationError', event.detail);
     const args = event?.detail?.args;
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     return false;
   }

--- a/demos/vanilla/src/examples/example12.ts
+++ b/demos/vanilla/src/examples/example12.ts
@@ -24,6 +24,7 @@ import { Slicker, type VanillaForceGridBundle } from '@slickgrid-universal/vanil
 import { type MultipleSelectOption } from 'multiple-select-vanilla';
 import countriesJson from './data/countries.json?raw';
 import { ExampleGridOptions } from './example-grid-options.js';
+import { showToast } from './utilities.js';
 import './example12.scss';
 
 // you can create custom validator to pass to an inline editor
@@ -658,7 +659,7 @@ export default class Example12 {
         console.log(errorMsg);
       }
     } else {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     return false;
   }

--- a/demos/vanilla/src/examples/example14.ts
+++ b/demos/vanilla/src/examples/example14.ts
@@ -24,6 +24,7 @@ import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
 import countriesJson from './data/countries.json?raw';
 import { ExampleGridOptions } from './example-grid-options.js';
+import { showToast } from './utilities.js';
 import './example14.scss';
 
 const NB_ITEMS = 400;
@@ -724,7 +725,7 @@ export default class Example14 {
         console.log(errorMsg);
       }
     } else {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     return false;
   }

--- a/demos/vue/src/components/Example03.vue
+++ b/demos/vue/src/components/Example03.vue
@@ -24,6 +24,7 @@ import SAMPLE_COLLECTION_DATA_URL from './data/collection_100_numbers.json?url';
 import COUNTRIES_COLLECTION from './data/countries.json';
 import COUNTRY_NAMES from './data/country_names.json';
 import fetchJsonp from './jsonp.js';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 100;
 
@@ -554,7 +555,7 @@ function onCellClicked(_e: Event, args: any) {
 
 function onValidationError(_e: Event, args: any) {
   if (args.validationResults) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 }
 

--- a/demos/vue/src/components/Example20.vue
+++ b/demos/vue/src/components/Example20.vue
@@ -12,6 +12,7 @@ import {
   type SlickgridVueInstance,
 } from 'slickgrid-vue';
 import { onBeforeMount, ref, type Ref } from 'vue';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
@@ -304,7 +305,7 @@ function isNullUndefinedOrEmpty(data: any) {
 }
 
 function onCellValidationError(_e: Event, args: any) {
-  alert(args.validationResults.msg);
+  showToast(args.validationResults.msg, 'danger');
 }
 
 function setFrozenColumns(frozenCols: number) {

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -27,6 +27,7 @@ import {
 } from 'slickgrid-vue';
 import { onBeforeMount, onUnmounted, ref, type Ref } from 'vue';
 import COUNTRIES_COLLECTION from './data/countries.json';
+import { showToast } from './utilities.js';
 
 const NB_ITEMS = 500;
 const gridOptions = ref<GridOption>();
@@ -556,7 +557,7 @@ function handleValidationError(e: Event, args: any) {
       console.log(errorMsg);
     }
   } else {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
   e.preventDefault(); // OR eventData.preventDefault();
   return false;

--- a/demos/vue/test/cypress/e2e/example10.cy.ts
+++ b/demos/vue/test/cypress/e2e/example10.cy.ts
@@ -19,14 +19,14 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
     cy.get('@grid1')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(225, 1));
 
     cy.get('#slickGridContainer-grid2').as('grid2');
     cy.get('@grid2').should('have.css', 'width', '800px');
 
     cy.get('@grid2')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(255));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(255, 1));
   });
 
   it('should have exact Titles on 1st grid', () => {

--- a/frameworks/angular-slickgrid/src/demos/examples/example03.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example03.component.ts
@@ -27,6 +27,7 @@ import {
 import { CustomInputEditor } from './custom-inputEditor';
 import { CustomInputFilter } from './custom-inputFilter';
 import fetchJsonp from './jsonp';
+import { showToast } from './utilities';
 
 const NB_ITEMS = 100;
 const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_100_numbers.json';
@@ -622,7 +623,7 @@ export class Example3Component implements OnInit {
 
   onValidationError(e: Event, args: any) {
     if (args.validationResults) {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
   }
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example20.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example20.component.ts
@@ -12,6 +12,7 @@ import {
   type ColumnEditorDualInput,
   type GridOption,
 } from '../../library';
+import { showToast } from './utilities';
 
 @Component({
   templateUrl: './example20.component.html',
@@ -324,7 +325,7 @@ export class Example20Component implements OnInit, OnDestroy {
   }
 
   onValidationError(e: Event, args: any) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 
   setFrozenColumns(frozenCols: number) {

--- a/frameworks/angular-slickgrid/src/demos/examples/example26.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example26.component.ts
@@ -22,6 +22,7 @@ import { CustomButtonFormatterComponent } from './custom-buttonFormatter.compone
 import { CustomTitleFormatterComponent } from './custom-titleFormatter.component';
 import { EditorNgSelectComponent } from './editor-ng-select.component';
 import { FilterNgSelectComponent } from './filter-ng-select.component';
+import { showToast } from './utilities';
 
 const NB_ITEMS = 100;
 
@@ -336,7 +337,7 @@ export class Example26Component implements OnInit {
   }
 
   onCellValidationError(e: Event, args: any) {
-    alert(args.validationResults.msg);
+    showToast(args.validationResults.msg, 'danger');
   }
 
   changeAutoCommit() {

--- a/frameworks/angular-slickgrid/src/demos/examples/example30.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example30.component.ts
@@ -26,6 +26,7 @@ import {
   type SliderOption,
   type VanillaCalendarOption,
 } from '../../library';
+import { showToast } from './utilities';
 
 const NB_ITEMS = 500;
 const URL_COUNTRIES_COLLECTION = 'assets/data/countries.json';
@@ -613,7 +614,7 @@ export class Example30Component implements OnDestroy, OnInit {
         console.log(errorMsg);
       }
     } else {
-      alert(args.validationResults.msg);
+      showToast(args.validationResults.msg, 'danger');
     }
     return false;
   }

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example10.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example10.cy.ts
@@ -19,14 +19,14 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
     cy.get('@grid1')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(225));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(225, 1));
 
     cy.get('#slickGridContainer-grid2').as('grid2');
     cy.get('@grid2').should('have.css', 'width', '800px');
 
     cy.get('@grid2')
       .find('.slickgrid-container')
-      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(255));
+      .should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(255, 1));
   });
 
   it('should have exact Titles on 1st grid', () => {

--- a/test/cypress/e2e/example10.cy.ts
+++ b/test/cypress/e2e/example10.cy.ts
@@ -24,7 +24,7 @@ describe('Example 10 - GraphQL Grid', () => {
   it('should have a grid of size 900 by 275px', () => {
     cy.get('.grid10').should('have.css', 'width', '900px');
 
-    cy.get('.grid10 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(275));
+    cy.get('.grid10 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.approximately(275, 1));
   });
 
   it('should have English Text inside some of the Filters', () => {

--- a/test/cypress/e2e/example41.cy.ts
+++ b/test/cypress/e2e/example41.cy.ts
@@ -20,7 +20,7 @@ describe('Example 41 - SQL Grid', () => {
 
   it('should have a grid of size 900 by 275px', () => {
     cy.get('.grid41').should('have.css', 'width', '900px');
-    cy.get('.grid41 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.eq(275));
+    cy.get('.grid41 > .slickgrid-container').should(($el) => expect(parseInt(`${$el.height()}`, 10)).to.within(274, 276));
   });
 
   it('should have SQL query with defined Grid Presets', () => {


### PR DESCRIPTION
some examples like vanilla Example 11, have validation on the "Title" column and using `alert()` makes it impossible to enter a valid cell input since after closing the alert() it comes back right away going into an infinite loop