### PR TITLE
fix(regression): Grid Presets should preserve resize by content column widths

### DIFF
--- a/packages/common/src/services/__tests__/gridState.service.spec.ts
+++ b/packages/common/src/services/__tests__/gridState.service.spec.ts
@@ -250,6 +250,7 @@ describe('GridStateService', () => {
             headerCssClass: 'blue',
             id: 'field2',
             hidden: false,
+            originalWidth: 150,
             width: 150,
           },
           {
@@ -257,6 +258,7 @@ describe('GridStateService', () => {
             field: 'field1',
             hidden: false,
             id: 'field1',
+            originalWidth: 100,
             width: 100,
           },
           {
@@ -266,8 +268,8 @@ describe('GridStateService', () => {
           },
         ] as Column[];
         presetColumnsMock = [
-          { columnId: 'field2', width: 150, headerCssClass: 'blue' },
-          { columnId: 'field1', width: 100, cssClass: 'red' },
+          { columnId: 'field2', originalWidth: 150, width: 150, headerCssClass: 'blue' },
+          { columnId: 'field1', originalWidth: 100, width: 100, cssClass: 'red' },
           { columnId: 'field3' },
         ] as CurrentColumn[];
       });
@@ -381,6 +383,7 @@ describe('GridStateService', () => {
             headerCssClass: 'blue',
             id: 'field2',
             hidden: false,
+            originalWidth: 150,
             width: 150,
           },
           {
@@ -389,6 +392,7 @@ describe('GridStateService', () => {
             hidden: false,
             headerCssClass: undefined,
             id: 'field1',
+            originalWidth: 100,
             width: 100,
           },
           {
@@ -397,6 +401,7 @@ describe('GridStateService', () => {
             hidden: false,
             headerCssClass: undefined,
             id: 'field3',
+            originalWidth: undefined,
             width: undefined,
           },
         ]);

--- a/packages/common/src/services/__tests__/utilities.spec.ts
+++ b/packages/common/src/services/__tests__/utilities.spec.ts
@@ -1562,7 +1562,16 @@ describe('Service/Utilies', () => {
       ]);
 
       expect(results).toEqual([
-        { field: 'firstName', hidden: false, id: 'firstName', name: 'First Name', width: 250, cssClass: 'preset-class', headerCssClass: 'header-preset' },
+        {
+          field: 'firstName',
+          hidden: false,
+          id: 'firstName',
+          name: 'First Name',
+          originalWidth: 250,
+          width: 250,
+          cssClass: 'preset-class',
+          headerCssClass: 'header-preset',
+        },
         { field: 'lastName', hidden: false, id: 'lastName', name: 'Last Name', width: 620 },
         { field: 'age', hidden: true, id: 'age', name: 'age', width: 192 },
       ]);

--- a/packages/common/src/services/utilities.ts
+++ b/packages/common/src/services/utilities.ts
@@ -764,6 +764,7 @@ export function sortPresetColumns<T = any>(allColumns: Column<T>[], presetColumn
           cssClass: presetColumn.cssClass ?? column.cssClass,
           headerCssClass: presetColumn.headerCssClass ?? column.headerCssClass,
           width: presetColumn.width ?? column.width,
+          originalWidth: presetColumn.width,
         }),
         hidden: !presetColumnMap.has(column.id) || (presetColumns.find((c) => c.id === column.id)?.hidden ?? false),
         _originalIndex: originalIndex,


### PR DESCRIPTION
fixes another regression that wasn't preserving and restoring column widths from Grid Presets page reload. The resize by content relies on a local copies of `width` into `originalWidth`, if that last prop is empty then it assumes that a resize by content is required. So for the auto-resize by content to work with Grid Preset, we need to assign Grid Presets column width into `originalWidth` and then only after we can call auto-resize by content

```ts
autosizeColumnsByCellContentOnFirstLoad: true,
enableAutoResizeColumnsByCellContent: true,
```