### PR TITLE
chore(deps): remove @angular/animations since it's deprecated in ng22

### DIFF
--- a/frameworks/angular-slickgrid/package.json
+++ b/frameworks/angular-slickgrid/package.json
@@ -63,7 +63,6 @@
   "devDependencies": {
     "@4tw/cypress-drag-drop": "catalog:",
     "@angular-eslint/eslint-plugin": "catalog:",
-    "@angular/animations": "^21.2.14",
     "@angular/build": "^21.2.12",
     "@angular/cli": "^21.2.12",
     "@angular/common": "^21.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,9 +948,6 @@ importers:
       '@angular-eslint/eslint-plugin':
         specifier: 'catalog:'
         version: 21.4.0(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@angular/animations':
-        specifier: ^21.2.14
-        version: 21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.0))
       '@angular/build':
         specifier: ^21.2.12
         version: 21.2.12(@angular/compiler-cli@21.2.14(@angular/compiler@21.2.14)(typescript@5.9.3))(@angular/compiler@21.2.14)(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.2.14(@angular/animations@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.2.14(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.2.14(@angular/compiler@21.2.14)(rxjs@7.8.2)(zone.js@0.16.0)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.4)(chokidar@5.0.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.14(@angular/compiler@21.2.14)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.14)(sass-embedded@1.97.3)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@5.0.0-beta.2)(yaml@2.9.0)


### PR DESCRIPTION
- I never use it directly anyway so it's safe to remove even with ng21 and it's a dev dependency anyway