### PR TITLE
fix: frozen-bottom grids never clean up off-screen row cells

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5352,11 +5352,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   protected cleanUpCells(range: CellViewportRange, row: number): void {
-    // Ignore frozen rows
+    // Ignore frozen rows (mirror the guard used by cleanupRows: the top-band
+    // disjunct must be qualified with !frozenBottom, otherwise in frozenBottom
+    // mode the two disjuncts cover every row and NO row is ever cell-cleaned)
     if (
       this.hasFrozenRows &&
-      ((this._options.frozenBottom && row > this.actualFrozenRow) || // Frozen bottom rows
-        row <= this.actualFrozenRow) // Frozen top rows
+      ((this._options.frozenBottom && row >= this.actualFrozenRow) || // Frozen bottom rows
+        (!this._options.frozenBottom && row <= this.actualFrozenRow)) // Frozen top rows
     ) {
       return;
     }


### PR DESCRIPTION
Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1255 into slickgrid-universal

> ## The bug
> In `frozenBottom` mode, `cleanUpCells()` exempted **every** row from horizontal cell cleanup. Its top-band disjunct was `(row <= actualFrozenRow)`, missing the `!frozenBottom` qualifier that the sibling `cleanupRows()` already has:
> 
> ```ts
> // cleanUpCells (buggy)
> if (this.hasFrozenRows
>   && ((this._options.frozenBottom && row > this.actualFrozenRow)   // Frozen bottom rows
>     || (row <= this.actualFrozenRow)))                             // Frozen top rows  ← no !frozenBottom
>   { return; }
> 
> // cleanupRows (correct — has the guard)
> if (this.hasFrozenRows
>   && ((this._options.frozenBottom && i >= this.actualFrozenRow)
>     || (!this._options.frozenBottom && i <= this.actualFrozenRow)))
>   { removeFrozenRow = false; }
> ```
> 
> With `frozenBottom: true`, the two disjuncts (`> actualFrozenRow` and `<= actualFrozenRow`) cover the entire row range, so **no** row ever had its off-screen cells removed. Scrolling horizontally on a wide frozen-bottom grid accumulates cell DOM nodes on every scrollable row without bound — a memory/DOM leak that gradually degrades scroll performance. No visual corruption (cells are absolutely positioned), so it presents purely as a leak.
> 
> ## The fix
> One line: qualify the top-band disjunct with `!this._options.frozenBottom`, mirroring the guard `cleanupRows()` already uses, so only the actual frozen rows are exempt from horizontal cleanup.
> 
> ## Test
> Adds a permanent regression test — `cypress/e2e/quirk-frozen-bottom-cell-cleanup.cy.ts` — that scrolls a heavily-virtualized `frozenRow: 2, frozenBottom: true` grid right and back and asserts a scrollable row's rendered cell count stays bounded. Verified it **fails on the pre-fix code** (count balloons toward the full column count) and **passes with the fix**.


