### PR TITLE
fix: use numeric sort in deleteItems to prevent data loss

### DIFF
--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -216,6 +216,29 @@ describe('SlickDatView core file', () => {
         expect(dv.getItems()).toEqual([{ id: 0, name: 'John', age: 20 }]);
         expect(refreshSpy).toHaveBeenCalled();
       });
+
+      test('delete multiple items with multi-digit indices in correct numeric order', () => {
+        const refreshSpy = vi.spyOn(dv, 'refresh');
+        const items = [
+          { id: 0, name: 'Item0' },
+          { id: 1, name: 'Item1' },
+          { id: 2, name: 'Item2' },
+          { id: 3, name: 'Item3' },
+          { id: 10, name: 'Item10' },
+          { id: 20, name: 'Item20' },
+        ];
+
+        dv.setItems(items);
+        dv.deleteItems([20, 2, 10]); // Non-sequential, multi-digit indices
+
+        // Should delete items at indices 2, 10, 20 (Item2, Item10, Item20)
+        expect(dv.getItems()).toEqual([
+          { id: 0, name: 'Item0' },
+          { id: 1, name: 'Item1' },
+          { id: 3, name: 'Item3' },
+        ]);
+        expect(refreshSpy).toHaveBeenCalled();
+      });
     });
 
     describe('deleteItems()', () => {

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -751,7 +751,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
       }
 
       // Remove from back to front
-      indexesToDelete.sort();
+      indexesToDelete.sort((a, b) => a - b);
       for (let i = indexesToDelete.length - 1; i >= 0; --i) {
         this.items.splice(indexesToDelete[i], 1);
       }


### PR DESCRIPTION
**fixes an old issue opened in SlickGrid (6pac) project: https://github.com/6pac/SlickGrid/issues/1178**

_vibe coded a fix with Copilot_

## Description
Fixes incorrect array sorting in `deleteItems()` method that could cause data loss when deleting multiple items.

## Problem
The `indexesToDelete` array was sorted without a comparator using `sort()`, which defaults to lexicographic (string) ordering instead of numeric ordering. This caused incorrect item deletion when array indices contained multi-digit numbers.

**Example:**
- Indices: `[10, 2, 3, 20]`
- Without comparator: `['10', '2', '20', '3']` → incorrect order
- With comparator: `[2, 3, 10, 20]` → correct numeric order

Since items are deleted from back to front based on these indices, incorrect ordering resulted in wrong items being removed from the dataset.

## Solution
Added numeric comparator to `sort()` call: `sort((a, b) => a - b)`

## Files Changed
- `packages/common/src/core/slickDataview.ts` - Fixed `deleteItems()` method

## Testing
Existing unit tests cover this functionality and should pass with the fix applied.
