### PR TITLE
fix(a11y): Row Detail missing `aria-expanded` attribute for accessibility

### DIFF
--- a/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
@@ -45,6 +45,7 @@ const getEditorLockMock = {
 const gridStub = {
   getCellFromEvent: vi.fn(),
   getCellNode: vi.fn(),
+  getActiveCell: vi.fn(),
   getColumns: vi.fn(),
   getColumnByIdx: vi.fn(),
   getDataItem: vi.fn(),
@@ -62,6 +63,7 @@ const gridStub = {
   onBeforeEditCell: new SlickEvent(),
   onBeforeRemoveCachedRow: new SlickEvent(),
   onClick: new SlickEvent(),
+  onKeyDown: new SlickEvent(),
   onRendered: new SlickEvent(),
   onScroll: new SlickEvent(),
   onSort: new SlickEvent(),
@@ -1356,7 +1358,7 @@ describe('SlickRowDetailView plugin', () => {
       plugin.setOptions({ collapsedClass: 'some-collapsed' });
       plugin.expandableOverride(() => true);
       const formattedVal = plugin.getColumnDefinition().formatter!(0, 1, '', mockColumns[0], mockItem, gridStub);
-      expect((formattedVal as HTMLElement).outerHTML).toBe(`<div class="sgi detailView-toggle expand some-collapsed"></div>`);
+      expect((formattedVal as HTMLElement).outerHTML).toBe(`<div class="sgi detailView-toggle expand some-collapsed" aria-expanded="false"></div>`);
     });
 
     it('should execute formatter and expect it to return empty string and render nothing when isPadding is True', () => {
@@ -1383,7 +1385,7 @@ describe('SlickRowDetailView plugin', () => {
       plugin.expandableOverride(() => true);
       const formattedVal = plugin.getColumnDefinition().formatter!(0, 1, '', mockColumns[0], mockItem, gridStub);
       expect(((formattedVal as FormatterResultWithHtml).html as HTMLElement).outerHTML).toBe(
-        `<div class="sgi detailView-toggle collapse some-expanded"></div>`
+        `<div class="sgi detailView-toggle collapse some-expanded" aria-expanded="true"></div>`
       );
       expect((formattedVal as FormatterResultWithHtml).insertElementAfterTarget!.outerHTML).toBe(
         `<div class="dynamic-cell-detail cellDetailView_123" style="height: 50px; top: 25px;"><div class="detail-container detailViewContainer_123"><div class="innerDetailView_123"><div>Loading...</div></div></div></div>`
@@ -1405,11 +1407,166 @@ describe('SlickRowDetailView plugin', () => {
       plugin.expandableOverride(() => true);
       const formattedVal = plugin.getColumnDefinition().formatter!(0, 1, '', mockColumns[0], mockItem, gridStub);
       expect(((formattedVal as FormatterResultWithHtml).html as HTMLElement).outerHTML).toBe(
-        `<div class="sgi detailView-toggle collapse some-expanded"></div>`
+        `<div class="sgi detailView-toggle collapse some-expanded" aria-expanded="true"></div>`
       );
       expect((formattedVal as FormatterResultWithHtml).insertElementAfterTarget!.outerHTML).toBe(
         `<div class="dynamic-cell-detail cellDetailView_123" style="height: 50px; top: 25px;"><div class="detail-container detailViewContainer_123"><div class="innerDetailView_123"><div>Loading...</div></div></div></div>`
       );
+    });
+  });
+
+  describe('handleKeyDown - keyboard a11y handler', () => {
+    let preventDefaultSpy: ReturnType<typeof vi.spyOn>;
+    let stopPropagationSpy: ReturnType<typeof vi.spyOn>;
+    let toggleRowSelectionSpy: ReturnType<typeof vi.spyOn>;
+    let keyDownEvent: Event;
+    const detailColumn = { id: '_detail_selector', field: '_detail_selector' };
+    const mockActiveCell = { row: 0, cell: 0 };
+
+    beforeEach(() => {
+      vi.spyOn(gridStub, 'getActiveCell').mockReturnValue(mockActiveCell);
+      vi.spyOn(gridStub, 'getEditorLock').mockReturnValue({ isActive: () => false } as any);
+      vi.spyOn(gridStub, 'getColumnByIdx').mockReturnValue(detailColumn as any);
+      vi.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock); // reset to defaults (no useRowClick)
+
+      keyDownEvent = new Event('keydown');
+      Object.defineProperty(keyDownEvent, 'key', { writable: true, configurable: true, value: ' ' });
+      Object.defineProperty(keyDownEvent, 'isPropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+      Object.defineProperty(keyDownEvent, 'isImmediatePropagationStopped', { writable: true, configurable: true, value: vi.fn() });
+      preventDefaultSpy = vi.spyOn(keyDownEvent, 'preventDefault');
+      stopPropagationSpy = vi.spyOn(keyDownEvent, 'stopImmediatePropagation');
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should toggle (expand) a collapsed row with Space key', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection').mockImplementation(vi.fn());
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).toHaveBeenCalledWith(0, mockItem);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should expand a collapsed row with ArrowRight key', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection').mockImplementation(vi.fn());
+      Object.defineProperty(keyDownEvent, 'key', { writable: true, configurable: true, value: 'ArrowRight' });
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).toHaveBeenCalledWith(0, mockItem);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should NOT expand an already expanded row with ArrowRight key', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: false };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection');
+      Object.defineProperty(keyDownEvent, 'key', { writable: true, configurable: true, value: 'ArrowRight' });
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).not.toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(stopPropagationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should collapse an expanded row with ArrowLeft key', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: false };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection').mockImplementation(vi.fn());
+      Object.defineProperty(keyDownEvent, 'key', { writable: true, configurable: true, value: 'ArrowLeft' });
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).toHaveBeenCalledWith(0, mockItem);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should NOT collapse an already collapsed row with ArrowLeft key', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection');
+      Object.defineProperty(keyDownEvent, 'key', { writable: true, configurable: true, value: 'ArrowLeft' });
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).not.toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(stopPropagationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not toggle when inline editor is active', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      vi.spyOn(gridStub, 'getEditorLock').mockReturnValue({ isActive: () => true } as any);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection');
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).not.toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(stopPropagationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not toggle when focused on a non-toggle column (without useRowClick)', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      (gridStub.getColumnByIdx as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'firstName' });
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection');
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 1, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).not.toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
+
+    it('should toggle from any column when useRowClick is enabled', () => {
+      const mockProcess = vi.fn();
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      (gridStub.getColumnByIdx as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'firstName' });
+      vi.spyOn(gridStub, 'getOptions').mockReturnValue({
+        ...gridOptionsMock,
+        rowDetailView: { process: mockProcess, columnIndexPosition: 0, useRowClick: true, panelRows: 2 } as any,
+      });
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection').mockImplementation(vi.fn());
+      plugin.init(gridStub);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 1, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).toHaveBeenCalledWith(0, mockItem);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should not toggle when checkExpandableOverride returns false', () => {
+      const mockItem = { id: 123, firstName: 'John', lastName: 'Doe', __collapsed: true };
+      vi.spyOn(gridStub, 'getDataItem').mockReturnValue(mockItem);
+      toggleRowSelectionSpy = vi.spyOn(plugin, 'toggleRowSelection');
+      plugin.init(gridStub);
+      plugin.expandableOverride(() => false);
+
+      gridStub.onKeyDown.notify({ row: 0, cell: 0, grid: gridStub }, keyDownEvent);
+
+      expect(toggleRowSelectionSpy).not.toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -156,6 +156,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
 
     this._eventHandler
       .subscribe(this._grid.onClick, this.handleClick.bind(this))
