### PR TITLE
fix(regression): prevent row selection from being dropped when last column is hidden

### DIFF
--- a/demos/vanilla/src/examples/example37.ts
+++ b/demos/vanilla/src/examples/example37.ts
@@ -84,7 +84,7 @@ export default class Example37 {
 
   /* Define grid Options and Columns */
   defineGrids() {
-    this.columns1 = [
+    const baseColumns = [
       { id: 'id', name: '#', field: 'id', width: 32, maxWidth: 40, excludeFromHeaderMenu: true },
       { id: 'title', name: 'Title', field: 'title', width: 90, cssClass: 'cell-title' },
       { id: 'complete', name: '% Complete', field: 'percentComplete', sortable: true, width: 90 },
@@ -121,8 +121,18 @@ export default class Example37 {
         exportCustomFormatter: (_row, _cell, value) => (value ? 'Yes' : 'No'),
         formatter: Formatters.checkmarkMaterial,
       },
+    ] satisfies Column<any>[];
+
+    this.columns1 = [
+      ...baseColumns,
+      {
+        id: 'lastColumnHiddenColumn',
+        name: 'Last Column / Hidden Column',
+        field: 'lastColumnHiddenColumn',
+        hidden: true,
+      },
     ];
-    this.columns2 = [...this.columns1];
+    this.columns2 = [...baseColumns];
 
     this.gridOptions1 = {
       autoResize: {
@@ -154,6 +164,21 @@ export default class Example37 {
         copyActiveEditorCell: true,
         removeDoubleQuotesOnPaste: true,
         replaceNewlinesWith: ' ',
+      },
+
+      contextMenu: {
+        commandItems: [
+          {
+            command: 'commandWhichShouldBeShown',
+            title: 'Command which should be shown',
+            iconCssClass: 'mdi mdi-check',
+            itemVisibilityOverride: (item) => {
+              // before the fix: last column is hidden → range is silently dropped
+              this.sgb1.slickGrid?.setSelectedRows([item.row ?? 0]);
+              return this.sgb1.slickGrid?.getSelectedRows().includes(item.row ?? 0) ?? false; // always false ← bug
+            },
+          },
+        ],
       },
     };
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -7957,9 +7957,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return true;
   }
 
-  protected rowsToRanges(rows: number[], useVisibleColumnsOnly = false): SlickRange[] {
+  protected rowsToRanges(rows: number[]): SlickRange[] {
     const ranges: SlickRange[] = [];
-    const columns = useVisibleColumnsOnly ? this.getVisibleColumns() : this.columns;
+    const columns = this.getVisibleColumns();
     const lastCell = this.getColumnIndex(columns[columns.length - 1].id);
     for (let i = 0; i < rows.length; i++) {
       ranges.push(new SlickRange(rows[i], 0, rows[i], lastCell));
@@ -7980,14 +7980,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Array<number>} rowsArray - an array of row numbers.
    * @param {String} [caller] - an optional string to identify who called the method
    */
-  setSelectedRows(rows: number[], caller?: string, useVisibleColumnsOnly = false): void {
+  setSelectedRows(rows: number[], caller?: string): void {
     if (!this.selectionModel) {
       throw new Error('SlickGrid Selection model is not set');
     }
 
     const elock = this.getEditorLock();
     if (typeof elock?.isActive === 'function' && !elock.isActive()) {
-      this.selectionModel.setSelectedRanges(this.rowsToRanges(rows, useVisibleColumnsOnly), caller || 'SlickGrid.setSelectedRows');
+      this.selectionModel.setSelectedRanges(this.rowsToRanges(rows), caller || 'SlickGrid.setSelectedRows');
     }
   }
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -7957,9 +7957,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     return true;
   }
 
-  protected rowsToRanges(rows: number[]): SlickRange[] {
+  protected rowsToRanges(rows: number[], useVisibleColumnsOnly = false): SlickRange[] {
     const ranges: SlickRange[] = [];
-    const lastCell = this.columns.length - 1;
+    const columns = useVisibleColumnsOnly ? this.getVisibleColumns() : this.columns;
+    const lastCell = this.getColumnIndex(columns[columns.length - 1].id);
     for (let i = 0; i < rows.length; i++) {
       ranges.push(new SlickRange(rows[i], 0, rows[i], lastCell));
     }
@@ -7979,14 +7980,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Array<number>} rowsArray - an array of row numbers.
    * @param {String} [caller] - an optional string to identify who called the method
    */
-  setSelectedRows(rows: number[], caller?: string): void {
+  setSelectedRows(rows: number[], caller?: string, useVisibleColumnsOnly = false): void {
     if (!this.selectionModel) {
       throw new Error('SlickGrid Selection model is not set');
     }
 
     const elock = this.getEditorLock();
     if (typeof elock?.isActive === 'function' && !elock.isActive()) {
-      this.selectionModel.setSelectedRanges(this.rowsToRanges(rows), caller || 'SlickGrid.setSelectedRows');
+      this.selectionModel.setSelectedRanges(this.rowsToRanges(rows, useVisibleColumnsOnly), caller || 'SlickGrid.setSelectedRows');
     }
   }
 

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -112,6 +112,14 @@ describe('Example 37 - Hybrid Selection Model', () => {
       cy.get('#selectionRange1').contains(/"fromRow":0,"fromCell":1,"toRow":1[45],"toCell":3/);
       cy.get('.grid37-1 .slick-viewport-top.slick-viewport-left').scrollTo(0, 13 * 35);
     });
+
+    it('should show "Command which should be shown" in context menu even when last column definition is hidden', () => {
+      cy.get('.grid37-1 .slick-row[data-row="14"] .slick-cell.l1.r1').as('task14');
+      cy.get('@task14').should('contain', 'Task 14');
+      cy.get('@task14').rightclick({ force: true });
+      cy.get('.slick-context-menu .slick-menu-item').should('contain', 'Command which should be shown');
+      cy.get('body').type('{esc}');
+    });
   });
 
   describe('Grid 2', () => {


### PR DESCRIPTION
## Bug Fix: `setSelectedRows()` silently drops selection when last column is hidden

### Problem

When any column with `hidden: true` is the **last column** in the column definition array, calling `setSelectedRows()` (or right-clicking to open a context menu that uses `setSelectedRows` internally) silently fails — the row is never actually selected, and `getSelectedRows()` returns an empty array.

### Root Cause

`SlickGrid.rowsToRanges()` builds a `SlickRange` spanning from cell `0` to the last column index, computed as `this.columns.length - 1`. This index includes **all** columns, including hidden ones.

When the resulting range is passed to `setSelectedRanges()` while `_activeSelectionIsRow` is `false` (which happens when the active cell is on a regular non-row-select column, e.g. triggered by a right-click), `removeInvalidRanges()` is called. It validates both endpoints of the range via `canCellBeSelected()`, which returns `false` for any hidden column — **dropping the entire range**.

```
grid.setSelectedRows([row])
  → SlickGrid.rowsToRanges([row])
      → lastCell = this.columns.length - 1   ← may point to a hidden column
      → new SlickRange(row, 0, row, hiddenColIndex)

  → selectionModel.setSelectedRanges(ranges)  where _activeSelectionIsRow = false
      → removeInvalidRanges(ranges)
          → canCellBeSelected(row, hiddenColIndex)
              → columns[hiddenColIndex].hidden === true  → returns false
          → range is dropped ✗

  → getSelectedRows() returns []
```

### Fix

`rowsToRanges()` now accepts an optional `useVisibleColumnsOnly` flag (defaulting to `false` to preserve backward compatibility). When `true`, `lastCell` is computed from the last **visible** column's real index via `getColumnIndex()`. `SlickGrid.setSelectedRows()` exposes the same flag as an optional third parameter.

### Reproduce

A grid where the last column in the columns array has `hidden: true` (e.g. `effortDriven` below), combined with a Context Menu that calls `setSelectedRows()` inside `itemVisibilityOverride` to determine whether to show a menu item:

```ts
columns = [
  { id: 'title', ... },
  { id: 'finish', ... },
  {
    id: 'effortDriven',
    hidden: true,   // ← last column, hidden
    ...
  },
];

gridOptions = {
  ...
  enableSelection: false,
  selectionOptions: {
    selectionType: 'mixed',
  },
  contextMenu: {
    commandItems: [{
      command: 'copySelectedRows',
      itemVisibilityOverride: (item) => {
        // before the fix: last column is hidden → range is silently dropped
        grid.setSelectedRows([item.row]);
        return grid.getSelectedRows().includes(item.row); // always false ← bug
      }
    }]
  }
};
```

The exact scenario was tested and validated in `example48.component.ts` of the Angular Slickgrid demos using the modifications above.
