### PR TITLE
fix: Row Detail `keepComponentAlive` duplicates and render race timing issue

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example45-detail-view.ts
+++ b/demos/aurelia/src/examples/slickgrid/example45-detail-view.ts
@@ -25,7 +25,7 @@ export class Example45DetailView {
   @bindable() model?: Distributor;
   innerColDefs: Column[] = [];
   innerGridOptions!: GridOption;
-  aureliaGrid!: AureliaGridInstance;
+  aureliaGrid?: AureliaGridInstance;
   innerDataset: any[] = [];
   showGrid = false;
   gridId = '';
@@ -87,7 +87,7 @@ export class Example45DetailView {
 
   handleBeforeGridDestroy() {
     console.log('handleBeforeGridDestroy', this.model);
-    if (this.model?.isUsingInnerGridStatePresets) {
+    if (this.model?.isUsingInnerGridStatePresets && this.aureliaGrid?.gridStateService) {
       const gridState = this.aureliaGrid.gridStateService.getCurrentGridState();
       sessionStorage.setItem(`gridstate_${this.innerGridClass}`, JSON.stringify(gridState));
     }

--- a/demos/react/src/examples/slickgrid/Example45-detail-view.tsx
+++ b/demos/react/src/examples/slickgrid/Example45-detail-view.tsx
@@ -89,7 +89,7 @@ const Example45DetailView: React.FC<RowDetailViewProps<Distributor, typeof Examp
   }
 
   function handleBeforeGridDestroy() {
-    if (props.model.isUsingInnerGridStatePresets) {
+    if (props.model.isUsingInnerGridStatePresets && reactGridRef.current?.gridStateService) {
       const gridState = reactGridRef.current?.gridStateService.getCurrentGridState();
       sessionStorage.setItem(`gridstate_${innerGridClass}`, JSON.stringify(gridState));
     }

--- a/demos/vue/src/components/Example45Detail.vue
+++ b/demos/vue/src/components/Example45Detail.vue
@@ -36,7 +36,7 @@ const innerGridOptions = ref<GridOption>();
 const innerColDefs: Ref<Column[]> = ref([]);
 const innerDataset = ref<any[]>([]);
 const innerGridClass = ref(`row-detail-${props.model.id}`);
-let vueGrid!: SlickgridVueInstance;
+let vueGrid: SlickgridVueInstance | undefined;
 
 onBeforeMount(() => {
   defineGrid();
@@ -52,7 +52,7 @@ onMounted(() => {
 });
 
 function handleBeforeGridDestroy() {
-  if (props.model.isUsingInnerGridStatePresets) {
+  if (props.model.isUsingInnerGridStatePresets && vueGrid?.gridStateService) {
     const gridState = vueGrid.gridStateService.getCurrentGridState();
     sessionStorage.setItem(`gridstate_${innerGridClass.value}`, JSON.stringify(gridState));
   }

--- a/frameworks-plugins/angular-row-detail-plugin/src/angularRowDetailView.ts
+++ b/frameworks-plugins/angular-row-detail-plugin/src/angularRowDetailView.ts
@@ -228,15 +228,22 @@ export class AngularRowDetailView extends UniversalSlickRowDetailView {
         this.eventHandler.subscribe(this._grid.onSort, this.disposeAllViewComponents.bind(this));
 
         // redraw all Views whenever certain events are triggered
+        // use a setTimeout to ensure the grid has finished re-rendering before we redraw
+        // (onBeforeRowOutOfViewportRange may set rendered=false during the render cycle)
         this._subscriptions.push(
           this.eventPubSubService?.subscribe(
-            ['onFilterChanged', 'onGridMenuColumnsChanged', 'onColumnPickerColumnsChanged'],
-            this.redrawAllViewComponents.bind(this, false)
-          ),
-          this.eventPubSubService?.subscribe(['onGridMenuClearAllFilters', 'onGridMenuClearAllSorting'], () => {
-            clearTimeout(this._timer);
-            this._timer = setTimeout(() => this.redrawAllViewComponents());
-          })
+            [
+              'onFilterChanged',
+              'onGridMenuColumnsChanged',
+              'onColumnPickerColumnsChanged',
+              'onGridMenuClearAllFilters',
+              'onGridMenuClearAllSorting',
+            ],
+            () => {
+              clearTimeout(this._timer);
+              this._timer = setTimeout(() => this.redrawAllViewComponents());
+            }
+          )
         );
       }
     }

--- a/frameworks-plugins/angular-row-detail-plugin/src/angularRowDetailView.ts
+++ b/frameworks-plugins/angular-row-detail-plugin/src/angularRowDetailView.ts
@@ -282,8 +282,14 @@ export class AngularRowDetailView extends UniversalSlickRowDetailView {
     if (this._viewComponent && containerElement) {
       const viewObj = this._views.find((obj) => obj.id === item[this.datasetIdPropName]);
 
-      // If keep-component-alive is enabled and component already exists (but detached), reattach it instead of creating new
-      if (this.rowDetailViewOptions?.keepComponentAlive && viewObj?.componentRef && !viewObj.rendered) {
+      // If keep-component-alive is enabled and component already exists (but detached OR element disconnected from DOM),
+      // reattach it instead of creating new. The element can be disconnected when singleRowExpand triggers collapseAll()
+      // internally, which bypasses onBeforeRowDetailToggle and leaves rendered=true while removing the element from DOM.
+      if (
+        this.rowDetailViewOptions?.keepComponentAlive &&
+        viewObj?.componentRef &&
+        (!viewObj.rendered || !viewObj.componentRef.location.nativeElement?.isConnected)
+      ) {
         this.reattachViewComponent(viewObj);
         return viewObj;
       }

--- a/frameworks-plugins/aurelia-row-detail-plugin/src/aureliaRowDetailView.ts
+++ b/frameworks-plugins/aurelia-row-detail-plugin/src/aureliaRowDetailView.ts
@@ -273,9 +273,15 @@ export class AureliaRowDetailView extends UniversalSlickRowDetailView {
     if (this._viewModel && containerElement) {
       const slotObj = this._slots.find((obj) => obj.id === item[this.datasetIdPropName]);
 
-      // If keep-component-alive is enabled and component already exists (but detached), try to reattach it
+      // If keep-component-alive is enabled and component already exists (but detached OR host disconnected from DOM),
+      // try to reattach it. The host can be disconnected when singleRowExpand triggers collapseAll() internally,
+      // which bypasses onBeforeRowDetailToggle and leaves the controller alive while removing the host from DOM.
       // If reattach fails, fall back to re-rendering fresh
-      if (this.rowDetailViewOptions?.keepComponentAlive && slotObj?.controller && this._keepAliveSlotIds.has(slotObj.id)) {
+      if (
+        this.rowDetailViewOptions?.keepComponentAlive &&
+        slotObj?.controller &&
+        (this._keepAliveSlotIds.has(slotObj.id) || !slotObj.controller.host?.isConnected)
+      ) {
         const reattachSuccess = this.reattachViewSlot(slotObj);
         if (reattachSuccess) {
           return;

--- a/frameworks-plugins/aurelia-row-detail-plugin/src/aureliaRowDetailView.ts
+++ b/frameworks-plugins/aurelia-row-detail-plugin/src/aureliaRowDetailView.ts
@@ -209,15 +209,22 @@ export class AureliaRowDetailView extends UniversalSlickRowDetailView {
           this._eventHandler.subscribe(this._grid.onSort, this.disposeAllViewSlot.bind(this));
 
           // redraw all Views whenever certain events are triggered
+          // use a setTimeout to ensure the grid has finished re-rendering before we redraw
+          // (onBeforeRowOutOfViewportRange may set rendered=false during the render cycle)
           this._subscriptions.push(
             this.eventPubSubService?.subscribe(
-              ['onFilterChanged', 'onGridMenuColumnsChanged', 'onColumnPickerColumnsChanged'],
-              this.redrawAllViewSlots.bind(this, false)
-            ),
-            this.eventPubSubService?.subscribe(['onGridMenuClearAllFilters', 'onGridMenuClearAllSorting'], () => {
-              clearTimeout(this._timer);
-              this._timer = setTimeout(() => this.redrawAllViewSlots());
-            })
+              [
+                'onFilterChanged',
+                'onGridMenuColumnsChanged',
+                'onColumnPickerColumnsChanged',
+                'onGridMenuClearAllFilters',
+                'onGridMenuClearAllSorting',
+              ],
+              () => {
+                clearTimeout(this._timer);
+                this._timer = setTimeout(() => this.redrawAllViewSlots());
+              }
+            )
           );
         }
       }

--- a/frameworks-plugins/vue-row-detail-plugin/src/vueRowDetailView.ts
+++ b/frameworks-plugins/vue-row-detail-plugin/src/vueRowDetailView.ts
@@ -311,8 +311,10 @@ export class VueRowDetailView extends UniversalSlickRowDetailView {
     if (this._component && containerElement) {
       const viewObj = this._views.find((obj) => obj.id === itemId);
 
-      // If keep-component-alive is enabled and component already exists (but detached), reattach it instead of recreating
-      if (this.rowDetailViewOptions?.keepComponentAlive && viewObj?.instance && !viewObj.rendered) {
+      // If keep-component-alive is enabled and component already exists (but detached OR element disconnected from DOM),
+      // reattach it instead of recreating. The element can be disconnected when singleRowExpand triggers collapseAll()
+      // internally, which bypasses onBeforeRowDetailToggle and leaves rendered=true while removing the element from DOM.
+      if (this.rowDetailViewOptions?.keepComponentAlive && viewObj?.instance && (!viewObj.rendered || !viewObj.instance.$el?.isConnected)) {
         const reattachSuccess = this.reattachViewComponent(viewObj);
         if (reattachSuccess) {
           return;

--- a/frameworks/angular-slickgrid/src/demos/examples/example45-detail.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example45-detail.component.ts
@@ -30,7 +30,7 @@ export class Example45DetailComponent implements OnDestroy, OnInit {
   model!: Distributor;
   innerColDefs: Column[] = [];
   innerGridOptions!: GridOption;
-  angularGrid!: AngularGridInstance;
+  angularGrid?: AngularGridInstance;
   innerDataset: any[] = [];
   innerGridId = '';
   innerGridClass = '';
@@ -89,7 +89,7 @@ export class Example45DetailComponent implements OnDestroy, OnInit {
   }
 
   handleBeforeGridDestroy() {
-    if (this.model.isUsingInnerGridStatePresets) {
+    if (this.model.isUsingInnerGridStatePresets && this.angularGrid?.gridStateService) {
       const gridState = this.angularGrid.gridStateService.getCurrentGridState();
       sessionStorage.setItem(`gridstate_${this.innerGridClass}`, JSON.stringify(gridState));
     }


### PR DESCRIPTION
### First bug (`keepComponentAlive` + `singleRowExpand`)

When `keepComponentAlive: true` + `singleRowExpand: true`, expanding a new row
calls `expandDetailView()` which calls `collapseAll()` internally. This path
bypasses `onBeforeRowDetailToggle`, so the outgoing row's "rendered" flag (Angular/Vue)
or `_keepAliveSlotIds` membership (Aurelia) is never updated — even though the host
element has been removed from the DOM. On re-expansion, the reattach guard fails
to detect the disconnected state and a **new** component is created alongside the
still-alive old one, producing duplicate child grid headers/content.

**Fix:** also check `nativeElement.isConnected` (Angular/Vue) and
`controller.host.isConnected` (Aurelia) so that elements silently disconnected
by the `collapseAll` path trigger reattachment instead of recreation.

React is unaffected: its `keepComponentAlive` persists the container DOM element
itself in a `_persistedContainers` Map; `postTemplate` re-inserts the same live
container on every expansion, so `renderViewModel` is never invoked on re-expansion.

Fixes: Angular, Vue, Aurelia row detail plugins.

### Second bug found (row detail not rendered because of race timing issue)

The bug is a timing race in Angular-Slickgrid and Aurelia-Slickgrid: `onFilterChanged` fires `redrawAllViewComponents(false)` before the grid re-renders. During the re-render, `onBeforeRemoveCachedRow` → `handleRemoveRow` → `onBeforeRowOutOfViewportRange` fires for row 2, calling `disposeViewByItem` which sets `rendered = false`. But by then, `redrawAllViewComponents` has already passed the check and skipped it. No subsequent redraw is triggered, leaving the container empty.

**Root cause**: `onFilterChanged` fires the `redrawAllViewComponents(false)` callback **synchronously**, before the grid re-renders. During that re-render, `onBeforeRemoveCachedRow` → `handleRemoveRow` → `onBeforeRowOutOfViewportRange` fires for the row that moved positions, which calls `disposeViewByItem` → sets `view.rendered = false`. By then `redrawAllViewComponents` has already skipped that view (it checked `rendered = true`), and there's no subsequent trigger to re-render it. The container stays in the DOM but empty.

**Why React/Vue don't have this bug**: their `redrawAllViewComponents` already wraps its body in `clearTimeout`/`setTimeout` internally — it always defers execution.

**Fix**: Consolidate all filter/column events into a single `setTimeout`-delayed handler (same pattern already used for `onGridMenuClearAllFilters`). Applied to Angular and Aurelia. React and Vue are unaffected.