### PR TITLE
fix(core): column should auto-scroll when dragging outside browser view

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3453,7 +3453,6 @@ describe('SlickGrid core file', () => {
 
       const dragEvent = new CustomEvent('DragEvent');
       vi.spyOn(viewportTopLeft, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0 } as DOMRect);
-      Object.defineProperty(dragEvent, 'originalEvent', { writable: true, value: { pageX: 20 } });
       Object.defineProperty(dragEvent, 'related', { writable: true, value: headerColumnElms[0] });
       Object.defineProperty(dragEvent, 'item', { writable: true, value: headerColumnElms[0] });
       Object.defineProperty(headerColumnElms[0], 'clientLeft', { writable: true, value: 25 });
@@ -3463,6 +3462,12 @@ describe('SlickGrid core file', () => {
       expect(sortInstance).toBeTruthy();
       sortInstance.options.onStart(dragEvent);
       sortInstance.options.onMove(dragEvent);
+
+      const docDragEvt = new Event('drag') as DragEvent;
+      Object.defineProperty(docDragEvt, 'pageX', { writable: true, value: 20 }); // pageX < viewportLeft → scroll left
+      Object.defineProperty(docDragEvt, 'clientX', { writable: true, value: 20 });
+      Object.defineProperty(docDragEvt, 'clientY', { writable: true, value: 10 });
+      document.dispatchEvent(docDragEvt);
       expect(viewportTopLeft.scrollLeft).toBe(0);
 
       vi.advanceTimersByTime(100);
@@ -3486,7 +3491,6 @@ describe('SlickGrid core file', () => {
 
       const dragEvent = new CustomEvent('DragEvent');
       vi.spyOn(viewportTopLeft, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0 } as DOMRect);
-      Object.defineProperty(dragEvent, 'originalEvent', { writable: true, value: { pageX: DEFAULT_GRID_WIDTH + 11 } });
       Object.defineProperty(dragEvent, 'item', { writable: true, value: headerColumnElms[0] });
       Object.defineProperty(headerColumnElms[0], 'clientLeft', { writable: true, value: 25 });
       Object.defineProperty(viewportTopLeft, 'clientLeft', { writable: true, value: 25 });
@@ -3494,6 +3498,12 @@ describe('SlickGrid core file', () => {
 
       expect(sortInstance).toBeTruthy();
       sortInstance.options.onStart(dragEvent);
+
+      const docDragEvt = new Event('drag') as DragEvent;
+      Object.defineProperty(docDragEvt, 'pageX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 }); // pageX > containerRight → scroll right
+      Object.defineProperty(docDragEvt, 'clientX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientY', { writable: true, value: 10 });
+      document.dispatchEvent(docDragEvt);
       expect(viewportTopLeft.scrollLeft).toBe(0);
 
       vi.advanceTimersByTime(100);
@@ -3517,7 +3527,6 @@ describe('SlickGrid core file', () => {
 
       const dragEvent = new CustomEvent('DragEvent');
       vi.spyOn(viewportTopLeft, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0 } as DOMRect);
-      Object.defineProperty(dragEvent, 'originalEvent', { writable: true, value: { pageX: DEFAULT_GRID_WIDTH + 11 } });
       Object.defineProperty(dragEvent, 'item', { writable: true, value: headerColumnElms[0] });
       Object.defineProperty(headerColumnElms[0], 'clientLeft', { writable: true, value: 25 });
       Object.defineProperty(viewportTopLeft, 'clientLeft', { writable: true, value: 25 });
@@ -3525,6 +3534,12 @@ describe('SlickGrid core file', () => {
 
       expect(sortInstance).toBeTruthy();
       sortInstance.options.onStart(dragEvent);
+
+      const docDragEvt = new Event('drag') as DragEvent;
+      Object.defineProperty(docDragEvt, 'pageX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientY', { writable: true, value: 10 });
+      document.dispatchEvent(docDragEvt);
       expect(viewportTopLeft.scrollLeft).toBe(0);
 
       vi.advanceTimersByTime(100);
@@ -3532,6 +3547,45 @@ describe('SlickGrid core file', () => {
       expect(viewportTopLeft.scrollLeft).toBe(10);
       sortInstance.options.onEnd(dragEvent);
       expect(onColumnsReorderedSpy).not.toHaveBeenCalled(); // same order won't call event
+    });
+
+    it('should stop auto-scroll when cursor moves back into safe zone during drag', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, defaultOptions);
+      const headerColumnsElm = document.querySelector('.slick-header-columns.slick-header-columns-left') as any;
+      Object.keys(headerColumnsElm).forEach((prop) => {
+        if (prop.startsWith('Sortable')) {
+          sortInstance = headerColumnsElm[prop];
+        }
+      });
+      const headerColumnElms = document.querySelectorAll<HTMLDivElement>('.slick-header-column');
+      const viewportTopLeft = document.querySelector('.slick-viewport-top.slick-viewport-left') as HTMLDivElement;
+      const dragEvent = new CustomEvent('DragEvent');
+      vi.spyOn(viewportTopLeft, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0 } as DOMRect);
+      Object.defineProperty(dragEvent, 'item', { writable: true, value: headerColumnElms[0] });
+
+      sortInstance.options.onStart(dragEvent);
+
+      // first drag beyond container right → starts scroll timer
+      const docDragEvt = new Event('drag') as DragEvent;
+      Object.defineProperty(docDragEvt, 'pageX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientY', { writable: true, value: 10 });
+      document.dispatchEvent(docDragEvt);
+      vi.advanceTimersByTime(100);
+      expect(viewportTopLeft.scrollLeft).toBe(10); // scrolled right
+
+      // now move cursor back into safe zone → timer should stop
+      const docDragSafe = new Event('drag') as DragEvent;
+      Object.defineProperty(docDragSafe, 'pageX', { writable: true, value: DEFAULT_GRID_WIDTH / 2 });
+      Object.defineProperty(docDragSafe, 'clientX', { writable: true, value: DEFAULT_GRID_WIDTH / 2 });
+      Object.defineProperty(docDragSafe, 'clientY', { writable: true, value: 10 });
+      document.dispatchEvent(docDragSafe);
+
+      viewportTopLeft.scrollLeft = 0; // reset to confirm timer is stopped
+      vi.advanceTimersByTime(100);
+      expect(viewportTopLeft.scrollLeft).toBe(0); // no more auto-scrolling
+
+      sortInstance.options.onEnd(dragEvent);
     });
 
     it('should try reordering column but stay at same scroll position when grid has frozen columns', () => {
@@ -3549,18 +3603,24 @@ describe('SlickGrid core file', () => {
 
       const dragEvent = new CustomEvent('DragEvent');
       vi.spyOn(viewportTopLeft, 'getBoundingClientRect').mockReturnValue({ left: 25, top: 10, right: 0, bottom: 0 } as DOMRect);
-      Object.defineProperty(dragEvent, 'originalEvent', { writable: true, value: { pageX: 20 } });
-      Object.defineProperty(dragEvent, 'item', { writable: true, value: headerColumnElms[0] });
+      Object.defineProperty(dragEvent, 'item', { writable: true, value: headerColumnElms[0] }); // frozen left column
       Object.defineProperty(headerColumnElms[0], 'clientLeft', { writable: true, value: 25 });
       Object.defineProperty(viewportTopLeft, 'clientLeft', { writable: true, value: 25 });
 
       expect(sortInstance).toBeTruthy();
       sortInstance.options.onStart(dragEvent);
+
+      // even if drag event fires, canDragScroll=false for frozen left column → no scroll
+      const docDragEvt = new Event('drag') as DragEvent;
+      Object.defineProperty(docDragEvt, 'pageX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientX', { writable: true, value: DEFAULT_GRID_WIDTH + 11 });
+      Object.defineProperty(docDragEvt, 'clientY', { writable: true, value: 10 });
+      document.dispatchEvent(docDragEvt);
       expect(viewportTopLeft.scrollLeft).toBe(0);
 
       vi.advanceTimersByTime(100);
 
-      expect(viewportTopLeft.scrollLeft).toBe(0); // same position
+      expect(viewportTopLeft.scrollLeft).toBe(0); // same position, frozen column can't trigger scroll
       sortInstance.options.onEnd(dragEvent);
       expect(onColumnsReorderedSpy).not.toHaveBeenCalled();
     });

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2147,15 +2147,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // add/remove extra scroll padding for calculation
     const scrollColumnsRight = () => (this._viewportScrollContainerX.scrollLeft += 10);
     const scrollColumnsLeft = () => (this._viewportScrollContainerX.scrollLeft -= 10);
-    let prevColumnIds: Array<string | number> = [];
-    let columnMap: Map<string | number, { index: number; hidden: boolean; column: C }>;
-
-    let canDragScroll = false;
-
     const stopAutoScroll = () => {
       clearInterval(columnScrollTimer);
       columnScrollTimer = undefined;
     };
+    let prevColumnIds: Array<string | number> = [];
+    let columnMap: Map<string | number, { index: number; hidden: boolean; column: C }>;
+    let canDragScroll = false;
 
     // fires on document during native drag; also bind 'mousemove' for SortableJS forceFallback mode
     const autoScrollHandler = (e: DragEvent | MouseEvent) => {
@@ -2185,7 +2183,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       // allow column to be resized even when they are not orderable
       preventOnFilter: false,
       revertClone: true,
-      scroll: false, // disable built-in scroll, we handle browser-edge auto-scroll ourselves
+      // use built-in SortableJS proximity scroll for non-frozen grids; frozen grids need custom scroll (wrong pane would be scrolled)
+      scroll: !this.hasFrozenColumns(),
       // lock unorderable columns by using a combo of filter + onMove
       filter: `.${this._options.unorderableColumnCssClass}`,
       onMove: (event) => {
@@ -2198,8 +2197,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         canDragScroll = !this.hasFrozenColumns() || this._headerR.contains(e.item);
 
         // bind 'drag' for native HTML5 drag and 'mousemove' for SortableJS forceFallback
-        this._bindingEventService.bind(document as any, 'drag', autoScrollHandler as EventListener, {}, 'colreorder');
-        this._bindingEventService.bind(document as any, 'mousemove', autoScrollHandler as EventListener, {}, 'colreorder');
+        this._bindingEventService.bind(document, 'drag', autoScrollHandler as EventListener, {}, 'colreorder');
+        this._bindingEventService.bind(document, 'mousemove', autoScrollHandler as EventListener, {}, 'colreorder');
 
         prevColumnIds = this.columns.map((c) => c.id);
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -14,7 +14,7 @@ import {
   queueMicrotaskPolyfill,
   type CSSStyleDeclarationWritable,
 } from '@slickgrid-universal/utils';
-import type { SortableEvent, Options as SortableOptions } from 'sortablejs';
+import type { Options as SortableOptions } from 'sortablejs';
 import Sortable from 'sortablejs/modular/sortable.core.esm.js';
 import type { TrustedHTML } from 'trusted-types/lib';
 import type { SelectionModel } from '../enums/index.js';
@@ -2151,6 +2151,29 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     let columnMap: Map<string | number, { index: number; hidden: boolean; column: C }>;
 
     let canDragScroll = false;
+
+    const stopAutoScroll = () => {
+      clearInterval(columnScrollTimer);
+      columnScrollTimer = undefined;
+    };
+
+    // fires on document during native drag; also bind 'mousemove' for SortableJS forceFallback mode
+    const autoScrollHandler = (e: DragEvent | MouseEvent) => {
+      const { clientX, clientY, pageX } = e as MouseEvent;
+      if (clientX && clientY && canDragScroll) {
+        const containerOffset = getOffset(this._container);
+        const viewportLeft = getOffset(this._viewportScrollContainerX).left;
+        const containerRight = containerOffset.left + this._container.clientWidth;
+        if (!columnScrollTimer && pageX > containerRight) {
+          columnScrollTimer = setInterval(scrollColumnsRight, 100);
+        } else if (!columnScrollTimer && pageX < viewportLeft) {
+          columnScrollTimer = setInterval(scrollColumnsLeft, 100);
+        } else if (columnScrollTimer && pageX <= containerRight && pageX >= viewportLeft) {
+          stopAutoScroll();
+        }
+      }
+    };
+
     const sortableOptions = {
       animation: 50,
       direction: 'horizontal',
@@ -2162,7 +2185,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       // allow column to be resized even when they are not orderable
       preventOnFilter: false,
       revertClone: true,
-      scroll: !this.hasFrozenColumns(), // enable auto-scroll
+      scroll: false, // disable built-in scroll, we handle browser-edge auto-scroll ourselves
       // lock unorderable columns by using a combo of filter + onMove
       filter: `.${this._options.unorderableColumnCssClass}`,
       onMove: (event) => {
@@ -2170,22 +2193,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       },
       onStart: (e) => {
         e.item.classList.add('slick-header-column-active');
-        canDragScroll = !this.hasFrozenColumns() || getOffset(e.item).left > getOffset(this._viewportScrollContainerX).left;
+        // only right-section columns (non-frozen) should auto-scroll; use contains() since
+        // _headerR has `left:-1000px` which breaks offset-based comparisons
+        canDragScroll = !this.hasFrozenColumns() || this._headerR.contains(e.item);
 
-        if (canDragScroll && (e as SortableEvent & { originalEvent: MouseEvent }).originalEvent.pageX > this._container.clientWidth) {
-          if (!columnScrollTimer) {
-            columnScrollTimer = setInterval(scrollColumnsRight, 100);
-          }
-        } else if (
-          canDragScroll &&
-          (e as SortableEvent & { originalEvent: MouseEvent }).originalEvent.pageX < getOffset(this._viewportScrollContainerX).left
-        ) {
-          if (!columnScrollTimer) {
-            columnScrollTimer = setInterval(scrollColumnsLeft, 100);
-          }
-        } else {
-          clearInterval(columnScrollTimer);
-        }
+        // bind 'drag' for native HTML5 drag and 'mousemove' for SortableJS forceFallback
+        this._bindingEventService.bind(document as any, 'drag', autoScrollHandler as EventListener, {}, 'colreorder');
+        this._bindingEventService.bind(document as any, 'mousemove', autoScrollHandler as EventListener, {}, 'colreorder');
+
         prevColumnIds = this.columns.map((c) => c.id);
 
         // Create a map to track original column positions and hidden state
@@ -2196,7 +2211,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       },
       onEnd: (e) => {
         e.item.classList.remove('slick-header-column-active');
-        clearInterval(columnScrollTimer);
+        stopAutoScroll();
+        this._bindingEventService.unbindAll('colreorder');
         const prevScrollLeft = this.scrollLeft;
 
         if (!this.getEditorLock()?.commitCurrentEdit()) {

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -884,6 +884,9 @@ describe('Example 04 - Frozen Grid', () => {
       // Close the context menu opened by beforeEach
       cy.get('body').type('{esc}');
 
+      // Control app timers to make drag auto-scroll deterministic in CI.
+      cy.clock();
+
       // Right viewport should start at scroll 0 (columns were made very wide in previous resize tests)
       cy.get('.slick-viewport-top.slick-viewport-right').its('0.scrollLeft').should('equal', 0);
 
@@ -894,6 +897,7 @@ describe('Example 04 - Frozen Grid', () => {
         Object.keys($rightHeader[0]).forEach((prop) => {
           if (prop.startsWith('Sortable')) sortInstance = ($rightHeader[0] as any)[prop];
         });
+        expect(sortInstance).to.exist;
         const startColumnEl = $rightHeader[0].querySelectorAll('.slick-header-column')[0] as HTMLElement;
         sortInstance.options.onStart({ item: startColumnEl });
       });
@@ -901,8 +905,8 @@ describe('Example 04 - Frozen Grid', () => {
       // Step 2: fire a document drag event far past the right edge — triggers the setInterval(scrollColumnsRight, 100) timer
       cy.document().trigger('drag', { pageX: 2000, clientX: 2000, clientY: 50 });
 
-      // Step 3: wait for the 100ms scroll interval to tick several times
-      cy.wait(300);
+      // Step 3: advance mocked time so the 100ms scroll interval ticks several times.
+      cy.tick(350);
 
       // Auto-scroll should have moved the right viewport to the right
       cy.get('.slick-viewport-top.slick-viewport-right').its('0.scrollLeft').should('be.greaterThan', 0);
@@ -914,6 +918,7 @@ describe('Example 04 - Frozen Grid', () => {
         Object.keys($rightHeader[0]).forEach((prop) => {
           if (prop.startsWith('Sortable')) sortInstance = ($rightHeader[0] as any)[prop];
         });
+        expect(sortInstance).to.exist;
         const cols = $rightHeader[0].querySelectorAll('.slick-header-column');
         const startColumnEl = cols[0] as HTMLElement; // "Start"
         const finishColumnEl = cols[1] as HTMLElement; // "Finish"

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -879,5 +879,61 @@ describe('Example 04 - Frozen Grid', () => {
 
       // Shift+Tab dosn't work in Cypress, so we can't go further with tests
     });
+
+    it('should auto-scroll right viewport and reorder columns when "Start" is dragged ~550px past the right edge (ending up after "Finish")', () => {
+      // Close the context menu opened by beforeEach
+      cy.get('body').type('{esc}');
+
+      // Right viewport should start at scroll 0 (columns were made very wide in previous resize tests)
+      cy.get('.slick-viewport-top.slick-viewport-right').its('0.scrollLeft').should('equal', 0);
+
+      // Step 1: call SortableJS onStart for the "Start" column (1st right-section column).
+      // This sets canDragScroll=true (it's in _headerR) and binds the document 'drag' auto-scroll listener.
+      cy.get('.slick-header-columns-right').then(($rightHeader) => {
+        let sortInstance: any;
+        Object.keys($rightHeader[0]).forEach((prop) => {
+          if (prop.startsWith('Sortable')) sortInstance = ($rightHeader[0] as any)[prop];
+        });
+        const startColumnEl = $rightHeader[0].querySelectorAll('.slick-header-column')[0] as HTMLElement;
+        sortInstance.options.onStart({ item: startColumnEl });
+      });
+
+      // Step 2: fire a document drag event far past the right edge — triggers the setInterval(scrollColumnsRight, 100) timer
+      cy.document().trigger('drag', { pageX: 2000, clientX: 2000, clientY: 50 });
+
+      // Step 3: wait for the 100ms scroll interval to tick several times
+      cy.wait(300);
+
+      // Auto-scroll should have moved the right viewport to the right
+      cy.get('.slick-viewport-top.slick-viewport-right').its('0.scrollLeft').should('be.greaterThan', 0);
+
+      // Step 4: simulate the drag result — "Start" was moved ~550px to the right, past "Finish".
+      // SortableJS reads the DOM order via toArray() inside onEnd, so physically reorder the children first.
+      cy.get('.slick-header-columns-right').then(($rightHeader) => {
+        let sortInstance: any;
+        Object.keys($rightHeader[0]).forEach((prop) => {
+          if (prop.startsWith('Sortable')) sortInstance = ($rightHeader[0] as any)[prop];
+        });
+        const cols = $rightHeader[0].querySelectorAll('.slick-header-column');
+        const startColumnEl = cols[0] as HTMLElement; // "Start"
+        const finishColumnEl = cols[1] as HTMLElement; // "Finish"
+
+        // Move "Finish" before "Start" → mirrors dragging Start past Finish
+        $rightHeader[0].insertBefore(finishColumnEl, startColumnEl);
+
+        // onEnd reads the new DOM order via toArray() and calls setColumns() if the order changed
+        sortInstance.options.onEnd({ item: startColumnEl, stopPropagation: () => {} });
+      });
+
+      // Right section should now be: Finish, Start, Completed, Cost | Duration, City of Origin, Action
+      cy.get('.slick-header-columns-right .slick-header-column:nth(0)').should('contain', 'Finish');
+      cy.get('.slick-header-columns-right .slick-header-column:nth(1)').should('contain', 'Start');
+      cy.get('.slick-header-columns-right .slick-header-column:nth(2)').should('contain', 'Completed');
+
+      // Left (frozen) section should remain unchanged: Sel, Title, % Complete
+      cy.get('.slick-header-columns-left .slick-header-column:nth(0)').should('contain', '');
+      cy.get('.slick-header-columns-left .slick-header-column:nth(1)').should('contain', 'Title');
+      cy.get('.slick-header-columns-left .slick-header-column:nth(2)').should('contain', '% Complete');
+    });
   });
 });

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -880,7 +880,7 @@ describe('Example 04 - Frozen Grid', () => {
       // Shift+Tab dosn't work in Cypress, so we can't go further with tests
     });
 
-    it('should auto-scroll right viewport and reorder columns when "Start" is dragged ~550px past the right edge (ending up after "Finish")', () => {
+    it('should auto-scroll right viewport and reorder columns when "Start" is dragged well past the right edge (ending up after "Finish")', () => {
       // Close the context menu opened by beforeEach
       cy.get('body').type('{esc}');
 
@@ -902,8 +902,12 @@ describe('Example 04 - Frozen Grid', () => {
         sortInstance.options.onStart({ item: startColumnEl });
       });
 
-      // Step 2: fire a document drag event far past the right edge — triggers the setInterval(scrollColumnsRight, 100) timer
-      cy.document().trigger('drag', { pageX: 2000, clientX: 2000, clientY: 50 });
+      // Step 2: fire a document drag event well past the right edge (viewport-relative)
+      // to avoid CI flakiness caused by environment-dependent viewport widths.
+      cy.window().then((win) => {
+        const dragX = win.innerWidth + 1200;
+        cy.document().trigger('drag', { pageX: dragX, clientX: dragX, clientY: 50 });
+      });
 
       // Step 3: advance mocked time so the 100ms scroll interval ticks several times.
       cy.tick(350);
@@ -911,7 +915,7 @@ describe('Example 04 - Frozen Grid', () => {
       // Auto-scroll should have moved the right viewport to the right
       cy.get('.slick-viewport-top.slick-viewport-right').its('0.scrollLeft').should('be.greaterThan', 0);
 
-      // Step 4: simulate the drag result — "Start" was moved ~550px to the right, past "Finish".
+      // Step 4: simulate the drag result — "Start" was moved to the right, past "Finish".
       // SortableJS reads the DOM order via toArray() inside onEnd, so physically reorder the children first.
       cy.get('.slick-header-columns-right').then(($rightHeader) => {
         let sortInstance: any;

--- a/test/cypress/e2e/example04.cy.ts
+++ b/test/cypress/e2e/example04.cy.ts
@@ -879,7 +879,9 @@ describe('Example 04 - Frozen Grid', () => {
 
       // Shift+Tab dosn't work in Cypress, so we can't go further with tests
     });
+  });
 
+  describe('drag & drop column reordering with auto-scroll', () => {
     it('should auto-scroll right viewport and reorder columns when "Start" is dragged well past the right edge (ending up after "Finish")', () => {
       // Close the context menu opened by beforeEach
       cy.get('body').type('{esc}');
@@ -887,7 +889,11 @@ describe('Example 04 - Frozen Grid', () => {
       // Control app timers to make drag auto-scroll deterministic in CI.
       cy.clock();
 
-      // Right viewport should start at scroll 0 (columns were made very wide in previous resize tests)
+      // Normalize right viewport scroll so this test is isolated from previous test state.
+      cy.get('.slick-viewport-top.slick-viewport-right').then(($viewport) => {
+        $viewport[0].scrollLeft = 0;
+        $viewport[0].dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
       cy.get('.slick-viewport-top.slick-viewport-right').its('0.scrollLeft').should('equal', 0);
 
       // Step 1: call SortableJS onStart for the "Start" column (1st right-section column).


### PR DESCRIPTION
_vibe coded with copilot using Claude Sonnet 4.6_

when we're reordering columns that are wider than viewport, it should auto-scroll when we drag outside of the browser web view (as shown below)

<img width="1652" height="920" alt="msedge_HuqXjQ8Ue9" src="https://github.com/user-attachments/assets/8a329529-bb3f-40b1-941e-6c6151511e30" />