+      .subscribe(this._grid.onKeyDown, this.handleKeyDown.bind(this))
       .subscribe(this._grid.onBeforeEditCell, () => this.collapseAll())
       .subscribe(this._grid.onScroll, () => this.recalculateOutOfRangeViews(true, 0))
       .subscribe(this._grid.onBeforeRemoveCachedRow, (_e, args) => this.handleRemoveRow(args.row))
@@ -671,7 +672,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
         if (this._addonOptions.collapsedClass) {
           collapsedClasses += this._addonOptions.collapsedClass;
         }
-        return createDomElement('div', { className: classNameToList(collapsedClasses).join(' ') });
+        return createDomElement('div', { className: classNameToList(collapsedClasses).join(' '), ariaExpanded: 'false' });
       } else {
         const rowHeight = this.gridOptions.rowHeight || 0;
         let outterHeight = (dataContext[`${this._keyPrefix}sizePadding`] || 0) * this.gridOptions.rowHeight!;
@@ -708,7 +709,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
         cellDetailContainerElm.appendChild(innerContainerElm);
 
         const result: FormatterResultWithHtml = {
-          html: createDomElement('div', { className: classNameToList(expandedClasses).join(' ') }),
+          html: createDomElement('div', { className: classNameToList(expandedClasses).join(' '), ariaExpanded: 'true' }),
           insertElementAfterTarget: cellDetailContainerElm,
         };
 
@@ -726,6 +727,28 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
         this.collapseDetailView(itemId);
       } else {
         this.expandDetailView(itemId);
+      }
+    }
+  }
+
+  /** Handle keyboard a11y for row detail toggle: Space, ArrowRight (expand), ArrowLeft (collapse). */
+  protected handleKeyDown(e: SlickEventData): void {
+    const key = e.key;
+    const activeCell = this._grid.getActiveCell();
+    const isSupportedKey = key === ' ' || key === 'ArrowRight' || key === 'ArrowLeft';
+    if (isSupportedKey && activeCell && !this._grid.getEditorLock()?.isActive()) {
+      const dataContext = this._grid.getDataItem(activeCell.row);
+      if (this.checkExpandableOverride(activeCell.row, dataContext, this._grid)) {
+        const column = this._grid.getColumnByIdx(activeCell.cell);
+        const isTogglerCell = this._addonOptions.useRowClick || column?.id === this._addonOptions.columnId;
+        const isCollapsed = !!dataContext[`${this._keyPrefix}collapsed`];
+        const isValidDirection = !(key === 'ArrowRight' && !isCollapsed) && !(key === 'ArrowLeft' && isCollapsed);
+
+        if (isTogglerCell && isValidDirection) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          this.toggleRowSelection(activeCell.row, dataContext);
+        }
       }
     }
   }


### PR DESCRIPTION
### Summary
Two a11y gaps in the Row Detail plugin that match the pattern already established in Tree Data and Grouping:

1. No aria-expanded on the toggle icon in `detailSelectionFormatter`
2. No keyboard handler — Tree Data and Grouping both subscribe `onKeyDown` with Space (toggle), `ArrowRight` (expand), `ArrowLeft` (collapse) + editor-lock guard