### PR TITLE
fix(core): probe positioned-child limit in getMaxSupportedCssHeight

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1517,15 +1517,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       ? this._options.ffMaxSupportedCssHeight
       : this._options.maxSupportedCssHeight;
     const div = createDomElement('div', { style: { display: 'hidden' } }, document.body);
+    const marker = createDomElement('div', { style: { position: 'absolute' } }, div);
 
     let condition = true;
     while (condition) {
       const test = supportedHeight * 2;
       Utils.height(div, test);
       const height = Utils.height(div);
+      marker.style.top = `${test - 1}px`;
+      const offsetTop = marker.offsetTop;
 
       /* v8 ignore else */
-      if (test > testUpTo! || height !== test) {
+      if (test > testUpTo! || height !== test || offsetTop !== test - 1) {
         condition = false;
         break;
       } else {


### PR DESCRIPTION
Apply fix from 6pac repo's

> ## Problem
> `getMaxSupportedCssHeight()` probes the browser's height limit by doubling a div's height and reading it back. On Chromium that read-back survives to 32,000,000px — but Blink separately clamps **absolutely-positioned layout** at 16,777,214px (2²⁴−2). Since grid rows are absolutely-positioned children of the canvas, any grid whose canvas exceeds ~16.7M px silently misplaces every row past that boundary.
> 
> Reproduced on a 1.5M-row grid at the default 25px row height (canvas capped at the probed 32M px):
> 
> ```
> row 1,499,964:  style.top: 26,703,000px   →   offsetTop: 16,777,214
> ```
> 
> Every row between ~16.7M and 32M canvas px stacks up at the clamp. At 25px rows this hits any grid beyond ~671k rows; the virtual-paging machinery that exists precisely to avoid the browser limit never engages because the probe reports a limit the browser can't actually position at.
> 
> ## Fix
> Probe what the grid actually depends on: alongside the height read-back, position a 1px marker child at `top: test - 1` and require `marker.offsetTop === test - 1`. The probe stops at the first height where either check fails.
> 
> On Blink the doubling sequence (1M → 2M → … → 16M → 32M) now fails at the 32M step and returns **16,000,000**, safely inside the real limit, so the existing page-switching machinery simply engages earlier. Firefox is unaffected (`ffMaxSupportedCssHeight` caps the probe at 6M, below the clamp). The `options.maxSupportedCssHeight` / `ffMaxSupportedCssHeight` escape hatches are unchanged.
> 
> ## Verification
> * Chromium now probes 16,000,000 (was 32,000,000).
> * The 1.5M-row repro above renders correctly: for rendered rows at every scroll position, `offsetTop` equals the requested `style.top` (paging keeps in-canvas positions under 16M).
> * Full Cypress suite passes (grids in the examples are far below the threshold, so no behaviour change for them).
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

