### PR TITLE
feat(core): add variable row height support

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example55.html
+++ b/demos/aurelia/src/examples/slickgrid/example55.html
@@ -1,0 +1,34 @@
+<div class="container-fluid">
+  <h2>
+    Example 55: Variable Row Height (Provider)
+    <span class="float-end">
+      <a
+        style="font-size: 18px"
+        target="_blank"
+        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/aurelia/src/examples/slickgrid/example55.ts"
+      >
+        <span class="mdi mdi-link-variant"></span> code
+      </a>
+    </span>
+  </h2>
+
+  <div class="subtitle">Variable row heights driven by <code>rowHeightProvider</code>.</div>
+
+  <div class="row" style="margin-bottom: 6px">
+    <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" click.trigger="scrollToRow90()" data-test="scroll-row-90-example55">
+        <span class="mdi mdi-arrow-down"></span>
+        <span> Scroll To row 90</span>
+      </button>
+    </div>
+  </div>
+
+  <aurelia-slickgrid
+    grid-id="grid55"
+    columns.bind="columns"
+    options.bind="gridOptions"
+    dataset.bind="dataset"
+    on-aurelia-grid-created.trigger="aureliaGridReady($event.detail)"
+  >
+  </aurelia-slickgrid>
+</div>

--- a/demos/aurelia/src/examples/slickgrid/example55.scss
+++ b/demos/aurelia/src/examples/slickgrid/example55.scss
@@ -1,0 +1,12 @@
+#slickGridContainer-grid55 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
+  line-height: 1.25;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/demos/aurelia/src/examples/slickgrid/example55.scss
+++ b/demos/aurelia/src/examples/slickgrid/example55.scss
@@ -3,8 +3,6 @@
 }
 
 #slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
