### PR TITLE
fix: footer-row lifecycle - construction crash, inconsistent getFooterRow, double onFooterRowCellRendered

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1407,7 +1407,7 @@ describe('SlickGrid core file', () => {
       vi.spyOn(grid, 'getDataLength').mockReturnValueOnce(-1);
       grid.updateRowCount();
 
-      expect(onBeforeFooterRowCellDestroySpy).toHaveBeenCalledTimes(4); // 2x left and 2x right, because we have 2x columns
+      expect(onBeforeFooterRowCellDestroySpy).toHaveBeenCalledTimes(2); // because we have 2x columns
       footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');
@@ -1611,7 +1611,7 @@ describe('SlickGrid core file', () => {
 
       expect(grid.getRowCache()).toEqual({});
       expect(onBeforeRemoveCachedRowSpy).toHaveBeenCalledTimes(4);
-      expect(onBeforeFooterRowCellDestroySpy).toHaveBeenCalledTimes(4); // 2x left and 2x right, because we have 2x columns
+      expect(onBeforeFooterRowCellDestroySpy).toHaveBeenCalledTimes(2); // because we have 2x columns
       footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');
@@ -1643,7 +1643,7 @@ describe('SlickGrid core file', () => {
       grid.setFooterRowVisibility(true);
       grid.updateColumns(); // this will trigger onBeforeFooterRowCellDestroySpy
 
-      expect(onBeforeFooterRowCellDestroySpy).toHaveBeenCalledTimes(4); // 2x left and 2x right, because we have 2x columns
+      expect(onBeforeFooterRowCellDestroySpy).toHaveBeenCalledTimes(2); // because we have 2x columns
       footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1671,6 +1671,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Get the Footer DOM element */
   getFooterRow(): HTMLDivElement | HTMLDivElement[] {
+    // return undefined consistently when there is no footer, instead of throwing on
+    // the non-frozen `_footerRow[0]` path while the frozen path returns undefined
     return this.hasFrozenColumns() ? this._footerRow : this._footerRow?.[0];
   }
 
@@ -1831,35 +1833,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     emptyElement(this._headerRowL);
     emptyElement(this._headerRowR);
 
-    if (this._options.createFooterRow) {
-      const footerRowLColumnElements = this._footerRowL.querySelectorAll('.slick-footerrow-column');
-      footerRowLColumnElements.forEach((column) => {
-        const columnDef = Utils.storage.get(column, 'column');
-        if (columnDef) {
-          this.triggerEvent(this.onBeforeFooterRowCellDestroy, {
-            node: this,
-            column: columnDef,
-            grid: this,
-          });
-        }
-      });
-      emptyElement(this._footerRowL);
-
-      if (this.hasFrozenColumns()) {
-        const footerRowRColumnElements = this._footerRowR.querySelectorAll('.slick-footerrow-column');
-        footerRowRColumnElements.forEach((column) => {
-          const columnDef = Utils.storage.get(column, 'column');
-          if (columnDef) {
-            this.triggerEvent(this.onBeforeFooterRowCellDestroy, {
-              node: this,
-              column: columnDef,
-              grid: this,
-            });
-          }
-        });
-        emptyElement(this._footerRowR);
-      }
-    }
+    // NOTE: footer-row destroy/create is handled entirely by createColumnFooter(),
+    // which is always called immediately after createColumnHeaders(). The duplicate
+    // footer blocks that used to live here fired onFooterRowCellRendered twice per
+    // column and emptied the right footer only under hasFrozenColumns() (leaving
+    // stale right-footer cells after un-freezing).
 
     for (let i = 0, ln = this.columns.length; i < ln; i++) {
       const m: C = this.columns[i];
@@ -1987,25 +1965,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           grid: this,
         });
       }
-      if (this._options.createFooterRow && this._options.showFooterRow) {
-        const footerRowTarget = this.hasFrozenColumns()
-          ? i <= this._options.frozenColumn!
-            ? this._footerRow[0]
-            : this._footerRow[1]
-          : this._footerRow[0];
-        const footerRowCell = createDomElement(
-          'div',
-          { className: `slick-state-default slick-footerrow-column l${i} r${i}` },
-          footerRowTarget
-        );
-        Utils.storage.put(footerRowCell, 'column', m);
 
-        this.triggerEvent(this.onFooterRowCellRendered, {
-          node: footerRowCell,
-          column: m,
-          grid: this,
-        });
-      }
+      // footer-row cells are created by createColumnFooter() (called right after), not here
     }
 
     this.setSortColumns(this.sortColumns);
@@ -4894,7 +4855,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (!this._options.autoHeight || this._options.frozenColumn !== -1) {
       this.topPanelH = this._options.showTopPanel ? this._options.topPanelHeight! + this.getVBoxDelta(this._topPanelScrollers[0]) : 0;
       this.headerRowH = this._options.showHeaderRow ? this._options.headerRowHeight! + this.getVBoxDelta(this._headerRowScroller[0]) : 0;
-      this.footerRowH = this._options.showFooterRow ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0]) : 0;
+      this.footerRowH =
+        this._options.createFooterRow && this._options.showFooterRow
+          ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0])
+          : 0;
     }
 
     if (this._options.autoHeight) {
@@ -4903,7 +4867,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         ? this._options.preHeaderPanelHeight! + this.getVBoxDelta(this._preHeaderPanelScroller)
         : 0;
       fullHeight += this._options.showHeaderRow ? this._options.headerRowHeight! + this.getVBoxDelta(this._headerRowScroller[0]) : 0;
-      fullHeight += this._options.showFooterRow ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0]) : 0;
+      fullHeight +=
+        this._options.createFooterRow && this._options.showFooterRow
+          ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0])
+          : 0;
       fullHeight += this.getCanvasWidth() > this.viewportW ? this.scrollbarDimensions?.height || 0 : 0;
 
       this.viewportH = this.getRowPosition(this.getDataLengthIncludingAddNew()) + (this._options.frozenColumn === -1 ? fullHeight : 0);


