### PR TITLE
fix: respect `multiSelect` in checkbox and row keyboard selection

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example30.ts
+++ b/demos/aurelia/src/examples/slickgrid/example30.ts
@@ -497,7 +497,6 @@ export class Example30 {
       preHeaderPanelHeight: 28,
       enableCheckboxSelector: true,
       enableSelection: true,
-      multiSelect: false,
       checkboxSelector: {
         hideInFilterHeaderRow: false,
         hideInColumnTitleRow: true,

--- a/demos/react/src/examples/slickgrid/Example30.tsx
+++ b/demos/react/src/examples/slickgrid/Example30.tsx
@@ -492,7 +492,6 @@ const Example30: React.FC = () => {
       preHeaderPanelHeight: 28,
       enableCheckboxSelector: true,
       enableSelection: true,
-      multiSelect: false,
       checkboxSelector: {
         hideInFilterHeaderRow: false,
         hideInColumnTitleRow: true,

--- a/demos/vue/src/components/Example30.vue
+++ b/demos/vue/src/components/Example30.vue
@@ -456,7 +456,6 @@ function defineGrid() {
     preHeaderPanelHeight: 28,
     enableCheckboxSelector: true,
     enableSelection: true,
-    multiSelect: false,
     checkboxSelector: {
       hideInFilterHeaderRow: false,
       hideInColumnTitleRow: true,

--- a/docs/grid-functionalities/composite-editor-modal.md
+++ b/docs/grid-functionalities/composite-editor-modal.md
@@ -143,6 +143,8 @@ Mass Update allows you to apply changes (from the modal form) to the entire data
 
 Note however that there is a subtle difference compare to the Create Item action, you need to specifically tag which column will show up in the Mass Update and you need to do that by adding `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the form.
 
+Important: `selectionOptions.selectActiveRow: false` is commonly used for checkbox-based multi-row workflows, but you must also keep `multiSelect` enabled (default `true`), otherwise `mass-selection` and `auto-mass` will not work as expected because only one row can stay selected at a time.
+
 `auto-mass` option: If you decide to use Mass Update and Mass Selection and wish to only expose 1 button to do the action and let the system decide if it's doing a Mass Update or a Mass Selection change, you can use the modal type `auto-mass` (if it detect that some rows are selected it will use Mass Selection or else Mass Update). From our experience, user prefer to expose the 2 separate action buttons (less confusion), but this for you to decide, you have the option.
 
 ##### with TypeScript
@@ -236,6 +238,8 @@ example class MyCompositeDemo {
 
 ## Mass Selection
 Similar to the Mass Update but apply changes only on the selected rows. The setup is nearly identical to the Mass Update, just make sure to display appropriate modal title. Also note that you also need to add `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the Mass Selection changes form.
+
+**Important**: Mass Selection requires real multi-row selection, so even if you use `selectionOptions.selectActiveRow: false`, you must keep `multiSelect` enabled (default `true`); with `multiSelect: false`, only one row can remain selected and the modal will not behave as expected.
 
 Refer to the [Mass Update](#mass-update) section for code sample.
 

--- a/docs/grid-functionalities/row-selection.md
+++ b/docs/grid-functionalities/row-selection.md
@@ -6,6 +6,7 @@
 - [Disable Custom Rows Selections via `selectableOverride`](#disable-custom-rows-selections-via-selectableoverride)
 - [Disable External Button when having Empty Selection](#disable-external-button-when-having-empty-selection)
 - [Change Row Selections](#change-row-selections)
+- [Understanding the multiSelect Option](#understanding-the-multiselect-option)
 - Troubleshooting
   - [Adding a Column dynamically is removing the Row Selection column, why is that?](#adding-a-column-dynamically-is-removing-the-row-selection-column-why-is-that)
 - [Hybrid Selection Model (cell+row selection)](#hybrid-selection-model-and-drag-fill)
@@ -338,6 +339,28 @@ export class Example1 {
   }
 }
 ```
+
+## Understanding the `multiSelect` Option
+The `multiSelect` grid option is a critical setting that controls how row selection works across all selection methods (checkboxes, keyboard navigation, and click handlers). Understanding this option is key to implementing the correct selection behavior for your use case.
+
+### `multiSelect: false` (Single Selection Mode)
+When `multiSelect: false`, the grid enforces **strict single selection**:
+- **Checkbox Selection**: Clicking a checkbox selects only that row. Clicking a checkbox that's already selected will **deselect** it (toggle behavior). Only one row can be selected at a time.
+- **Keyboard Selection**: Using Shift+Arrow keys to extend a range will select only the current row (range is clamped to a single row). Regular arrow navigation moves between rows but doesn't change selection.
+- **Overall Behavior**: At most one row is selected at any time. If you programmatically select a row while another is selected, only the new row remains selected.
+
+### `multiSelect: true` (Multiple Selection Mode)
+When `multiSelect: true`, the grid allows **multiple rows to be selected**:
+- **Checkbox Selection**: Clicking a checkbox adds or removes that row from the selection set. Multiple rows can be checked independently.
+- **Keyboard Selection**: Using Shift+Arrow keys extends the selection range to include multiple rows. Ctrl/Cmd+Click or Shift+Click can be used to build complex selections.
+- **Overall Behavior**: Multiple rows can be selected and retained in the selection set.
+
+### Selection Methods & `multiSelect`
+All row selection methods respect the `multiSelect` option:
+1. **Checkbox Selection** (when `enableCheckboxSelector: true`): Respects `multiSelect` setting
+2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
+3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
+4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/docs/grid-functionalities/row-selection.md
+++ b/docs/grid-functionalities/row-selection.md
@@ -81,7 +81,7 @@ gridObjChanged(grid) {
 ```
 
 ## Multiple Row Selections
-As for multiple row selections, you need to disable `enableCellNavigation` and enable `enableCheckboxSelector` and `enableRowSelection`. Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`). There are 2 ways to choose for the implementation of a row selection, option **1.** is the most common option and is the recommend way of doing it.
+As for multiple row selections, you need to enable `enableCheckboxSelector` and `enableRowSelection`, keep `multiSelect` enabled (default is `true`), and typically use `selectionOptions.selectActiveRow: false` when you do not want active-row clicks to interfere with checkbox-based multi-selection. Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`). There are 2 ways to choose for the implementation of a row selection, option **1.** is the most common option and is the recommend way of doing it.
 
 ### 1. with Custom Events (preferred way)
 You can also do it through a Custom Event listener since all SlickGrid events are exposed as Custom Events. For more info see [Wiki - OnEvents](grid-dataview-events.md)
@@ -113,6 +113,7 @@ export class Example1 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     }
   }
 
@@ -139,6 +140,7 @@ export class Example1 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     }
   }
 
@@ -361,6 +363,8 @@ All row selection methods respect the `multiSelect` option:
 2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
 3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
 4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
+
+`selectionOptions.selectActiveRow` only controls whether activating a row also selects it; it does not override `multiSelect` and cannot enable multiple selection when `multiSelect: false`.
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/composite-editor-modal.md
@@ -108,6 +108,8 @@ Mass Update allows you to apply changes (from the modal form) to the entire data
 
 Note however that there is a subtle difference compare to the Create Item action, you need to specifically tag which column will show up in the Mass Update and you need to do that by adding `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the form.
 
+Important: `selectionOptions.selectActiveRow: false` is commonly used for checkbox-based multi-row workflows, but you must also keep `multiSelect` enabled (default `true`), otherwise `mass-selection` and `auto-mass` will not work as expected because only one row can stay selected at a time.
+
 `auto-mass` option: If you decide to use Mass Update and Mass Selection and wish to only expose 1 button to do the action and let the system decide if it's doing a Mass Update or a Mass Selection change, you can use the modal type `auto-mass` (if it detect that some rows are selected it will use Mass Selection or else Mass Update). From our experience, user prefer to expose the 2 separate action buttons (less confusion), but this for you to decide, you have the option.
 
 ##### with TypeScript
@@ -165,6 +167,8 @@ example class MyCompositeDemo {
 
 ## Mass Selection
 Similar to the Mass Update but apply changes only on the selected rows. The setup is nearly identical to the Mass Update, just make sure to display appropriate modal title. Also note that you also need to add `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the Mass Selection changes form.
+
+**Important**: Mass Selection requires real multi-row selection, so even if you use `selectionOptions.selectActiveRow: false`, you must keep `multiSelect` enabled (default `true`); with `multiSelect: false`, only one row can remain selected and the modal will not behave as expected.
 
 Refer to the [Mass Update](#mass-update) section for code sample.
 

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
@@ -6,6 +6,7 @@
 - [Disable Custom Rows Selections via `selectableOverride`](#disable-custom-rows-selections-via-selectableoverride)
 - [Disable External Button when having Empty Selection](#disable-external-button-when-having-empty-selection)
 - [Change Row Selections](#change-row-selections)
+- [Understanding the multiSelect Option](#understanding-the-multiselect-option)
 - Troubleshooting
   - [Adding a Column dynamically is removing the Row Selection column, why is that?](#adding-a-column-dynamically-is-removing-the-row-selection-column-why-is-that)
 - [Hybrid Selection Model (cell+row selection)](#hybrid-selection-model-and-drag-fill)
@@ -294,6 +295,28 @@ copyDraggedCellRange(args: OnDragReplaceCellsEventArgs) {
   }
 }
 ```
+
+## Understanding the `multiSelect` Option
+The `multiSelect` grid option is a critical setting that controls how row selection works across all selection methods (checkboxes, keyboard navigation, and click handlers). Understanding this option is key to implementing the correct selection behavior for your use case.
+
+### `multiSelect: false` (Single Selection Mode)
+When `multiSelect: false`, the grid enforces **strict single selection**:
+- **Checkbox Selection**: Clicking a checkbox selects only that row. Clicking a checkbox that's already selected will **deselect** it (toggle behavior). Only one row can be selected at a time.
+- **Keyboard Selection**: Using Shift+Arrow keys to extend a range will select only the current row (range is clamped to a single row). Regular arrow navigation moves between rows but doesn't change selection.
+- **Overall Behavior**: At most one row is selected at any time. If you programmatically select a row while another is selected, only the new row remains selected.
+
+### `multiSelect: true` (Multiple Selection Mode)
+When `multiSelect: true`, the grid allows **multiple rows to be selected**:
+- **Checkbox Selection**: Clicking a checkbox adds or removes that row from the selection set. Multiple rows can be checked independently.
+- **Keyboard Selection**: Using Shift+Arrow keys extends the selection range to include multiple rows. Ctrl/Cmd+Click or Shift+Click can be used to build complex selections.
+- **Overall Behavior**: Multiple rows can be selected and retained in the selection set.
+
+### Selection Methods & `multiSelect`
+All row selection methods respect the `multiSelect` option:
+1. **Checkbox Selection** (when `enableCheckboxSelector: true`): Respects `multiSelect` setting
+2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
+3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
+4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
@@ -55,7 +55,7 @@ onSelectedRowsChanged(e, args) {
 ```
 
 ## Multiple Row Selections
-As for multiple row selections, you need to provide an extra grid option of `rowSelectionOptions` which is an object and within it, you need to disable the `selectActiveRow` flag. The other configurations are the same as a Single Selection, which is to enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x). Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`).
+As for multiple row selections, you need to provide `selectionOptions.selectActiveRow: false` and keep `multiSelect` enabled (default is `true`). The other configurations are the same as a Single Selection, which is to enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x). Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`).
 
 #### View
 ```html
@@ -84,6 +84,7 @@ export class Example1 implements OnInit {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     }
   }
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example30.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example30.component.ts
@@ -504,7 +504,6 @@ export class Example30Component implements OnDestroy, OnInit {
       preHeaderPanelHeight: 28,
       enableCheckboxSelector: true,
       enableSelection: true,
-      multiSelect: false,
       checkboxSelector: {
         hideInFilterHeaderRow: false,
         hideInColumnTitleRow: true,

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/composite-editor-modal.md
@@ -108,6 +108,8 @@ Mass Update allows you to apply changes (from the modal form) to the entire data
 
 Note however that there is a subtle difference compare to the Create Item action, you need to specifically tag which column will show up in the Mass Update and you need to do that by adding `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the form.
 
+Important: `selectionOptions.selectActiveRow: false` is commonly used for checkbox-based multi-row workflows, but you must also keep `multiSelect` enabled (default `true`), otherwise `mass-selection` and `auto-mass` will not work as expected because only one row can stay selected at a time.
+
 `auto-mass` option: If you decide to use Mass Update and Mass Selection and wish to only expose 1 button to do the action and let the system decide if it's doing a Mass Update or a Mass Selection change, you can use the modal type `auto-mass` (if it detect that some rows are selected it will use Mass Selection or else Mass Update). From our experience, user prefer to expose the 2 separate action buttons (less confusion), but this for you to decide, you have the option.
 
 ##### with TypeScript
@@ -165,6 +167,8 @@ example class MyCompositeDemo {
 
 ## Mass Selection
 Similar to the Mass Update but apply changes only on the selected rows. The setup is nearly identical to the Mass Update, just make sure to display appropriate modal title. Also note that you also need to add `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the Mass Selection changes form.
+
+**Important**: Mass Selection requires real multi-row selection, so even if you use `selectionOptions.selectActiveRow: false`, you must keep `multiSelect` enabled (default `true`); with `multiSelect: false`, only one row can remain selected and the modal will not behave as expected.
 
 Refer to the [Mass Update](#mass-update) section for code sample.
 

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
@@ -6,6 +6,7 @@
 - [Disable Custom Rows Selections via `selectableOverride`](#disable-custom-rows-selections-via-selectableoverride)
 - [Disable External Button when having Empty Selection](#disable-external-button-when-having-empty-selection)
 - [Change Row Selections](#change-row-selections)
+- [Understanding the multiSelect Option](#understanding-the-multiselect-option)
 - Troubleshooting
   - [Adding a Column dynamically is removing the Row Selection column, why is that?](#adding-a-column-dynamically-is-removing-the-row-selection-column-why-is-that)
 - [Hybrid Selection Model (cell+row selection)](#hybrid-selection-model-and-drag-fill)
@@ -308,6 +309,28 @@ export class Example {
   }
 }
 ```
+
+## Understanding the `multiSelect` Option
+The `multiSelect` grid option is a critical setting that controls how row selection works across all selection methods (checkboxes, keyboard navigation, and click handlers). Understanding this option is key to implementing the correct selection behavior for your use case.
+
+### `multiSelect: false` (Single Selection Mode)
+When `multiSelect: false`, the grid enforces **strict single selection**:
+- **Checkbox Selection**: Clicking a checkbox selects only that row. Clicking a checkbox that's already selected will **deselect** it (toggle behavior). Only one row can be selected at a time.
+- **Keyboard Selection**: Using Shift+Arrow keys to extend a range will select only the current row (range is clamped to a single row). Regular arrow navigation moves between rows but doesn't change selection.
+- **Overall Behavior**: At most one row is selected at any time. If you programmatically select a row while another is selected, only the new row remains selected.
+
+### `multiSelect: true` (Multiple Selection Mode)
+When `multiSelect: true`, the grid allows **multiple rows to be selected**:
+- **Checkbox Selection**: Clicking a checkbox adds or removes that row from the selection set. Multiple rows can be checked independently.
+- **Keyboard Selection**: Using Shift+Arrow keys extends the selection range to include multiple rows. Ctrl/Cmd+Click or Shift+Click can be used to build complex selections.
+- **Overall Behavior**: Multiple rows can be selected and retained in the selection set.
+
+### Selection Methods & `multiSelect`
+All row selection methods respect the `multiSelect` option:
+1. **Checkbox Selection** (when `enableCheckboxSelector: true`): Respects `multiSelect` setting
+2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
+3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
+4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
@@ -56,7 +56,7 @@ onSelectedRowsChanged(e, args) {
 ```
 
 ## Multiple Row Selections
-As for multiple row selections, you need to provide an extra grid option of `rowSelectionOptions` which is an object and within it, you need to disable the `selectActiveRow` flag. The other configurations are the same as a Single Selection, which is to enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x). Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `gridChanged`).
+As for multiple row selections, you need to provide `selectionOptions.selectActiveRow: false` and keep `multiSelect` enabled (default is `true`). The other configurations are the same as a Single Selection, which is to enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x). Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `gridChanged`).
 
 #### View
 ```html
@@ -90,6 +90,7 @@ export class Example1 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     }
   }
 
@@ -121,6 +122,7 @@ export class Example1 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     }
   }
 
@@ -331,6 +333,8 @@ All row selection methods respect the `multiSelect` option:
 2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
 3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
 4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
+
+`selectionOptions.selectActiveRow` only controls whether activating a row also selects it; it does not override `multiSelect` and cannot enable multiple selection when `multiSelect: false`.
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/slickgrid-react/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/composite-editor-modal.md
@@ -113,6 +113,8 @@ Mass Update allows you to apply changes (from the modal form) to the entire data
 
 Note however that there is a subtle difference compare to the Create Item action, you need to specifically tag which column will show up in the Mass Update and you need to do that by adding `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the form.
 
+Important: `selectionOptions.selectActiveRow: false` is commonly used for checkbox-based multi-row workflows, but you must also keep `multiSelect` enabled (default `true`), otherwise `mass-selection` and `auto-mass` will not work as expected because only one row can stay selected at a time.
+
 `auto-mass` option: If you decide to use Mass Update and Mass Selection and wish to only expose 1 button to do the action and let the system decide if it's doing a Mass Update or a Mass Selection change, you can use the modal type `auto-mass` (if it detect that some rows are selected it will use Mass Selection or else Mass Update). From our experience, user prefer to expose the 2 separate action buttons (less confusion), but this for you to decide, you have the option.
 
 ##### with TypeScript
@@ -176,6 +178,8 @@ const Example: React.FC = () => {
 
 ## Mass Selection
 Similar to the Mass Update but apply changes only on the selected rows. The setup is nearly identical to the Mass Update, just make sure to display appropriate modal title. Also note that you also need to add `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the Mass Selection changes form.
+
+**Important**: Mass Selection requires real multi-row selection, so even if you use `selectionOptions.selectActiveRow: false`, you must keep `multiSelect` enabled (default `true`); with `multiSelect: false`, only one row can remain selected and the modal will not behave as expected.
 
 Refer to the [Mass Update](#mass-update) section for code sample.
 

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -87,7 +87,7 @@ gridObjChanged(grid) {
 ```
 
 ## Multiple Row Selections
-As for multiple row selections, you need to disable `enableCellNavigation` and enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x). Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`). There are 2 ways to choose for the implementation of a row selection, option **1.** is the most common option and is the recommend way of doing it.
+As for multiple row selections, you need to enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x), keep `multiSelect` enabled (default is `true`), and typically use `selectionOptions.selectActiveRow: false` when you do not want active-row clicks to interfere with checkbox-based multi-selection. Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`). There are 2 ways to choose for the implementation of a row selection, option **1.** is the most common option and is the recommend way of doing it.
 
 ### 1. with event (preferred way)
 You can also do it through an event since all SlickGrid events are exposed. For more info see [Docs - OnEvents - `3. event`](../events/grid-dataview-events.md)
@@ -113,6 +113,7 @@ const Example: React.FC = () => {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     }
   }
 
@@ -151,6 +152,7 @@ const Example: React.FC = () => {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
+      // keep `multiSelect` enabled (default) for actual multiple row selection
     });
   }
 
@@ -419,6 +421,8 @@ All row selection methods respect the `multiSelect` option:
 2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
 3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
 4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
+
+`selectionOptions.selectActiveRow` only controls whether activating a row also selects it; it does not override `multiSelect` and cannot enable multiple selection when `multiSelect: false`.
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -6,6 +6,7 @@
 - [Disable Custom Rows Selections via `selectableOverride`](#disable-custom-rows-selections-via-selectableoverride)
 - [Disable External Button when having Empty Selection](#disable-external-button-when-having-empty-selection)
 - [Change Row Selections](#change-row-selections)
+- [Understanding the multiSelect Option](#understanding-the-multiselect-option)
 - Troubleshooting
   - [Adding a Column dynamically is removing the Row Selection column, why is that?](#adding-a-column-dynamically-is-removing-the-row-selection-column-why-is-that)
 - [Hybrid Selection Model (cell+row selection)](#hybrid-selection-model-and-drag-fill)
@@ -396,6 +397,28 @@ const Example: React.FC = () => {
 
 export default Example;
 ```
+
+## Understanding the `multiSelect` Option
+The `multiSelect` grid option is a critical setting that controls how row selection works across all selection methods (checkboxes, keyboard navigation, and click handlers). Understanding this option is key to implementing the correct selection behavior for your use case.
+
+### `multiSelect: false` (Single Selection Mode)
+When `multiSelect: false`, the grid enforces **strict single selection**:
+- **Checkbox Selection**: Clicking a checkbox selects only that row. Clicking a checkbox that's already selected will **deselect** it (toggle behavior). Only one row can be selected at a time.
+- **Keyboard Selection**: Using Shift+Arrow keys to extend a range will select only the current row (range is clamped to a single row). Regular arrow navigation moves between rows but doesn't change selection.
+- **Overall Behavior**: At most one row is selected at any time. If you programmatically select a row while another is selected, only the new row remains selected.
+
+### `multiSelect: true` (Multiple Selection Mode)
+When `multiSelect: true`, the grid allows **multiple rows to be selected**:
+- **Checkbox Selection**: Clicking a checkbox adds or removes that row from the selection set. Multiple rows can be checked independently.
+- **Keyboard Selection**: Using Shift+Arrow keys extends the selection range to include multiple rows. Ctrl/Cmd+Click or Shift+Click can be used to build complex selections.
+- **Overall Behavior**: Multiple rows can be selected and retained in the selection set.
+
+### Selection Methods & `multiSelect`
+All row selection methods respect the `multiSelect` option:
+1. **Checkbox Selection** (when `enableCheckboxSelector: true`): Respects `multiSelect` setting
+2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
+3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
+4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/composite-editor-modal.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/composite-editor-modal.md
@@ -114,6 +114,8 @@ Mass Update allows you to apply changes (from the modal form) to the entire data
 
 Note however that there is a subtle difference compare to the Create Item action, you need to specifically tag which column will show up in the Mass Update and you need to do that by adding `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the form.
 
+Important: `selectionOptions.selectActiveRow: false` is commonly used for checkbox-based multi-row workflows, but you must also keep `multiSelect` enabled (default `true`), otherwise `mass-selection` and `auto-mass` will not work as expected because only one row can stay selected at a time.
+
 `auto-mass` option: If you decide to use Mass Update and Mass Selection and wish to only expose 1 button to do the action and let the system decide if it's doing a Mass Update or a Mass Selection change, you can use the modal type `auto-mass` (if it detect that some rows are selected it will use Mass Selection or else Mass Update). From our experience, user prefer to expose the 2 separate action buttons (less confusion), but this for you to decide, you have the option.
 
 ##### with TypeScript
@@ -177,6 +179,8 @@ function openCompositeModal(modalType: CompositeEditorModalType = 'mass-update')
 
 ## Mass Selection
 Similar to the Mass Update but apply changes only on the selected rows. The setup is nearly identical to the Mass Update, just make sure to display appropriate modal title. Also note that you also need to add `massUpdate: true` flag inside the `editor` property of each column definition that you wish to be included in the Mass Selection changes form.
+
+**Important**: Mass Selection requires real multi-row selection, so even if you use `selectionOptions.selectActiveRow: false`, you must keep `multiSelect` enabled (default `true`); with `multiSelect: false`, only one row can remain selected and the modal will not behave as expected.
 
 Refer to the [Mass Update](#mass-update) section for code sample.
 

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
@@ -6,6 +6,7 @@
 - [Disable Custom Rows Selections via `selectableOverride`](#disable-custom-rows-selections-via-selectableoverride)
 - [Disable External Button when having Empty Selection](#disable-external-button-when-having-empty-selection)
 - [Change Row Selections](#change-row-selections)
+- [Understanding the multiSelect Option](#understanding-the-multiselect-option)
 - Troubleshooting
   - [Adding a Column dynamically is removing the Row Selection column, why is that?](#adding-a-column-dynamically-is-removing-the-row-selection-column-why-is-that)
 - [Hybrid Selection Model (cell+row selection)](#hybrid-selection-model-and-drag-fill)
@@ -462,6 +463,28 @@ function copyDraggedCellRange(args: OnDragReplaceCellsEventArgs) {
 }
 </script>
 ```
+
+## Understanding the `multiSelect` Option
+The `multiSelect` grid option is a critical setting that controls how row selection works across all selection methods (checkboxes, keyboard navigation, and click handlers). Understanding this option is key to implementing the correct selection behavior for your use case.
+
+### `multiSelect: false` (Single Selection Mode)
+When `multiSelect: false`, the grid enforces **strict single selection**:
+- **Checkbox Selection**: Clicking a checkbox selects only that row. Clicking a checkbox that's already selected will **deselect** it (toggle behavior). Only one row can be selected at a time.
+- **Keyboard Selection**: Using Shift+Arrow keys to extend a range will select only the current row (range is clamped to a single row). Regular arrow navigation moves between rows but doesn't change selection.
+- **Overall Behavior**: At most one row is selected at any time. If you programmatically select a row while another is selected, only the new row remains selected.
+
+### `multiSelect: true` (Multiple Selection Mode)
+When `multiSelect: true`, the grid allows **multiple rows to be selected**:
+- **Checkbox Selection**: Clicking a checkbox adds or removes that row from the selection set. Multiple rows can be checked independently.
+- **Keyboard Selection**: Using Shift+Arrow keys extends the selection range to include multiple rows. Ctrl/Cmd+Click or Shift+Click can be used to build complex selections.
+- **Overall Behavior**: Multiple rows can be selected and retained in the selection set.
+
+### Selection Methods & `multiSelect`
+All row selection methods respect the `multiSelect` option:
+1. **Checkbox Selection** (when `enableCheckboxSelector: true`): Respects `multiSelect` setting
+2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
+3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
+4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
@@ -97,7 +97,7 @@ function gridObjChanged(grid) {
 ```
 
 ## Multiple Row Selections
-As for multiple row selections, you need to disable `enableCellNavigation` and enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x). Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`). There are 2 ways to choose for the implementation of a row selection, option **1.** is the most common option and is the recommend way of doing it.
+As for multiple row selections, you need to enable `enableCheckboxSelector` and `enableSelection` (or `enableRowSelection` in <=9.x), keep `multiSelect` enabled (default is `true`), and typically use `selectionOptions.selectActiveRow: false` when you do not want active-row clicks to interfere with checkbox-based multi-selection. Then as describe earlier, you will subscribe to `onSelectedRowsChanged` (for that you need to bind to `(gridChanged)`). There are 2 ways to choose for the implementation of a row selection, option **1.** is the most common option and is the recommend way of doing it.
 
 ### 1. with event (preferred way)
 You can also do it through an event since all SlickGrid events are exposed. For more info see [Docs - OnEvents - `3. event`](../events/grid-dataview-events.md)
@@ -134,6 +134,7 @@ function defineGrid() {
       // True (Single Selection), False (Multiple Selections)
       selectActiveRow: false
     },
+    // keep `multiSelect` enabled (default) for actual multiple row selection
   }
 }
 
@@ -184,6 +185,7 @@ function defineGrid() {
       // True (Single Selection), False (Multiple Selections)
       selectActiveRow: false
     },
+    // keep `multiSelect` enabled (default) for actual multiple row selection
   }
 }
 
@@ -485,6 +487,8 @@ All row selection methods respect the `multiSelect` option:
 2. **Keyboard Selection** (Shift+Arrow): Respects `multiSelect` setting
 3. **Programmatic Selection** (calling `setSelectedRows()`): Not restricted by `multiSelect` but subsequent UI interactions will respect it
 4. **Other Selection Handlers**: All adhere to the `multiSelect` constraint
+
+`selectionOptions.selectActiveRow` only controls whether activating a row also selects it; it does not override `multiSelect` and cannot enable multiple selection when `multiSelect: false`.
 
 ## Troubleshooting
 ### Adding a Column dynamically is removing the Row Selection column, why is that?

--- a/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCheckboxSelectColumn.spec.ts
@@ -449,6 +449,37 @@ describe('SlickCheckboxSelectColumn Plugin', () => {
     expect(setActiveCellSpy).toHaveBeenCalledWith(2, 0);
   });
 
+  it('should call "toggleRowSelection" and keep only one selected row when grid multiSelect is false', () => {
+    vi.spyOn(gridStub, 'getDataItem').mockReturnValue({ firstName: 'John', lastName: 'Doe', age: 30 });
+    vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    vi.spyOn(gridStub, 'getOptions').mockReturnValue({ multiSelect: false });
+    vi.spyOn(gridStub, 'getSelectedRows').mockReturnValue([1, 2]);
+    const setActiveCellSpy = vi.spyOn(gridStub, 'setActiveCell');
+    const setSelectedRowSpy = vi.spyOn(gridStub, 'setSelectedRows');
+
+    plugin.init(gridStub);
+    plugin.toggleRowSelection(2);
+
+    expect(setSelectedRowSpy).toHaveBeenCalledWith([2], 'click.toggle');
+    expect(setActiveCellSpy).toHaveBeenCalledWith(2, 0);
+  });
+
+  it('should call "toggleRowSelection" and unselect row when grid multiSelect is false and row is already selected', () => {
+    vi.spyOn(gridStub, 'getDataItem').mockReturnValue({ firstName: 'John', lastName: 'Doe', age: 30 });
+    vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    vi.spyOn(gridStub, 'getOptions').mockReturnValue({ multiSelect: false });
+    vi.spyOn(gridStub, 'getSelectedRows').mockReturnValue([2]);
+    const setActiveCellSpy = vi.spyOn(gridStub, 'setActiveCell');
+    const setSelectedRowSpy = vi.spyOn(gridStub, 'setSelectedRows');
+
+    plugin.init(gridStub);
+    plugin.selectedRowsLookup = { 2: true };
+    plugin.toggleRowSelection(2);
+
+    expect(setSelectedRowSpy).toHaveBeenCalledWith([], 'click.toggle');
+    expect(setActiveCellSpy).toHaveBeenCalledWith(2, 0);
+  });
+
   it('should fill the "selectableOverride" and expect', () => {
     vi.spyOn(gridStub, 'getDataItem').mockReturnValue({ firstName: 'John', lastName: 'Doe', age: 30 });
     vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);

--- a/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
@@ -482,6 +482,23 @@ describe('Row Selection Model Plugin', () => {
     ]);
   });
 
+  it('should keep single row range on Shift+ArrowDown when multiSelect is false in row mode', () => {
+    vi.spyOn(gridStub, 'getOptions').mockReturnValue({ ...mockGridOptions, multiSelect: false });
+    vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 1, row: 2 });
+    vi.spyOn(gridStub, 'getDataLength').mockReturnValue(6);
+    vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+
+    plugin.activeSelectionIsRow = true;
+    plugin.init(gridStub);
+    plugin.setSelectedRanges([new SlickRange(2, 0, 2, 2)]);
+
+    const setSelectRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const keyDownEvent = addVanillaEventPropagation(new Event('keydown'), ['shiftKey'], 'ArrowDown');
+    gridStub.onKeyDown.notify({ cell: 1, row: 2, grid: gridStub }, keyDownEvent, gridStub);
+
+    expect(setSelectRangeSpy).toHaveBeenCalledWith([{ fromCell: 0, fromRow: 3, toCell: 2, toRow: 3 }]);
+  });
+
   it('should not call "setSelectedRanges" when triggered by "onClick" and "canCellBeActive" returns false', () => {
     vi.spyOn(gridStub, 'canCellBeActive').mockReturnValue(false);
     vi.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 2, row: 3 });

--- a/packages/common/src/extensions/slickCheckboxSelectColumn.ts
+++ b/packages/common/src/extensions/slickCheckboxSelectColumn.ts
@@ -326,9 +326,14 @@ export class SlickCheckboxSelectColumn<T = any> {
       this._addonOptions.onRowToggleStart(event, { row, previousSelectedRows });
     }
 
-    const newSelectedRows = this._selectedRowsLookup[row]
-      ? this._grid.getSelectedRows().filter((n) => n !== row)
-      : this._grid.getSelectedRows().concat(row);
+    const isMultiSelect = this._grid.getOptions().multiSelect !== false;
+    const newSelectedRows = isMultiSelect
+      ? this._selectedRowsLookup[row]
+        ? this._grid.getSelectedRows().filter((n) => n !== row)
+        : this._grid.getSelectedRows().concat(row)
+      : this._selectedRowsLookup[row]
+        ? []
+        : [row];
     this._grid.setSelectedRows(newSelectedRows, 'click.toggle');
     this._grid.setActiveCell(row, this.getCheckboxColumnCellIndex());
 

--- a/packages/common/src/extensions/slickHybridSelectionModel.ts
+++ b/packages/common/src/extensions/slickHybridSelectionModel.ts
@@ -468,14 +468,7 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
     } else {
       const activeRow = this._grid.getActiveCell();
       const isMultiSelect = this.gridOptions.multiSelect !== false;
-      if (
-        activeRow &&
-        e.shiftKey &&
-        !e.ctrlKey &&
-        !e.altKey &&
-        !e.metaKey &&
-        (e.key === 'ArrowUp' || e.key === 'ArrowDown')
-      ) {
+      if (activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
         let selectedRows = this.getSelectedRows();
         selectedRows.sort((x, y) => x - y);
 

--- a/packages/common/src/extensions/slickHybridSelectionModel.ts
+++ b/packages/common/src/extensions/slickHybridSelectionModel.ts
@@ -467,8 +467,8 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
       }
     } else {
       const activeRow = this._grid.getActiveCell();
+      const isMultiSelect = this.gridOptions.multiSelect !== false;
       if (
-        this.gridOptions.multiSelect &&
         activeRow &&
         e.shiftKey &&
         !e.ctrlKey &&
@@ -495,6 +495,10 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
 
         if (active >= 0 && active < this._grid.getDataLength()) {
           this._grid.scrollRowIntoView(active);
+          if (!isMultiSelect) {
+            top = active;
+            bottom = active;
+          }
           const tempRanges = this.rowsToRanges(this.getRowsRange(top, bottom));
           this.setSelectedRanges(tempRanges);
         }

--- a/packages/common/src/interfaces/selectionModelOption.interface.ts
+++ b/packages/common/src/interfaces/selectionModelOption.interface.ts
@@ -17,7 +17,7 @@ export interface HybridSelectionModelOption {
   /** defaults to True, do we want to select the active cell? */
   selectActiveCell?: boolean;
 
-  /** defaults to True, do we want to select the active row? */
+  /** defaults to True, should the currently-active row be automatically selected during navigation? */
   selectActiveRow?: boolean;
 
   /** cell range selector */


### PR DESCRIPTION
**fixes an old issue opened in SlickGrid (6pac) project: https://github.com/6pac/SlickGrid/issues/345**

_vibe coded a fix with Copilot_

## Summary
This change fixes checkbox row selection behavior so it correctly follows the grid `multiSelect` option.

- When `multiSelect` is true:
  - Checkbox clicks keep existing toggle behavior (add/remove row from selection).
- When `multiSelect` is false:
  - Checkbox clicks enforce single selection (only one row selected at a time).
  - Clicking an already selected checkbox clears selection.
- Active cell is still updated after checkbox toggle to preserve keyboard/editor flow.
- Row-mode Shift+Arrow selection in the hybrid selection model now clamps to a single row when `multiSelect` is false.

## Root cause
Checkbox toggling previously always used additive selection logic, even when `multiSelect` was disabled.  
Also, row keyboard range selection had logic gaps for single-select mode in the merged hybrid selection model.

## Repro steps (before fix)
1. Open a grid with checkbox selector enabled and set `multiSelect` to false.
2. Click checkbox on row A.
3. Click checkbox on row B.
4. Observe both rows can remain selected (incorrect for single-select mode).

Optional keyboard repro:
1. Keep `multiSelect` false.
2. Enter row selection mode.
3. Use Shift+Arrow Up/Down.
4. Observe range-style behavior instead of single-row behavior.

## Expected behavior (after fix)
1. With `multiSelect` false, selecting row B after row A keeps only row B selected.
2. Clicking an already selected checkbox clears selection.
3. Shift+Arrow in row mode keeps selection to one row.
4. Active cell remains synchronized on checkbox toggle.

## What was changed
- Updated checkbox toggle logic to branch on `multiSelect` :
  - true: preserve existing toggle semantics.
  - false: enforce `[row]` or `[]` selection only.
- Kept active-cell update after toggle.
- Updated hybrid row keyboard handling so Shift+Arrow still works, but clamps to a single row when `multiSelect` is false.
- Added/updated unit tests for:
  - checkbox single-select behavior
  - keyboard single-select clamp behavior

## Validation
- Unit tests pass.
- Coverage checks pass.
- Cypress run in progress by maintainer.

I'll need to add a note warning on the next release:

**⚠️ Breaking Change - `multiSelect` Option Now Properly Enforced**

The `multiSelect` option is now properly respected. If you previously set `multiSelect: false` expecting it to work differently, this will now correctly enforce single-row-only selection. To allow multiple row selection while preventing the currently-active row from being automatically selected during navigation, use `selectionOptions.selectActiveRow: false` instead (keeping `multiSelect` at its default `true`).

---

This makes it clearer that `selectActiveRow: false` is specifically about navigation behavior (not auto-selecting as you arrow through rows), whereas `multiSelect` is about how many rows you can select in total.