### PR TITLE
chore(tests): change Cypress config to use `scrollBehavior: 'nearest'`

### DIFF
--- a/demos/aurelia/test/cypress.config.ts
+++ b/demos/aurelia/test/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   defaultCommandTimeout: 5000,
   pageLoadTimeout: 90000,
   numTestsKeptInMemory: 5,
+  scrollBehavior: 'nearest',
   retries: {
     experimentalStrategy: 'detect-flake-and-pass-on-threshold',
     experimentalOptions: {

--- a/demos/react/test/cypress.config.ts
+++ b/demos/react/test/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   defaultCommandTimeout: 5000,
   pageLoadTimeout: 90000,
   numTestsKeptInMemory: 5,
+  scrollBehavior: 'nearest',
   retries: {
     experimentalStrategy: 'detect-flake-and-pass-on-threshold',
     experimentalOptions: {

--- a/demos/vanilla/src/examples/example17.html
+++ b/demos/vanilla/src/examples/example17.html
@@ -20,20 +20,8 @@
   Dragging from 2nd column to make a selection, and the viewport will auto scroll.
 </h6>
 
-<div style.bind="subTitleStyle">
-  <span class="ml-1 mb-2">
-    <label for="">Grid 1 - Pinned Columns: </label>
-    <input
-      type="number"
-      data-test="frozen-column-count"
-      class="frozen-column-count is-narrow input is-small"
-      value.bind="frozenColumnCount"
-    />
-    <button class="button is-small" data-test="set-frozen-columns-btn" onclick.trigger="changeFrozenColumnCount()">Set</button>
-  </span>
-</div>
 <div>
-  <div class="row scroll-configs" style.bind="subTitleStyle">
+  <div class="row scroll-configs">
     <span>
       <label for="min-internal">MIN interval to show next cell (ms): </label>
       <input id="min-internal" class="is-narrow input is-small" type="number" data-test="min-interval-input" value.bind="minInterval" />
@@ -43,8 +31,18 @@
       <input id="delay-cursor" class="is-narrow input is-small" type="number" data-test="delay-cursor-input" value.bind="delayCursor" />
     </span>
   </div>
-  <div class="row my-3" style.bind="subTitleStyle">
-    <label for="is-autoscroll">Auto Scroll: (need click Set Options): </label>
+  <div class="row my-3">
+    <span class="ml-1 mb-2">
+      <label for="">Grid 1 - Pinned Columns: </label>
+      <input
+        type="number"
+        data-test="frozen-column-count"
+        class="frozen-column-count is-narrow input is-small"
+        value.bind="frozenColumnCount"
+      />
+      <button class="button is-small" data-test="set-frozen-columns-btn" onclick.trigger="changeFrozenColumnCount()">Set</button>
+    </span>
+    <label for="is-autoscroll">Auto Scroll: </label>
     <input id="is-autoscroll" type="checkbox" data-test="is-autoscroll-chk" checked.bind="isAutoScroll" />
 
     <span class="ml-2">

--- a/demos/vanilla/src/examples/example17.html
+++ b/demos/vanilla/src/examples/example17.html
@@ -1,6 +1,9 @@
 <h3 class="title is-3">
   Example 17 - Auto-Scroll with Range Selector
   <span class="subtitle">(with Salesforce Theme)</span>
+  <button class="button is-small" type="button" data-test="toggle-subtitle" onclick.trigger="toggleSubTitle()">
+    <span class="mdi mdi-information-outline" title="Toggle example sub-title details"></span>
+  </button>
   <div class="subtitle code-link">
     <span class="is-size-6">see</span>
     <a
@@ -12,9 +15,12 @@
     </a>
   </div>
 </h3>
-<h6 class="italic content example-details">Dragging from 2nd column to make a selection, and the viewport will auto scroll.</h6>
 
-<div>
+<h6 class="italic content example-details" style.bind="subTitleStyle">
+  Dragging from 2nd column to make a selection, and the viewport will auto scroll.
+</h6>
+
+<div style.bind="subTitleStyle">
   <span class="ml-1 mb-2">
     <label for="">Grid 1 - Pinned Columns: </label>
     <input
@@ -27,7 +33,7 @@
   </span>
 </div>
 <div>
-  <div class="row scroll-configs">
+  <div class="row scroll-configs" style.bind="subTitleStyle">
     <span>
       <label for="min-internal">MIN interval to show next cell (ms): </label>
       <input id="min-internal" class="is-narrow input is-small" type="number" data-test="min-interval-input" value.bind="minInterval" />
@@ -37,7 +43,7 @@
       <input id="delay-cursor" class="is-narrow input is-small" type="number" data-test="delay-cursor-input" value.bind="delayCursor" />
     </span>
   </div>
-  <div class="row my-3">
+  <div class="row my-3" style.bind="subTitleStyle">
     <label for="is-autoscroll">Auto Scroll: (need click Set Options): </label>
     <input id="is-autoscroll" type="checkbox" data-test="is-autoscroll-chk" checked.bind="isAutoScroll" />
 

--- a/demos/vanilla/src/examples/example17.ts
+++ b/demos/vanilla/src/examples/example17.ts
@@ -31,6 +31,7 @@ export default class Example17 {
   maxInterval = 600;
   delayCursor = 5;
   frozenColumnCount = -1;
+  subTitleStyle = 'display: block';
 
   attached() {
     this.defineGrids();
@@ -284,5 +285,9 @@ export default class Example17 {
     };
     this.sgb1.slickGrid?.setOptions(newOption);
     this.sgb2.slickGrid?.setOptions(newOption);
+  }
+
+  toggleSubTitle() {
+    this.subTitleStyle = this.subTitleStyle === 'display: block' ? 'display: none' : 'display: block';
   }
 }

--- a/demos/vue/test/cypress.config.mjs
+++ b/demos/vue/test/cypress.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
   defaultCommandTimeout: 5000,
   pageLoadTimeout: 90000,
   numTestsKeptInMemory: 5,
+  scrollBehavior: 'nearest',
   retries: {
     experimentalStrategy: 'detect-flake-and-pass-on-threshold',
     experimentalOptions: {

--- a/frameworks/angular-slickgrid/test/cypress.config.ts
+++ b/frameworks/angular-slickgrid/test/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   defaultCommandTimeout: 5000,
   pageLoadTimeout: 90000,
   numTestsKeptInMemory: 5,
+  scrollBehavior: 'nearest',
   retries: {
     experimentalStrategy: 'detect-flake-and-pass-on-threshold',
     experimentalOptions: {

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   defaultCommandTimeout: 5000,
   pageLoadTimeout: 90000,
   numTestsKeptInMemory: 5,
+  scrollBehavior: 'nearest',
   retries: {
     experimentalStrategy: 'detect-flake-and-pass-on-threshold',
     experimentalOptions: {

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   video: false,
   projectId: 'p5zxx6',
   viewportWidth: 1200,
-  viewportHeight: 950,
+  viewportHeight: 1050,
   fixturesFolder: 'test/cypress/fixtures',
   screenshotsFolder: 'test/cypress/screenshots',
   videosFolder: 'test/cypress/videos',

--- a/test/cypress/e2e/example17.cy.ts
+++ b/test/cypress/e2e/example17.cy.ts
@@ -150,7 +150,7 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
   });
 
   /* this test is very flaky, let's skip it since it doesn't bring much value anyway */
-  it.skip('should MAX interval take effect when auto scroll: 600ms -> 200ms', { scrollBehavior: false }, () => {
+  it('should MAX interval take effect when auto scroll: 600ms -> 200ms', { scrollBehavior: false }, () => {
     // By default the MAX interval to show next cell is 600ms.
     testInterval(0, 9).then((defaultInterval) => {
       // Setting the interval to 200ms (1/3 of the default).
@@ -264,6 +264,8 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
     cy.get('.grid17-1 .slick-viewport-bottom.slick-viewport-right').scrollTo(CELL_WIDTH * 3, CELL_HEIGHT * 3);
     cy.get('.grid17-2 .slick-viewport-bottom.slick-viewport-right').scrollTo(CELL_WIDTH * 3, CELL_HEIGHT * 3);
 
+    cy.get('[data-test="toggle-subtitle"]').click();
+
     // bottom right - to topLeft
     getScrollDistanceWhenDragOutsideGrid('.grid17-1', 'bottomRight', 'topLeft', 6, 4, 140).then((result: any) => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
@@ -280,6 +282,7 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
     'should have a frozen & grouping by Duration grid after click Set/Clear grouping by Duration button',
     { scrollBehavior: false },
     () => {
+      cy.get('[data-test="toggle-subtitle"]').click();
       cy.get('[data-test="set-clear-grouping-btn"]').trigger('click');
       cy.get(`.grid17-1 [style="transform: translateY(${CELL_HEIGHT * 0}px);"]`).should('have.length', 2 * 2);
       cy.get(`.grid17-2 [style="transform: translateY(${CELL_HEIGHT * 0}px);"]`).should('have.length', 2 * 2);
@@ -306,16 +309,14 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
   }
 
   // skip flaky test for now
-  it.skip(
-    'should auto scroll to display the selecting element even unselectable cell exist in grouping grid',
-    { scrollBehavior: false },
-    () => {
-      testDragInGrouping('.grid17-1');
-      testDragInGrouping('.grid17-2');
-    }
-  );
+  it('should auto scroll to display the selecting element even unselectable cell exist in grouping grid', { scrollBehavior: false }, () => {
+    cy.get('[data-test="toggle-subtitle"]').click();
+    testDragInGrouping('.grid17-1');
+    testDragInGrouping('.grid17-2');
+  });
 
   it('should reset to default grid when click Set/Clear Frozen button and Set/Clear grouping button', () => {
+    cy.get('[data-test="toggle-subtitle"]').click();
     cy.get('[data-test="set-clear-frozen-btn"]').trigger('click');
     cy.get('[data-test="set-clear-grouping-btn"]').trigger('click');
     cy.get(`.grid17-1 [style="transform: translateY(${CELL_HEIGHT * 0}px);"]`).should('have.length', 1);

--- a/test/cypress/e2e/example17.cy.ts
+++ b/test/cypress/e2e/example17.cy.ts
@@ -32,6 +32,7 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
       .find('.slick-header-columns')
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+    cy.get('[data-test="toggle-subtitle"]').click();
   });
 
   it(
@@ -264,8 +265,6 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
     cy.get('.grid17-1 .slick-viewport-bottom.slick-viewport-right').scrollTo(CELL_WIDTH * 3, CELL_HEIGHT * 3);
     cy.get('.grid17-2 .slick-viewport-bottom.slick-viewport-right').scrollTo(CELL_WIDTH * 3, CELL_HEIGHT * 3);
 
-    cy.get('[data-test="toggle-subtitle"]').click();
-
     // bottom right - to topLeft
     getScrollDistanceWhenDragOutsideGrid('.grid17-1', 'bottomRight', 'topLeft', 6, 4, 140).then((result: any) => {
       expect(result.scrollTopBefore).to.be.greaterThan(result.scrollTopAfter);
@@ -282,7 +281,6 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
     'should have a frozen & grouping by Duration grid after click Set/Clear grouping by Duration button',
     { scrollBehavior: false },
     () => {
-      cy.get('[data-test="toggle-subtitle"]').click();
       cy.get('[data-test="set-clear-grouping-btn"]').trigger('click');
       cy.get(`.grid17-1 [style="transform: translateY(${CELL_HEIGHT * 0}px);"]`).should('have.length', 2 * 2);
       cy.get(`.grid17-2 [style="transform: translateY(${CELL_HEIGHT * 0}px);"]`).should('have.length', 2 * 2);
@@ -310,13 +308,11 @@ describe('Example 17 - Auto-Scroll with Range Selector', () => {
 
   // skip flaky test for now
   it('should auto scroll to display the selecting element even unselectable cell exist in grouping grid', { scrollBehavior: false }, () => {
-    cy.get('[data-test="toggle-subtitle"]').click();
     testDragInGrouping('.grid17-1');
     testDragInGrouping('.grid17-2');
   });
 
   it('should reset to default grid when click Set/Clear Frozen button and Set/Clear grouping button', () => {
-    cy.get('[data-test="toggle-subtitle"]').click();
     cy.get('[data-test="set-clear-frozen-btn"]').trigger('click');
     cy.get('[data-test="set-clear-grouping-btn"]').trigger('click');
     cy.get(`.grid17-1 [style="transform: translateY(${CELL_HEIGHT * 0}px);"]`).should('have.length', 1);


### PR DESCRIPTION
Cypress default for `scrollBehavior` is `'top'`, but I think it's better to use `'nearest'` and that also helps upgrading pnpm v10 to v11 (separate PR)