### PR TITLE
fix(a11y): add missing ARIA row/rowgroup structure to grid headers

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3101,6 +3101,33 @@ describe('SlickGrid core file', () => {
       expect(grid.getContainerNode().getAttribute('aria-rowcount')).toBe('11');
     });
 
+    it('should expect the header structure to have the ARIA roles required between grid and columnheader', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true });
+
+      const headerColumnElm = container.querySelector('[role="columnheader"]') as HTMLDivElement;
+      expect(headerColumnElm).toBeTruthy();
+      // a columnheader requires a "row" parent, and that row requires a "rowgroup" (or grid) parent,
+      // otherwise axe reports `aria-required-parent` + `aria-required-children` on every grid
+      expect(headerColumnElm.parentElement!.classList.contains('slick-header-columns')).toBe(true);
+      expect(headerColumnElm.parentElement!.getAttribute('role')).toBe('row');
+      expect(headerColumnElm.parentElement!.parentElement!.getAttribute('role')).toBe('rowgroup');
+
+      // same skeleton for the header row (filter row): rowgroup > row > gridcell
+      const headerRowCellElm = container.querySelector('.slick-headerrow-column') as HTMLDivElement;
+      expect(headerRowCellElm.getAttribute('role')).toBe('gridcell');
+      expect(headerRowCellElm.parentElement!.getAttribute('role')).toBe('row');
+      expect(headerRowCellElm.parentElement!.parentElement!.getAttribute('role')).toBe('rowgroup');
+    });
+
+    it('should expect the focus sinks to be hidden from the a11y tree', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, defaultOptions);
+
+      // 0x0 helper divs with tabindex=-1 are otherwise computed as unallowed children of role="grid"
+      const sinks = container.querySelectorAll('div[tabindex="-1"]:not([class])');
+      expect(sinks.length).toBe(2);
+      sinks.forEach((sink) => expect(sink.getAttribute('aria-hidden')).toBe('true'));
+    });
+
     it('should return undefined editor when getDataItem() did not find any associated cell item', () => {
       const columns = [
         { id: 'name', field: 'name', name: 'Name' },

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -698,6 +698,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._container
     );
 
+    // 0x0 helper div, programmatically focusable only (tabindex=-1). Exposing it to the a11y tree makes it
+    // an unallowed child of role="grid" (axe `aria-required-children`), so keep it out of the tree.
+    this._focusSink.setAttribute('aria-hidden', 'true');
+
     if (this._options.createTopHeaderPanel) {
       this._topHeaderPanelScroller = createDomElement(
         'div',
@@ -761,8 +765,10 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // Append the header scroller containers
     const headerContainerL = createDomElement('div', { className: 'slick-header-container' }, this._paneHeaderL);
     const headerContainerR = createDomElement('div', { className: 'slick-header-container' }, this._paneHeaderR);
-    this._headerScrollerL = createDomElement('div', { className: 'slick-header slick-state-default slick-header-left' }, headerContainerL);
-    this._headerScrollerR = createDomElement('div', { className: 'slick-header slick-state-default slick-header-right' }, headerContainerR);
+    // prettier-ignore
+    this._headerScrollerL = createDomElement('div', { className: 'slick-header slick-state-default slick-header-left', role: 'rowgroup' }, headerContainerL);
+    // prettier-ignore
+    this._headerScrollerR = createDomElement('div', { className: 'slick-header slick-state-default slick-header-right', role: 'rowgroup' }, headerContainerR);
 
     // header scroll position could change when using frozen grid and tabbing on next available header
     // so we need to make sure that all containers (header, headerrow, toppanel) are all in sync when that happens
@@ -777,20 +783,22 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // Append the columnn containers to the headers
     this._headerL = createDomElement(
       'div',
-      { className: 'slick-header-columns slick-header-columns-left', style: { left: '-1000px' } },
+      { className: 'slick-header-columns slick-header-columns-left', style: { left: '-1000px' }, role: 'row' },
       this._headerScrollerL
     );
     this._headerR = createDomElement(
       'div',
-      { className: 'slick-header-columns slick-header-columns-right', style: { left: '-1000px' } },
+      { className: 'slick-header-columns slick-header-columns-right', style: { left: '-1000px' }, role: 'row' },
       this._headerScrollerR
     );
 
     // Cache the header columns
     this._headers = [this._headerL, this._headerR];
 
-    this._headerRowScrollerL = createDomElement('div', { className: 'slick-headerrow slick-state-default' }, this._paneTopL);
-    this._headerRowScrollerR = createDomElement('div', { className: 'slick-headerrow slick-state-default' }, this._paneTopR);
+    // prettier-ignore
+    this._headerRowScrollerL = createDomElement('div', { className: 'slick-headerrow slick-state-default', role: 'rowgroup' }, this._paneTopL);
+    // prettier-ignore
+    this._headerRowScrollerR = createDomElement('div', { className: 'slick-headerrow slick-state-default', role: 'rowgroup' }, this._paneTopR);
 
     this._headerRowScroller = [this._headerRowScrollerL, this._headerRowScrollerR];
 
@@ -807,12 +815,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this._headerRowL = createDomElement(
       'div',
-      { className: 'slick-headerrow-columns slick-headerrow-columns-left' },
+      { className: 'slick-headerrow-columns slick-headerrow-columns-left', role: 'row' },
       this._headerRowScrollerL
     );
     this._headerRowR = createDomElement(
       'div',
-      { className: 'slick-headerrow-columns slick-headerrow-columns-right' },
+      { className: 'slick-headerrow-columns slick-headerrow-columns-right', role: 'row' },
       this._headerRowScrollerR
     );
 
@@ -1957,7 +1965,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (this._options.showHeaderRow) {
         const headerRowCell = createDomElement(
           'div',
-          { className: `slick-state-default slick-headerrow-column l${i} r${i}` },
+          { className: `slick-state-default slick-headerrow-column l${i} r${i}`, role: 'gridcell' },
           headerRowTarget
         );
         const frozenClasses = this.hasFrozenColumns() && i <= this._options.frozenColumn! ? 'frozen' : null;


### PR DESCRIPTION
### Describe your change

The grid container gets `role="grid"` and header cells get `role="columnheader"`, but the three container
levels in between (`.slick-header-container > .slick-header > .slick-header-columns`) carry no role. Since
elements without a role and without focusability are transparent in the accessibility tree, this produces two
axe violations on every grid:

- **`aria-required-parent`** — one violation per column: `role="columnheader"` has no `role="row"` parent
  (`Required ARIA parent role not present: row`).
- **`aria-required-children`** — `role="grid"` is computed to directly own `[role=columnheader]` and
  `div[tabindex]` (the two 0×0 focus sinks), neither of which is an allowed child of `grid`.

Nothing is visually broken — the impact is that screen readers do not get the table structure.

This adds the missing skeleton at element-creation time:

| Element | Role added |
|---|---|
| `.slick-header` (header scroller, L/R) | `rowgroup` |
| `.slick-header-columns` (L/R) | `row` |
| `.slick-headerrow` (filter row scroller, L/R) | `rowgroup` |
| `.slick-headerrow-columns` (L/R) | `row` |
| `.slick-headerrow-column` (filter row cell) | `gridcell` |
| focus sinks (0×0, `tabindex="-1"`) | `aria-hidden="true"` |

Two notes on scope:

- The **filter row is fixed as a unit**. Giving `.slick-headerrow-columns` a `row` role without giving its
  cells a `gridcell` role would introduce a *new* `aria-required-children` violation (a `row` must own cells)
  on grids that show the filter row, so both are in this patch.
- The focus sinks are `tabindex="-1"`, so they are not tabbable and `aria-hidden` does not trigger
  `aria-hidden-focus`.

`aria-colcount` / `aria-rowcount` are already handled correctly (`updateRowCount()`), so they are untouched.

### How to reproduce

Run axe (e.g. a Lighthouse accessibility audit) on any example page containing a grid. Originally reported
downstream by a consumer of a fork: 15 `aria-required-parent` violations (= column count) plus 1
`aria-required-children` violation, on a 15-column grid.

### Verification

- `pnpm exec tsc --build ./tsconfig.packages.json` — no errors in the changed file.
- `packages/common` unit tests: **4297 passed** (181 files), which includes the 2 tests added here.
  No existing assertion changes: the suite asserts `className` on those containers, not the full attribute set.
- `oxlint` clean, `prettier --check` clean (long lines use the `// prettier-ignore` convention already used in
  this file).
- Two unit tests added in `slickGrid.spec.ts`: one asserting the `rowgroup > row > columnheader` and
  `rowgroup > row > gridcell` chains, one asserting the focus sinks are `aria-hidden`.

The equivalent fix has also been running as a runtime patch in a downstream facade, verified against both axe
rules (ownership computed the same way axe does) across three feature combinations — plain grid, inline filter
row, and grouping + footer totals + toolbar — plus a negative control confirming the check actually catches the
violation when the roles are removed.
