### PR TITLE
fix: frozen-bottom hit testing resolves the wrong row when data is shorter than the viewport

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -7414,7 +7414,7 @@ describe('SlickGrid core file', () => {
         expect(result).toEqual({ row: 1, cell: 1 });
       });
 
-      it('should return { row:1, cell:1 } when clicked cell is second cell of second row with a frozenRow and frozenBottom is inside range', () => {
+      it('should return { row:2, cell:1 } when clicked cell is second cell of second row with a frozenRow and frozenBottom is inside range', () => {
         grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, enableCellNavigation: true, frozenRow: 3, frozenBottom: true });
         const secondRowSlickCells = container.querySelectorAll('.slick-row:nth-child(2) .slick-cell');
         const event = new CustomEvent('click');
@@ -7423,7 +7423,7 @@ describe('SlickGrid core file', () => {
         Object.defineProperty(event, 'clientY', { writable: true, value: DEFAULT_COLUMN_HEIGHT * 1 + 5 });
         const result = grid.getCellFromEvent(event);
 
-        expect(result).toEqual({ row: 1, cell: 1 });
+        expect(result).toEqual({ row: 2, cell: 1 });
       });
 
       it('should return null when using frozenRow that result into invalid row/cell number', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6744,7 +6744,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const isBottom = Utils.parents(cellNode, '.grid-canvas-bottom').length;
 
       if (isBottom) {
-        rowOffset = this._options.frozenBottom ? (Utils.height(this._canvasTopL) as number) : this.frozenRowsHeight;
+        // same render-path offset as above: getFrozenRowOffset, not a live top-canvas measurement
+        rowOffset = this.getFrozenRowOffset(this.actualFrozenRow);
       }
 
       const x = targetEvent.clientX - c.left;
@@ -6888,7 +6889,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       const isBottom = Utils.parents(this.activeCellNode, '.grid-canvas-bottom').length;
 
       if (this.hasFrozenRows && isBottom) {
-        rowOffset -= this._options.frozenBottom ? (Utils.height(this._canvasTopL) as number) : this.frozenRowsHeight;
+        // use the same offset the render path uses to place bottom-canvas rows
+        // (getFrozenRowOffset), not a live measurement of the top canvas — the two
+        // diverge in frozenBottom mode (e.g. small datasets) and hit-testing then
+        // resolves the wrong row
+        rowOffset -= this.getFrozenRowOffset(this.actualFrozenRow);
       }
 
       const cell = this.getCellFromPoint(activeCellOffset.left, Math.ceil(activeCellOffset.top) - rowOffset);


### PR DESCRIPTION
Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1258 into slickgrid-universal

> ## The bug
> In `frozenBottom` mode, `getCellFromEvent()` and `setActiveCellInternal()` computed the bottom-canvas row offset from a **live measurement of the top canvas**:
> 
> ```ts
> rowOffset = (this._options.frozenBottom) ? Utils.height(this._canvasTopL) as number : this.frozenRowsHeight;
> ```
> 
> But the render path places bottom-canvas rows using `getFrozenRowOffset()`. The two diverge whenever the dataset is **shorter than the viewport**, because `updateRowCount` floors the body canvas height at the viewport height:
> 
> ```ts
> this.th = Math.max(scrollableRowsHeight, tempViewportH - scrollbarH);
> …
> Utils.height(this._canvasTopL, this.h);   // ≈ viewport height, not content height
> ```
> 
> So with e.g. 8 rows × 25px in a 500px container, the live measurement reads ~443px while the rows were placed with a 175px offset — clicking the frozen bottom row resolves to a row **~10 rows away** (wrong `getCellFromEvent` result, wrong active cell).
> 
> ## The fix
> Both call sites now use `getFrozenRowOffset(this.actualFrozenRow)` — the exact offset the render path used to place the row (hit-testing must invert rendering, not re-measure). For the top-freeze branch this is behavior-identical: `getFrozenRowOffset` returns `frozenRowsHeight` there.
> 
> ## Repro
> `{ frozenRow: 1, frozenBottom: true }`, 8 rows, 500px-tall container → click the frozen bottom row → pre-fix `getCellFromEvent` returns a wrong row (e.g. 17 instead of 7).
> 
> ## Test
> `cypress/e2e/quirk-frozen-bottom-hit-testing.cy.ts` — the repro page synthesizes clicks at real cell rects (frozen-bottom row, a body row, and a top-freeze **control grid** to guard the unchanged branch) and asserts `getCellFromEvent` resolves the correct rows. Verified to **fail pre-fix and pass post-fix**; frozen + editing suites ran 28/28 as a regression gate (the fix touches the active-cell path).