-  line-height: 1.25;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -38,6 +38,7 @@ export class Example55 {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -67,7 +67,7 @@ export class Example55 {
       const lineCount = (i % 4) + 1;
       const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
       const wordCount = summary.trim().split(/\s+/).length;
-      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      const computedRowHeight = Math.max(45, 8 + lineCount * 16);
       data.push({
         id: i,
         title: `Story ${i}`,

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -17,8 +17,11 @@ export class Example55 {
   dataset: StoryItem[] = [];
   gridOptions!: GridOption;
 
-  attached() {
+  constructor() {
     this.defineGrid();
+  }
+
+  attached() {
     this.dataset = this.getData(NB_ITEMS);
   }
 

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -1,0 +1,77 @@
+import { type AureliaGridInstance, type Column, type GridOption } from 'aurelia-slickgrid';
+import './example55.scss';
+
+const NB_ITEMS = 200;
+
+interface StoryItem {
+  id: number;
+  title: string;
+  owner: string;
+  summary: string;
+  rowHeight: number;
+}
+
+export class Example55 {
+  aureliaGrid?: AureliaGridInstance;
+  columns: Column[] = [];
+  dataset: StoryItem[] = [];
+  gridOptions!: GridOption;
+
+  attached() {
+    this.defineGrid();
+    this.dataset = this.getData(NB_ITEMS);
+  }
+
+  aureliaGridReady(aureliaGrid: AureliaGridInstance) {
+    this.aureliaGrid = aureliaGrid;
+  }
+
+  scrollToRow90() {
+    this.aureliaGrid?.slickGrid?.scrollRowToTop(90);
+  }
+
+  defineGrid() {
+    this.columns = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
+      { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
+    ];
+
+    this.gridOptions = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      gridHeight: 560,
+      gridWidth: 1080,
+      rowHeightProvider: (_grid, _row, item: StoryItem) => item.rowHeight,
+    };
+  }
+
+  getData(itemCount: number): StoryItem[] {
+    const owners = ['Alex', 'Priya', 'Mia', 'Sam', 'Chris'];
+    const fragments = [
+      'Refactor keyboard shortcut handling for better readability.',
+      'Adjust frozen rows when view-model updates after grouping.',
+      'Improve screen-reader labels on grid menu actions.',
+      'Align batch editor validation with backend constraints.',
+      'Capture edge-case around hidden columns and row-span.',
+    ];
+
+    const data: StoryItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const lineCount = (i % 4) + 1;
+      const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
+      const wordCount = summary.trim().split(/\s+/).length;
+      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      data.push({
+        id: i,
+        title: `Story ${i}`,
+        owner: owners[i % owners.length],
+        summary,
+        rowHeight: wordCount < 10 ? 33 : computedRowHeight,
+      });
+    }
+    return data;
+  }
+}

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -45,6 +45,7 @@ export class Example55 {
     this.gridOptions = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       gridHeight: 560,
       gridWidth: 1080,

--- a/demos/aurelia/src/examples/slickgrid/example56.html
+++ b/demos/aurelia/src/examples/slickgrid/example56.html
@@ -1,0 +1,41 @@
+<div class="container-fluid">
+  <h2>
+    Example 56: Variable Row Height (Dynamic)
+    <span class="float-end">
+      <a
+        style="font-size: 18px"
+        target="_blank"
+        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/aurelia/src/examples/slickgrid/example56.ts"
+      >
+        <span class="mdi mdi-link-variant"></span> code
+      </a>
+    </span>
+  </h2>
+
+  <div class="subtitle">
+    Variable row heights via <code>ItemMetadata.height</code> fallback, with compact mode rebuilding heights through
+    <code>invalidateRowHeights()</code>.
+  </div>
+
+  <div class="row" style="margin-bottom: 6px">
+    <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" click.trigger="toggleDensity()" data-test="toggle-density">
+        <span class="mdi mdi-flip-vertical"></span>
+        <span> Toggle Compact Density</span>
+      </button>
+      <button class="btn btn-outline-secondary btn-sm ms-2 btn-icon" click.trigger="scrollToRow90()" data-test="scroll-row-90-example56">
+        <span class="mdi mdi-arrow-down"></span>
+        <span> Scroll To row 90</span>
+      </button>
+    </div>
+  </div>
+
+  <aurelia-slickgrid
+    grid-id="grid56"
+    columns.bind="columns"
+    options.bind="gridOptions"
+    dataset.bind="dataset"
+    on-aurelia-grid-created.trigger="aureliaGridReady($event.detail)"
+  >
+  </aurelia-slickgrid>
+</div>

--- a/demos/aurelia/src/examples/slickgrid/example56.scss
+++ b/demos/aurelia/src/examples/slickgrid/example56.scss
@@ -3,9 +3,6 @@
 }
 
 #slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
-  font-size: 14px;
-  line-height: 1.35;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/aurelia/src/examples/slickgrid/example56.scss
+++ b/demos/aurelia/src/examples/slickgrid/example56.scss
@@ -1,0 +1,13 @@
+#slickGridContainer-grid56 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/demos/aurelia/src/examples/slickgrid/example56.ts
+++ b/demos/aurelia/src/examples/slickgrid/example56.ts
@@ -17,8 +17,11 @@ export class Example56 {
   gridOptions!: GridOption;
   isCompact = false;
 
-  attached() {
+  constructor() {
     this.defineGrid();
+  }
+
+  attached() {
     this.dataset = this.getData(NB_ITEMS);
   }
 

--- a/demos/aurelia/src/examples/slickgrid/example56.ts
+++ b/demos/aurelia/src/examples/slickgrid/example56.ts
@@ -43,6 +43,16 @@ export class Example56 {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
       { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
+          return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
+        },
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
     ];
 

--- a/demos/aurelia/src/examples/slickgrid/example56.ts
+++ b/demos/aurelia/src/examples/slickgrid/example56.ts
@@ -1,0 +1,97 @@
+import { type AureliaGridInstance, type Column, type GridOption } from 'aurelia-slickgrid';
+import './example56.scss';
+
+const NB_ITEMS = 150;
+
+interface TaskItem {
+  id: number;
+  title: string;
+  status: 'Todo' | 'In Progress' | 'Done';
+  notes: string;
+}
+
+export class Example56 {
+  aureliaGrid?: AureliaGridInstance;
+  columns: Column[] = [];
+  dataset: TaskItem[] = [];
+  gridOptions!: GridOption;
+  isCompact = false;
+
+  attached() {
+    this.defineGrid();
+    this.dataset = this.getData(NB_ITEMS);
+  }
+
+  aureliaGridReady(aureliaGrid: AureliaGridInstance) {
+    this.aureliaGrid = aureliaGrid;
+  }
+
+  toggleDensity() {
+    this.isCompact = !this.isCompact;
+    this.aureliaGrid?.slickGrid?.invalidateRowHeights?.();
+  }
+
+  scrollToRow90() {
+    this.aureliaGrid?.slickGrid?.scrollRowToTop(90);
+  }
+
+  defineGrid() {
+    this.columns = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
+      { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
+    ];
+
+    this.gridOptions = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      frozenRow: 2,
+      gridHeight: 560,
+      gridWidth: 1080,
+      dataView: {
+        globalItemMetadataProvider: {
+          getRowMetadata: (item: TaskItem) => {
+            if (item.notes === 'Short note.') {
+              return { height: this.isCompact ? 40 : 33 };
+            }
+
+            const lineCount = this.getEstimatedLineCount(item.notes);
+            const verticalPadding = 8;
+            const lineHeight = this.isCompact ? 21 : 18;
+            const minRowHeight = this.isCompact ? 46 : 40;
+            const baseHeight = Math.max(minRowHeight, verticalPadding + lineCount * lineHeight);
+
+            return { height: baseHeight };
+          },
+        },
+      },
+    };
+  }
+
+  private getEstimatedLineCount(text: string): number {
+    return Math.max(1, Math.ceil(text.length / 55));
+  }
+
+  private getData(itemCount: number): TaskItem[] {
+    const statuses: Array<TaskItem['status']> = ['Todo', 'In Progress', 'Done'];
+    const notesPool = [
+      'Short note.',
+      'Need to validate keyboard navigation and ensure screen reader output remains stable across frozen panes.',
+      'Review row height invalidation path when data changes quickly due to live updates from backend polling.',
+      'Longer QA note: validate scrolling behavior at top and bottom boundaries, compare rendered range against expected rows, and confirm no visual clipping for wrapped cells.',
+    ];
+
+    const data: TaskItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      data.push({
+        id: i,
+        title: `Task ${i}`,
+        status: statuses[i % statuses.length],
+        notes: notesPool[i % notesPool.length],
+      });
+    }
+    return data;
+  }
+}

--- a/demos/aurelia/src/examples/slickgrid/example56.ts
+++ b/demos/aurelia/src/examples/slickgrid/example56.ts
@@ -59,6 +59,7 @@ export class Example56 {
     this.gridOptions = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       frozenRow: 2,
       gridHeight: 560,

--- a/demos/aurelia/src/my-app.ts
+++ b/demos/aurelia/src/my-app.ts
@@ -60,6 +60,8 @@ const myRoutes: Routeable[] = [
   { path: 'example52', component: () => import('./examples/slickgrid/example52.js'), title: '52- SQL Backend Service' },
   { path: 'example53', component: () => import('./examples/slickgrid/example53.js'), title: '53- Custom Filter Bar' },
   { path: 'example54', component: () => import('./examples/slickgrid/example54.js'), title: '54- AI / Web MCP Toolkit' },
+  { path: 'example55', component: () => import('./examples/slickgrid/example55.js'), title: '55- Variable Row Height (Provider)' },
+  { path: 'example56', component: () => import('./examples/slickgrid/example56.js'), title: '56- Variable Row Height (Dynamic)' },
   { path: 'home', component: () => import('./home-page.js'), title: 'Home' },
 ];
 @route({

--- a/demos/aurelia/test/cypress/e2e/example55.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example55.cy.ts
@@ -1,6 +1,6 @@
 describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   const hOf = (r: number) => {
-    const cycle = [33, 40, 56, 72];
+    const cycle = [33, 45, 56, 72];
     return cycle[r % cycle.length];
   };
   const topOf = (r: number) => {
@@ -16,8 +16,8 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
   });
 
-  it('should render looping row heights (33, 40, 56, 72)', () => {
-    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+  it('should render looping row heights (33, 45, 56, 72)', () => {
+    const expectedHeights = [33, 45, 56, 72, 33, 45, 56, 72];
     const defaultRowHeight = 40;
 
     for (const [row, expectedHeight] of expectedHeights.entries()) {

--- a/demos/aurelia/test/cypress/e2e/example55.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example55.cy.ts
@@ -20,17 +20,18 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
     const defaultRowHeight = 40;
 
-    for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`.slick-row[data-row=${r}]`)
+    for (const [row, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`.slick-row[data-row=${row}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
-          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          expect(style).to.contain(`transform: translateY(${topOf(row)}px)`);
           if (expectedHeight === defaultRowHeight) {
             expect(style).not.to.contain('height:');
           } else {
             expect(style).to.contain(`height: ${expectedHeight}px`);
           }
         });
+      cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
     }
   });
 

--- a/demos/aurelia/test/cypress/e2e/example55.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example55.cy.ts
@@ -21,7 +21,7 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const defaultRowHeight = 40;
 
     for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+      cy.get(`.slick-row[data-row=${r}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
           expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
@@ -37,12 +37,12 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   it('should keep row 90 aligned at top after clicking scroll button', () => {
     cy.get('[data-test="scroll-row-90-example55"]').click();
 
-    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+    cy.get('.slick-viewport-top.slick-viewport-left')
       .invoke('scrollTop')
       .then((scrollTop) => {
         expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
       });
 
-    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/demos/aurelia/test/cypress/e2e/example55.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example55.cy.ts
@@ -1,0 +1,48 @@
+describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
+  const hOf = (r: number) => {
+    const cycle = [33, 40, 56, 72];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example55`);
+    cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
+  });
+
+  it('should render looping row heights (33, 40, 56, 72)', () => {
+    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+    const defaultRowHeight = 40;
+
+    for (const [r, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+        .invoke('attr', 'style')
+        .then((style = '') => {
+          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          if (expectedHeight === defaultRowHeight) {
+            expect(style).not.to.contain('height:');
+          } else {
+            expect(style).to.contain(`height: ${expectedHeight}px`);
+          }
+        });
+    }
+  });
+
+  it('should keep row 90 aligned at top after clicking scroll button', () => {
+    cy.get('[data-test="scroll-row-90-example55"]').click();
+
+    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+      .invoke('scrollTop')
+      .then((scrollTop) => {
+        expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
+      });
+
+    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/demos/aurelia/test/cypress/e2e/example56.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example56.cy.ts
@@ -1,0 +1,101 @@
+describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
+  const BASE_ROW_HEIGHT = 40;
+  const FROZEN_ROW_COUNT = 2;
+
+  const hDefault = (r: number) => {
+    const cycle = [33, 44, 44, 80];
+    return cycle[r % cycle.length];
+  };
+  const hCompact = (r: number) => {
+    const cycle = [40, 50, 50, 92];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number, hOf: (row: number) => number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  const frozenTopHeight = (hOf: (row: number) => number) => topOf(FROZEN_ROW_COUNT, hOf);
+
+  const relativeTopInCanvas = (r: number, hOf: (row: number) => number) => {
+    if (r < FROZEN_ROW_COUNT) {
+      return topOf(r, hOf);
+    }
+    return topOf(r, hOf) - frozenTopHeight(hOf);
+  };
+
+  const canvasSelector = (r: number) =>
+    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+
+  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(r);
+    const expectedTop = relativeTopInCanvas(r, hOf);
+
+    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+      .should('have.attr', 'style')
+      .and('contain', `transform: translateY(${expectedTop}px)`)
+      .then((style) => {
+        if (expectedHeight !== BASE_ROW_HEIGHT) {
+          expect(style).to.contain(`height: ${expectedHeight}px`);
+        } else {
+          expect(style).not.to.contain('height:');
+        }
+      });
+  };
+
+  const ensureDefaultDensity = () => {
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .invoke('attr', 'style')
+      .then((style) => {
+        if ((style ?? '').includes('height: 50px')) {
+          cy.get('[data-test="toggle-density"]').click();
+        }
+      });
+
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .should('have.attr', 'style')
+      .and('contain', 'height: 44px');
+  };
+
+  beforeEach(() => {
+    cy.visit(`${Cypress.config('baseUrl')}/example56`);
+    ensureDefaultDensity();
+  });
+
+  it('should display Example title', () => {
+    cy.get('h2').should('contain', 'Example 56: Variable Row Height (Dynamic)');
+  });
+
+  it('should render frozen and scrollable rows with expected transform and row heights from metadata fallback', () => {
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hDefault);
+    }
+  });
+
+  it('should increase row heights and row positions after toggling density', () => {
+    assertRowStyle(10, hDefault);
+
+    cy.get('[data-test="toggle-density"]').click();
+
+    assertRowStyle(10, hCompact);
+
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hCompact);
+    }
+  });
+
+  it('should scroll row 90 to top of scrollable pane with frozen top rows', () => {
+    const expectedScrollTop = topOf(90, hDefault) - frozenTopHeight(hDefault);
+
+    cy.get('[data-test="scroll-row-90-example56"]').click();
+
+    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+      expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
+    });
+
+    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/demos/aurelia/test/cypress/e2e/example56.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example56.cy.ts
@@ -29,11 +29,11 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
   const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
-  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
-    const expectedHeight = hOf(r);
-    const expectedTop = relativeTopInCanvas(r, hOf);
+  const assertRowStyle = (row: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(row);
+    const expectedTop = relativeTopInCanvas(row, hOf);
 
-    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+    cy.get(`${canvasSelector(row)} .slick-row[data-row=${row}]`)
       .should('have.attr', 'style')
       .and('contain', `transform: translateY(${expectedTop}px)`)
       .then((style) => {
@@ -43,6 +43,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
           expect(style).not.to.contain('height:');
         }
       });
+    cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
   };
 
   const ensureDefaultDensity = () => {

--- a/demos/aurelia/test/cypress/e2e/example56.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example56.cy.ts
@@ -27,8 +27,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
     return topOf(r, hOf) - frozenTopHeight(hOf);
   };
 
-  const canvasSelector = (r: number) =>
-    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+  const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
   const assertRowStyle = (r: number, hOf: (row: number) => number) => {
     const expectedHeight = hOf(r);
@@ -47,7 +46,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
   };
 
   const ensureDefaultDensity = () => {
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+    cy.get('.grid-canvas-top .slick-row[data-row=1]')
       .invoke('attr', 'style')
       .then((style) => {
         if ((style ?? '').includes('height: 50px')) {
@@ -55,9 +54,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
         }
       });
 
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
-      .should('have.attr', 'style')
-      .and('contain', 'height: 44px');
+    cy.get('.grid-canvas-top .slick-row[data-row=1]').should('have.attr', 'style').and('contain', 'height: 44px');
   };
 
   beforeEach(() => {
@@ -92,10 +89,10 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
     cy.get('[data-test="scroll-row-90-example56"]').click();
 
-    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+    cy.get('.slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
       expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
     });
 
-    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/demos/react/src/examples/slickgrid/App.tsx
+++ b/demos/react/src/examples/slickgrid/App.tsx
@@ -56,6 +56,8 @@ const routes = [
   { path: 'example52', route: '/example52', element: lazy(() => import('./Example52.js')), title: '52- SQL Backend Service' },
   { path: 'example53', route: '/example53', element: lazy(() => import('./Example53.js')), title: '53- Custom Filter Bar' },
   { path: 'example54', route: '/example54', element: lazy(() => import('./Example54.js')), title: '54- AI / Web MCP Toolkit' },
+  { path: 'example55', route: '/example55', element: lazy(() => import('./Example55.js')), title: '55- Variable Row Height (Provider)' },
+  { path: 'example56', route: '/example56', element: lazy(() => import('./Example56.js')), title: '56- Variable Row Height (Dynamic)' },
 ];
 
 export default function Routes() {

--- a/demos/react/src/examples/slickgrid/Example55.tsx
+++ b/demos/react/src/examples/slickgrid/Example55.tsx
@@ -36,6 +36,7 @@ const Example55: React.FC = () => {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 

--- a/demos/react/src/examples/slickgrid/Example55.tsx
+++ b/demos/react/src/examples/slickgrid/Example55.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { SlickgridReact, type Column, type GridOption, type SlickgridReactInstance } from 'slickgrid-react';
+import './example55.scss';
+
+const NB_ITEMS = 200;
+
+interface StoryItem {
+  id: number;
+  title: string;
+  owner: string;
+  summary: string;
+  rowHeight: number;
+}
+
+const Example55: React.FC = () => {
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [dataset, setDataset] = useState<StoryItem[]>([]);
+  const [gridOptions, setGridOptions] = useState<GridOption | undefined>(undefined);
+  const reactGridRef = useRef<SlickgridReactInstance | null>(null);
+
+  useEffect(() => {
+    defineGrid();
+    setDataset(getData(NB_ITEMS));
+  }, []);
+
+  function reactGridReady(reactGrid: SlickgridReactInstance) {
+    reactGridRef.current = reactGrid;
+  }
+
+  function scrollToRow90() {
+    reactGridRef.current?.slickGrid?.scrollRowToTop(90);
+  }
+
+  function defineGrid() {
+    const columnDefinitions: Column[] = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
+      { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
+    ];
+
+    const options: GridOption = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      gridHeight: 560,
+      gridWidth: 1080,
+      rowHeightProvider: (_grid, _row, item: StoryItem) => item.rowHeight,
+    };
+
+    setColumns(columnDefinitions);
+    setGridOptions(options);
+  }
+
+  function getData(itemCount: number): StoryItem[] {
+    const owners = ['Alex', 'Priya', 'Mia', 'Sam', 'Chris'];
+    const fragments = [
+      'Refactor keyboard shortcut handling for better readability.',
+      'Adjust frozen rows when view-model updates after grouping.',
+      'Improve screen-reader labels on grid menu actions.',
+      'Align batch editor validation with backend constraints.',
+      'Capture edge-case around hidden columns and row-span.',
+    ];
+
+    const data: StoryItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const lineCount = (i % 4) + 1;
+      const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
+      const wordCount = summary.trim().split(/\s+/).length;
+      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      data.push({
+        id: i,
+        title: `Story ${i}`,
+        owner: owners[i % owners.length],
+        summary,
+        rowHeight: wordCount < 10 ? 33 : computedRowHeight,
+      });
+    }
+    return data;
+  }
+
+  return !gridOptions ? (
+    ''
+  ) : (
+    <div className="demo55">
+      <div id="demo-container" className="container-fluid">
+        <h2>
+          Example 55: Variable Row Height (Provider)
+          <span className="float-end font18">
+            see&nbsp;
+            <a
+              target="_blank"
+              href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/react/src/examples/slickgrid/Example55.tsx"
+            >
+              <span className="mdi mdi-link-variant"></span> code
+            </a>
+          </span>
+        </h2>
+
+        <div className="subtitle">
+          Variable row heights driven by <code>rowHeightProvider</code>.
+        </div>
+
+        <div className="row" style={{ marginBottom: '6px' }}>
+          <div className="col-md-12">
+            <button className="btn btn-outline-secondary btn-sm btn-icon" onClick={scrollToRow90} data-test="scroll-row-90-example55">
+              <span className="mdi mdi-arrow-down"></span>
+              <span> Scroll To row 90</span>
+            </button>
+          </div>
+        </div>
+
+        <SlickgridReact
+          gridId="grid55"
+          columns={columns}
+          options={gridOptions}
+          dataset={dataset}
+          onReactGridCreated={($event) => reactGridReady($event.detail)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Example55;

--- a/demos/react/src/examples/slickgrid/Example55.tsx
+++ b/demos/react/src/examples/slickgrid/Example55.tsx
@@ -68,7 +68,7 @@ const Example55: React.FC = () => {
       const lineCount = (i % 4) + 1;
       const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
       const wordCount = summary.trim().split(/\s+/).length;
-      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      const computedRowHeight = Math.max(45, 8 + lineCount * 16);
       data.push({
         id: i,
         title: `Story ${i}`,

--- a/demos/react/src/examples/slickgrid/Example55.tsx
+++ b/demos/react/src/examples/slickgrid/Example55.tsx
@@ -43,6 +43,7 @@ const Example55: React.FC = () => {
     const options: GridOption = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       gridHeight: 560,
       gridWidth: 1080,

--- a/demos/react/src/examples/slickgrid/Example56.tsx
+++ b/demos/react/src/examples/slickgrid/Example56.tsx
@@ -42,6 +42,16 @@ const Example56: React.FC = () => {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
       { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
+          return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
+        },
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
     ];
 

--- a/demos/react/src/examples/slickgrid/Example56.tsx
+++ b/demos/react/src/examples/slickgrid/Example56.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { SlickgridReact, type Column, type GridOption, type SlickgridReactInstance } from 'slickgrid-react';
+import './example56.scss';
+
+const NB_ITEMS = 150;
+
+interface TaskItem {
+  id: number;
+  title: string;
+  status: 'Todo' | 'In Progress' | 'Done';
+  notes: string;
+}
+
+const Example56: React.FC = () => {
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [dataset, setDataset] = useState<TaskItem[]>([]);
+  const [gridOptions, setGridOptions] = useState<GridOption | undefined>(undefined);
+
+  const reactGridRef = useRef<SlickgridReactInstance | null>(null);
+  const compactRef = useRef(false);
+
+  useEffect(() => {
+    defineGrid();
+    setDataset(getData(NB_ITEMS));
+  }, []);
+
+  function reactGridReady(reactGrid: SlickgridReactInstance) {
+    reactGridRef.current = reactGrid;
+  }
+
+  function toggleDensity() {
+    compactRef.current = !compactRef.current;
+    reactGridRef.current?.slickGrid?.invalidateRowHeights?.();
+  }
+
+  function scrollToRow90() {
+    reactGridRef.current?.slickGrid?.scrollRowToTop(90);
+  }
+
+  function defineGrid() {
+    const columnDefinitions: Column[] = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
+      { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
+    ];
+
+    const options: GridOption = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      frozenRow: 2,
+      gridHeight: 560,
+      gridWidth: 1080,
+      dataView: {
+        globalItemMetadataProvider: {
+          getRowMetadata: (item: TaskItem) => {
+            if (item.notes === 'Short note.') {
+              return { height: compactRef.current ? 40 : 33 };
+            }
+
+            const lineCount = getEstimatedLineCount(item.notes);
+            const verticalPadding = 8;
+            const lineHeight = compactRef.current ? 21 : 18;
+            const minRowHeight = compactRef.current ? 46 : 40;
+            const baseHeight = Math.max(minRowHeight, verticalPadding + lineCount * lineHeight);
+
+            return { height: baseHeight };
+          },
+        },
+      },
+    };
+
+    setColumns(columnDefinitions);
+    setGridOptions(options);
+  }
+
+  function getEstimatedLineCount(text: string): number {
+    return Math.max(1, Math.ceil(text.length / 55));
+  }
+
+  function getData(itemCount: number): TaskItem[] {
+    const statuses: Array<TaskItem['status']> = ['Todo', 'In Progress', 'Done'];
+    const notesPool = [
+      'Short note.',
+      'Need to validate keyboard navigation and ensure screen reader output remains stable across frozen panes.',
+      'Review row height invalidation path when data changes quickly due to live updates from backend polling.',
+      'Longer QA note: validate scrolling behavior at top and bottom boundaries, compare rendered range against expected rows, and confirm no visual clipping for wrapped cells.',
+    ];
+
+    const data: TaskItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      data.push({
+        id: i,
+        title: `Task ${i}`,
+        status: statuses[i % statuses.length],
+        notes: notesPool[i % notesPool.length],
+      });
+    }
+    return data;
+  }
+
+  return !gridOptions ? (
+    ''
+  ) : (
+    <div className="demo56">
+      <div id="demo-container" className="container-fluid">
+        <h2>
+          Example 56: Variable Row Height (Dynamic)
+          <span className="float-end font18">
+            see&nbsp;
+            <a
+              target="_blank"
+              href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/react/src/examples/slickgrid/Example56.tsx"
+            >
+              <span className="mdi mdi-link-variant"></span> code
+            </a>
+          </span>
+        </h2>
+
+        <div className="subtitle">
+          Variable row heights via <code>ItemMetadata.height</code> fallback, with compact mode rebuilding heights through
+          <code>invalidateRowHeights()</code>.
+        </div>
+
+        <div className="row" style={{ marginBottom: '6px' }}>
+          <div className="col-md-12">
+            <button className="btn btn-outline-secondary btn-sm btn-icon" onClick={toggleDensity} data-test="toggle-density">
+              <span className="mdi mdi-flip-vertical"></span>
+              <span> Toggle Compact Density</span>
+            </button>
+            <button className="btn btn-outline-secondary btn-sm ms-2 btn-icon" onClick={scrollToRow90} data-test="scroll-row-90-example56">
+              <span className="mdi mdi-arrow-down"></span>
+              <span> Scroll To row 90</span>
+            </button>
+          </div>
+        </div>
+
+        <SlickgridReact
+          gridId="grid56"
+          columns={columns}
+          options={gridOptions}
+          dataset={dataset}
+          onReactGridCreated={($event) => reactGridReady($event.detail)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Example56;

--- a/demos/react/src/examples/slickgrid/Example56.tsx
+++ b/demos/react/src/examples/slickgrid/Example56.tsx
@@ -58,6 +58,7 @@ const Example56: React.FC = () => {
     const options: GridOption = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       frozenRow: 2,
       gridHeight: 560,

--- a/demos/react/src/examples/slickgrid/example55.scss
+++ b/demos/react/src/examples/slickgrid/example55.scss
@@ -1,0 +1,12 @@
+#slickGridContainer-grid55 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
+  line-height: 1.25;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/demos/react/src/examples/slickgrid/example55.scss
+++ b/demos/react/src/examples/slickgrid/example55.scss
@@ -3,8 +3,6 @@
 }
 
 #slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
-  line-height: 1.25;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/react/src/examples/slickgrid/example56.scss
+++ b/demos/react/src/examples/slickgrid/example56.scss
@@ -3,9 +3,6 @@
 }
 
 #slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
-  font-size: 14px;
-  line-height: 1.35;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/react/src/examples/slickgrid/example56.scss
+++ b/demos/react/src/examples/slickgrid/example56.scss
@@ -1,0 +1,13 @@
+#slickGridContainer-grid56 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/demos/react/test/cypress/e2e/example55.cy.ts
+++ b/demos/react/test/cypress/e2e/example55.cy.ts
@@ -1,6 +1,6 @@
 describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   const hOf = (r: number) => {
-    const cycle = [33, 40, 56, 72];
+    const cycle = [33, 45, 56, 72];
     return cycle[r % cycle.length];
   };
   const topOf = (r: number) => {
@@ -16,8 +16,8 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
   });
 
-  it('should render looping row heights (33, 40, 56, 72)', () => {
-    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+  it('should render looping row heights (33, 45, 56, 72)', () => {
+    const expectedHeights = [33, 45, 56, 72, 33, 45, 56, 72];
     const defaultRowHeight = 40;
 
     for (const [row, expectedHeight] of expectedHeights.entries()) {

--- a/demos/react/test/cypress/e2e/example55.cy.ts
+++ b/demos/react/test/cypress/e2e/example55.cy.ts
@@ -20,17 +20,18 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
     const defaultRowHeight = 40;
 
-    for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`.slick-row[data-row=${r}]`)
+    for (const [row, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`.slick-row[data-row=${row}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
-          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          expect(style).to.contain(`transform: translateY(${topOf(row)}px)`);
           if (expectedHeight === defaultRowHeight) {
             expect(style).not.to.contain('height:');
           } else {
             expect(style).to.contain(`height: ${expectedHeight}px`);
           }
         });
+      cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
     }
   });
 

--- a/demos/react/test/cypress/e2e/example55.cy.ts
+++ b/demos/react/test/cypress/e2e/example55.cy.ts
@@ -21,7 +21,7 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const defaultRowHeight = 40;
 
     for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+      cy.get(`.slick-row[data-row=${r}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
           expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
@@ -37,12 +37,12 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   it('should keep row 90 aligned at top after clicking scroll button', () => {
     cy.get('[data-test="scroll-row-90-example55"]').click();
 
-    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+    cy.get('.slick-viewport-top.slick-viewport-left')
       .invoke('scrollTop')
       .then((scrollTop) => {
         expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
       });
 
-    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/demos/react/test/cypress/e2e/example55.cy.ts
+++ b/demos/react/test/cypress/e2e/example55.cy.ts
@@ -1,0 +1,48 @@
+describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
+  const hOf = (r: number) => {
+    const cycle = [33, 40, 56, 72];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example55`);
+    cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
+  });
+
+  it('should render looping row heights (33, 40, 56, 72)', () => {
+    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+    const defaultRowHeight = 40;
+
+    for (const [r, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+        .invoke('attr', 'style')
+        .then((style = '') => {
+          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          if (expectedHeight === defaultRowHeight) {
+            expect(style).not.to.contain('height:');
+          } else {
+            expect(style).to.contain(`height: ${expectedHeight}px`);
+          }
+        });
+    }
+  });
+
+  it('should keep row 90 aligned at top after clicking scroll button', () => {
+    cy.get('[data-test="scroll-row-90-example55"]').click();
+
+    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+      .invoke('scrollTop')
+      .then((scrollTop) => {
+        expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
+      });
+
+    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/demos/react/test/cypress/e2e/example56.cy.ts
+++ b/demos/react/test/cypress/e2e/example56.cy.ts
@@ -1,0 +1,101 @@
+describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
+  const BASE_ROW_HEIGHT = 40;
+  const FROZEN_ROW_COUNT = 2;
+
+  const hDefault = (r: number) => {
+    const cycle = [33, 44, 44, 80];
+    return cycle[r % cycle.length];
+  };
+  const hCompact = (r: number) => {
+    const cycle = [40, 50, 50, 92];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number, hOf: (row: number) => number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  const frozenTopHeight = (hOf: (row: number) => number) => topOf(FROZEN_ROW_COUNT, hOf);
+
+  const relativeTopInCanvas = (r: number, hOf: (row: number) => number) => {
+    if (r < FROZEN_ROW_COUNT) {
+      return topOf(r, hOf);
+    }
+    return topOf(r, hOf) - frozenTopHeight(hOf);
+  };
+
+  const canvasSelector = (r: number) =>
+    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+
+  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(r);
+    const expectedTop = relativeTopInCanvas(r, hOf);
+
+    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+      .should('have.attr', 'style')
+      .and('contain', `transform: translateY(${expectedTop}px)`)
+      .then((style) => {
+        if (expectedHeight !== BASE_ROW_HEIGHT) {
+          expect(style).to.contain(`height: ${expectedHeight}px`);
+        } else {
+          expect(style).not.to.contain('height:');
+        }
+      });
+  };
+
+  const ensureDefaultDensity = () => {
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .invoke('attr', 'style')
+      .then((style) => {
+        if ((style ?? '').includes('height: 50px')) {
+          cy.get('[data-test="toggle-density"]').click();
+        }
+      });
+
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .should('have.attr', 'style')
+      .and('contain', 'height: 44px');
+  };
+
+  beforeEach(() => {
+    cy.visit(`${Cypress.config('baseUrl')}/example56`);
+    ensureDefaultDensity();
+  });
+
+  it('should display Example title', () => {
+    cy.get('h2').should('contain', 'Example 56: Variable Row Height (Dynamic)');
+  });
+
+  it('should render frozen and scrollable rows with expected transform and row heights from metadata fallback', () => {
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hDefault);
+    }
+  });
+
+  it('should increase row heights and row positions after toggling density', () => {
+    assertRowStyle(10, hDefault);
+
+    cy.get('[data-test="toggle-density"]').click();
+
+    assertRowStyle(10, hCompact);
+
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hCompact);
+    }
+  });
+
+  it('should scroll row 90 to top of scrollable pane with frozen top rows', () => {
+    const expectedScrollTop = topOf(90, hDefault) - frozenTopHeight(hDefault);
+
+    cy.get('[data-test="scroll-row-90-example56"]').click();
+
+    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+      expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
+    });
+
+    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/demos/react/test/cypress/e2e/example56.cy.ts
+++ b/demos/react/test/cypress/e2e/example56.cy.ts
@@ -29,11 +29,11 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
   const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
-  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
-    const expectedHeight = hOf(r);
-    const expectedTop = relativeTopInCanvas(r, hOf);
+  const assertRowStyle = (row: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(row);
+    const expectedTop = relativeTopInCanvas(row, hOf);
 
-    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+    cy.get(`${canvasSelector(row)} .slick-row[data-row=${row}]`)
       .should('have.attr', 'style')
       .and('contain', `transform: translateY(${expectedTop}px)`)
       .then((style) => {
@@ -43,6 +43,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
           expect(style).not.to.contain('height:');
         }
       });
+    cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
   };
 
   const ensureDefaultDensity = () => {

--- a/demos/react/test/cypress/e2e/example56.cy.ts
+++ b/demos/react/test/cypress/e2e/example56.cy.ts
@@ -27,8 +27,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
     return topOf(r, hOf) - frozenTopHeight(hOf);
   };
 
-  const canvasSelector = (r: number) =>
-    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+  const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
   const assertRowStyle = (r: number, hOf: (row: number) => number) => {
     const expectedHeight = hOf(r);
@@ -47,7 +46,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
   };
 
   const ensureDefaultDensity = () => {
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+    cy.get('.grid-canvas-top .slick-row[data-row=1]')
       .invoke('attr', 'style')
       .then((style) => {
         if ((style ?? '').includes('height: 50px')) {
@@ -55,9 +54,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
         }
       });
 
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
-      .should('have.attr', 'style')
-      .and('contain', 'height: 44px');
+    cy.get('.grid-canvas-top .slick-row[data-row=1]').should('have.attr', 'style').and('contain', 'height: 44px');
   };
 
   beforeEach(() => {
@@ -92,10 +89,10 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
     cy.get('[data-test="scroll-row-90-example56"]').click();
 
-    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+    cy.get('.slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
       expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
     });
 
-    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/demos/vanilla/src/app-routing.ts
+++ b/demos/vanilla/src/app-routing.ts
@@ -41,6 +41,8 @@ import Example40 from './examples/example40.js';
 import Example41 from './examples/example41.js';
 import Example42 from './examples/example42.js';
 import Example43 from './examples/example43.js';
+import Example44 from './examples/example44.js';
+import Example45 from './examples/example45.js';
 import Icons from './examples/icons.js';
 import type { RouterConfig } from './interfaces.js';
 
@@ -92,6 +94,8 @@ export class AppRouting {
       { route: 'example41', name: 'example41', view: './examples/example41.html', viewModel: Example41, title: 'Example41' },
       { route: 'example42', name: 'example42', view: './examples/example42.html', viewModel: Example42, title: 'Example42' },
       { route: 'example43', name: 'example43', view: './examples/example43.html', viewModel: Example43, title: 'Example43' },
+      { route: 'example44', name: 'example44', view: './examples/example44.html', viewModel: Example44, title: 'Example44' },
+      { route: 'example45', name: 'example45', view: './examples/example45.html', viewModel: Example45, title: 'Example45' },
       { route: '', redirect: 'example01' },
       { route: '**', redirect: 'example01' },
     ];

--- a/demos/vanilla/src/app.html
+++ b/demos/vanilla/src/app.html
@@ -87,6 +87,8 @@
           <a class="navbar-item" onclick.trigger="loadRoute('example41')">Example41 - Grid with SQL Backend Service</a>
           <a class="navbar-item" onclick.trigger="loadRoute('example42')">Example42 - Custom Filter Bar</a>
           <a class="navbar-item" onclick.trigger="loadRoute('example43')">Example43 - AI / Web MCP Toolkit</a>
+          <a class="navbar-item" onclick.trigger="loadRoute('example44')">Example44 - Variable Row Height (Provider)</a>
+          <a class="navbar-item" onclick.trigger="loadRoute('example45')">Example45 - Variable Row Height (Metadata Fallback)</a>
         </div>
       </div>
     </div>

--- a/demos/vanilla/src/examples/example44.html
+++ b/demos/vanilla/src/examples/example44.html
@@ -1,0 +1,26 @@
+<h3 class="title is-3">
+  Example 44 - Variable Row Height (Provider)
+  <span class="d-inline-flex">
+    <button class="button is-small" onclick.trigger="scrollToRow90()" data-test="scroll-row-90-example44">
+      <span class="mdi mdi-arrow-down"></span>
+      <span> Scroll To row 90</span>
+    </button>
+  </span>
+
+  <div class="subtitle code-link">
+    <span class="is-size-6">see</span>
+    <a
+      class="is-size-5"
+      target="_blank"
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vanilla/src/examples/example44.ts"
+    >
+      <span class="mdi mdi-link-variant"></span> code
+    </a>
+  </div>
+</h3>
+
+<h6 class="title is-6 italic">
+  Variable row heights driven by <code>rowHeightProvider</code>. Short summaries stay compact while longer summaries grow.
+</h6>
+
+<div class="grid44"></div>

--- a/demos/vanilla/src/examples/example44.scss
+++ b/demos/vanilla/src/examples/example44.scss
@@ -3,8 +3,6 @@
 }
 
 .grid44 .slickgrid-container .slick-cell.cell-wrap {
-  line-height: 1.25;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/vanilla/src/examples/example44.scss
+++ b/demos/vanilla/src/examples/example44.scss
@@ -1,0 +1,12 @@
+.grid44 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+.grid44 .slickgrid-container .slick-cell.cell-wrap {
+  line-height: 1.25;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/demos/vanilla/src/examples/example44.ts
+++ b/demos/vanilla/src/examples/example44.ts
@@ -43,6 +43,7 @@ export default class Example44 {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 

--- a/demos/vanilla/src/examples/example44.ts
+++ b/demos/vanilla/src/examples/example44.ts
@@ -73,7 +73,7 @@ export default class Example44 {
       const lineCount = (i % 4) + 1;
       const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
       const wordCount = summary.trim().split(/\s+/).length;
-      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      const computedRowHeight = Math.max(45, 8 + lineCount * 16);
       data.push({
         id: i,
         title: `Story ${i}`,

--- a/demos/vanilla/src/examples/example44.ts
+++ b/demos/vanilla/src/examples/example44.ts
@@ -1,0 +1,87 @@
+import type { Column, GridOption } from '@slickgrid-universal/common';
+import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+import { ExampleGridOptions } from './example-grid-options.js';
+import './example44.scss';
+
+const NB_ITEMS = 200;
+
+interface StoryItem {
+  id: number;
+  title: string;
+  owner: string;
+  summary: string;
+  rowHeight: number;
+}
+
+export default class Example44 {
+  columns: Column[] = [];
+  dataset: StoryItem[] = [];
+  gridOptions!: GridOption;
+  sgb!: SlickVanillaGridBundle;
+
+  attached() {
+    this.defineGrid();
+    this.dataset = this.getData(NB_ITEMS);
+    this.sgb = new Slicker.GridBundle(
+      document.querySelector('.grid44') as HTMLDivElement,
+      this.columns,
+      { ...ExampleGridOptions, ...this.gridOptions },
+      this.dataset
+    );
+  }
+
+  dispose() {
+    this.sgb?.dispose();
+  }
+
+  scrollToRow90() {
+    this.sgb?.slickGrid?.scrollRowToTop(90);
+  }
+
+  defineGrid() {
+    this.columns = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
+      { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
+    ];
+
+    const gridOptions: GridOption = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      gridHeight: 560,
+      gridWidth: 1080,
+      rowHeightProvider: (_grid, _row, item: StoryItem) => item.rowHeight,
+    };
+    this.gridOptions = gridOptions;
+  }
+
+  getData(itemCount: number): StoryItem[] {
+    const owners = ['Alex', 'Priya', 'Mia', 'Sam', 'Chris'];
+    const fragments = [
+      'Refactor keyboard shortcut handling for better readability.',
+      'Adjust frozen rows when view-model updates after grouping.',
+      'Improve screen-reader labels on grid menu actions.',
+      'Align batch editor validation with backend constraints.',
+      'Capture edge-case around hidden columns and row-span.',
+    ];
+
+    const data: StoryItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const lineCount = (i % 4) + 1;
+      const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
+      const wordCount = summary.trim().split(/\s+/).length;
+      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      data.push({
+        id: i,
+        title: `Story ${i}`,
+        owner: owners[i % owners.length],
+        summary,
+        // Keep very short notes compact to make row-height differences easier to spot.
+        rowHeight: wordCount < 10 ? 33 : computedRowHeight,
+      });
+    }
+    return data;
+  }
+}

--- a/demos/vanilla/src/examples/example44.ts
+++ b/demos/vanilla/src/examples/example44.ts
@@ -50,6 +50,7 @@ export default class Example44 {
     const gridOptions: GridOption = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       gridHeight: 560,
       gridWidth: 1080,

--- a/demos/vanilla/src/examples/example45.html
+++ b/demos/vanilla/src/examples/example45.html
@@ -1,0 +1,31 @@
+<h3 class="title is-3">
+  Example 45 - Variable Row Height (Dynamic)
+  <span class="d-inline-flex">
+    <button class="button is-small" onclick.trigger="toggleDensity()" data-test="toggle-density">
+      <span class="mdi mdi-flip-vertical"></span>
+      <span> Toggle Compact Density</span>
+    </button>
+    <button class="button is-small ml-2" onclick.trigger="scrollToRow90()" data-test="scroll-row-90-example45">
+      <span class="mdi mdi-arrow-down"></span>
+      <span> Scroll To row 90</span>
+    </button>
+  </span>
+
+  <div class="subtitle code-link">
+    <span class="is-size-6">see</span>
+    <a
+      class="is-size-5"
+      target="_blank"
+      href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vanilla/src/examples/example45.ts"
+    >
+      <span class="mdi mdi-link-variant"></span> code
+    </a>
+  </div>
+</h3>
+
+<h6 class="title is-6 italic">
+  Variable row heights via <code>ItemMetadata.height</code> fallback, with compact mode rebuilding heights through
+  <code>invalidateRowHeights()</code>.
+</h6>
+
+<div class="grid45"></div>

--- a/demos/vanilla/src/examples/example45.scss
+++ b/demos/vanilla/src/examples/example45.scss
@@ -3,9 +3,6 @@
 }
 
 .grid45 .slickgrid-container .slick-cell.cell-wrap {
-  font-size: 14px;
-  line-height: 1.35;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/vanilla/src/examples/example45.scss
+++ b/demos/vanilla/src/examples/example45.scss
@@ -1,0 +1,13 @@
+.grid45 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+.grid45 .slickgrid-container .slick-cell.cell-wrap {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/demos/vanilla/src/examples/example45.ts
+++ b/demos/vanilla/src/examples/example45.ts
@@ -1,0 +1,108 @@
+import type { Column, GridOption } from '@slickgrid-universal/common';
+import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
+import { ExampleGridOptions } from './example-grid-options.js';
+import './example45.scss';
+
+const NB_ITEMS = 150;
+
+interface TaskItem {
+  id: number;
+  title: string;
+  status: 'Todo' | 'In Progress' | 'Done';
+  notes: string;
+}
+
+export default class Example45 {
+  columns: Column[] = [];
+  dataset: TaskItem[] = [];
+  gridOptions!: GridOption;
+  sgb!: SlickVanillaGridBundle;
+  isCompact = false;
+
+  attached() {
+    this.defineGrid();
+    this.dataset = this.getData(NB_ITEMS);
+
+    this.sgb = new Slicker.GridBundle(
+      document.querySelector('.grid45') as HTMLDivElement,
+      this.columns,
+      { ...ExampleGridOptions, ...this.gridOptions },
+      this.dataset
+    );
+  }
+
+  dispose() {
+    this.sgb?.dispose();
+  }
+
+  toggleDensity() {
+    this.isCompact = !this.isCompact;
+    (this.sgb?.slickGrid as { invalidateRowHeights?: () => void } | undefined)?.invalidateRowHeights?.();
+  }
+
+  scrollToRow90() {
+    this.sgb?.slickGrid?.scrollRowToTop(90);
+  }
+
+  defineGrid() {
+    this.columns = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
+      { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
+    ];
+
+    const gridOptions: GridOption = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      frozenRow: 2,
+      gridHeight: 560,
+      gridWidth: 1080,
+      dataView: {
+        globalItemMetadataProvider: {
+          getRowMetadata: (item: TaskItem) => {
+            if (item.notes === 'Short note.') {
+              return { height: this.isCompact ? 40 : 33 };
+            }
+
+            const lineCount = this.getEstimatedLineCount(item.notes);
+            const verticalPadding = 8; // 4px top + 4px bottom
+            const lineHeight = this.isCompact ? 21 : 18;
+            const minRowHeight = this.isCompact ? 46 : 40;
+            const baseHeight = Math.max(minRowHeight, verticalPadding + lineCount * lineHeight);
+
+            return { height: baseHeight };
+          },
+        },
+      },
+    };
+    this.gridOptions = gridOptions;
+  }
+
+  private getEstimatedLineCount(text: string): number {
+    // Tuned for Notes column width (~420px) and wrapped content in this demo.
+    return Math.max(1, Math.ceil(text.length / 55));
+  }
+
+  private getData(itemCount: number): TaskItem[] {
+    const statuses: Array<TaskItem['status']> = ['Todo', 'In Progress', 'Done'];
+    const notesPool = [
+      'Short note.',
+      'Need to validate keyboard navigation and ensure screen reader output remains stable across frozen panes.',
+      'Review row height invalidation path when data changes quickly due to live updates from backend polling.',
+      'Longer QA note: validate scrolling behavior at top and bottom boundaries, compare rendered range against expected rows, and confirm no visual clipping for wrapped cells.',
+    ];
+
+    const data: TaskItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      data.push({
+        id: i,
+        title: `Task ${i}`,
+        status: statuses[i % statuses.length],
+        notes: notesPool[i % notesPool.length],
+      });
+    }
+    return data;
+  }
+}

--- a/demos/vanilla/src/examples/example45.ts
+++ b/demos/vanilla/src/examples/example45.ts
@@ -49,6 +49,16 @@ export default class Example45 {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
       { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
+          return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
+        },
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
     ];
 

--- a/demos/vanilla/src/examples/example45.ts
+++ b/demos/vanilla/src/examples/example45.ts
@@ -65,6 +65,7 @@ export default class Example45 {
     const gridOptions: GridOption = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       frozenRow: 2,
       gridHeight: 560,

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -64,7 +64,7 @@ function getData(itemCount: number): StoryItem[] {
     const lineCount = (i % 4) + 1;
     const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
     const wordCount = summary.trim().split(/\s+/).length;
-    const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+    const computedRowHeight = Math.max(45, 8 + lineCount * 16);
     data.push({
       id: i,
       title: `Story ${i}`,

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -35,6 +35,7 @@ function defineGrid() {
     { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
     { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
     { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+    { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
     { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
   ];
 

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -117,8 +117,6 @@ function getData(itemCount: number): StoryItem[] {
 }
 
 #slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
-  line-height: 1.25;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { SlickgridVue, type Column, type GridOption, type SlickgridVueInstance } from 'slickgrid-vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
+
+const NB_ITEMS = 200;
+
+interface StoryItem {
+  id: number;
+  title: string;
+  owner: string;
+  summary: string;
+  rowHeight: number;
+}
+
+const gridOptions = ref<GridOption>();
+const columns: Ref<Column[]> = ref([]);
+const dataset = ref<StoryItem[]>([]);
+let vueGrid!: SlickgridVueInstance;
+
+onBeforeMount(() => {
+  defineGrid();
+  dataset.value = getData(NB_ITEMS);
+});
+
+function vueGridReady(grid: SlickgridVueInstance) {
+  vueGrid = grid;
+}
+
+function scrollToRow90() {
+  vueGrid?.slickGrid?.scrollRowToTop(90);
+}
+
+function defineGrid() {
+  columns.value = [
+    { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+    { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
+    { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+    { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
+  ];
+
+  gridOptions.value = {
+    enableCellNavigation: true,
+    enableTextSelectionOnCells: true,
+    rowHeight: 40,
+    gridHeight: 560,
+    gridWidth: 1080,
+    rowHeightProvider: (_grid, _row, item: StoryItem) => item.rowHeight,
+  };
+}
+
+function getData(itemCount: number): StoryItem[] {
+  const owners = ['Alex', 'Priya', 'Mia', 'Sam', 'Chris'];
+  const fragments = [
+    'Refactor keyboard shortcut handling for better readability.',
+    'Adjust frozen rows when view-model updates after grouping.',
+    'Improve screen-reader labels on grid menu actions.',
+    'Align batch editor validation with backend constraints.',
+    'Capture edge-case around hidden columns and row-span.',
+  ];
+
+  const data: StoryItem[] = [];
+  for (let i = 0; i < itemCount; i++) {
+    const lineCount = (i % 4) + 1;
+    const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
+    const wordCount = summary.trim().split(/\s+/).length;
+    const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+    data.push({
+      id: i,
+      title: `Story ${i}`,
+      owner: owners[i % owners.length],
+      summary,
+      rowHeight: wordCount < 10 ? 33 : computedRowHeight,
+    });
+  }
+  return data;
+}
+</script>
+
+<template>
+  <h2>
+    Example 55: Variable Row Height (Provider)
+    <span class="float-end">
+      <a
+        style="font-size: 18px"
+        target="_blank"
+        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vue/src/components/Example55.vue"
+      >
+        <span class="mdi mdi-link-variant"></span> code
+      </a>
+    </span>
+  </h2>
+
+  <div class="subtitle">Variable row heights driven by <code>rowHeightProvider</code>.</div>
+
+  <div class="row" style="margin-bottom: 6px">
+    <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" @click="scrollToRow90()" data-test="scroll-row-90-example55">
+        <span class="mdi mdi-arrow-down"></span>
+        <span> Scroll To row 90</span>
+      </button>
+    </div>
+  </div>
+
+  <slickgrid-vue
+    v-model:options="gridOptions"
+    v-model:columns="columns"
+    v-model:dataset="dataset"
+    grid-id="grid55"
+    @onVueGridCreated="vueGridReady($event.detail)"
+  >
+  </slickgrid-vue>
+</template>
+
+<style lang="scss">
+#slickGridContainer-grid55 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
+  line-height: 1.25;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -42,6 +42,7 @@ function defineGrid() {
   gridOptions.value = {
     enableCellNavigation: true,
     enableTextSelectionOnCells: true,
+    enableVariableRowHeight: true,
     rowHeight: 40,
     gridHeight: 560,
     gridWidth: 1080,

--- a/demos/vue/src/components/Example56.vue
+++ b/demos/vue/src/components/Example56.vue
@@ -40,6 +40,16 @@ function defineGrid() {
     { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
     { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
     { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+    {
+      id: 'rowHeight',
+      name: 'Height',
+      field: 'rowHeight',
+      formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
+        return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
+      },
+      minWidth: 90,
+      width: 90,
+    },
     { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
   ];
 

--- a/demos/vue/src/components/Example56.vue
+++ b/demos/vue/src/components/Example56.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { SlickgridVue, type Column, type GridOption, type SlickgridVueInstance } from 'slickgrid-vue';
+import { onBeforeMount, ref, type Ref } from 'vue';
+
+const NB_ITEMS = 150;
+
+interface TaskItem {
+  id: number;
+  title: string;
+  status: 'Todo' | 'In Progress' | 'Done';
+  notes: string;
+}
+
+const gridOptions = ref<GridOption>();
+const columns: Ref<Column[]> = ref([]);
+const dataset = ref<TaskItem[]>([]);
+const isCompact = ref(false);
+let vueGrid!: SlickgridVueInstance;
+
+onBeforeMount(() => {
+  defineGrid();
+  dataset.value = getData(NB_ITEMS);
+});
+
+function vueGridReady(grid: SlickgridVueInstance) {
+  vueGrid = grid;
+}
+
+function toggleDensity() {
+  isCompact.value = !isCompact.value;
+  vueGrid?.slickGrid?.invalidateRowHeights?.();
+}
+
+function scrollToRow90() {
+  vueGrid?.slickGrid?.scrollRowToTop(90);
+}
+
+function defineGrid() {
+  columns.value = [
+    { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+    { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
+    { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+    { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
+  ];
+
+  gridOptions.value = {
+    enableCellNavigation: true,
+    enableTextSelectionOnCells: true,
+    rowHeight: 40,
+    frozenRow: 2,
+    gridHeight: 560,
+    gridWidth: 1080,
+    dataView: {
+      globalItemMetadataProvider: {
+        getRowMetadata: (item: TaskItem) => {
+          if (item.notes === 'Short note.') {
+            return { height: isCompact.value ? 40 : 33 };
+          }
+
+          const lineCount = getEstimatedLineCount(item.notes);
+          const verticalPadding = 8;
+          const lineHeight = isCompact.value ? 21 : 18;
+          const minRowHeight = isCompact.value ? 46 : 40;
+          const baseHeight = Math.max(minRowHeight, verticalPadding + lineCount * lineHeight);
+
+          return { height: baseHeight };
+        },
+      },
+    },
+  };
+}
+
+function getEstimatedLineCount(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 55));
+}
+
+function getData(itemCount: number): TaskItem[] {
+  const statuses: Array<TaskItem['status']> = ['Todo', 'In Progress', 'Done'];
+  const notesPool = [
+    'Short note.',
+    'Need to validate keyboard navigation and ensure screen reader output remains stable across frozen panes.',
+    'Review row height invalidation path when data changes quickly due to live updates from backend polling.',
+    'Longer QA note: validate scrolling behavior at top and bottom boundaries, compare rendered range against expected rows, and confirm no visual clipping for wrapped cells.',
+  ];
+
+  const data: TaskItem[] = [];
+  for (let i = 0; i < itemCount; i++) {
+    data.push({
+      id: i,
+      title: `Task ${i}`,
+      status: statuses[i % statuses.length],
+      notes: notesPool[i % notesPool.length],
+    });
+  }
+  return data;
+}
+</script>
+
+<template>
+  <h2>
+    Example 56: Variable Row Height (Dynamic)
+    <span class="float-end">
+      <a
+        style="font-size: 18px"
+        target="_blank"
+        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/demos/vue/src/components/Example56.vue"
+      >
+        <span class="mdi mdi-link-variant"></span> code
+      </a>
+    </span>
+  </h2>
+
+  <div class="subtitle">
+    Variable row heights via <code>ItemMetadata.height</code> fallback, with compact mode rebuilding heights through
+    <code>invalidateRowHeights()</code>.
+  </div>
+
+  <div class="row" style="margin-bottom: 6px">
+    <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" @click="toggleDensity()" data-test="toggle-density">
+        <span class="mdi mdi-flip-vertical"></span>
+        <span> Toggle Compact Density</span>
+      </button>
+      <button class="btn btn-outline-secondary btn-sm ms-2 btn-icon" @click="scrollToRow90()" data-test="scroll-row-90-example56">
+        <span class="mdi mdi-arrow-down"></span>
+        <span> Scroll To row 90</span>
+      </button>
+    </div>
+  </div>
+
+  <slickgrid-vue
+    v-model:options="gridOptions"
+    v-model:columns="columns"
+    v-model:dataset="dataset"
+    grid-id="grid56"
+    @onVueGridCreated="vueGridReady($event.detail)"
+  >
+  </slickgrid-vue>
+</template>
+
+<style lang="scss">
+#slickGridContainer-grid56 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/demos/vue/src/components/Example56.vue
+++ b/demos/vue/src/components/Example56.vue
@@ -144,9 +144,6 @@ function getData(itemCount: number): TaskItem[] {
 }
 
 #slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
-  font-size: 14px;
-  line-height: 1.35;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/demos/vue/src/components/Example56.vue
+++ b/demos/vue/src/components/Example56.vue
@@ -56,6 +56,7 @@ function defineGrid() {
   gridOptions.value = {
     enableCellNavigation: true,
     enableTextSelectionOnCells: true,
+    enableVariableRowHeight: true,
     rowHeight: 40,
     frozenRow: 2,
     gridHeight: 560,

--- a/demos/vue/src/router/index.ts
+++ b/demos/vue/src/router/index.ts
@@ -62,6 +62,8 @@ export const routes: RouteRecordRaw[] = [
   { path: '/example52', name: '52- SQL Backend Service', component: () => import('../components/Example52.vue') },
   { path: '/example53', name: '53- Custom Filter Bar', component: () => import('../components/Example53.vue') },
   { path: '/example54', name: '54- AI / Web MCP Toolkit', component: () => import('../components/Example54.vue') },
+  { path: '/example55', name: '55- Variable Row Height (Provider)', component: () => import('../components/Example55.vue') },
+  { path: '/example56', name: '56- Variable Row Height (Dynamic)', component: () => import('../components/Example56.vue') },
 ];
 
 export const router = createRouter({

--- a/demos/vue/test/cypress/e2e/example55.cy.ts
+++ b/demos/vue/test/cypress/e2e/example55.cy.ts
@@ -1,6 +1,6 @@
 describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   const hOf = (r: number) => {
-    const cycle = [33, 40, 56, 72];
+    const cycle = [33, 45, 56, 72];
     return cycle[r % cycle.length];
   };
   const topOf = (r: number) => {
@@ -16,8 +16,8 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
   });
 
-  it('should render looping row heights (33, 40, 56, 72)', () => {
-    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+  it('should render looping row heights (33, 45, 56, 72)', () => {
+    const expectedHeights = [33, 45, 56, 72, 33, 45, 56, 72];
     const defaultRowHeight = 40;
 
     for (const [row, expectedHeight] of expectedHeights.entries()) {

--- a/demos/vue/test/cypress/e2e/example55.cy.ts
+++ b/demos/vue/test/cypress/e2e/example55.cy.ts
@@ -20,17 +20,18 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
     const defaultRowHeight = 40;
 
-    for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`.slick-row[data-row=${r}]`)
+    for (const [row, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`.slick-row[data-row=${row}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
-          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          expect(style).to.contain(`transform: translateY(${topOf(row)}px)`);
           if (expectedHeight === defaultRowHeight) {
             expect(style).not.to.contain('height:');
           } else {
             expect(style).to.contain(`height: ${expectedHeight}px`);
           }
         });
+      cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
     }
   });
 

--- a/demos/vue/test/cypress/e2e/example55.cy.ts
+++ b/demos/vue/test/cypress/e2e/example55.cy.ts
@@ -21,7 +21,7 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const defaultRowHeight = 40;
 
     for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+      cy.get(`.slick-row[data-row=${r}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
           expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
@@ -37,12 +37,12 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   it('should keep row 90 aligned at top after clicking scroll button', () => {
     cy.get('[data-test="scroll-row-90-example55"]').click();
 
-    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+    cy.get('.slick-viewport-top.slick-viewport-left')
       .invoke('scrollTop')
       .then((scrollTop) => {
         expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
       });
 
-    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/demos/vue/test/cypress/e2e/example55.cy.ts
+++ b/demos/vue/test/cypress/e2e/example55.cy.ts
@@ -1,0 +1,48 @@
+describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
+  const hOf = (r: number) => {
+    const cycle = [33, 40, 56, 72];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example55`);
+    cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
+  });
+
+  it('should render looping row heights (33, 40, 56, 72)', () => {
+    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+    const defaultRowHeight = 40;
+
+    for (const [r, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+        .invoke('attr', 'style')
+        .then((style = '') => {
+          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          if (expectedHeight === defaultRowHeight) {
+            expect(style).not.to.contain('height:');
+          } else {
+            expect(style).to.contain(`height: ${expectedHeight}px`);
+          }
+        });
+    }
+  });
+
+  it('should keep row 90 aligned at top after clicking scroll button', () => {
+    cy.get('[data-test="scroll-row-90-example55"]').click();
+
+    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+      .invoke('scrollTop')
+      .then((scrollTop) => {
+        expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
+      });
+
+    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/demos/vue/test/cypress/e2e/example56.cy.ts
+++ b/demos/vue/test/cypress/e2e/example56.cy.ts
@@ -1,0 +1,101 @@
+describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
+  const BASE_ROW_HEIGHT = 40;
+  const FROZEN_ROW_COUNT = 2;
+
+  const hDefault = (r: number) => {
+    const cycle = [33, 44, 44, 80];
+    return cycle[r % cycle.length];
+  };
+  const hCompact = (r: number) => {
+    const cycle = [40, 50, 50, 92];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number, hOf: (row: number) => number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  const frozenTopHeight = (hOf: (row: number) => number) => topOf(FROZEN_ROW_COUNT, hOf);
+
+  const relativeTopInCanvas = (r: number, hOf: (row: number) => number) => {
+    if (r < FROZEN_ROW_COUNT) {
+      return topOf(r, hOf);
+    }
+    return topOf(r, hOf) - frozenTopHeight(hOf);
+  };
+
+  const canvasSelector = (r: number) =>
+    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+
+  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(r);
+    const expectedTop = relativeTopInCanvas(r, hOf);
+
+    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+      .should('have.attr', 'style')
+      .and('contain', `transform: translateY(${expectedTop}px)`)
+      .then((style) => {
+        if (expectedHeight !== BASE_ROW_HEIGHT) {
+          expect(style).to.contain(`height: ${expectedHeight}px`);
+        } else {
+          expect(style).not.to.contain('height:');
+        }
+      });
+  };
+
+  const ensureDefaultDensity = () => {
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .invoke('attr', 'style')
+      .then((style) => {
+        if ((style ?? '').includes('height: 50px')) {
+          cy.get('[data-test="toggle-density"]').click();
+        }
+      });
+
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .should('have.attr', 'style')
+      .and('contain', 'height: 44px');
+  };
+
+  beforeEach(() => {
+    cy.visit(`${Cypress.config('baseUrl')}/example56`);
+    ensureDefaultDensity();
+  });
+
+  it('should display Example title', () => {
+    cy.get('h2').should('contain', 'Example 56: Variable Row Height (Dynamic)');
+  });
+
+  it('should render frozen and scrollable rows with expected transform and row heights from metadata fallback', () => {
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hDefault);
+    }
+  });
+
+  it('should increase row heights and row positions after toggling density', () => {
+    assertRowStyle(10, hDefault);
+
+    cy.get('[data-test="toggle-density"]').click();
+
+    assertRowStyle(10, hCompact);
+
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hCompact);
+    }
+  });
+
+  it('should scroll row 90 to top of scrollable pane with frozen top rows', () => {
+    const expectedScrollTop = topOf(90, hDefault) - frozenTopHeight(hDefault);
+
+    cy.get('[data-test="scroll-row-90-example56"]').click();
+
+    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+      expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
+    });
+
+    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/demos/vue/test/cypress/e2e/example56.cy.ts
+++ b/demos/vue/test/cypress/e2e/example56.cy.ts
@@ -29,11 +29,11 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
   const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
-  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
-    const expectedHeight = hOf(r);
-    const expectedTop = relativeTopInCanvas(r, hOf);
+  const assertRowStyle = (row: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(row);
+    const expectedTop = relativeTopInCanvas(row, hOf);
 
-    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+    cy.get(`${canvasSelector(row)} .slick-row[data-row=${row}]`)
       .should('have.attr', 'style')
       .and('contain', `transform: translateY(${expectedTop}px)`)
       .then((style) => {
@@ -43,6 +43,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
           expect(style).not.to.contain('height:');
         }
       });
+    cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
   };
 
   const ensureDefaultDensity = () => {

--- a/demos/vue/test/cypress/e2e/example56.cy.ts
+++ b/demos/vue/test/cypress/e2e/example56.cy.ts
@@ -27,8 +27,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
     return topOf(r, hOf) - frozenTopHeight(hOf);
   };
 
-  const canvasSelector = (r: number) =>
-    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+  const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
   const assertRowStyle = (r: number, hOf: (row: number) => number) => {
     const expectedHeight = hOf(r);
@@ -47,7 +46,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
   };
 
   const ensureDefaultDensity = () => {
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+    cy.get('.grid-canvas-top .slick-row[data-row=1]')
       .invoke('attr', 'style')
       .then((style) => {
         if ((style ?? '').includes('height: 50px')) {
@@ -55,9 +54,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
         }
       });
 
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
-      .should('have.attr', 'style')
-      .and('contain', 'height: 44px');
+    cy.get('.grid-canvas-top .slick-row[data-row=1]').should('have.attr', 'style').and('contain', 'height: 44px');
   };
 
   beforeEach(() => {
@@ -92,10 +89,10 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
     cy.get('[data-test="scroll-row-90-example56"]').click();
 
-    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+    cy.get('.slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
       expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
     });
 
-    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -69,6 +69,7 @@
 * [Pagination](grid-functionalities/pagination.md)
 * [Infinite Scroll](grid-functionalities/infinite-scroll.md)
 * [Pinning (frozen) of Columns/Rows](grid-functionalities/frozen-columns-rows.md)
+* [Variable Row Height](grid-functionalities/variable-row-height.md)
 * [Row Detail](grid-functionalities/row-detail.md)
 * [Row Move (dragging)](grid-functionalities/row-move.md)
 * [Row Selection](grid-functionalities/row-selection.md)

--- a/docs/grid-functionalities/variable-row-height.md
+++ b/docs/grid-functionalities/variable-row-height.md
@@ -1,0 +1,68 @@
+#### Index
+- [Introduction](#introduction)
+- [Height Resolution Order](#height-resolution-order)
+- [Using rowHeightProvider](#using-rowheightprovider)
+- [Using Item Metadata Height Fallback](#using-item-metadata-height-fallback)
+- [Runtime Updates](#runtime-updates)
+
+### Introduction
+By default, SlickGrid uses the grid option `rowHeight` for every row. This is still the baseline behavior.
+
+When variable row height is enabled, each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+
+### Height Resolution Order
+For each row, height resolution follows this order:
+
+1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
+2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
+3. Grid option `rowHeight` (default fallback)
+
+### Using rowHeightProvider
+Use `rowHeightProvider` when height is derived directly from row/item data.
+
+```ts
+import type { Column, GridOption } from '@slickgrid-universal/common';
+
+const gridOptions: GridOption = {
+  rowHeight: 40,
+  rowHeightProvider: (_grid, _row, item: { summary: string }) => {
+    const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
+    return Math.max(33, 8 + lineCount * 16);
+  },
+};
+```
+
+### Using Item Metadata Height Fallback
+Use metadata fallback when you already customize row metadata and prefer to keep row logic in metadata.
+
+```ts
+import type { GridOption, ItemMetadata } from '@slickgrid-universal/common';
+
+const gridOptions: GridOption = {
+  rowHeight: 40,
+  dataView: {
+    globalItemMetadataProvider: {
+      getRowMetadata: (item: { notes: string }): ItemMetadata => {
+        if (item.notes === 'Short note.') {
+          return { height: 33 };
+        }
+
+        const lineCount = Math.max(1, Math.ceil(item.notes.length / 55));
+        return { height: Math.max(40, 8 + lineCount * 18) };
+      },
+    },
+  },
+};
+```
+
+If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+
+### Runtime Updates
+If row height inputs change at runtime (content, mode toggles, metadata rules), call `invalidateRowHeights()` to rebuild row positions and repaint.
+
+```ts
+// Vanilla bundle example
+this.sgb?.slickGrid?.invalidateRowHeights?.();
+```
+
+Use `invalidateRowHeights()` after any change that can alter computed row height.

--- a/docs/grid-functionalities/variable-row-height.md
+++ b/docs/grid-functionalities/variable-row-height.md
@@ -34,12 +34,18 @@ const gridOptions: GridOption = {
 
 ### Using Item Metadata Height Fallback
 Use metadata fallback when you already customize row metadata and prefer to keep row logic in metadata.
+Set `variableRowHeight: true` to activate variable height mode without a `rowHeightProvider`.
+
+> **Note:** `variableRowHeight: true` is only needed when using `ItemMetadata.height` **without** a `rowHeightProvider`.
+> When `rowHeightProvider` is defined, variable height mode is activated automatically.
+> Without this flag, `getRowMetadata` is still called for other purposes (e.g. colspan) and does **not** activate variable row height.
 
 ```ts
 import type { GridOption, ItemMetadata } from '@slickgrid-universal/common';
 
 const gridOptions: GridOption = {
   rowHeight: 40,
+  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }): ItemMetadata => {

--- a/docs/grid-functionalities/variable-row-height.md
+++ b/docs/grid-functionalities/variable-row-height.md
@@ -6,9 +6,7 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row. This is still the baseline behavior.
-
-When variable row height is enabled, each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
 
 ### Height Resolution Order
 For each row, height resolution follows this order:
@@ -33,19 +31,17 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
-Use metadata fallback when you already customize row metadata and prefer to keep row logic in metadata.
-Set `variableRowHeight: true` to activate variable height mode without a `rowHeightProvider`.
+Use metadata fallback when you already customize row metadata and prefer to keep row height logic there.
+Variable height mode is activated automatically as soon as `getRowMetadata` returns an object with a numeric `height` property on any row.
 
-> **Note:** `variableRowHeight: true` is only needed when using `ItemMetadata.height` **without** a `rowHeightProvider`.
-> When `rowHeightProvider` is defined, variable height mode is activated automatically.
-> Without this flag, `getRowMetadata` is still called for other purposes (e.g. colspan) and does **not** activate variable row height.
+> **Note:** Simply having a `getRowMetadata` function (e.g. for colspan only) does **not** activate variable height mode.
+> The grid probes the first available data item and only enables variable height when a numeric `height` is found in the returned metadata.
 
 ```ts
 import type { GridOption, ItemMetadata } from '@slickgrid-universal/common';
 
 const gridOptions: GridOption = {
   rowHeight: 40,
-  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }): ItemMetadata => {

--- a/docs/grid-functionalities/variable-row-height.md
+++ b/docs/grid-functionalities/variable-row-height.md
@@ -6,14 +6,15 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+By default, SlickGrid uses the grid option `rowHeight` for every row. Variable row height is opt-in and only active when `enableVariableRowHeight` is set to `true`.
 
 ### Height Resolution Order
-For each row, height resolution follows this order:
+When `enableVariableRowHeight: true`, each row height is resolved in this order:
 
 1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
-2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
-3. Grid option `rowHeight` (default fallback)
+2. Grid option `rowHeight` (default fallback)
+
+The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
 Use `rowHeightProvider` when height is derived directly from row/item data.
@@ -22,6 +23,7 @@ Use `rowHeightProvider` when height is derived directly from row/item data.
 import type { Column, GridOption } from '@slickgrid-universal/common';
 
 const gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
   rowHeightProvider: (_grid, _row, item: { summary: string }) => {
     const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
@@ -31,16 +33,14 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
-Use metadata fallback when you already customize row metadata and prefer to keep row height logic there.
-Variable height mode is activated automatically as soon as `getRowMetadata` returns an object with a numeric `height` property on any row.
-
-> **Note:** Simply having a `getRowMetadata` function (e.g. for colspan only) does **not** activate variable height mode.
-> The grid probes the first available data item and only enables variable height when a numeric `height` is found in the returned metadata.
+Use metadata height when you already customize row metadata and prefer to keep row height logic there.
+Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts
 import type { GridOption, ItemMetadata } from '@slickgrid-universal/common';
 
 const gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
   dataView: {
     globalItemMetadataProvider: {
@@ -57,7 +57,8 @@ const gridOptions: GridOption = {
 };
 ```
 
-If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+If you supply a custom `rowHeightProvider`, it fully replaces the default provider behavior.
+When your custom provider returns `undefined`, the grid uses `rowHeight` for that row.
 
 ### Runtime Updates
 If row height inputs change at runtime (content, mode toggles, metadata rules), call `invalidateRowHeights()` to rebuild row positions and repaint.

--- a/docs/grid-functionalities/variable-row-height.md
+++ b/docs/grid-functionalities/variable-row-height.md
@@ -19,6 +19,9 @@ The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata
 ### Using rowHeightProvider
 Use `rowHeightProvider` when height is derived directly from row/item data.
 
+> **Important:** Defining a custom `rowHeightProvider` replaces SlickGrid's default provider.
+> The default provider reads `ItemMetadata.height`; once overridden, metadata height is no longer read unless your custom provider reads it explicitly.
+
 ```ts
 import type { Column, GridOption } from '@slickgrid-universal/common';
 

--- a/frameworks/angular-slickgrid/docs/TOC.md
+++ b/frameworks/angular-slickgrid/docs/TOC.md
@@ -76,6 +76,7 @@
 * [Header Menu & Header Buttons](grid-functionalities/header-menu-header-buttons.md)
 * [Infinite Scroll](grid-functionalities/infinite-scroll.md)
 * [Pinning (frozen) of Columns/Rows](grid-functionalities/frozen-columns-rows.md)
+* [Variable Row Height](grid-functionalities/variable-row-height.md)
 * [Providing data to the grid](grid-functionalities/providing-grid-data.md)
 * [Row Detail](grid-functionalities/row-detail.md)
 * [Row Move (dragging)](grid-functionalities/row-move.md)

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -31,9 +31,15 @@ gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Set `variableRowHeight: true` to activate variable height mode via metadata.
+
+> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
+> `rowHeightProvider` activates variable mode automatically.
+
 ```ts
 gridOptions: GridOption = {
   rowHeight: 40,
+  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -6,9 +6,7 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row.
-
-Use variable row height when row content requires different heights while keeping virtual scrolling and frozen panes aligned.
+By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
 
 ### Height Resolution Order
 For each row, height resolution follows this order:

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -1,0 +1,59 @@
+#### Index
+- [Introduction](#introduction)
+- [Height Resolution Order](#height-resolution-order)
+- [Using rowHeightProvider](#using-rowheightprovider)
+- [Using Item Metadata Height Fallback](#using-item-metadata-height-fallback)
+- [Runtime Updates](#runtime-updates)
+
+### Introduction
+By default, SlickGrid uses the grid option `rowHeight` for every row.
+
+Use variable row height when row content requires different heights while keeping virtual scrolling and frozen panes aligned.
+
+### Height Resolution Order
+For each row, height resolution follows this order:
+
+1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
+2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
+3. Grid option `rowHeight` (default fallback)
+
+### Using rowHeightProvider
+```ts
+import { Column, GridOption } from 'angular-slickgrid';
+
+gridOptions: GridOption = {
+  rowHeight: 40,
+  rowHeightProvider: (_grid, _row, item: { summary: string }) => {
+    const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
+    return Math.max(33, 8 + lineCount * 16);
+  },
+};
+```
+
+### Using Item Metadata Height Fallback
+```ts
+gridOptions: GridOption = {
+  rowHeight: 40,
+  dataView: {
+    globalItemMetadataProvider: {
+      getRowMetadata: (item: { notes: string }) => {
+        if (item.notes === 'Short note.') {
+          return { height: 33 };
+        }
+
+        const lineCount = Math.max(1, Math.ceil(item.notes.length / 55));
+        return { height: Math.max(40, 8 + lineCount * 18) };
+      },
+    },
+  },
+};
+```
+
+If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+
+### Runtime Updates
+After any change that impacts row height, call:
+
+```ts
+this.angularGrid?.slickGrid?.invalidateRowHeights?.();
+```

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -17,6 +17,11 @@ When `enableVariableRowHeight: true`, each row height is resolved in this order:
 The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
+Use `rowHeightProvider` when height is derived directly from row/item data.
+
+> **Important:** Defining a custom `rowHeightProvider` replaces SlickGrid's default provider.
+> The default provider reads `ItemMetadata.height`; once overridden, metadata height is no longer read unless your custom provider reads it explicitly.
+
 ```ts
 import { Column, GridOption } from 'angular-slickgrid';
 
@@ -31,6 +36,7 @@ gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Use metadata height when you already customize row metadata and prefer to keep row height logic there.
 Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -6,20 +6,22 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+By default, SlickGrid uses the grid option `rowHeight` for every row. Variable row height is opt-in and only active when `enableVariableRowHeight` is set to `true`.
 
 ### Height Resolution Order
-For each row, height resolution follows this order:
+When `enableVariableRowHeight: true`, each row height is resolved in this order:
 
 1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
-2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
-3. Grid option `rowHeight` (default fallback)
+2. Grid option `rowHeight` (default fallback)
+
+The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
 ```ts
 import { Column, GridOption } from 'angular-slickgrid';
 
 gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
   rowHeightProvider: (_grid, _row, item: { summary: string }) => {
     const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
@@ -29,15 +31,12 @@ gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
-Set `variableRowHeight: true` to activate variable height mode via metadata.
-
-> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
-> `rowHeightProvider` activates variable mode automatically.
+Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts
 gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
-  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {
@@ -53,7 +52,8 @@ gridOptions: GridOption = {
 };
 ```
 
-If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+If you supply a custom `rowHeightProvider`, it fully replaces the default provider behavior.
+When your custom provider returns `undefined`, the grid uses `rowHeight` for that row.
 
 ### Runtime Updates
 After any change that impacts row height, call:

--- a/frameworks/angular-slickgrid/src/demos/app-routing.module.ts
+++ b/frameworks/angular-slickgrid/src/demos/app-routing.module.ts
@@ -56,6 +56,8 @@ export const routes: Routes = [
   { path: 'example52', loadComponent: () => import('./examples/example52.component').then((m) => m.Example52Component) },
   { path: 'example53', loadComponent: () => import('./examples/example53.component').then((m) => m.Example53Component) },
   { path: 'example54', loadComponent: () => import('./examples/example54.component').then((m) => m.Example54Component) },
+  { path: 'example55', loadComponent: () => import('./examples/example55.component').then((m) => m.Example55Component) },
+  { path: 'example56', loadComponent: () => import('./examples/example56.component').then((m) => m.Example56Component) },
   { path: '', redirectTo: '/example34', pathMatch: 'full' },
   { path: '**', redirectTo: '/example34', pathMatch: 'full' },
 ];

--- a/frameworks/angular-slickgrid/src/demos/app.component.html
+++ b/frameworks/angular-slickgrid/src/demos/app.component.html
@@ -206,6 +206,12 @@
         <li class="nav-item">
           <a class="nav-link" routerLinkActive="active" [routerLink]="['/example54']">54- AI / Web MCP Toolkit</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" routerLinkActive="active" [routerLink]="['/example55']">55- Variable Row Height (Provider)</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" routerLinkActive="active" [routerLink]="['/example56']">56- Variable Row Height (Dynamic)</a>
+        </li>
       </ul>
     </section>
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.html
@@ -1,0 +1,34 @@
+<div id="demo-container" class="container-fluid">
+  <h2>
+    Example 55: Variable Row Height (Provider)
+    <span class="float-end">
+      <a
+        style="font-size: 18px"
+        target="_blank"
+        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts"
+      >
+        <span class="mdi mdi-link-variant"></span> code
+      </a>
+    </span>
+  </h2>
+
+  <div class="subtitle">Variable row heights driven by <code>rowHeightProvider</code>.</div>
+
+  <div class="row" style="margin-bottom: 6px">
+    <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" (click)="scrollToRow90()" data-test="scroll-row-90-example55">
+        <span class="mdi mdi-arrow-down"></span>
+        <span> Scroll To row 90</span>
+      </button>
+    </div>
+  </div>
+
+  <angular-slickgrid
+    gridId="grid55"
+    [columns]="columns"
+    [options]="gridOptions"
+    [dataset]="dataset"
+    (onAngularGridCreated)="angularGridReady($event.detail)"
+  >
+  </angular-slickgrid>
+</div>

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.scss
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.scss
@@ -1,0 +1,12 @@
+#slickGridContainer-grid55 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
+  line-height: 1.25;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.scss
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.scss
@@ -3,8 +3,6 @@
 }
 
 #slickGridContainer-grid55 .slickgrid-container .slick-cell.cell-wrap {
-  line-height: 1.25;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
@@ -1,0 +1,83 @@
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
+import { AngularSlickgridComponent, type AngularGridInstance, type Column, type GridOption } from '../../library';
+
+const NB_ITEMS = 200;
+
+interface StoryItem {
+  id: number;
+  title: string;
+  owner: string;
+  summary: string;
+  rowHeight: number;
+}
+
+@Component({
+  templateUrl: './example55.component.html',
+  styleUrls: ['example55.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  imports: [AngularSlickgridComponent],
+})
+export class Example55Component implements OnInit {
+  angularGrid?: AngularGridInstance;
+  columns: Column[] = [];
+  dataset: StoryItem[] = [];
+  gridOptions!: GridOption;
+
+  angularGridReady(angularGrid: AngularGridInstance) {
+    this.angularGrid = angularGrid;
+  }
+
+  ngOnInit(): void {
+    this.defineGrid();
+    this.dataset = this.getData(NB_ITEMS);
+  }
+
+  scrollToRow90() {
+    this.angularGrid?.slickGrid?.scrollRowToTop(90);
+  }
+
+  defineGrid() {
+    this.columns = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
+      { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
+    ];
+
+    this.gridOptions = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      gridHeight: 560,
+      gridWidth: 1080,
+      rowHeightProvider: (_grid, _row, item: StoryItem) => item.rowHeight,
+    };
+  }
+
+  getData(itemCount: number): StoryItem[] {
+    const owners = ['Alex', 'Priya', 'Mia', 'Sam', 'Chris'];
+    const fragments = [
+      'Refactor keyboard shortcut handling for better readability.',
+      'Adjust frozen rows when view-model updates after grouping.',
+      'Improve screen-reader labels on grid menu actions.',
+      'Align batch editor validation with backend constraints.',
+      'Capture edge-case around hidden columns and row-span.',
+    ];
+
+    const data: StoryItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      const lineCount = (i % 4) + 1;
+      const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
+      const wordCount = summary.trim().split(/\s+/).length;
+      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      data.push({
+        id: i,
+        title: `Story ${i}`,
+        owner: owners[i % owners.length],
+        summary,
+        rowHeight: wordCount < 10 ? 33 : computedRowHeight,
+      });
+    }
+    return data;
+  }
+}

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
@@ -70,7 +70,7 @@ export class Example55Component implements OnInit {
       const lineCount = (i % 4) + 1;
       const summary = Array.from({ length: lineCount }, (_, idx) => `${fragments[(i + idx) % fragments.length]}`).join(' ');
       const wordCount = summary.trim().split(/\s+/).length;
-      const computedRowHeight = Math.max(40, 8 + lineCount * 16);
+      const computedRowHeight = Math.max(45, 8 + lineCount * 16);
       data.push({
         id: i,
         title: `Story ${i}`,

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
@@ -41,6 +41,7 @@ export class Example55Component implements OnInit {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
+      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
@@ -48,6 +48,7 @@ export class Example55Component implements OnInit {
     this.gridOptions = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       gridHeight: 560,
       gridWidth: 1080,

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.html
@@ -1,0 +1,41 @@
+<div id="demo-container" class="container-fluid">
+  <h2>
+    Example 56: Variable Row Height (Dynamic)
+    <span class="float-end">
+      <a
+        style="font-size: 18px"
+        target="_blank"
+        href="https://github.com/ghiscoding/slickgrid-universal/blob/master/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts"
+      >
+        <span class="mdi mdi-link-variant"></span> code
+      </a>
+    </span>
+  </h2>
+
+  <div class="subtitle">
+    Variable row heights via <code>ItemMetadata.height</code> fallback, with compact mode rebuilding heights through
+    <code>invalidateRowHeights()</code>.
+  </div>
+
+  <div class="row" style="margin-bottom: 6px">
+    <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" (click)="toggleDensity()" data-test="toggle-density">
+        <span class="mdi mdi-flip-vertical"></span>
+        <span> Toggle Compact Density</span>
+      </button>
+      <button class="btn btn-outline-secondary btn-sm ms-2 btn-icon" (click)="scrollToRow90()" data-test="scroll-row-90-example56">
+        <span class="mdi mdi-arrow-down"></span>
+        <span> Scroll To row 90</span>
+      </button>
+    </div>
+  </div>
+
+  <angular-slickgrid
+    gridId="grid56"
+    [columns]="columns"
+    [options]="gridOptions"
+    [dataset]="dataset"
+    (onAngularGridCreated)="angularGridReady($event.detail)"
+  >
+  </angular-slickgrid>
+</div>

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.scss
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.scss
@@ -3,9 +3,6 @@
 }
 
 #slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
-  font-size: 14px;
-  line-height: 1.35;
-  padding: 4px 6px;
   white-space: normal;
   text-overflow: clip;
   overflow: hidden;

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.scss
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.scss
@@ -1,0 +1,13 @@
+#slickGridContainer-grid56 {
+  --slick-cell-border-left: 1px solid #dedede;
+}
+
+#slickGridContainer-grid56 .slickgrid-container .slick-cell.cell-wrap {
+  font-size: 14px;
+  line-height: 1.35;
+  padding: 4px 6px;
+  white-space: normal;
+  text-overflow: clip;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
@@ -46,6 +46,16 @@ export class Example56Component implements OnInit {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
       { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
+          return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
+        },
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
     ];
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
@@ -1,0 +1,103 @@
+import { Component, ViewEncapsulation, type OnInit } from '@angular/core';
+import { AngularSlickgridComponent, type AngularGridInstance, type Column, type GridOption } from '../../library';
+
+const NB_ITEMS = 150;
+
+interface TaskItem {
+  id: number;
+  title: string;
+  status: 'Todo' | 'In Progress' | 'Done';
+  notes: string;
+}
+
+@Component({
+  templateUrl: './example56.component.html',
+  styleUrls: ['example56.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  imports: [AngularSlickgridComponent],
+})
+export class Example56Component implements OnInit {
+  angularGrid?: AngularGridInstance;
+  columns: Column[] = [];
+  dataset: TaskItem[] = [];
+  gridOptions!: GridOption;
+  isCompact = false;
+
+  angularGridReady(angularGrid: AngularGridInstance) {
+    this.angularGrid = angularGrid;
+  }
+
+  ngOnInit(): void {
+    this.defineGrid();
+    this.dataset = this.getData(NB_ITEMS);
+  }
+
+  toggleDensity() {
+    this.isCompact = !this.isCompact;
+    this.angularGrid?.slickGrid?.invalidateRowHeights?.();
+  }
+
+  scrollToRow90() {
+    this.angularGrid?.slickGrid?.scrollRowToTop(90);
+  }
+
+  defineGrid() {
+    this.columns = [
+      { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
+      { id: 'title', name: 'Task', field: 'title', minWidth: 180, width: 220 },
+      { id: 'status', name: 'Status', field: 'status', minWidth: 120, width: 140 },
+      { id: 'notes', name: 'Notes', field: 'notes', cssClass: 'cell-wrap', width: 420, maxWidth: 520 },
+    ];
+
+    this.gridOptions = {
+      enableCellNavigation: true,
+      enableTextSelectionOnCells: true,
+      rowHeight: 40,
+      frozenRow: 2,
+      gridHeight: 560,
+      gridWidth: 1080,
+      dataView: {
+        globalItemMetadataProvider: {
+          getRowMetadata: (item: TaskItem) => {
+            if (item.notes === 'Short note.') {
+              return { height: this.isCompact ? 40 : 33 };
+            }
+
+            const lineCount = this.getEstimatedLineCount(item.notes);
+            const verticalPadding = 8;
+            const lineHeight = this.isCompact ? 21 : 18;
+            const minRowHeight = this.isCompact ? 46 : 40;
+            const baseHeight = Math.max(minRowHeight, verticalPadding + lineCount * lineHeight);
+
+            return { height: baseHeight };
+          },
+        },
+      },
+    };
+  }
+
+  private getEstimatedLineCount(text: string): number {
+    return Math.max(1, Math.ceil(text.length / 55));
+  }
+
+  private getData(itemCount: number): TaskItem[] {
+    const statuses: Array<TaskItem['status']> = ['Todo', 'In Progress', 'Done'];
+    const notesPool = [
+      'Short note.',
+      'Need to validate keyboard navigation and ensure screen reader output remains stable across frozen panes.',
+      'Review row height invalidation path when data changes quickly due to live updates from backend polling.',
+      'Longer QA note: validate scrolling behavior at top and bottom boundaries, compare rendered range against expected rows, and confirm no visual clipping for wrapped cells.',
+    ];
+
+    const data: TaskItem[] = [];
+    for (let i = 0; i < itemCount; i++) {
+      data.push({
+        id: i,
+        title: `Task ${i}`,
+        status: statuses[i % statuses.length],
+        notes: notesPool[i % notesPool.length],
+      });
+    }
+    return data;
+  }
+}

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
@@ -62,6 +62,7 @@ export class Example56Component implements OnInit {
     this.gridOptions = {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
+      enableVariableRowHeight: true,
       rowHeight: 40,
       frozenRow: 2,
       gridHeight: 560,

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
@@ -1,6 +1,6 @@
 describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   const hOf = (r: number) => {
-    const cycle = [33, 40, 56, 72];
+    const cycle = [33, 45, 56, 72];
     return cycle[r % cycle.length];
   };
   const topOf = (r: number) => {
@@ -16,8 +16,8 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
   });
 
-  it('should render looping row heights (33, 40, 56, 72)', () => {
-    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+  it('should render looping row heights (33, 45, 56, 72)', () => {
+    const expectedHeights = [33, 45, 56, 72, 33, 45, 56, 72];
     const defaultRowHeight = 40;
 
     for (const [row, expectedHeight] of expectedHeights.entries()) {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
@@ -20,17 +20,18 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
     const defaultRowHeight = 40;
 
-    for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`.slick-row[data-row=${r}]`)
+    for (const [row, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`.slick-row[data-row=${row}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
-          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          expect(style).to.contain(`transform: translateY(${topOf(row)}px)`);
           if (expectedHeight === defaultRowHeight) {
             expect(style).not.to.contain('height:');
           } else {
             expect(style).to.contain(`height: ${expectedHeight}px`);
           }
         });
+      cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
     }
   });
 

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
@@ -21,7 +21,7 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const defaultRowHeight = 40;
 
     for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+      cy.get(`.slick-row[data-row=${r}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
           expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
@@ -37,12 +37,12 @@ describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
   it('should keep row 90 aligned at top after clicking scroll button', () => {
     cy.get('[data-test="scroll-row-90-example55"]').click();
 
-    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+    cy.get('.slick-viewport-top.slick-viewport-left')
       .invoke('scrollTop')
       .then((scrollTop) => {
         expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
       });
 
-    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example55.cy.ts
@@ -1,0 +1,48 @@
+describe('Example 55 - Variable Row Height (Provider)', { retries: 1 }, () => {
+  const hOf = (r: number) => {
+    const cycle = [33, 40, 56, 72];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example55`);
+    cy.get('h2').should('contain', 'Example 55: Variable Row Height (Provider)');
+  });
+
+  it('should render looping row heights (33, 40, 56, 72)', () => {
+    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+    const defaultRowHeight = 40;
+
+    for (const [r, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`#slickGridContainer-grid55 .slick-row[data-row=${r}]`)
+        .invoke('attr', 'style')
+        .then((style = '') => {
+          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          if (expectedHeight === defaultRowHeight) {
+            expect(style).not.to.contain('height:');
+          } else {
+            expect(style).to.contain(`height: ${expectedHeight}px`);
+          }
+        });
+    }
+  });
+
+  it('should keep row 90 aligned at top after clicking scroll button', () => {
+    cy.get('[data-test="scroll-row-90-example55"]').click();
+
+    cy.get('#slickGridContainer-grid55 .slick-viewport-top.slick-viewport-left')
+      .invoke('scrollTop')
+      .then((scrollTop) => {
+        expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
+      });
+
+    cy.get('#slickGridContainer-grid55 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example56.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example56.cy.ts
@@ -1,0 +1,101 @@
+describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
+  const BASE_ROW_HEIGHT = 40;
+  const FROZEN_ROW_COUNT = 2;
+
+  const hDefault = (r: number) => {
+    const cycle = [33, 44, 44, 80];
+    return cycle[r % cycle.length];
+  };
+  const hCompact = (r: number) => {
+    const cycle = [40, 50, 50, 92];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number, hOf: (row: number) => number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  const frozenTopHeight = (hOf: (row: number) => number) => topOf(FROZEN_ROW_COUNT, hOf);
+
+  const relativeTopInCanvas = (r: number, hOf: (row: number) => number) => {
+    if (r < FROZEN_ROW_COUNT) {
+      return topOf(r, hOf);
+    }
+    return topOf(r, hOf) - frozenTopHeight(hOf);
+  };
+
+  const canvasSelector = (r: number) =>
+    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+
+  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(r);
+    const expectedTop = relativeTopInCanvas(r, hOf);
+
+    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+      .should('have.attr', 'style')
+      .and('contain', `transform: translateY(${expectedTop}px)`)
+      .then((style) => {
+        if (expectedHeight !== BASE_ROW_HEIGHT) {
+          expect(style).to.contain(`height: ${expectedHeight}px`);
+        } else {
+          expect(style).not.to.contain('height:');
+        }
+      });
+  };
+
+  const ensureDefaultDensity = () => {
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .invoke('attr', 'style')
+      .then((style) => {
+        if ((style ?? '').includes('height: 50px')) {
+          cy.get('[data-test="toggle-density"]').click();
+        }
+      });
+
+    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+      .should('have.attr', 'style')
+      .and('contain', 'height: 44px');
+  };
+
+  beforeEach(() => {
+    cy.visit(`${Cypress.config('baseUrl')}/example56`);
+    ensureDefaultDensity();
+  });
+
+  it('should display Example title', () => {
+    cy.get('h2').should('contain', 'Example 56: Variable Row Height (Dynamic)');
+  });
+
+  it('should render frozen and scrollable rows with expected transform and row heights from metadata fallback', () => {
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hDefault);
+    }
+  });
+
+  it('should increase row heights and row positions after toggling density', () => {
+    assertRowStyle(10, hDefault);
+
+    cy.get('[data-test="toggle-density"]').click();
+
+    assertRowStyle(10, hCompact);
+
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hCompact);
+    }
+  });
+
+  it('should scroll row 90 to top of scrollable pane with frozen top rows', () => {
+    const expectedScrollTop = topOf(90, hDefault) - frozenTopHeight(hDefault);
+
+    cy.get('[data-test="scroll-row-90-example56"]').click();
+
+    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+      expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
+    });
+
+    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example56.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example56.cy.ts
@@ -29,11 +29,11 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
   const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
-  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
-    const expectedHeight = hOf(r);
-    const expectedTop = relativeTopInCanvas(r, hOf);
+  const assertRowStyle = (row: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(row);
+    const expectedTop = relativeTopInCanvas(row, hOf);
 
-    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+    cy.get(`${canvasSelector(row)} .slick-row[data-row=${row}]`)
       .should('have.attr', 'style')
       .and('contain', `transform: translateY(${expectedTop}px)`)
       .then((style) => {
@@ -43,6 +43,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
           expect(style).not.to.contain('height:');
         }
       });
+    cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
   };
 
   const ensureDefaultDensity = () => {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example56.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example56.cy.ts
@@ -27,8 +27,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
     return topOf(r, hOf) - frozenTopHeight(hOf);
   };
 
-  const canvasSelector = (r: number) =>
-    r < FROZEN_ROW_COUNT ? '#slickGridContainer-grid56 .grid-canvas-top' : '#slickGridContainer-grid56 .grid-canvas-bottom';
+  const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid-canvas-top' : '.grid-canvas-bottom');
 
   const assertRowStyle = (r: number, hOf: (row: number) => number) => {
     const expectedHeight = hOf(r);
@@ -47,7 +46,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
   };
 
   const ensureDefaultDensity = () => {
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
+    cy.get('.grid-canvas-top .slick-row[data-row=1]')
       .invoke('attr', 'style')
       .then((style) => {
         if ((style ?? '').includes('height: 50px')) {
@@ -55,9 +54,7 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
         }
       });
 
-    cy.get('#slickGridContainer-grid56 .grid-canvas-top .slick-row[data-row=1]')
-      .should('have.attr', 'style')
-      .and('contain', 'height: 44px');
+    cy.get('.grid-canvas-top .slick-row[data-row=1]').should('have.attr', 'style').and('contain', 'height: 44px');
   };
 
   beforeEach(() => {
@@ -92,10 +89,10 @@ describe('Example 56 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
     cy.get('[data-test="scroll-row-90-example56"]').click();
 
-    cy.get('#slickGridContainer-grid56 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+    cy.get('.slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
       expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
     });
 
-    cy.get('#slickGridContainer-grid56 .slick-row[data-row=90]').should('exist');
+    cy.get('.slick-row[data-row=90]').should('exist');
   });
 });

--- a/frameworks/aurelia-slickgrid/docs/TOC.md
+++ b/frameworks/aurelia-slickgrid/docs/TOC.md
@@ -74,6 +74,7 @@
 * [Header Menu & Header Buttons](grid-functionalities/header-menu-header-buttons.md)
 * [Infinite Scroll](grid-functionalities/infinite-scroll.md)
 * [Pinning (frozen) of Columns/Rows](grid-functionalities/frozen-columns-rows.md)
+* [Variable Row Height](grid-functionalities/variable-row-height.md)
 * [Providing data to the grid](grid-functionalities/providing-grid-data.md)
 * [Row Detail](grid-functionalities/row-detail.md)
 * [Row Move (dragging)](grid-functionalities/row-move.md)

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -31,9 +31,15 @@ gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Set `variableRowHeight: true` to activate variable height mode via metadata.
+
+> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
+> `rowHeightProvider` activates variable mode automatically.
+
 ```ts
 gridOptions: GridOption = {
   rowHeight: 40,
+  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -1,0 +1,59 @@
+#### Index
+- [Introduction](#introduction)
+- [Height Resolution Order](#height-resolution-order)
+- [Using rowHeightProvider](#using-rowheightprovider)
+- [Using Item Metadata Height Fallback](#using-item-metadata-height-fallback)
+- [Runtime Updates](#runtime-updates)
+
+### Introduction
+By default, SlickGrid uses the grid option `rowHeight` for every row.
+
+Use variable row height to size rows from content while keeping virtualization and frozen panes synchronized.
+
+### Height Resolution Order
+For each row, height resolution follows this order:
+
+1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
+2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
+3. Grid option `rowHeight` (default fallback)
+
+### Using rowHeightProvider
+```ts
+import type { GridOption } from 'aurelia-slickgrid';
+
+gridOptions: GridOption = {
+  rowHeight: 40,
+  rowHeightProvider: (_grid, _row, item: { summary: string }) => {
+    const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
+    return Math.max(33, 8 + lineCount * 16);
+  },
+};
+```
+
+### Using Item Metadata Height Fallback
+```ts
+gridOptions: GridOption = {
+  rowHeight: 40,
+  dataView: {
+    globalItemMetadataProvider: {
+      getRowMetadata: (item: { notes: string }) => {
+        if (item.notes === 'Short note.') {
+          return { height: 33 };
+        }
+
+        const lineCount = Math.max(1, Math.ceil(item.notes.length / 55));
+        return { height: Math.max(40, 8 + lineCount * 18) };
+      },
+    },
+  },
+};
+```
+
+If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+
+### Runtime Updates
+After any change that impacts row height, call:
+
+```ts
+this.aureliaGrid?.slickGrid?.invalidateRowHeights?.();
+```

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -6,9 +6,7 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row.
-
-Use variable row height to size rows from content while keeping virtualization and frozen panes synchronized.
+By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
 
 ### Height Resolution Order
 For each row, height resolution follows this order:

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -17,6 +17,11 @@ When `enableVariableRowHeight: true`, each row height is resolved in this order:
 The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
+Use `rowHeightProvider` when height is derived directly from row/item data.
+
+> **Important:** Defining a custom `rowHeightProvider` replaces SlickGrid's default provider.
+> The default provider reads `ItemMetadata.height`; once overridden, metadata height is no longer read unless your custom provider reads it explicitly.
+
 ```ts
 import type { GridOption } from 'aurelia-slickgrid';
 
@@ -31,6 +36,7 @@ gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Use metadata height when you already customize row metadata and prefer to keep row height logic there.
 Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/variable-row-height.md
@@ -6,20 +6,22 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+By default, SlickGrid uses the grid option `rowHeight` for every row. Variable row height is opt-in and only active when `enableVariableRowHeight` is set to `true`.
 
 ### Height Resolution Order
-For each row, height resolution follows this order:
+When `enableVariableRowHeight: true`, each row height is resolved in this order:
 
 1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
-2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
-3. Grid option `rowHeight` (default fallback)
+2. Grid option `rowHeight` (default fallback)
+
+The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
 ```ts
 import type { GridOption } from 'aurelia-slickgrid';
 
 gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
   rowHeightProvider: (_grid, _row, item: { summary: string }) => {
     const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
@@ -29,15 +31,12 @@ gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
-Set `variableRowHeight: true` to activate variable height mode via metadata.
-
-> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
-> `rowHeightProvider` activates variable mode automatically.
+Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts
 gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
-  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {
@@ -53,7 +52,8 @@ gridOptions: GridOption = {
 };
 ```
 
-If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+If you supply a custom `rowHeightProvider`, it fully replaces the default provider behavior.
+When your custom provider returns `undefined`, the grid uses `rowHeight` for that row.
 
 ### Runtime Updates
 After any change that impacts row height, call:

--- a/frameworks/slickgrid-react/docs/TOC.md
+++ b/frameworks/slickgrid-react/docs/TOC.md
@@ -74,6 +74,7 @@
 * [Header Menu & Header Buttons](grid-functionalities/header-menu-header-buttons.md)
 * [Infinite Scroll](grid-functionalities/infinite-scroll.md)
 * [Pinning (frozen) of Columns/Rows](grid-functionalities/frozen-columns-rows.md)
+* [Variable Row Height](grid-functionalities/variable-row-height.md)
 * [Providing data to the grid](grid-functionalities/providing-grid-data.md)
 * [Row Detail](grid-functionalities/row-detail.md)
 * [Row Move (dragging)](grid-functionalities/row-move.md)

--- a/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
@@ -6,9 +6,7 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row.
-
-Use variable row height when row content needs dynamic sizing while preserving virtualization and frozen panes behavior.
+By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
 
 ### Height Resolution Order
 For each row, height resolution follows this order:

--- a/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
@@ -31,9 +31,15 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Set `variableRowHeight: true` to activate variable height mode via metadata.
+
+> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
+> `rowHeightProvider` activates variable mode automatically.
+
 ```tsx
 const gridOptions: GridOption = {
   rowHeight: 40,
+  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {

--- a/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
@@ -1,0 +1,59 @@
+#### Index
+- [Introduction](#introduction)
+- [Height Resolution Order](#height-resolution-order)
+- [Using rowHeightProvider](#using-rowheightprovider)
+- [Using Item Metadata Height Fallback](#using-item-metadata-height-fallback)
+- [Runtime Updates](#runtime-updates)
+
+### Introduction
+By default, SlickGrid uses the grid option `rowHeight` for every row.
+
+Use variable row height when row content needs dynamic sizing while preserving virtualization and frozen panes behavior.
+
+### Height Resolution Order
+For each row, height resolution follows this order:
+
+1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
+2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
+3. Grid option `rowHeight` (default fallback)
+
+### Using rowHeightProvider
+```tsx
+import type { GridOption } from '@slickgrid-universal/common';
+
+const gridOptions: GridOption = {
+  rowHeight: 40,
+  rowHeightProvider: (_grid, _row, item: { summary: string }) => {
+    const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
+    return Math.max(33, 8 + lineCount * 16);
+  },
+};
+```
+
+### Using Item Metadata Height Fallback
+```tsx
+const gridOptions: GridOption = {
+  rowHeight: 40,
+  dataView: {
+    globalItemMetadataProvider: {
+      getRowMetadata: (item: { notes: string }) => {
+        if (item.notes === 'Short note.') {
+          return { height: 33 };
+        }
+
+        const lineCount = Math.max(1, Math.ceil(item.notes.length / 55));
+        return { height: Math.max(40, 8 + lineCount * 18) };
+      },
+    },
+  },
+};
+```
+
+If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+
+### Runtime Updates
+After any change that impacts row height, call:
+
+```tsx
+reactGridRef.current?.slickGrid?.invalidateRowHeights?.();
+```

--- a/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
@@ -6,20 +6,22 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+By default, SlickGrid uses the grid option `rowHeight` for every row. Variable row height is opt-in and only active when `enableVariableRowHeight` is set to `true`.
 
 ### Height Resolution Order
-For each row, height resolution follows this order:
+When `enableVariableRowHeight: true`, each row height is resolved in this order:
 
 1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
-2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
-3. Grid option `rowHeight` (default fallback)
+2. Grid option `rowHeight` (default fallback)
+
+The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
 ```tsx
 import type { GridOption } from '@slickgrid-universal/common';
 
 const gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
   rowHeightProvider: (_grid, _row, item: { summary: string }) => {
     const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
@@ -29,15 +31,12 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
-Set `variableRowHeight: true` to activate variable height mode via metadata.
-
-> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
-> `rowHeightProvider` activates variable mode automatically.
+Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```tsx
 const gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
-  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {
@@ -53,7 +52,8 @@ const gridOptions: GridOption = {
 };
 ```
 
-If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+If you supply a custom `rowHeightProvider`, it fully replaces the default provider behavior.
+When your custom provider returns `undefined`, the grid uses `rowHeight` for that row.
 
 ### Runtime Updates
 After any change that impacts row height, call:

--- a/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/variable-row-height.md
@@ -17,6 +17,11 @@ When `enableVariableRowHeight: true`, each row height is resolved in this order:
 The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
+Use `rowHeightProvider` when height is derived directly from row/item data.
+
+> **Important:** Defining a custom `rowHeightProvider` replaces SlickGrid's default provider.
+> The default provider reads `ItemMetadata.height`; once overridden, metadata height is no longer read unless your custom provider reads it explicitly.
+
 ```tsx
 import type { GridOption } from '@slickgrid-universal/common';
 
@@ -31,6 +36,7 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Use metadata height when you already customize row metadata and prefer to keep row height logic there.
 Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```tsx

--- a/frameworks/slickgrid-vue/docs/TOC.md
+++ b/frameworks/slickgrid-vue/docs/TOC.md
@@ -74,6 +74,7 @@
 * [Custom Menu Slots](grid-functionalities/menu-slots.md)
 * [Infinite Scroll](grid-functionalities/infinite-scroll.md)
 * [Pinning (frozen) of Columns/Rows](grid-functionalities/frozen-columns-rows.md)
+* [Variable Row Height](grid-functionalities/variable-row-height.md)
 * [Providing data to the grid](grid-functionalities/providing-grid-data.md)
 * [Row Detail](grid-functionalities/row-detail.md)
 * [Row Move (dragging)](grid-functionalities/row-move.md)

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
@@ -6,9 +6,7 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row.
-
-Use variable row height when rows need content-based heights while preserving virtual scrolling and frozen-pane behavior.
+By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
 
 ### Height Resolution Order
 For each row, height resolution follows this order:

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
@@ -31,9 +31,15 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Set `variableRowHeight: true` to activate variable height mode via metadata.
+
+> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
+> `rowHeightProvider` activates variable mode automatically.
+
 ```ts
 const gridOptions: GridOption = {
   rowHeight: 40,
+  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
@@ -1,0 +1,59 @@
+#### Index
+- [Introduction](#introduction)
+- [Height Resolution Order](#height-resolution-order)
+- [Using rowHeightProvider](#using-rowheightprovider)
+- [Using Item Metadata Height Fallback](#using-item-metadata-height-fallback)
+- [Runtime Updates](#runtime-updates)
+
+### Introduction
+By default, SlickGrid uses the grid option `rowHeight` for every row.
+
+Use variable row height when rows need content-based heights while preserving virtual scrolling and frozen-pane behavior.
+
+### Height Resolution Order
+For each row, height resolution follows this order:
+
+1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
+2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
+3. Grid option `rowHeight` (default fallback)
+
+### Using rowHeightProvider
+```ts
+import type { GridOption } from 'slickgrid-vue';
+
+const gridOptions: GridOption = {
+  rowHeight: 40,
+  rowHeightProvider: (_grid, _row, item: { summary: string }) => {
+    const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
+    return Math.max(33, 8 + lineCount * 16);
+  },
+};
+```
+
+### Using Item Metadata Height Fallback
+```ts
+const gridOptions: GridOption = {
+  rowHeight: 40,
+  dataView: {
+    globalItemMetadataProvider: {
+      getRowMetadata: (item: { notes: string }) => {
+        if (item.notes === 'Short note.') {
+          return { height: 33 };
+        }
+
+        const lineCount = Math.max(1, Math.ceil(item.notes.length / 55));
+        return { height: Math.max(40, 8 + lineCount * 18) };
+      },
+    },
+  },
+};
+```
+
+If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+
+### Runtime Updates
+After any change that impacts row height, call:
+
+```ts
+vueGrid.slickGrid?.invalidateRowHeights?.();
+```

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
@@ -6,20 +6,22 @@
 - [Runtime Updates](#runtime-updates)
 
 ### Introduction
-By default, SlickGrid uses the grid option `rowHeight` for every row. When variable row height is in play (via `rowHeightProvider` or `ItemMetadata.height` detection), each row can resolve to a different height while preserving virtual scrolling and frozen panes.
+By default, SlickGrid uses the grid option `rowHeight` for every row. Variable row height is opt-in and only active when `enableVariableRowHeight` is set to `true`.
 
 ### Height Resolution Order
-For each row, height resolution follows this order:
+When `enableVariableRowHeight: true`, each row height is resolved in this order:
 
 1. `rowHeightProvider(grid, row, item)` return value (when defined and when it returns a number)
-2. `ItemMetadata.height` from `dataView.globalItemMetadataProvider.getRowMetadata(item, row)`
-3. Grid option `rowHeight` (default fallback)
+2. Grid option `rowHeight` (default fallback)
+
+The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
 ```ts
 import type { GridOption } from 'slickgrid-vue';
 
 const gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
   rowHeightProvider: (_grid, _row, item: { summary: string }) => {
     const lineCount = Math.max(1, Math.ceil(item.summary.length / 55));
@@ -29,15 +31,12 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
-Set `variableRowHeight: true` to activate variable height mode via metadata.
-
-> **Note:** Only needed when using `ItemMetadata.height` without a `rowHeightProvider`.
-> `rowHeightProvider` activates variable mode automatically.
+Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts
 const gridOptions: GridOption = {
+  enableVariableRowHeight: true,
   rowHeight: 40,
-  variableRowHeight: true, // required when using metadata height without a rowHeightProvider
   dataView: {
     globalItemMetadataProvider: {
       getRowMetadata: (item: { notes: string }) => {
@@ -53,7 +52,8 @@ const gridOptions: GridOption = {
 };
 ```
 
-If `rowHeightProvider` is omitted (or returns `undefined` for a row), `ItemMetadata.height` is used as fallback.
+If you supply a custom `rowHeightProvider`, it fully replaces the default provider behavior.
+When your custom provider returns `undefined`, the grid uses `rowHeight` for that row.
 
 ### Runtime Updates
 After any change that impacts row height, call:

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/variable-row-height.md
@@ -17,6 +17,11 @@ When `enableVariableRowHeight: true`, each row height is resolved in this order:
 The default `rowHeightProvider` reads `ItemMetadata.height` from `getRowMetadata`, so metadata-only setups work without defining your own provider.
 
 ### Using rowHeightProvider
+Use `rowHeightProvider` when height is derived directly from row/item data.
+
+> **Important:** Defining a custom `rowHeightProvider` replaces SlickGrid's default provider.
+> The default provider reads `ItemMetadata.height`; once overridden, metadata height is no longer read unless your custom provider reads it explicitly.
+
 ```ts
 import type { GridOption } from 'slickgrid-vue';
 
@@ -31,6 +36,7 @@ const gridOptions: GridOption = {
 ```
 
 ### Using Item Metadata Height Fallback
+Use metadata height when you already customize row metadata and prefer to keep row height logic there.
 Set `enableVariableRowHeight: true` and rely on the default `rowHeightProvider`.
 
 ```ts

--- a/packages/common/src/core/__tests__/slickCore.spec.ts
+++ b/packages/common/src/core/__tests__/slickCore.spec.ts
@@ -2,6 +2,7 @@ import { type BasePubSubService } from '@slickgrid-universal/event-pub-sub';
 import { describe, expect, it, vi } from 'vitest';
 import type { EditController } from '../../interfaces/editController.interface.js';
 import {
+  RowPositionIndexer,
   SlickCopyRange,
   SlickEditorLock,
   SlickEvent,
@@ -394,6 +395,48 @@ describe('SlickCore file', () => {
 
       groupTotals.initialized = true;
       expect(groupTotals.initialized).toBeTruthy();
+    });
+  });
+
+  describe('RowPositionIndexer class', () => {
+    it('should build row top positions and row heights from callback values', () => {
+      const indexer = new RowPositionIndexer();
+      indexer.rebuild(3, 25, (row) => [25, 40, 30][row]);
+
+      expect(indexer.count).toBe(3);
+      expect(indexer.top(0)).toBe(0);
+      expect(indexer.top(1)).toBe(25);
+      expect(indexer.top(2)).toBe(65);
+      expect(indexer.height(0)).toBe(25);
+      expect(indexer.height(1)).toBe(40);
+      expect(indexer.height(2)).toBe(30);
+    });
+
+    it('should fallback to default row height for undefined callback values and for extrapolated rows', () => {
+      const indexer = new RowPositionIndexer();
+      indexer.rebuild(2, 20, (row) => (row === 0 ? 35 : undefined));
+
+      expect(indexer.height(0)).toBe(35);
+      expect(indexer.height(1)).toBe(20);
+      expect(indexer.top(2)).toBe(55);
+      expect(indexer.height(2)).toBe(20);
+      expect(indexer.top(3)).toBe(75);
+    });
+
+    it('should map vertical positions to row indexes for in-range and extrapolated positions', () => {
+      const indexer = new RowPositionIndexer();
+      indexer.rebuild(3, 25, (row) => [25, 40, 30][row]); // tops: 0, 25, 65, total: 95
+
+      expect(indexer.rowAt(-3)).toBe(0);
+      expect(indexer.rowAt(0)).toBe(0);
+      expect(indexer.rowAt(24)).toBe(0);
+      expect(indexer.rowAt(25)).toBe(1);
+      expect(indexer.rowAt(64)).toBe(1);
+      expect(indexer.rowAt(65)).toBe(2);
+      expect(indexer.rowAt(94)).toBe(2);
+      expect(indexer.rowAt(95)).toBe(3);
+      expect(indexer.rowAt(119)).toBe(3);
+      expect(indexer.rowAt(120)).toBe(4);
     });
   });
 

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2576,6 +2576,22 @@ describe('SlickGrid core file', () => {
 
         expect(grid.getFrozenRowOffset(2)).toBe(DEFAULT_COLUMN_HEIGHT * 2);
       });
+
+      it('should return frozen-bottom offset based on computed row positions in variable row height mode', () => {
+        const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
+        const data = [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
+        const rowHeights = [20, 35, 40, 45];
+        grid = new SlickGrid<any, Column>(container, data, columns, {
+          ...defaultOptions,
+          rowHeight: 20,
+          frozenBottom: true,
+          frozenRow: 2,
+          rowHeightProvider: (_grid, row) => rowHeights[row],
+        });
+
+        // actualFrozenRow is 2 (4 - 2), so the offset uses top position of row 2: 20 + 35 = 55
+        expect(grid.getFrozenRowOffset(2)).toBe(55);
+      });
     });
   });
 
@@ -5856,6 +5872,47 @@ describe('SlickGrid core file', () => {
       expect(renderSpy).toHaveBeenCalled();
     });
 
+    it('should scroll to computed row position when calling scrollRowToTop() in variable row height mode', () => {
+      const rowHeights = [25, 40, 30];
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        rowHeight: 25,
+        rowHeightProvider: (_grid, row) => rowHeights[row],
+      });
+      const scrollToSpy = vi.spyOn(grid, 'scrollTo');
+      const renderSpy = vi.spyOn(grid, 'render');
+
+      grid.scrollRowToTop(2);
+
+      // top of row 2 is 25 + 40
+      expect(scrollToSpy).toHaveBeenCalledWith(65);
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
+    it('should scroll to computed row position minus frozen top rows height in variable row height mode', () => {
+      const rowHeights = [20, 30, 40, 50];
+      const variableData = [
+        { id: 0, firstName: 'A', lastName: 'A', age: 1 },
+        { id: 1, firstName: 'B', lastName: 'B', age: 2 },
+        { id: 2, firstName: 'C', lastName: 'C', age: 3 },
+        { id: 3, firstName: 'D', lastName: 'D', age: 4 },
+      ];
+      grid = new SlickGrid<any, Column>(container, variableData, columns, {
+        ...defaultOptions,
+        frozenRow: 2,
+        rowHeight: 25,
+        rowHeightProvider: (_grid, row) => rowHeights[row],
+      });
+      const scrollToSpy = vi.spyOn(grid, 'scrollTo');
+      const renderSpy = vi.spyOn(grid, 'render');
+
+      grid.scrollRowToTop(3);
+
+      // top of row 3 is 20 + 30 + 40 = 90; frozen top rows height is 20 + 30 = 50; scroll target is 40
+      expect(scrollToSpy).toHaveBeenCalledWith(40);
+      expect(renderSpy).toHaveBeenCalled();
+    });
+
     it('should do page up when calling scrollRowIntoView() and we are further than row index that we want to scroll to', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, frozenRow: 0 });
       const scrollToSpy = vi.spyOn(grid, 'scrollTo');
@@ -5867,6 +5924,99 @@ describe('SlickGrid core file', () => {
 
       expect(scrollToSpy).toHaveBeenCalledWith(2 * DEFAULT_COLUMN_HEIGHT); // default rowHeight: 25
       expect(renderSpy).toHaveBeenCalled();
+    });
+
+    it('should render inline row height and rebuild index when row heights are invalidated', () => {
+      const oneColumn = [{ id: 'firstName', field: 'firstName', name: 'First Name', sortable: true }] as Column[];
+      const providerHeights = [25, 40];
+      const rowHeightProvider = vi.fn((_grid: SlickGrid, row: number) => providerHeights[row]);
+      grid = new SlickGrid<any, Column>(
+        container,
+        [
+          { id: 0, firstName: 'John' },
+          { id: 1, firstName: 'Jane' },
+        ],
+        oneColumn,
+        {
+          ...defaultOptions,
+          rowHeight: 25,
+          rowHeightProvider,
+        }
+      );
+
+      expect(grid.getRowHeight(0)).toBe(25);
+      expect(grid.getRowHeight(1)).toBe(40);
+
+      const row0 = container.querySelector('.slick-row[data-row="0"]') as HTMLDivElement;
+      const row1 = container.querySelector('.slick-row[data-row="1"]') as HTMLDivElement;
+      expect(row0.style.height).toBe('');
+      expect(row1.style.height).toBe('40px');
+
+      rowHeightProvider.mockClear();
+      providerHeights[1] = 70;
+      const invalidateSpy = vi.spyOn(grid, 'invalidate');
+      grid.invalidateRowHeights();
+      grid.updateRowCount();
+
+      expect(invalidateSpy).toHaveBeenCalled();
+      expect(rowHeightProvider).toHaveBeenCalled();
+      expect(grid.getRowHeight(1)).toBe(70);
+    });
+
+    it('should rebuild row height index when rowHeightProvider is changed via setOptions()', () => {
+      const providerA = vi.fn((_grid: SlickGrid, row: number) => [25, 40][row]);
+      const providerB = vi.fn((_grid: SlickGrid, row: number) => [25, 80][row]);
+      grid = new SlickGrid<any, Column>(
+        container,
+        [
+          { id: 0, firstName: 'John' },
+          { id: 1, firstName: 'Jane' },
+        ],
+        [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[],
+        {
+          ...defaultOptions,
+          rowHeight: 25,
+          rowHeightProvider: providerA,
+        }
+      );
+
+      expect(grid.getRowHeight(1)).toBe(40);
+
+      providerB.mockClear();
+      grid.setOptions({ rowHeightProvider: providerB });
+      grid.updateRowCount();
+
+      expect(providerB).toHaveBeenCalled();
+      expect(grid.getRowHeight(1)).toBe(80);
+    });
+
+    it('should support metadata-only variable row height mode when rowHeightProvider is undefined', () => {
+      const dv = new SlickDataView({
+        globalItemMetadataProvider: {
+          getRowMetadata: (_item, row) => ({ height: [25, 65][row] }),
+        },
+      });
+      dv.setItems([
+        { id: 0, firstName: 'John' },
+        { id: 1, firstName: 'Jane' },
+      ]);
+
+      grid = new SlickGrid<any, Column>(container, dv, [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[], {
+        ...defaultOptions,
+        rowHeight: 25,
+        dataView: {
+          globalItemMetadataProvider: {
+            getRowMetadata: (_item, row) => ({ height: [25, 65][row] }),
+          },
+        },
+      });
+
+      expect(grid.getRowHeight(0)).toBe(25);
+      expect(grid.getRowHeight(1)).toBe(65);
+
+      const scrollToSpy = vi.spyOn(grid, 'scrollTo');
+      grid.scrollRowToTop(1);
+      expect(scrollToSpy).toHaveBeenCalledWith(25);
     });
 
     it('should do nothing when trying to navigateTop when the dataset is empty', () => {

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -2583,6 +2583,7 @@ describe('SlickGrid core file', () => {
         const rowHeights = [20, 35, 40, 45];
         grid = new SlickGrid<any, Column>(container, data, columns, {
           ...defaultOptions,
+          enableVariableRowHeight: true,
           rowHeight: 20,
           frozenBottom: true,
           frozenRow: 2,
@@ -5876,6 +5877,7 @@ describe('SlickGrid core file', () => {
       const rowHeights = [25, 40, 30];
       grid = new SlickGrid<any, Column>(container, data, columns, {
         ...defaultOptions,
+        enableVariableRowHeight: true,
         rowHeight: 25,
         rowHeightProvider: (_grid, row) => rowHeights[row],
       });
@@ -5899,6 +5901,7 @@ describe('SlickGrid core file', () => {
       ];
       grid = new SlickGrid<any, Column>(container, variableData, columns, {
         ...defaultOptions,
+        enableVariableRowHeight: true,
         frozenRow: 2,
         rowHeight: 25,
         rowHeightProvider: (_grid, row) => rowHeights[row],
@@ -5939,6 +5942,7 @@ describe('SlickGrid core file', () => {
         oneColumn,
         {
           ...defaultOptions,
+          enableVariableRowHeight: true,
           rowHeight: 25,
           rowHeightProvider,
         }
@@ -5975,6 +5979,7 @@ describe('SlickGrid core file', () => {
         [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[],
         {
           ...defaultOptions,
+          enableVariableRowHeight: true,
           rowHeight: 25,
           rowHeightProvider: providerA,
         }
@@ -5990,7 +5995,7 @@ describe('SlickGrid core file', () => {
       expect(grid.getRowHeight(1)).toBe(80);
     });
 
-    it('should support metadata-only variable row height mode when rowHeightProvider is undefined', () => {
+    it('should support metadata-only variable row height mode via default rowHeightProvider', () => {
       const dv = new SlickDataView({
         globalItemMetadataProvider: {
           getRowMetadata: (_item, row) => ({ height: [25, 65][row] }),
@@ -6003,6 +6008,7 @@ describe('SlickGrid core file', () => {
 
       grid = new SlickGrid<any, Column>(container, dv, [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[], {
         ...defaultOptions,
+        enableVariableRowHeight: true,
         rowHeight: 25,
         dataView: {
           globalItemMetadataProvider: {
@@ -6017,6 +6023,29 @@ describe('SlickGrid core file', () => {
       const scrollToSpy = vi.spyOn(grid, 'scrollTo');
       grid.scrollRowToTop(1);
       expect(scrollToSpy).toHaveBeenCalledWith(25);
+    });
+
+    it('should use default rowHeight when custom rowHeightProvider returns undefined even if metadata defines height', () => {
+      const data = [
+        { id: 0, firstName: 'John' },
+        { id: 1, firstName: 'Jane' },
+      ];
+      const customProvider = vi.fn(() => undefined);
+
+      grid = new SlickGrid<any, Column>(container, data, [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[], {
+        ...defaultOptions,
+        enableVariableRowHeight: true,
+        rowHeight: 25,
+        rowHeightProvider: customProvider,
+        dataView: {
+          globalItemMetadataProvider: {
+            getRowMetadata: (_item, row) => ({ height: [25, 70][row] }),
+          },
+        },
+      });
+
+      expect(grid.getRowHeight(1)).toBe(25);
+      expect(customProvider).toHaveBeenCalled();
     });
 
     it('should do nothing when trying to navigateTop when the dataset is empty', () => {

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -973,3 +973,112 @@ export class SlickSelectionUtils {
 
 export const SlickGlobalEditorLock: SlickEditorLock = new SlickEditorLock();
 export const preClickClassName = 'slick-edit-preclick';
+
+/**
+ * RowPositionIndexer - a prefix-sum index of row top positions, used by SlickGrid when variable
+ * row height mode is enabled (i.e. when a `rowHeightProvider` grid option is supplied).
+ *
+ * `rowPos[i]` holds the virtual top pixel position of row `i` (i.e. the summed heights of all
+ * preceding rows) and `rowPos[rowCount]` holds the total height of all indexed rows, which makes
+ * row-to-position lookups an O(1) array read and position-to-row lookups an O(log n) binary search.
+ *
+ * Row indexes are expected to be 0 or greater (guaranteed by the grid core; user-provided indexes
+ * are validated in the public grid methods). Rows at or beyond the indexed range extrapolate
+ * linearly using the default row height, mirroring the fixed-row-height arithmetic it replaces
+ * (needed for the Add-New row and `leaveSpaceForNewRows` padding).
+ */
+export class RowPositionIndexer {
+  protected rowPos: Float64Array = new Float64Array(1);
+  protected rowCount = 0;
+  protected defaultRowHeight = 25;
+  protected hint = 0; // last binary search result; consecutive queries usually hit the same or an adjacent row
+
+  /** Number of rows currently indexed. */
+  get count(): number {
+    return this.rowCount;
+  }
+
+  /**
+   * Rebuilds the index by querying the height of every row. O(n) - the provided callback is
+   * called once per row and must therefore be fast (a simple lookup, no DOM access).
+   *
+   * @param {number} rowCount - The number of rows to index.
+   * @param {number} defaultRowHeight - The height used when the callback returns `undefined` and for extrapolating beyond the indexed range.
+   * @param {(row: number) => number | undefined} getRowHeight - Returns the height of a row in pixels, or `undefined` to use the default.
+   */
+  rebuild(rowCount: number, defaultRowHeight: number, getRowHeight: (row: number) => number | undefined): void {
+    this.rowCount = rowCount;
+    this.defaultRowHeight = defaultRowHeight;
+    this.hint = 0;
+    if (this.rowPos.length < rowCount + 1) {
+      this.rowPos = new Float64Array(rowCount + 1);
+    }
+    const pos = this.rowPos;
+    let acc = 0;
+    for (let i = 0; i < rowCount; i++) {
+      pos[i] = acc;
+      acc += getRowHeight(i) ?? defaultRowHeight;
+    }
+    pos[rowCount] = acc;
+  }
+
+  /**
+   * Returns the virtual top pixel position of a row.
+   *
+   * @param {number} row - The row index (>= 0); indexes beyond the indexed range extrapolate using the default row height.
+   * @returns {number} The virtual pixel position of the top of the row.
+   */
+  top(row: number): number {
+    if (row >= this.rowCount) {
+      return this.rowPos[this.rowCount] + (row - this.rowCount) * this.defaultRowHeight;
+    }
+    return this.rowPos[row];
+  }
+
+  /**
+   * Returns the height of a row.
+   *
+   * @param {number} row - The row index (>= 0); indexes beyond the indexed range return the default row height.
+   * @returns {number} The row height in pixels.
+   */
+  height(row: number): number {
+    if (row >= this.rowCount) {
+      return this.defaultRowHeight;
+    }
+    return this.rowPos[row + 1] - this.rowPos[row];
+  }
+
+  /**
+   * Returns the index of the row containing a virtual vertical pixel position.
+   * Positions below zero return row 0; positions beyond the indexed range extrapolate using the
+   * default row height (results may be beyond the last row - callers clamp, as in fixed mode).
+   *
+   * @param {number} y - The virtual vertical position in pixels.
+   * @returns {number} The row index at that position.
+   */
+  rowAt(y: number): number {
+    const total = this.rowPos[this.rowCount];
+    if (y >= total) {
+      return this.rowCount + Math.floor((y - total) / this.defaultRowHeight);
+    }
+
+    // check the last result first: consecutive queries during scrolling usually target the same neighborhood
+    const h = this.hint;
+    if (h < this.rowCount && this.rowPos[h] <= y && y < this.rowPos[h + 1]) {
+      return h;
+    }
+
+    let lo = 0;
+    let hi = this.rowCount - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >>> 1;
+      if (this.rowPos[mid] <= y) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    this.hint = lo;
+    return lo;
+  }
+}

--- a/packages/common/src/core/slickCore.ts
+++ b/packages/common/src/core/slickCore.ts
@@ -976,7 +976,7 @@ export const preClickClassName = 'slick-edit-preclick';
 
 /**
  * RowPositionIndexer - a prefix-sum index of row top positions, used by SlickGrid when variable
- * row height mode is enabled (i.e. when a `rowHeightProvider` grid option is supplied).
+ * row height mode is enabled (i.e. when `enableVariableRowHeight` is true).
  *
  * `rowPos[i]` holds the virtual top pixel position of row `i` (i.e. the summed heights of all
  * preceding rows) and `rowPos[rowCount]` holds the total height of all indexed rows, which makes

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4034,7 +4034,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this._metadataHasHeight === undefined) {
       this._metadataHasHeight = false;
       const dataView = this.data as CustomDataView<TData>;
-      const len = typeof dataView?.getLength === 'function' ? dataView.getLength() : (Array.isArray(this.data) ? this.data.length : 0);
+      const len = typeof dataView?.getLength === 'function' ? dataView.getLength() : Array.isArray(this.data) ? this.data.length : 0;
       for (let i = 0; i < Math.min(len, 20); i++) {
         const item = typeof dataView?.getItem === 'function' ? dataView.getItem(i) : (this.data as TData[])[i];
         if (item !== undefined && typeof getMetadata(item, i as any)?.height === 'number') {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4030,20 +4030,25 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return false;
     }
     // Lazily probe whether getRowMetadata actually returns a height property.
-    // Cache the result so this stays O(1) after the first call.
+    // Only cache `true` (confirmed variable-height) or `false` when we had real data to probe.
+    // When no data is available yet, leave `_metadataHasHeight` as undefined so we re-probe once data arrives.
     if (this._metadataHasHeight === undefined) {
-      this._metadataHasHeight = false;
       const dataView = this.data as CustomDataView<TData>;
       const len = typeof dataView?.getLength === 'function' ? dataView.getLength() : Array.isArray(this.data) ? this.data.length : 0;
-      for (let i = 0; i < Math.min(len, 20); i++) {
-        const item = typeof dataView?.getItem === 'function' ? dataView.getItem(i) : (this.data as TData[])[i];
-        if (item !== undefined && typeof getMetadata(item, i as any)?.height === 'number') {
-          this._metadataHasHeight = true;
-          break;
+      if (len > 0) {
+        // we have data — probe up to 20 rows and cache a definitive answer
+        this._metadataHasHeight = false;
+        for (let i = 0; i < Math.min(len, 20); i++) {
+          const item = typeof dataView?.getItem === 'function' ? dataView.getItem(i) : (this.data as TData[])[i];
+          if (item !== undefined && typeof getMetadata(item, i as any)?.height === 'number') {
+            this._metadataHasHeight = true;
+            break;
+          }
         }
       }
+      // else: no data yet — return false without caching so we re-probe on the next call
     }
-    return this._metadataHasHeight;
+    return this._metadataHasHeight ?? false;
   }
 
   /**

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2948,7 +2948,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
     (this._options.shadowRoot || document.head).appendChild(this._style);
 
-    const rowHeight = this._options.rowHeight! - this.cellHeightDiff;
     const rules = [
       `.${this.uid} .slick-group-header-column { left: 1000px; }`,
       `.${this.uid} .slick-header-column { left: 1000px; }`,
@@ -2959,16 +2958,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       `.${this.uid} .slick-footerrow-columns { height: ${this._options.footerRowHeight}px; }`,
     ];
 
-    if (this.isVariableRowHeight()) {
-      // in variable row height mode the cell height fills the row, and the row height is set
-      // per-row via inline style for rows that differ from the default; the stylesheet only
-      // provides the default row height so that unchanged rows don't need an inline style
-      rules.push(`.${this.uid} .slick-cell { height: calc(100% - ${this.cellHeightDiff}px); }`);
-      rules.push(`.${this.uid} .slick-row { height: ${this._options.rowHeight}px; }`);
-    } else {
-      rules.push(`.${this.uid} .slick-cell { height: ${rowHeight}px; }`);
-      rules.push(`.${this.uid} .slick-row { height: ${this._options.rowHeight}px; }`);
-    }
+    // Rows get a default height from CSS; in variable-height mode, individual rows override
+    // this via inline `style="height: Xpx"`. Cells use `height: 100%` (stylesheet) to fill their row.
+    rules.push(`.${this.uid} .slick-row { height: ${this._options.rowHeight}px; }`);
 
     const sheet = this._style.sheet;
 
@@ -4030,13 +4022,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       return false;
     }
     // Lazily probe whether getRowMetadata actually returns a height property.
-    // Only cache `true` (confirmed variable-height) or `false` when we had real data to probe.
-    // When no data is available yet, leave `_metadataHasHeight` as undefined so we re-probe once data arrives.
+    // Only cache when we have real data to probe; when data isn't available yet return false
+    // (safe default) without caching, so the next call re-probes once data arrives.
     if (this._metadataHasHeight === undefined) {
       const dataView = this.data as CustomDataView<TData>;
       const len = typeof dataView?.getLength === 'function' ? dataView.getLength() : Array.isArray(this.data) ? this.data.length : 0;
       if (len > 0) {
-        // we have data — probe up to 20 rows and cache a definitive answer
+        // we have data — probe up to 20 rows and cache the definitive answer
         this._metadataHasHeight = false;
         for (let i = 0; i < Math.min(len, 20); i++) {
           const item = typeof dataView?.getItem === 'function' ? dataView.getItem(i) : (this.data as TData[])[i];
@@ -4048,7 +4040,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       }
       // else: no data yet — return false without caching so we re-probe on the next call
     }
-    return this._metadataHasHeight ?? false;
+    return this._metadataHasHeight === true;
   }
 
   /**

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -93,6 +93,7 @@ import type {
 } from '../interfaces/index.js';
 import {
   preClickClassName,
+  RowPositionIndexer,
   SlickDragExtendHandle,
   SlickEvent,
   SlickEventData,
@@ -406,6 +407,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected hasFrozenRows = false;
   protected frozenRowsHeight = 0;
   protected actualFrozenRow = -1;
+  protected rowPositionIndexer?: RowPositionIndexer; // row top positions (variable row height mode only)
+  protected rowHeightsDirty = true; // set when row heights may have changed; the index is rebuilt on the next updateRowCount()
+  protected frozenRowHeightsChanged = false; // set when an index rebuild changed the frozen rows height; consumed at the end of updateRowCount()
   protected _prevFrozenColumnIdx = -1;
   /** flag to indicate if invalid frozen alert has been shown already or not? This is to avoid showing it more than once */
   protected _invalidfrozenAlerted = false;
@@ -2735,12 +2739,25 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (this._options.frozenRow! > -1) {
       this.hasFrozenRows = true;
-      this.frozenRowsHeight = this._options.frozenRow! * this._options.rowHeight!;
       const dataLength = this.getDataLength();
       this.actualFrozenRow = this._options.frozenBottom ? dataLength - this._options.frozenRow! : this._options.frozenRow!;
+      this.frozenRowsHeight = this.computeFrozenRowsHeight(dataLength);
     } else {
       this.hasFrozenRows = false;
     }
+  }
+
+  /**
+   * Computes the combined pixel height of the frozen rows: the first `frozenRow` rows, or the
+   * last `frozenRow` rows (i.e. from `actualFrozenRow` onward) when `frozenBottom` is enabled.
+   *
+   * @param {number} dataLength - The current dataset length.
+   * @returns {number} The combined frozen rows height in pixels.
+   */
+  protected computeFrozenRowsHeight(dataLength: number): number {
+    return this._options.frozenBottom
+      ? this.getRowPosition(dataLength) - this.getRowPosition(this.actualFrozenRow)
+      : this.getRowPosition(this._options.frozenRow!);
   }
 
   /** add/remove frozen class to left headers/footer when defined */
@@ -2939,9 +2956,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       `.${this.uid} .slick-topheader-panel { height: ${this._options.topHeaderPanelHeight}px; }`,
       `.${this.uid} .slick-headerrow-columns { height: ${this._options.headerRowHeight}px; }`,
       `.${this.uid} .slick-footerrow-columns { height: ${this._options.footerRowHeight}px; }`,
-      `.${this.uid} .slick-cell { height: ${rowHeight}px; }`,
-      `.${this.uid} .slick-row { height: ${this._options.rowHeight}px; }`,
     ];
+
+    if (this.isVariableRowHeight()) {
+      // in variable row height mode the cell height fills the row, and the row height is set
+      // per-row via inline style for rows that differ from the default; the stylesheet only
+      // provides the default row height so that unchanged rows don't need an inline style
+      rules.push(`.${this.uid} .slick-cell { height: calc(100% - ${this.cellHeightDiff}px); }`);
+      rules.push(`.${this.uid} .slick-row { height: ${this._options.rowHeight}px; }`);
+    } else {
+      rules.push(`.${this.uid} .slick-cell { height: ${rowHeight}px; }`);
+      rules.push(`.${this.uid} .slick-row { height: ${this._options.rowHeight}px; }`);
+    }
 
     const sheet = this._style.sheet;
 
@@ -3698,6 +3724,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this.syncDataViewFormattedCachePlanner(true);
     }
 
+    // any option affecting row heights requires a rebuild of the row position index
+    if (newOptions.rowHeight !== undefined || newOptions.rowHeightProvider !== undefined) {
+      this.rowHeightsDirty = true;
+    }
+
     this.internal_setOptions(suppressRender, suppressColumnSet, suppressSetOverflow);
   }
 
@@ -3981,20 +4012,77 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   // Rendering / Scrolling
 
-  protected getRowHeight(): number {
+  /**
+   * Whether the grid is in variable row height mode.
+   * Enabled when a `rowHeightProvider` callback is supplied, or when the DataView has a
+   * `globalItemMetadataProvider.getRowMetadata` callback (allowing `ItemMetadata.height` fallback
+   * without defining a `rowHeightProvider`).
+   *
+   * @returns {boolean} True when variable row height mode is enabled.
+   */
+  protected isVariableRowHeight(): boolean {
+    return (
+      typeof this._options.rowHeightProvider === 'function' ||
+      typeof this._options.dataView?.globalItemMetadataProvider?.getRowMetadata === 'function'
+    );
+  }
+
+  /**
+   * Retrieves the height of a row.
+   * In variable row height mode (i.e. when a `rowHeightProvider` is configured) and with a row
+   * index provided, returns that row's individual height; otherwise returns the default row
+   * height defined in the grid options.
+   *
+   * @param {number} [row] - The row index. When omitted the default row height is returned.
+   * @returns {number} The row height in pixels.
+   */
+  getRowHeight(row?: number): number {
+    if (row !== undefined && this.isVariableRowHeight() && this.rowPositionIndexer) {
+      return this.rowPositionIndexer.height(row);
+    }
     return this._options.rowHeight!;
   }
 
+  /**
+   * Returns the virtual top pixel position of a row within the full grid content,
+   * i.e. without the virtual-scrolling page offset applied. Since a row's top position equals
+   * the combined height of all rows before it, this also serves as "the combined pixel height
+   * of the first N rows" when called with a row count.
+   *
+   * @param {number} row - The row index (or a row count when summing row heights).
+   * @returns {number} The virtual pixel position of the top of the row.
+   */
+  protected getRowPosition(row: number): number {
+    if (this.isVariableRowHeight() && this.rowPositionIndexer) {
+      return this.rowPositionIndexer.top(row);
+    }
+    return this._options.rowHeight! * row;
+  }
+
+  /**
+   * Computes the row index at a virtual vertical pixel position within the full grid content,
+   * i.e. without the virtual-scrolling page offset applied.
+   *
+   * @param {number} y - The virtual vertical position in pixels.
+   * @returns {number} The calculated row index.
+   */
+  protected getRowIndexFromPosition(y: number): number {
+    if (this.isVariableRowHeight() && this.rowPositionIndexer) {
+      return this.rowPositionIndexer.rowAt(y);
+    }
+    return Math.floor(y / this._options.rowHeight!);
+  }
+
   protected getRowTop(row: number): number {
-    return Math.round(this._options.rowHeight! * row - this.offset);
+    return Math.round(this.getRowPosition(row) - this.offset);
   }
 
   protected getRowBottom(row: number): number {
-    return this.getRowTop(row) + this._options.rowHeight!;
+    return this.getRowTop(row) + this.getRowHeight(row);
   }
 
   protected getRowFromPosition(y: number): number {
-    return Math.floor((y + this.offset) / this._options.rowHeight!);
+    return this.getRowIndexFromPosition(y + this.offset);
   }
 
   /**
@@ -4175,6 +4263,15 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       rowDiv.style.top = `${topOffset}px`; // default to `top: {offset}px`
     }
 
+    if (this.isVariableRowHeight()) {
+      // only rows with a non-default height get an inline height so that rows with
+      // the default height can be sized by the stylesheet rule
+      const rowHeight = this.getRowHeight(row);
+      if (rowHeight !== this._options.rowHeight) {
+        rowDiv.style.height = `${rowHeight}px`;
+      }
+    }
+
     let rowDivR: HTMLElement | undefined;
     divArrayL.push(rowDiv);
 
@@ -4321,7 +4418,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // update cell rowspan height when spanning more than 1 row
     const cellHeight = this.getCellHeight(row, rowspan);
-    if (rowspan > 1 && cellHeight !== this._options.rowHeight! - this.cellHeightDiff) {
+    if (rowspan > 1 && cellHeight !== this.getRowHeight(row) - this.cellHeightDiff) {
       cellDiv.style.height = `${cellHeight || 0}px`;
     }
 
@@ -4519,6 +4616,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Invalidate all grid rows */
   invalidateAllRows(): void {
+    // invalidated row content may resize the rows, so conservatively mark dirty for rebuild
+    this.rowHeightsDirty = true;
     if (this.currentEditor) {
       this.makeActiveCellNormal();
     }
@@ -4547,6 +4646,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     let row;
     this.vScrollDir = 0;
+    this.rowHeightsDirty = true;
     const rl = rows.length;
 
     // use Set to avoid duplicates
@@ -4780,19 +4880,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   getCellHeight(row: number, rowspan: number): number {
-    let cellHeight = this._options.rowHeight || 0;
     if (rowspan > 1) {
       const rowSpanBottomIdx = row + rowspan - 1;
-      cellHeight = this.getRowBottom(rowSpanBottomIdx) - this.getRowTop(row);
-    } else {
-      const rowHeight = this.getRowHeight();
-      /* v8 ignore if */
-      if (rowHeight !== cellHeight - this.cellHeightDiff) {
-        cellHeight = rowHeight;
-      }
+      return Math.ceil(this.getRowBottom(rowSpanBottomIdx) - this.getRowTop(row));
     }
-    cellHeight -= this.cellHeightDiff;
-    return Math.ceil(cellHeight);
+    return Math.ceil(this.getRowHeight(row) - this.cellHeightDiff);
   }
 
   /**
@@ -4823,8 +4915,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       fullHeight += this._options.showFooterRow ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0]) : 0;
       fullHeight += this.getCanvasWidth() > this.viewportW ? this.scrollbarDimensions?.height || 0 : 0;
 
-      this.viewportH =
-        this._options.rowHeight! * this.getDataLengthIncludingAddNew() + (this._options.frozenColumn === -1 ? fullHeight : 0);
+      this.viewportH = this.getRowPosition(this.getDataLengthIncludingAddNew()) + (this._options.frozenColumn === -1 ? fullHeight : 0);
     } else {
       const style = getComputedStyle(this._container);
       const containerBoxH = style.boxSizing !== 'content-box' ? this.getVBoxDelta(this._container) : 0;
@@ -5000,6 +5091,53 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.pagingIsLastPage = pagingInfo.pageNum === pagingInfo.totalPages - 1;
   }
 
+  /**
+   * (re)Builds the row position index used in variable row height mode when needed, i.e. when it is
+   * marked dirty (see invalidateRowHeights) or when the indexed row count no longer matches the
+   * dataset length. Since the frozen rows height depends on individual row heights, it is refreshed
+   * after every rebuild. Does nothing (and drops the index) when variable row height is disabled.
+   *
+   * @param {number} rowCount - The number of rows to index (including the Add-New row when enabled).
+   */
+  protected ensureRowPositionIndexer(rowCount: number): void {
+    if (!this.isVariableRowHeight()) {
+      this.rowPositionIndexer = undefined;
+      return;
+    }
+    if (!this.rowPositionIndexer) {
+      this.rowPositionIndexer = new RowPositionIndexer();
+      this.rowHeightsDirty = true;
+    }
+    if (this.rowHeightsDirty || this.rowPositionIndexer.count !== rowCount) {
+      const provider = this._options.rowHeightProvider;
+      // height resolution chain: provider -> ItemMetadata.height -> default rowHeight (in rebuild)
+      this.rowPositionIndexer.rebuild(
+        rowCount,
+        this._options.rowHeight!,
+        (row: number) => provider?.(this as unknown as SlickGrid, row, this.getDataItem(row)) ?? this.getItemMetadaWhenExists(row)?.height
+      );
+      this.rowHeightsDirty = false;
+      if (this.hasFrozenRows) {
+        const prevFrozenRowsHeight = this.frozenRowsHeight;
+        this.frozenRowsHeight = this.computeFrozenRowsHeight(this.getDataLength());
+        // pane splits and frozen canvas sizes derive from this value, so a change requires a canvas resize
+        this.frozenRowHeightsChanged = this.frozenRowsHeight !== prevFrozenRowsHeight;
+      }
+    }
+  }
+
+  /**
+   * Invalidate all row heights (variable row height mode) and fully re-render the grid.
+   * Call this after the values driving `rowHeightProvider` have changed without a change in row
+   * count; the row position index is then rebuilt with the new heights.
+   */
+  invalidateRowHeights(): void {
+    if (this.isVariableRowHeight()) {
+      this.rowHeightsDirty = true;
+      this.invalidate();
+    }
+  }
+
   /** Update the dataset row count */
   updateRowCount(): void {
     if (this.initialized) {
@@ -5028,11 +5166,23 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         numberOfRows = dataLengthIncludingAddNew + (this._options.leaveSpaceForNewRows ? this.numVisibleRows - 1 : 0);
       }
 
+      // (re)build the row position index (variable row height mode) before any height computations
+      this.ensureRowPositionIndexer(dataLengthIncludingAddNew);
+
+      // pixel height of the rows contained in the scrolling canvas; for frozen-top grids with variable
+      // row heights the scrolling rows are the ones after the frozen rows, so their combined height is
+      // the remainder after subtracting the frozen rows height (in fixed mode any `numberOfRows` rows
+      // have the same combined height, so the simple multiplication covers all layouts)
+      const scrollableRowsHeight =
+        this.isVariableRowHeight() && this.hasFrozenRows && !this._options.frozenBottom
+          ? this.getRowPosition(dataLength) - this.frozenRowsHeight
+          : this.getRowPosition(numberOfRows);
+
       const tempViewportH = Utils.height(this._viewportScrollContainerY) as number;
       const oldViewportHasVScroll = this.viewportHasVScroll;
       // with autoHeight, we do not need to accommodate the vertical scroll bar
       this.viewportHasVScroll =
-        this._options.alwaysShowVerticalScroll || (!this._options.autoHeight && numberOfRows * this._options.rowHeight! > tempViewportH);
+        this._options.alwaysShowVerticalScroll || (!this._options.autoHeight && scrollableRowsHeight > tempViewportH);
 
       this.makeActiveCellNormal();
 
@@ -5058,9 +5208,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       oldH = this.h;
       if (this._options.autoHeight) {
-        this.h = this._options.rowHeight! * numberOfRows;
+        this.h = scrollableRowsHeight;
       } else {
-        this.th = Math.max(this._options.rowHeight! * numberOfRows, tempViewportH - (this.scrollbarDimensions?.height || 0));
+        this.th = Math.max(scrollableRowsHeight, tempViewportH - (this.scrollbarDimensions?.height || 0));
         if (this.th < this.maxSupportedCssHeight) {
           // just one page
           this.h = this.ph = this.th;
@@ -5109,6 +5259,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         this.resizeCanvas();
       }
 
+      if (this.frozenRowHeightsChanged) {
+        this.frozenRowHeightsChanged = false;
+        // re-apply the pane splits and frozen canvas sizes that were computed from the previous
+        // frozen rows height (same self-limiting recursion pattern as the autoHeight resize above:
+        // the nested updateRowCount recomputes an unchanged value, so it cannot re-trigger)
+        this.resizeCanvas();
+      }
+
       if (this._options.forceFitColumns && oldViewportHasVScroll !== this.viewportHasVScroll) {
         this.legacyAutosizeColumns();
       }
@@ -5154,7 +5312,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    */
   getRenderedRange(viewportTop?: number, viewportLeft?: number): CellViewportRange {
     const range = this.getVisibleRange(viewportTop, viewportLeft);
-    const buffer = Math.round(this.viewportH / this._options.rowHeight!);
+    const buffer = Math.round(this.viewportH / this.getRowHeight());
     const minBuffer = this._options.minRowBuffer as number;
 
     if (this.vScrollDir === -1) {
@@ -6550,7 +6708,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (this._options.frozenBottom) {
         if (row >= this.actualFrozenRow) {
           if (this.h < this.viewportTopH) {
-            offset = this.actualFrozenRow * this._options.rowHeight!;
+            offset = this.getRowPosition(this.actualFrozenRow);
           } else {
             offset = this.h;
           }
@@ -6625,7 +6783,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const frozenRowOffset = this.getFrozenRowOffset(row);
 
     const y1 = this.getRowTop(row) - frozenRowOffset;
-    const y2 = y1 + this._options.rowHeight! - 1;
+    const y2 = y1 + this.getRowHeight(row) - 1;
     let x1 = 0;
     for (let i = 0; i < cell; i++) {
       if (this.columns[i] && !this.columns[i].hidden) {
@@ -7053,21 +7211,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
       // if frozen row on top
       // subtract number of frozen row
-      const rowNumber = this.hasFrozenRows && !this._options.frozenBottom ? row - this._options.frozenRow! : row;
-
-      const rowAtTop = rowNumber * this._options.rowHeight!;
-      const rowAtBottom =
-        (rowNumber + 1) * this._options.rowHeight! -
-        viewportScrollH +
-        (this.viewportHasHScroll ? this.scrollbarDimensions?.height || 0 : 0);
+      const rowAtTop =
+        this.hasFrozenRows && !this._options.frozenBottom ? this.getRowPosition(row) - this.frozenRowsHeight : this.getRowPosition(row);
+      const rowBottomPosition = rowAtTop + this.getRowHeight(row);
+      const rowAtBottom = rowBottomPosition - viewportScrollH + (this.viewportHasHScroll ? this.scrollbarDimensions?.height || 0 : 0);
 
       // need to page down?
-      if ((rowNumber + 1) * this._options.rowHeight! > this.scrollTop + viewportScrollH + this.offset) {
+      if (rowBottomPosition > this.scrollTop + viewportScrollH + this.offset) {
         this.scrollTo(doPaging ? rowAtTop : rowAtBottom);
         this.render();
       }
       // or page up?
-      else if (rowNumber * this._options.rowHeight! < this.scrollTop + this.offset) {
+      else if (rowAtTop < this.scrollTop + this.offset) {
         this.scrollTo(doPaging ? rowAtBottom : rowAtTop);
         this.render();
       }
@@ -7079,7 +7234,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {Number} row - grid row number
    */
   scrollRowToTop(row: number): void {
-    this.scrollTo(row * this._options.rowHeight!);
+    const rowAtTop =
+      this.hasFrozenRows && !this._options.frozenBottom ? this.getRowPosition(row) - this.frozenRowsHeight : this.getRowPosition(row);
+    this.scrollTo(rowAtTop);
     this.render();
   }
 
@@ -7087,8 +7244,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const deltaRows = dir * this.numVisibleRows;
     /// First fully visible row crosses the line with
     /// y === bottomOfTopmostFullyVisibleRow
-    const bottomOfTopmostFullyVisibleRow = this.scrollTop + this._options.rowHeight! - 1;
-    this.scrollTo((this.getRowFromPosition(bottomOfTopmostFullyVisibleRow) + deltaRows) * this._options.rowHeight!);
+    const bottomOfTopmostFullyVisibleRow = this.scrollTop + this.getRowHeight() - 1;
+    this.scrollTo(this.getRowPosition(this.getRowFromPosition(bottomOfTopmostFullyVisibleRow) + deltaRows));
     this.render();
 
     if (this._options.enableCellNavigation && isDefined(this.activeRow)) {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -410,6 +410,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected rowPositionIndexer?: RowPositionIndexer; // row top positions (variable row height mode only)
   protected rowHeightsDirty = true; // set when row heights may have changed; the index is rebuilt on the next updateRowCount()
   protected frozenRowHeightsChanged = false; // set when an index rebuild changed the frozen rows height; consumed at the end of updateRowCount()
+  protected _metadataHasHeight?: boolean; // cached probe result: does getRowMetadata return a height property?
   protected _prevFrozenColumnIdx = -1;
   /** flag to indicate if invalid frozen alert has been shown already or not? This is to avoid showing it more than once */
   protected _invalidfrozenAlerted = false;
@@ -4021,10 +4022,28 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @returns {boolean} True when variable row height mode is enabled.
    */
   protected isVariableRowHeight(): boolean {
-    return (
-      typeof this._options.rowHeightProvider === 'function' ||
-      typeof this._options.dataView?.globalItemMetadataProvider?.getRowMetadata === 'function'
-    );
+    if (typeof this._options.rowHeightProvider === 'function') {
+      return true;
+    }
+    const getMetadata = this._options.dataView?.globalItemMetadataProvider?.getRowMetadata;
+    if (typeof getMetadata !== 'function') {
+      return false;
+    }
+    // Lazily probe whether getRowMetadata actually returns a height property.
+    // Cache the result so this stays O(1) after the first call.
+    if (this._metadataHasHeight === undefined) {
+      this._metadataHasHeight = false;
+      const dataView = this.data as CustomDataView<TData>;
+      const len = typeof dataView?.getLength === 'function' ? dataView.getLength() : (Array.isArray(this.data) ? this.data.length : 0);
+      for (let i = 0; i < Math.min(len, 20); i++) {
+        const item = typeof dataView?.getItem === 'function' ? dataView.getItem(i) : (this.data as TData[])[i];
+        if (item !== undefined && typeof getMetadata(item, i as any)?.height === 'number') {
+          this._metadataHasHeight = true;
+          break;
+        }
+      }
+    }
+    return this._metadataHasHeight;
   }
 
   /**
@@ -5132,6 +5151,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * count; the row position index is then rebuilt with the new heights.
    */
   invalidateRowHeights(): void {
+    this._metadataHasHeight = undefined; // reset probe cache so mode re-evaluates with current metadata
     if (this.isVariableRowHeight()) {
       this.rowHeightsDirty = true;
       this.invalidate();

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -238,8 +238,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     allowDragFromClosest: 'div.slick-cell.dnd, div.slick-cell.cell-reorder',
     alwaysShowVerticalScroll: false,
     alwaysAllowHorizontalScroll: false,
+    enableVariableRowHeight: false,
     explicitInitialization: false,
     rowHeight: 25,
+    rowHeightProvider: (grid, row) => grid.getItemMetadaWhenExists(row)?.height,
     defaultColumnWidth: 80,
     enableHtmlRendering: true,
     enableAddRow: false,
@@ -410,7 +412,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected rowPositionIndexer?: RowPositionIndexer; // row top positions (variable row height mode only)
   protected rowHeightsDirty = true; // set when row heights may have changed; the index is rebuilt on the next updateRowCount()
   protected frozenRowHeightsChanged = false; // set when an index rebuild changed the frozen rows height; consumed at the end of updateRowCount()
-  protected _metadataHasHeight?: boolean; // cached probe result: does getRowMetadata return a height property?
   protected _prevFrozenColumnIdx = -1;
   /** flag to indicate if invalid frozen alert has been shown already or not? This is to avoid showing it more than once */
   protected _invalidfrozenAlerted = false;
@@ -3718,7 +3719,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     // any option affecting row heights requires a rebuild of the row position index
-    if (newOptions.rowHeight !== undefined || newOptions.rowHeightProvider !== undefined) {
+    if (
+      newOptions.rowHeight !== undefined ||
+      newOptions.rowHeightProvider !== undefined ||
+      newOptions.enableVariableRowHeight !== undefined
+    ) {
       this.rowHeightsDirty = true;
     }
 
@@ -4006,46 +4011,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   // Rendering / Scrolling
 
   /**
-   * Whether the grid is in variable row height mode.
-   * Enabled when a `rowHeightProvider` callback is supplied, or when the DataView has a
-   * `globalItemMetadataProvider.getRowMetadata` callback (allowing `ItemMetadata.height` fallback
-   * without defining a `rowHeightProvider`).
-   *
-   * @returns {boolean} True when variable row height mode is enabled.
-   */
-  protected isVariableRowHeight(): boolean {
-    if (typeof this._options.rowHeightProvider === 'function') {
-      return true;
-    }
-    const getMetadata = this._options.dataView?.globalItemMetadataProvider?.getRowMetadata;
-    if (typeof getMetadata !== 'function') {
-      return false;
-    }
-    // Lazily probe whether getRowMetadata actually returns a height property.
-    // Only cache when we have real data to probe; when data isn't available yet return false
-    // (safe default) without caching, so the next call re-probes once data arrives.
-    if (this._metadataHasHeight === undefined) {
-      const dataView = this.data as CustomDataView<TData>;
-      const len = typeof dataView?.getLength === 'function' ? dataView.getLength() : Array.isArray(this.data) ? this.data.length : 0;
-      if (len > 0) {
-        // we have data — probe up to 20 rows and cache the definitive answer
-        this._metadataHasHeight = false;
-        for (let i = 0; i < Math.min(len, 20); i++) {
-          const item = typeof dataView?.getItem === 'function' ? dataView.getItem(i) : (this.data as TData[])[i];
-          if (item !== undefined && typeof getMetadata(item, i as any)?.height === 'number') {
-            this._metadataHasHeight = true;
-            break;
-          }
-        }
-      }
-      // else: no data yet — return false without caching so we re-probe on the next call
-    }
-    return this._metadataHasHeight === true;
-  }
-
-  /**
    * Retrieves the height of a row.
-   * In variable row height mode (i.e. when a `rowHeightProvider` is configured) and with a row
+   * In variable row height mode (i.e. when `enableVariableRowHeight` is true) and with a row
    * index provided, returns that row's individual height; otherwise returns the default row
    * height defined in the grid options.
    *
@@ -4053,7 +4020,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @returns {number} The row height in pixels.
    */
   getRowHeight(row?: number): number {
-    if (row !== undefined && this.isVariableRowHeight() && this.rowPositionIndexer) {
+    if (row !== undefined && this._options.enableVariableRowHeight && this.rowPositionIndexer) {
       return this.rowPositionIndexer.height(row);
     }
     return this._options.rowHeight!;
@@ -4069,7 +4036,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @returns {number} The virtual pixel position of the top of the row.
    */
   protected getRowPosition(row: number): number {
-    if (this.isVariableRowHeight() && this.rowPositionIndexer) {
+    if (this._options.enableVariableRowHeight && this.rowPositionIndexer) {
       return this.rowPositionIndexer.top(row);
     }
     return this._options.rowHeight! * row;
@@ -4083,7 +4050,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @returns {number} The calculated row index.
    */
   protected getRowIndexFromPosition(y: number): number {
-    if (this.isVariableRowHeight() && this.rowPositionIndexer) {
+    if (this._options.enableVariableRowHeight && this.rowPositionIndexer) {
       return this.rowPositionIndexer.rowAt(y);
     }
     return Math.floor(y / this._options.rowHeight!);
@@ -4279,7 +4246,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       rowDiv.style.top = `${topOffset}px`; // default to `top: {offset}px`
     }
 
-    if (this.isVariableRowHeight()) {
+    if (this._options.enableVariableRowHeight) {
       // only rows with a non-default height get an inline height so that rows with
       // the default height can be sized by the stylesheet rule
       const rowHeight = this.getRowHeight(row);
@@ -5116,7 +5083,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * @param {number} rowCount - The number of rows to index (including the Add-New row when enabled).
    */
   protected ensureRowPositionIndexer(rowCount: number): void {
-    if (!this.isVariableRowHeight()) {
+    if (!this._options.enableVariableRowHeight) {
       this.rowPositionIndexer = undefined;
       return;
     }
@@ -5126,11 +5093,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
     if (this.rowHeightsDirty || this.rowPositionIndexer.count !== rowCount) {
       const provider = this._options.rowHeightProvider;
-      // height resolution chain: provider -> ItemMetadata.height -> default rowHeight (in rebuild)
-      this.rowPositionIndexer.rebuild(
-        rowCount,
-        this._options.rowHeight!,
-        (row: number) => provider?.(this as unknown as SlickGrid, row, this.getDataItem(row)) ?? this.getItemMetadaWhenExists(row)?.height
+      this.rowPositionIndexer.rebuild(rowCount, this._options.rowHeight!, (row: number) =>
+        provider?.(this as unknown as SlickGrid, row, this.getDataItem(row))
       );
       this.rowHeightsDirty = false;
       if (this.hasFrozenRows) {
@@ -5148,8 +5112,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
    * count; the row position index is then rebuilt with the new heights.
    */
   invalidateRowHeights(): void {
-    this._metadataHasHeight = undefined; // reset probe cache so mode re-evaluates with current metadata
-    if (this.isVariableRowHeight()) {
+    if (this._options.enableVariableRowHeight) {
       this.rowHeightsDirty = true;
       this.invalidate();
     }
@@ -5191,7 +5154,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       // the remainder after subtracting the frozen rows height (in fixed mode any `numberOfRows` rows
       // have the same combined height, so the simple multiplication covers all layouts)
       const scrollableRowsHeight =
-        this.isVariableRowHeight() && this.hasFrozenRows && !this._options.frozenBottom
+        this._options.enableVariableRowHeight && this.hasFrozenRows && !this._options.frozenBottom
           ? this.getRowPosition(dataLength) - this.frozenRowsHeight
           : this.getRowPosition(numberOfRows);
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4863,11 +4863,19 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   getCellHeight(row: number, rowspan: number): number {
+    let cellHeight = this._options.rowHeight || 0;
     if (rowspan > 1) {
       const rowSpanBottomIdx = row + rowspan - 1;
-      return Math.ceil(this.getRowBottom(rowSpanBottomIdx) - this.getRowTop(row));
+      cellHeight = this.getRowBottom(rowSpanBottomIdx) - this.getRowTop(row);
+    } else {
+      const rowHeight = this.getRowHeight(row);
+      if (rowHeight !== cellHeight - this.cellHeightDiff) {
+        cellHeight = rowHeight;
+      }
     }
-    return Math.ceil(this.getRowHeight(row) - this.cellHeightDiff);
+
+    cellHeight -= this.cellHeightDiff;
+    return Math.ceil(cellHeight);
   }
 
   /**

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -830,6 +830,21 @@ export interface GridOption<C extends Column = Column> {
   rowHeight?: number;
 
   /**
+   * Optional callback used in variable row height mode.
+   * Receives the grid instance (giving access to any grid state), the row index, and the row's
+   * data item. Returns the height in pixels of that row, or `undefined` to fall back to
+   * `ItemMetadata.height` (when the data provider supplies `getItemMetadata`) and finally to the
+   * default `rowHeight`.
+   * Variable row height mode is enabled when either this callback is supplied, or when
+   * `dataView.globalItemMetadataProvider.getRowMetadata` is configured.
+   * Heights are cached in a prefix-sum index that is rebuilt whenever the row count changes, rows
+   * are invalidated, or `grid.invalidateRowHeights()` is called; the callback is called once per
+   * row per rebuild, so it must be fast (a simple lookup or calculation - no DOM access).
+   * When heights change without a row count change, call `grid.invalidateRowHeights()`.
+   */
+  rowHeightProvider?: (grid: SlickGrid, row: number, item: any) => number | undefined;
+
+  /**
    * Defaults to "highlight-animate", a CSS class name used to simulate row highlight with an optional duration (e.g. after insert).
    * Note: make sure that the duration is always lower than the duration defined in the CSS/SASS variable `$slick-row-highlight-fade-animation`.
    * Also note that the highlight is temporary and will also disappear as soon as the user starts scrolling or a `render()` is being called

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -835,8 +835,9 @@ export interface GridOption<C extends Column = Column> {
    * data item. Returns the height in pixels of that row, or `undefined` to fall back to
    * `ItemMetadata.height` (when the data provider supplies `getItemMetadata`) and finally to the
    * default `rowHeight`.
-   * Variable row height mode is enabled when either this callback is supplied, or when
-   * `dataView.globalItemMetadataProvider.getRowMetadata` is configured.
+   * Variable row height mode is auto-detected: it activates when this callback is supplied, or
+   * when `dataView.globalItemMetadataProvider.getRowMetadata` returns a `height` property for any
+   * row (probed lazily on first use). No explicit option is required.
    * Heights are cached in a prefix-sum index that is rebuilt whenever the row count changes, rows
    * are invalidated, or `grid.invalidateRowHeights()` is called; the callback is called once per
    * row per rebuild, so it must be fast (a simple lookup or calculation - no DOM access).

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -830,14 +830,23 @@ export interface GridOption<C extends Column = Column> {
   rowHeight?: number;
 
   /**
+   * Defaults to false.
+   * Explicitly enable variable row height mode. When false, SlickGrid always uses fixed-height math
+   * and ignores per-row heights even if a `rowHeightProvider` is defined.
+   * This preserves the fixed-row-height fast path for grids that do not use variable row heights,
+   * avoiding per-row provider work on large datasets.
+   */
+  enableVariableRowHeight?: boolean;
+
+  /**
    * Optional callback used in variable row height mode.
    * Receives the grid instance (giving access to any grid state), the row index, and the row's
-   * data item. Returns the height in pixels of that row, or `undefined` to fall back to
-   * `ItemMetadata.height` (when the data provider supplies `getItemMetadata`) and finally to the
-   * default `rowHeight`.
-   * Variable row height mode is auto-detected: it activates when this callback is supplied, or
-   * when `dataView.globalItemMetadataProvider.getRowMetadata` returns a `height` property for any
-   * row (probed lazily on first use). No explicit option is required.
+   * data item. Returns the height in pixels of that row, or `undefined` to use the default
+   * `rowHeight`.
+   * Variable row height mode is active only when `enableVariableRowHeight` is true.
+   * By default, SlickGrid provides a metadata-backed provider (`ItemMetadata.height`), so
+   * metadata-only setups work by enabling the switch without defining this callback.
+   * Supplying a custom callback fully replaces the default provider behavior.
    * Heights are cached in a prefix-sum index that is rebuilt whenever the row count changes, rows
    * are invalidated, or `grid.invalidateRowHeights()` is called; the callback is called once per
    * row per rebuild, so it must be fast (a simple lookup or calculation - no DOM access).

--- a/packages/common/src/interfaces/itemMetadata.interface.ts
+++ b/packages/common/src/interfaces/itemMetadata.interface.ts
@@ -21,6 +21,13 @@ export interface ItemMetadata {
   /** Whether or not any cells in the row can be set as "active". */
   focusable?: boolean;
 
+  /**
+   * Row height in pixels, only used in variable row height mode (i.e. when a `rowHeightProvider`
+   * grid option is configured). Applied when the provider returns `undefined` for the row; when
+   * this is also undefined the default `rowHeight` grid option is used.
+   */
+  height?: number;
+
   /** A custom group formatter. */
   formatter?: GroupTotalsFormatter | Formatter;
 

--- a/packages/common/src/interfaces/itemMetadata.interface.ts
+++ b/packages/common/src/interfaces/itemMetadata.interface.ts
@@ -22,9 +22,10 @@ export interface ItemMetadata {
   focusable?: boolean;
 
   /**
-   * Row height in pixels, only used in variable row height mode (i.e. when a `rowHeightProvider`
-   * grid option is configured). Applied when the provider returns `undefined` for the row; when
-   * this is also undefined the default `rowHeight` grid option is used.
+   * Row height in pixels, used by SlickGrid's default `rowHeightProvider` when
+   * `enableVariableRowHeight` is true.
+   * If a custom `rowHeightProvider` is supplied, that callback fully controls row heights and this
+   * property is ignored unless the callback reads it explicitly.
    */
   height?: number;
 

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -438,6 +438,7 @@
     box-sizing: border-box;
     border-style: var(--slick-grid-border-style, v.$slick-grid-border-style);
     display: var(--slick-cell-display, v.$slick-cell-display);
+    height: 100%;
     padding: 1px 2px;
     align-items: center;
   }

--- a/test/cypress/e2e/example44.cy.ts
+++ b/test/cypress/e2e/example44.cy.ts
@@ -21,17 +21,18 @@ describe('Example 44 - Variable Row Height (Provider)', { retries: 1 }, () => {
     const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
     const defaultRowHeight = 40;
 
-    for (const [r, expectedHeight] of expectedHeights.entries()) {
-      cy.get(`.grid44 .slick-row[data-row=${r}]`)
+    for (const [row, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`.grid44 .slick-row[data-row=${row}]`)
         .invoke('attr', 'style')
         .then((style = '') => {
-          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          expect(style).to.contain(`transform: translateY(${topOf(row)}px)`);
           if (expectedHeight === defaultRowHeight) {
             expect(style).not.to.contain('height:');
           } else {
             expect(style).to.contain(`height: ${expectedHeight}px`);
           }
         });
+      cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
     }
   });
 

--- a/test/cypress/e2e/example44.cy.ts
+++ b/test/cypress/e2e/example44.cy.ts
@@ -1,7 +1,7 @@
 describe('Example 44 - Variable Row Height (Provider)', { retries: 1 }, () => {
   // mirrors example44 provider output pattern
   const hOf = (r: number) => {
-    const cycle = [33, 40, 56, 72];
+    const cycle = [33, 45, 56, 72];
     return cycle[r % cycle.length];
   };
   const topOf = (r: number) => {
@@ -17,8 +17,8 @@ describe('Example 44 - Variable Row Height (Provider)', { retries: 1 }, () => {
     cy.get('h3').should('contain', 'Example 44 - Variable Row Height (Provider)');
   });
 
-  it('should render looping row heights (33, 40, 56, 72)', () => {
-    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+  it('should render looping row heights (33, 45, 56, 72)', () => {
+    const expectedHeights = [33, 45, 56, 72, 33, 45, 56, 72];
     const defaultRowHeight = 40;
 
     for (const [row, expectedHeight] of expectedHeights.entries()) {

--- a/test/cypress/e2e/example44.cy.ts
+++ b/test/cypress/e2e/example44.cy.ts
@@ -1,0 +1,49 @@
+describe('Example 44 - Variable Row Height (Provider)', { retries: 1 }, () => {
+  // mirrors example44 provider output pattern
+  const hOf = (r: number) => {
+    const cycle = [33, 40, 56, 72];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseUrl')}/example44`);
+    cy.get('h3').should('contain', 'Example 44 - Variable Row Height (Provider)');
+  });
+
+  it('should render looping row heights (33, 40, 56, 72)', () => {
+    const expectedHeights = [33, 40, 56, 72, 33, 40, 56, 72];
+    const defaultRowHeight = 40;
+
+    for (const [r, expectedHeight] of expectedHeights.entries()) {
+      cy.get(`.grid44 .slick-row[data-row=${r}]`)
+        .invoke('attr', 'style')
+        .then((style = '') => {
+          expect(style).to.contain(`transform: translateY(${topOf(r)}px)`);
+          if (expectedHeight === defaultRowHeight) {
+            expect(style).not.to.contain('height:');
+          } else {
+            expect(style).to.contain(`height: ${expectedHeight}px`);
+          }
+        });
+    }
+  });
+
+  it('should keep row 90 aligned at top after clicking scroll button', () => {
+    cy.get('[data-test="scroll-row-90-example44"]').click();
+
+    cy.get('.grid44 .slick-viewport-top.slick-viewport-left')
+      .invoke('scrollTop')
+      .then((scrollTop) => {
+        expect(Number(scrollTop)).to.be.closeTo(topOf(90), 2);
+      });
+
+    cy.get('.grid44 .slick-row[data-row=90]').should('exist');
+  });
+});

--- a/test/cypress/e2e/example45.cy.ts
+++ b/test/cypress/e2e/example45.cy.ts
@@ -30,11 +30,11 @@ describe('Example 45 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
 
   const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid45 .grid-canvas-top' : '.grid45 .grid-canvas-bottom');
 
-  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
-    const expectedHeight = hOf(r);
-    const expectedTop = relativeTopInCanvas(r, hOf);
+  const assertRowStyle = (row: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(row);
+    const expectedTop = relativeTopInCanvas(row, hOf);
 
-    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+    cy.get(`${canvasSelector(row)} .slick-row[data-row=${row}]`)
       .should('have.attr', 'style')
       .and('contain', `transform: translateY(${expectedTop}px)`)
       .then((style) => {
@@ -44,6 +44,7 @@ describe('Example 45 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
           expect(style).not.to.contain('height:');
         }
       });
+    cy.get(`[data-row="${row}"] > .slick-cell:nth(3)`).should('contain', `${expectedHeight}px`);
   };
 
   const ensureDefaultDensity = () => {

--- a/test/cypress/e2e/example45.cy.ts
+++ b/test/cypress/e2e/example45.cy.ts
@@ -1,0 +1,99 @@
+describe('Example 45 - Variable Row Height (Dynamic)', { retries: 1 }, () => {
+  const BASE_ROW_HEIGHT = 40;
+  const FROZEN_ROW_COUNT = 2;
+
+  // mirrors example45 metadata fallback output pattern
+  const hDefault = (r: number) => {
+    const cycle = [33, 44, 44, 80];
+    return cycle[r % cycle.length];
+  };
+  const hCompact = (r: number) => {
+    const cycle = [40, 50, 50, 92];
+    return cycle[r % cycle.length];
+  };
+  const topOf = (r: number, hOf: (row: number) => number) => {
+    let t = 0;
+    for (let i = 0; i < r; i++) {
+      t += hOf(i);
+    }
+    return t;
+  };
+
+  const frozenTopHeight = (hOf: (row: number) => number) => topOf(FROZEN_ROW_COUNT, hOf);
+
+  const relativeTopInCanvas = (r: number, hOf: (row: number) => number) => {
+    if (r < FROZEN_ROW_COUNT) {
+      return topOf(r, hOf);
+    }
+    return topOf(r, hOf) - frozenTopHeight(hOf);
+  };
+
+  const canvasSelector = (r: number) => (r < FROZEN_ROW_COUNT ? '.grid45 .grid-canvas-top' : '.grid45 .grid-canvas-bottom');
+
+  const assertRowStyle = (r: number, hOf: (row: number) => number) => {
+    const expectedHeight = hOf(r);
+    const expectedTop = relativeTopInCanvas(r, hOf);
+
+    cy.get(`${canvasSelector(r)} .slick-row[data-row=${r}]`)
+      .should('have.attr', 'style')
+      .and('contain', `transform: translateY(${expectedTop}px)`)
+      .then((style) => {
+        if (expectedHeight !== BASE_ROW_HEIGHT) {
+          expect(style).to.contain(`height: ${expectedHeight}px`);
+        } else {
+          expect(style).not.to.contain('height:');
+        }
+      });
+  };
+
+  const ensureDefaultDensity = () => {
+    cy.get('.grid45 .grid-canvas-top .slick-row[data-row=1]')
+      .invoke('attr', 'style')
+      .then((style) => {
+        if ((style ?? '').includes('height: 50px')) {
+          cy.get('[data-test="toggle-density"]').click();
+        }
+      });
+
+    cy.get('.grid45 .grid-canvas-top .slick-row[data-row=1]').should('have.attr', 'style').and('contain', 'height: 44px');
+  };
+
+  beforeEach(() => {
+    cy.visit(`${Cypress.config('baseUrl')}/example45`);
+    ensureDefaultDensity();
+  });
+
+  it('should display Example title', () => {
+    cy.get('h3').should('contain', 'Example 45 - Variable Row Height (Dynamic)');
+  });
+
+  it('should render frozen and scrollable rows with expected transform and row heights from metadata fallback', () => {
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hDefault);
+    }
+  });
+
+  it('should increase row heights and row positions after toggling density', () => {
+    assertRowStyle(10, hDefault);
+
+    cy.get('[data-test="toggle-density"]').click();
+
+    assertRowStyle(10, hCompact);
+
+    for (const r of [0, 1, 2, 3, 4, 5, 6]) {
+      assertRowStyle(r, hCompact);
+    }
+  });
+
+  it('should scroll row 90 to top of scrollable pane with frozen top rows', () => {
+    const expectedScrollTop = topOf(90, hDefault) - frozenTopHeight(hDefault);
+
+    cy.get('[data-test="scroll-row-90-example45"]').click();
+
+    cy.get('.grid45 .slick-viewport-bottom.slick-viewport-left').should(($viewport) => {
+      expect($viewport.scrollTop()).to.be.closeTo(expectedScrollTop, 2);
+    });
+
+    cy.get('.grid45 .slick-row[data-row=90]').should('exist');
+  });
+});


### PR DESCRIPTION
_vibe coded mostly with Claude Sonnet 4.6 for initial draft and copilot auto mode for the rest_

## What
Port/align behavior from 6pac/SlickGrid PR #1235 into slickgrid-universal, with one intentional API clarification.

Variable row height is now explicit opt-in via enableVariableRowHeight.

~~~js
const grid = new Slick.Grid('#myGrid', data, columns, {
  rowHeight: 25, // default / fallback
  enableVariableRowHeight: true,
  // optional: custom provider
  rowHeightProvider: (grid, row, item) => (item?.tall ? 50 : undefined),
});
~~~

If enableVariableRowHeight is false, fixed-height path stays active (no variable-height indexing path).

Height resolution in variable mode:
1. rowHeightProvider result, if provided and returns a number
2. ItemMetadata.height, via default provider behavior
3. rowHeight fallback

Important: custom rowHeightProvider is authoritative. if it returns undefined, fallback is rowHeight (not metadata).

## Design
No duplicated render path. geometry still goes through shared row top/bottom/position helpers, with branching inside geometry primitives only.

Fixed mode keeps same arithmetic/perf profile.
Variable mode uses row-position index rebuilds only when needed (dirty flag / count changes / invalidation).

## Changes
1. Core variable-height flow in SlickGrid:
- explicit enableVariableRowHeight gate
- default metadata-aware provider behavior
- provider-only index rebuild source
- invalidateRowHeights support

2. Option + docs updates:
- grid option docs now describe explicit flag
- rowHeightProvider semantics clarified (override behavior + fallback behavior)

3. Rendering/CSS behavior:
- default row height still provided by stylesheet
- per-row inline height only when row differs from default
- kept local slickgrid-universal styling strategy

4. Cell height parity:
- getCellHeight aligned with 6pac logic (rowspan + cellHeightDiff flow)

## Verification
1. Targeted core spec passed after changes:
- slickGrid.spec.ts
- 411 passing, 0 failing

2. Confirmed behavior:
- metadata-only works with enableVariableRowHeight true and no custom provider
- fixed-height mode unchanged when flag is false
- custom provider returning undefined falls back to rowHeight

### Demo

<img width="1135" height="707" alt="image" src="https://github.com/user-attachments/assets/6495555e-2295-4868-b408-1d5886453f5d" />
