### PR TITLE
fix: left frozen columns & column resize interfere w/auto-scroll

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2557,7 +2557,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         }
 
         this.updateCanvasWidth();
-        if (this._options.autoScrollOnColumnResize && !this._options.forceFitColumns) {
+        if (
+          this._options.autoScrollOnColumnResize &&
+          !this._options.forceFitColumns &&
+          !(this.hasFrozenColumns() && i <= this._options.frozenColumn!)
+        ) {
           const columnRight = this.columnPosRight[i];
           const scrollLeft = this._viewportScrollContainerX.scrollLeft;
           const viewportWidth = this._viewportScrollContainerX.clientWidth;
@@ -2644,12 +2648,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           onResize: (e, resizeElms) => {
             const targetEvent = (e as TouchEvent).touches ? (e as TouchEvent).changedTouches[0] : e;
             const targetPageX = (targetEvent as MouseEvent).pageX;
-            updateColumnResizeAutoScroll((targetEvent as MouseEvent).clientX, targetPageX, (resizePageX: number) => {
-              applyColumnResize(resizePageX, {
-                resizeableElement: resizeElms.resizeableElement,
-                resizeableHandleElement: resizeableHandle,
+            if (!(this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
+              updateColumnResizeAutoScroll((targetEvent as MouseEvent).clientX, targetPageX, (resizePageX: number) => {
+                applyColumnResize(resizePageX, {
+                  resizeableElement: resizeElms.resizeableElement,
+                  resizeableHandleElement: resizeableHandle,
+                });
               });
-            });
+            }
             applyColumnResize(targetPageX + resizeAutoScrollDeltaX, resizeElms);
           },
           onResizeEnd: (_e, resizeElms) => {


### PR DESCRIPTION
_vibe coded with copilot using Claude Sonnet 4.6_

fixes a regression introduced by previous PRs #2538 and #2531

when trying to resize a column on the left side of a frozen column, the resize is behaving weirdly and all over the place. For example if I'm trying to resize a left side column by 1-2px, the auto-scroll seems to interfere and adds ~100px to the column resize instead of the expected 1-2px 

<img width="1652" height="920" alt="msedge_Y73MHNtPTc" src="https://github.com/user-attachments/assets/77fc0c14-b1a1-4efc-985e-da11f13c8a6a" />
