### PR TITLE
fix: Row Detail newly expanded row shouldn't be re-rendered

### DIFF
--- a/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
@@ -985,14 +985,20 @@ describe('SlickRowDetailView plugin', () => {
         .mockReturnValueOnce(123)
         .mockReturnValueOnce(123)
         .mockReturnValueOnce(123);
-      vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
-        121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        123: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-      });
-      vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 120, bottom: 150, left: 33, right: 18 } as any);
+      vi.spyOn(gridStub, 'getRowCache')
+        .mockReturnValue({
+          121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          123: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        })
+        .mockReturnValueOnce({
+          121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        });
+      vi.spyOn(gridStub, 'getRenderedRange')
+        .mockReturnValue({ top: 120, bottom: 150, left: 33, right: 18 } as any)
+        .mockReturnValueOnce({ top: 140, bottom: 150, left: 33, right: 18 } as any);
       divContainer.appendChild(cellDetailViewElm);
       Object.defineProperty(detailViewContainerElm, 'scrollHeight', { writable: true, configurable: true, value: 4 });
       vi.spyOn(gridStub, 'getOptions').mockReturnValue({
@@ -1014,7 +1020,7 @@ describe('SlickRowDetailView plugin', () => {
 
       const onRowBackToViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
       const eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
-      gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 33, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
+      gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 330, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
       gridStub.onScroll.notify({ scrollLeft: 22, scrollTop: 35, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
@@ -1041,13 +1047,19 @@ describe('SlickRowDetailView plugin', () => {
       vi.advanceTimersByTime(102);
       plugin.collapseDetailView(1);
 
-      vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
-        121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-      });
-      vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 120, bottom: 150, left: 33, right: 18 } as any);
+      vi.spyOn(gridStub, 'getRowCache')
+        .mockReturnValue({
+          121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        })
+        .mockReturnValueOnce({
+          121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        });
+      vi.spyOn(gridStub, 'getRenderedRange')
+        .mockReturnValue({ top: 120, bottom: 150, left: 33, right: 18 } as any)
+        .mockReturnValueOnce({ top: 140, bottom: 150, left: 33, right: 18 } as any);
 
       gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 53, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
@@ -1099,14 +1111,20 @@ describe('SlickRowDetailView plugin', () => {
       const loadingTemplate = () => '<span>loading...</span>';
       vi.spyOn(dataviewStub, 'getIdxById').mockReturnValue(3);
       vi.spyOn(dataviewStub, 'getRowById').mockReturnValue(122);
-      vi.spyOn(gridStub, 'getRowCache').mockReturnValueOnce({
-        121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        123: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-      });
-      vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 120, bottom: 126, left: 33, right: 18 } as any);
+      vi.spyOn(gridStub, 'getRowCache')
+        .mockReturnValue({
+          121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          122: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          123: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        })
+        .mockReturnValueOnce({
+          121: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        });
+      vi.spyOn(gridStub, 'getRenderedRange')
+        .mockReturnValue({ top: 120, bottom: 126, left: 33, right: 18 } as any)
+        .mockReturnValueOnce({ top: 140, bottom: 150, left: 33, right: 18 } as any);
       divContainer.appendChild(cellDetailViewElm);
       Object.defineProperty(detailViewContainerElm, 'scrollHeight', { writable: true, configurable: true, value: 4 });
       vi.spyOn(gridStub, 'getOptions').mockReturnValue({
@@ -1129,8 +1147,11 @@ describe('SlickRowDetailView plugin', () => {
       const onRowBackToViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
       const eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
       gridStub.onScroll.notify({ scrollLeft: 20, scrollTop: 33, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
+      vi.advanceTimersByTime(1);
       gridStub.onScroll.notify({ scrollLeft: 22, scrollTop: 35, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
+      vi.advanceTimersByTime(1);
       gridStub.onScroll.notify({ scrollLeft: 22, scrollTop: 0, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
+      vi.advanceTimersByTime(1);
 
       vi.advanceTimersByTime(101);
 
@@ -1164,16 +1185,23 @@ describe('SlickRowDetailView plugin', () => {
       vi.spyOn(dataviewStub, 'getItemById').mockReturnValue(itemMock);
       const loadingTemplate = () => '<span>loading...</span>';
       vi.spyOn(dataviewStub, 'getIdxById').mockReturnValue(3);
-      // row header is at index 10 (above the viewport), detail spans rows 11-22 (panelRows=12)
-      vi.spyOn(dataviewStub, 'getRowById').mockReturnValue(10);
-      // row 10 is in cache (minRowBuffer keeps it there even when not directly visible)
-      vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
-        10: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        22: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-        23: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
-      });
+      // row header is at index 123 (above the viewport), detail spans rows 11-22 (panelRows=12)
+      vi.spyOn(dataviewStub, 'getRowById').mockReturnValue(140).mockReturnValueOnce(120).mockReturnValueOnce(120).mockReturnValueOnce(120);
+      // row 123 is in cache (minRowBuffer keeps it there even when not directly visible)
+      vi.spyOn(gridStub, 'getRowCache')
+        .mockReturnValue({
+          123: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          125: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+          140: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        })
+        .mockReturnValueOnce({
+          124: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
+        });
       // visible.top=22 → last detail row (10+12=22) is exactly at the top of the viewport
-      vi.spyOn(gridStub, 'getRenderedRange').mockReturnValue({ top: 22, bottom: 40, left: 0, right: 10 } as any);
+      vi.spyOn(gridStub, 'getRenderedRange')
+        .mockReturnValue({ top: 140, bottom: 160, left: 0, right: 10 } as any)
+        .mockReturnValueOnce({ top: 120, bottom: 160, left: 0, right: 10 } as any);
       divContainer.appendChild(cellDetailViewElm);
       Object.defineProperty(detailViewContainerElm, 'scrollHeight', { writable: true, configurable: true, value: 4 });
       vi.spyOn(gridStub, 'getOptions').mockReturnValue({
@@ -1181,7 +1209,7 @@ describe('SlickRowDetailView plugin', () => {
         rowDetailView: {
           process: mockProcess,
           preTemplate: loadingTemplate,
-          panelRows: 12,
+          panelRows: 5,
           useRowClick: true,
           saveDetailViewOnScroll: true,
           singleRowExpand: false,
@@ -1191,12 +1219,16 @@ describe('SlickRowDetailView plugin', () => {
       plugin.init(gridStub);
       plugin.resizeDetailView(itemMock);
       plugin.expandDetailView(itemMock.id);
-      plugin.rowIdsOutOfViewport = [123];
+      plugin.rowIdsOutOfViewport = [10];
 
       const onRowBackToViewportSpy = vi.spyOn(plugin.onRowBackToViewportRange, 'notify');
       const eventData = { ...new SlickEventData(), preventDefault: vi.fn() };
 
       // trigger scroll — calculateFn runs after setTimeout(0)
+      gridStub.onScroll.notify({ scrollLeft: 0, scrollTop: 0, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
+      vi.advanceTimersByTime(1);
+      gridStub.onScroll.notify({ scrollLeft: 0, scrollTop: 10, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
+      vi.advanceTimersByTime(1);
       gridStub.onScroll.notify({ scrollLeft: 0, scrollTop: 100, scrollHeight: 10, grid: gridStub }, eventData as any, gridStub);
       vi.advanceTimersByTime(1);
 

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -327,8 +327,10 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
       // we need to reevaluate & invalidate any row detail that are shown on top of the row that we're closing
       this.reevaluateRenderedRowIds(item);
 
+      // a new expanded row is considered both expanded & rendered
       item[`${this._keyPrefix}collapsed`] = false;
       this._expandedRowIds.add(itemId);
+      this._renderedViewportRowIds.add(itemId);
 
       // in the case something went wrong loading it the first time such a scroll of screen before loaded
       if (!item[`${this._keyPrefix}detailContent`]) {


### PR DESCRIPTION
Row Detail keep references of 2 internal Set list (`_expandedRowIds` and `_renderedViewportRowIds`) of item ids to know if a Row Detail must be re-rendered or not. However when expanding a new row, it was only adding it to the `_expandedRowIds` not the `_renderedViewportRowIds` Set, and this could cause some issues. For example, I was able to replicate the bug with these steps: 1. opening a Row Detail with an inner grid, 2. adding a filter in that inner grid, 3. click on the outer main grid browser scroll and this was causing a re-render (and filters clared) in some cases event though the grid was still visible and did not actually left the visible viewport range yet ... so it makes sense to add it to the `_renderedViewportRowIds` when we expand a new row and not expect it to be re-rendered when scrolling by a few pixels (at least not until it moves out of the visible range)