### PR TITLE
fix: updateRowPositions leaves right-pane row fragments at stale positions

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -5666,12 +5666,18 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this.rowsCache && typeof this.rowsCache === 'object') {
       Object.keys(this.rowsCache).forEach((row) => {
         const rowNumber = row ? parseInt(row, 10) : 0;
-        const rowNode = this.rowsCache[rowNumber].rowNode![0];
-        if (this._options.rowTopOffsetRenderType === 'transform') {
-          rowNode.style.transform = `translateY(${this.getRowTop(rowNumber)}px)`;
-        } else {
-          rowNode.style.top = `${this.getRowTop(rowNumber)}px`; // default to `top: {offset}px`
-        }
+        // same formula appendRowHtml uses to place rows initially
+        const top = this.getRowTop(rowNumber) - this.getFrozenRowOffset(rowNumber);
+        // reposition EVERY fragment of the row: with frozen columns a row has one
+        // fragment per column pane, and repositioning only rowNode[0] left the
+        // right-pane fragment at its stale top after a paging-offset jump
+        this.rowsCache[rowNumber].rowNode!.forEach((rowNode) => {
+          if (this._options.rowTopOffsetRenderType === 'transform') {
+            rowNode.style.transform = `translateY(${top}px)`;
+          } else {
+            rowNode.style.top = `${top}px`; // default to `top: {offset}px`
+          }
+        });
       });
     }
   }


### PR DESCRIPTION
Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1257 into slickgrid-universal


> ## The bug
> `updateRowPositions()` — which runs whenever the virtual-scroll **paging offset** changes (`scrollTo`, huge datasets above the max supported CSS height) — repositioned only `rowNode[0]`:
> 
> ```ts
> const rowNode = this.rowsCache[rowNumber].rowNode![0];   // LEFT-pane fragment only
> rowNode.style.top = `${this.getRowTop(rowNumber)}px`;
> ```
> 
> With frozen columns a row has **one fragment per column pane**. After a paging-offset jump, the left fragment moved to its new offset-relative top while the right-pane fragment kept its stale top — the two halves of the same row drift vertically apart across the freeze line by exactly one paging offset unit.
> 
> Secondary inconsistency fixed in the same line: it used bare `getRowTop()`, while the render path (`appendRowHtml`) places rows at `getRowTop(row) - getFrozenRowOffset(row)`. The fix repositions **every** fragment with that same render-time formula, honoring `rowTopOffsetRenderType` per fragment.
> 
> ## Repro
> `frozenColumn: 0`, 100,000 rows × 25px (virtual height 2.5M > the ~1M css cap, so paging engages with n=250 pages), then step `scrollTo` finely across a page boundary. Pre-fix, a rendered row's left fragment sits at e.g. `top: 3976px` while its right fragment sits at `top: 10000px` — a divergence of exactly `cj` (6024px, the paging offset unit).
> 
> ## Test
> `cypress/e2e/quirk-row-positions-fragments.cy.ts` — the repro page's in-page self-check verifies paging is engaged (`n > 1`), walks `scrollTo` finely across up to 3 page boundaries, compares left/right fragment tops for every rendered `data-row` (hundreds of pairs), and asserts zero drift. Verified to **fail on the pre-fix code** (drift = one paging unit) **and pass with the fix**.