### PR DESCRIPTION
Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1256 into slickgrid-universal

> Three related footer-row lifecycle bugs, fixed together because they share the same code area and would conflict as separate PRs.
> 
> ## 1. `showFooterRow` without `createFooterRow` crashes at construction
> `getViewportHeight()`'s footer term was gated on `showFooterRow` alone and dereferenced the undefined `_footerRowScroller[0]`:
> 
> ```ts
> // before (crashes when createFooterRow is false)
> this.footerRowH = (this._options.showFooterRow) ? this._options.footerRowHeight! + this.getVBoxDelta(this._footerRowScroller[0]) : 0;
> ```
> 
> The header-row and top-header terms in the same function already use the `create && show` idiom. Both footer sites (regular and autoHeight paths) now match:
> 
> ```ts
> this.footerRowH = (this._options.createFooterRow && this._options.showFooterRow) ? … : 0;
> ```
> 
> **Repro:** `new Slick.Grid('#c', data, cols, { showFooterRow: true })` → TypeError at init.
> 
> ## 2. `getFooterRow()` fails inconsistently without a footer
> Without `createFooterRow`, the non-frozen path threw (`_footerRow[0]` of undefined) while the frozen path returned `undefined` — identical misuse, two different failure modes. Now returns `undefined` consistently (one optional chain).
> 
> **Repro:** `grid.getFooterRow()` on a footer-less grid → TypeError (non-frozen) vs `undefined` (frozen).
> 
> ## 3. `onFooterRowCellRendered` fired twice per column; stale right-footer cells after un-freezing
> `createColumnHeaders()` contained a duplicated footer destroy pass **and** a duplicated footer-cell creation block — but `createColumnFooter()` is called immediately after `createColumnHeaders()` at both call sites and does the complete job correctly. Consequences of the duplication:
> 
> * `onFooterRowCellRendered` fired **twice** per visible column on every `setColumns()` (once from each function), and footer cells were built twice.
> * The duplicate destroy pass gated its right side on `hasFrozenColumns()` rather than element existence, so after un-freezing (`frozenColumn: -1`) the right footer kept stale cells.
> 
> The duplicated blocks are deleted; `createColumnFooter()` is the single owner of footer cell lifecycle. (Its destroy pass also fires the event with `node: column` — the actual cell — rather than the duplicate's `node: this`.)
> 
> **Repro:** subscribe to `onFooterRowCellRendered`, call `grid.setColumns(grid.getColumns())` → handler fired 2× per column.
> 
> ## Test
> `cypress/e2e/quirk-footer-lifecycle.cy.ts` — a three-grid repro page with in-page self-checks (construct-without-crash, `undefined` contract, exactly-one-fire-per-column). Verified to **fail on the pre-fix code and pass with the fixes**. Also ran the frozen/example regression suites (31/31 green) since the fix touches `createColumnHeaders`.


