### PR TITLE
refactor: replace getHeadersWidth's out-of-range loop-index probe with hasFrozenColumns()

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1271,11 +1271,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (includeScrollbar) {
-      // attribute the scrollbar width to the scrollable band: R when columns are
-      // frozen, else the single L band. (This previously re-tested the loop variable
-      // AFTER the loop — i === columns.length, an out-of-range probe — which only
-      // happened to be equivalent because setFrozenOptions clamps frozenColumn to
-      // be < columns.length; hasFrozenColumns() states the intent directly.)
+      // attribute the scrollbar width to the active scrollable band: the right band
+      // when frozen columns are enabled, otherwise the left band.
       if (this.hasFrozenColumns()) {
         this.headersWidthR += this.scrollbarDimensions?.width || 0;
       } else {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1258,9 +1258,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.headersWidth = this.headersWidthL = this.headersWidthR = 0;
     const includeScrollbar = !this._options.autoHeight;
 
-    let i = 0;
-    const ii = this.columns.length;
-    for (i = 0; i < ii; i++) {
+    for (let i = 0, ii = this.columns.length; i < ii; i++) {
       if (!this.columns[i] || this.columns[i].hidden) {
         continue;
       }
@@ -1273,7 +1271,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (includeScrollbar) {
-      if (this._options.frozenColumn! > -1 && i > this._options.frozenColumn!) {
+      // attribute the scrollbar width to the scrollable band: R when columns are
+      // frozen, else the single L band. (This previously re-tested the loop variable
+      // AFTER the loop — i === columns.length, an out-of-range probe — which only
+      // happened to be equivalent because setFrozenOptions clamps frozenColumn to
+      // be < columns.length; hasFrozenColumns() states the intent directly.)
+      if (this.hasFrozenColumns()) {
         this.headersWidthR += this.scrollbarDimensions?.width || 0;
       } else {
         this.headersWidthL += this.scrollbarDimensions?.width || 0;


### PR DESCRIPTION
Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1260 into slickgrid-universal

> ## The quirk
> `getHeadersWidth()`'s post-loop scrollbar attribution re-tested the loop variable **after** the loop ended — `i === columns.length`, an out-of-range index probe:
> 
> ```ts
> if ((this._options.frozenColumn!) > -1 && (i > this._options.frozenColumn!)) {
>   this.headersWidthR += scrollbarWidth;   // i is columns.length here
> }
> ```
> 
> This only happened to be equivalent to _'is a left freeze active'_ because `setFrozenOptions` clamps `frozenColumn` to `< columns.length`, making the second conjunct invariantly true whenever the first is — an accidental invariant a future refactor could silently break.
> 
> ## The change
> State the intent directly with `hasFrozenColumns()` and scope the loop variable into the loop so the accidental dependency cannot recur. **Zero behavior change for every reachable state** (equivalence follows from the `setFrozenOptions` clamp).
> 
> Per the triage discussion this PR deliberately does **not** touch the double scrollbar addition further down in the same function (`headersWidthR/L` get the scrollbar added again in the band-finalization block) — that one has potential pixel-visible effects and deserves its own investigation.
> 
> ## Why no repro/test
> Nothing observable changes — there is no symptom to pin. Width-sensitive suites (frozen-columns-and-rows, example1, auto-resize) ran 18/18 green as a regression gate.
> 
> (Part of the quirks-triage series: 
> https://github.com/6pac/SlickGrid/pull/1255
> https://github.com/6pac/SlickGrid/pull/1256
> https://github.com/6pac/SlickGrid/pull/1257
> https://github.com/6pac/SlickGrid/pull/1258
> https://github.com/6pac/SlickGrid/pull/1259

