### PR TITLE
fix(a11y): add missing ARIA row/rowgroup structure to grid headers

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3138,6 +3138,40 @@ describe('SlickGrid core file', () => {
       expect(document.activeElement).toBe(focusSink);
     });
 
+    it('should remove external focus sinks when grid is destroyed', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, defaultOptions);
+
+      const focusSink = (grid as any)._focusSink as HTMLDivElement;
+      const focusSink2 = (grid as any)._focusSink2 as HTMLDivElement;
+
+      expect(document.body.contains(focusSink)).toBe(true);
+      expect(document.body.contains(focusSink2)).toBe(true);
+
+      grid.destroy(true);
+
+      expect(focusSink.isConnected).toBe(false);
+      expect(focusSink2.isConnected).toBe(false);
+    });
+
+    it('should keep ARIA header structure with frozen columns enabled', () => {
+      grid = new SlickGrid<any, Column>(container, items, [
+        { id: 'name', field: 'name', name: 'Name' },
+        { id: 'age', field: 'age', name: 'Age' },
+      ], {
+        ...defaultOptions,
+        showHeaderRow: true,
+        frozenColumn: 0,
+      });
+
+      const headerColumns = container.querySelectorAll('.slick-header-columns');
+      expect(headerColumns.length).toBe(2);
+      headerColumns.forEach((node) => expect(node.getAttribute('role')).toBe('row'));
+
+      const headerRowColumns = container.querySelectorAll('.slick-headerrow-columns');
+      expect(headerRowColumns.length).toBe(2);
+      headerRowColumns.forEach((node) => expect(node.getAttribute('role')).toBe('row'));
+    });
+
     it('should return undefined editor when getDataItem() did not find any associated cell item', () => {
       const columns = [
         { id: 'name', field: 'name', name: 'Name' },

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3101,6 +3101,43 @@ describe('SlickGrid core file', () => {
       expect(grid.getContainerNode().getAttribute('aria-rowcount')).toBe('11');
     });
 
+    it('should expect the header structure to have required ARIA rowgroup/row roles', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, showHeaderRow: true });
+
+      const headerColumnElm = container.querySelector('[role="columnheader"]') as HTMLDivElement;
+      expect(headerColumnElm).toBeTruthy();
+      expect(headerColumnElm.parentElement!.classList.contains('slick-header-columns')).toBe(true);
+      expect(headerColumnElm.parentElement!.getAttribute('role')).toBe('row');
+      expect(headerColumnElm.parentElement!.parentElement!.getAttribute('role')).toBe('rowgroup');
+
+      const headerRowCellElm = container.querySelector('.slick-headerrow-column') as HTMLDivElement;
+      expect(headerRowCellElm).toBeTruthy();
+      expect(headerRowCellElm.getAttribute('role')).toBe('gridcell');
+      expect(headerRowCellElm.parentElement!.getAttribute('role')).toBe('row');
+      expect(headerRowCellElm.parentElement!.parentElement!.getAttribute('role')).toBe('rowgroup');
+    });
+
+    it('should place focus sinks outside the grid subtree and keep them focusable without aria-hidden', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, defaultOptions);
+
+      const focusSink = (grid as any)._focusSink as HTMLDivElement;
+      const focusSink2 = (grid as any)._focusSink2 as HTMLDivElement;
+
+      expect(focusSink).toBeTruthy();
+      expect(focusSink2).toBeTruthy();
+      expect(container.contains(focusSink)).toBe(false);
+      expect(container.contains(focusSink2)).toBe(false);
+      expect(focusSink.parentElement).toBe(container.parentElement);
+      expect(focusSink2.parentElement).toBe(container.parentElement);
+      expect(focusSink.tabIndex).toBe(-1);
+      expect(focusSink2.tabIndex).toBe(-1);
+      expect(focusSink.getAttribute('aria-hidden')).toBeNull();
+      expect(focusSink2.getAttribute('aria-hidden')).toBeNull();
+
+      focusSink.focus();
+      expect(document.activeElement).toBe(focusSink);
+    });
+
     it('should return undefined editor when getDataItem() did not find any associated cell item', () => {
       const columns = [
         { id: 'name', field: 'name', name: 'Name' },

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -3154,14 +3154,19 @@ describe('SlickGrid core file', () => {
     });
 
     it('should keep ARIA header structure with frozen columns enabled', () => {
-      grid = new SlickGrid<any, Column>(container, items, [
-        { id: 'name', field: 'name', name: 'Name' },
-        { id: 'age', field: 'age', name: 'Age' },
-      ], {
-        ...defaultOptions,
-        showHeaderRow: true,
-        frozenColumn: 0,
-      });
+      grid = new SlickGrid<any, Column>(
+        container,
+        items,
+        [
+          { id: 'name', field: 'name', name: 'Name' },
+          { id: 'age', field: 'age', name: 'Age' },
+        ],
+        {
+          ...defaultOptions,
+          showHeaderRow: true,
+          frozenColumn: 0,
+        }
+      );
 
       const headerColumns = container.querySelectorAll('.slick-header-columns');
       expect(headerColumns.length).toBe(2);

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -763,8 +763,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // Append the header scroller containers
     const headerContainerL = createDomElement('div', { className: 'slick-header-container' }, this._paneHeaderL);
     const headerContainerR = createDomElement('div', { className: 'slick-header-container' }, this._paneHeaderR);
-    this._headerScrollerL = createDomElement('div', { className: 'slick-header slick-state-default slick-header-left', role: 'rowgroup' }, headerContainerL);
-    this._headerScrollerR = createDomElement('div', { className: 'slick-header slick-state-default slick-header-right', role: 'rowgroup' }, headerContainerR);
+    this._headerScrollerL = createDomElement(
+      'div',
+      { className: 'slick-header slick-state-default slick-header-left', role: 'rowgroup' },
+      headerContainerL
+    );
+    this._headerScrollerR = createDomElement(
+      'div',
+      { className: 'slick-header slick-state-default slick-header-right', role: 'rowgroup' },
+      headerContainerR
+    );
 
     // header scroll position could change when using frozen grid and tabbing on next available header
     // so we need to make sure that all containers (header, headerrow, toppanel) are all in sync when that happens
@@ -791,8 +799,16 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // Cache the header columns
     this._headers = [this._headerL, this._headerR];
 
-    this._headerRowScrollerL = createDomElement('div', { className: 'slick-headerrow slick-state-default', role: 'rowgroup' }, this._paneTopL);
-    this._headerRowScrollerR = createDomElement('div', { className: 'slick-headerrow slick-state-default', role: 'rowgroup' }, this._paneTopR);
+    this._headerRowScrollerL = createDomElement(
+      'div',
+      { className: 'slick-headerrow slick-state-default', role: 'rowgroup' },
+      this._paneTopL
+    );
+    this._headerRowScrollerR = createDomElement(
+      'div',
+      { className: 'slick-headerrow slick-state-default', role: 'rowgroup' },
+      this._paneTopR
+    );
 
     this._headerRowScroller = [this._headerRowScrollerL, this._headerRowScrollerR];
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -692,10 +692,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       this._container.style.position = 'relative';
     }
 
+    const focusSinkParent = this._container.parentElement ?? this._container.ownerDocument?.body ?? this._container;
+
     this._focusSink = createDomElement(
       'div',
       { tabIndex: -1, style: { position: 'fixed', width: '0px', height: '0px', top: '0px', left: '0px', outline: '0px' } },
-      this._container
+      focusSinkParent
     );
 
     if (this._options.createTopHeaderPanel) {
@@ -761,8 +763,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // Append the header scroller containers
     const headerContainerL = createDomElement('div', { className: 'slick-header-container' }, this._paneHeaderL);
     const headerContainerR = createDomElement('div', { className: 'slick-header-container' }, this._paneHeaderR);
-    this._headerScrollerL = createDomElement('div', { className: 'slick-header slick-state-default slick-header-left' }, headerContainerL);
-    this._headerScrollerR = createDomElement('div', { className: 'slick-header slick-state-default slick-header-right' }, headerContainerR);
+    this._headerScrollerL = createDomElement('div', { className: 'slick-header slick-state-default slick-header-left', role: 'rowgroup' }, headerContainerL);
+    this._headerScrollerR = createDomElement('div', { className: 'slick-header slick-state-default slick-header-right', role: 'rowgroup' }, headerContainerR);
 
     // header scroll position could change when using frozen grid and tabbing on next available header
     // so we need to make sure that all containers (header, headerrow, toppanel) are all in sync when that happens
@@ -777,20 +779,20 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // Append the columnn containers to the headers
     this._headerL = createDomElement(
       'div',
-      { className: 'slick-header-columns slick-header-columns-left', style: { left: '-1000px' } },
+      { className: 'slick-header-columns slick-header-columns-left', style: { left: '-1000px' }, role: 'row' },
       this._headerScrollerL
     );
     this._headerR = createDomElement(
       'div',
-      { className: 'slick-header-columns slick-header-columns-right', style: { left: '-1000px' } },
+      { className: 'slick-header-columns slick-header-columns-right', style: { left: '-1000px' }, role: 'row' },
       this._headerScrollerR
     );
 
     // Cache the header columns
     this._headers = [this._headerL, this._headerR];
 
-    this._headerRowScrollerL = createDomElement('div', { className: 'slick-headerrow slick-state-default' }, this._paneTopL);
-    this._headerRowScrollerR = createDomElement('div', { className: 'slick-headerrow slick-state-default' }, this._paneTopR);
+    this._headerRowScrollerL = createDomElement('div', { className: 'slick-headerrow slick-state-default', role: 'rowgroup' }, this._paneTopL);
+    this._headerRowScrollerR = createDomElement('div', { className: 'slick-headerrow slick-state-default', role: 'rowgroup' }, this._paneTopR);
 
     this._headerRowScroller = [this._headerRowScrollerL, this._headerRowScrollerR];
 
@@ -807,12 +809,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     this._headerRowL = createDomElement(
       'div',
-      { className: 'slick-headerrow-columns slick-headerrow-columns-left' },
+      { className: 'slick-headerrow-columns slick-headerrow-columns-left', role: 'row' },
       this._headerRowScrollerL
     );
     this._headerRowR = createDomElement(
       'div',
-      { className: 'slick-headerrow-columns slick-headerrow-columns-right' },
+      { className: 'slick-headerrow-columns slick-headerrow-columns-right', role: 'row' },
       this._headerRowScrollerR
     );
 
@@ -946,7 +948,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     this._focusSink2 = this._focusSink.cloneNode(true) as HTMLDivElement;
-    this._container.appendChild(this._focusSink2);
+    focusSinkParent.appendChild(this._focusSink2);
 
     if (!this._options.explicitInitialization) {
       this.finishInitialization();
@@ -1933,7 +1935,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (this._options.showHeaderRow) {
         const headerRowCell = createDomElement(
           'div',
-          { className: `slick-state-default slick-headerrow-column l${i} r${i}` },
+          { className: `slick-state-default slick-headerrow-column l${i} r${i}`, role: 'gridcell' },
           headerRowTarget
         );
         const frozenClasses = this.hasFrozenColumns() && i <= this._options.frozenColumn! ? 'frozen' : null;
@@ -3067,6 +3069,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     this._boundAncestors.length = 0; // reset array
+
+    this._focusSink?.remove();
+    this._focusSink2?.remove();
 
     emptyElement(this._container);
     this.removeCssRules();


### PR DESCRIPTION
_vibe coded with Copilot using GPT-5.3-Codex and double-checked implementation with Claude Sonnet 5_

### Describe your change

This PR supersedes #2680 and keeps the same a11y intent, with a standards-safe focus sink implementation.

The grid container uses role="grid" and header cells use role="columnheader", but intermediate header containers did not expose the required rowgroup and row hierarchy in the accessibility tree. That can produce two common audit failures:

- aria-required-parent: each columnheader must have a row parent
- aria-required-children: grid ownership can be computed incorrectly when required structural roles are missing

Nothing is visually broken, but assistive technology does not get a complete grid header structure.

This patch adds the missing header and filter-row role skeleton at creation time:

| Element | Role added |
|---|---|
| .slick-header (left/right header scroller) | rowgroup |
| .slick-header-columns (left/right) | row |
| .slick-headerrow (left/right filter-row scroller) | rowgroup |
| .slick-headerrow-columns (left/right) | row |
| .slick-headerrow-column (filter-row cell) | gridcell |

Focus sink handling is intentionally different from #2680:

- no aria-hidden on focus sinks
- focus sinks remain tabindex="-1" for keyboard sentinel behavior
- both sinks are moved outside the role="grid" subtree, so they are not owned children of grid
- destroy now explicitly removes both external sinks to avoid detached leftovers

Scope note:
- filter row changes are applied as one unit; adding role=row to .slick-headerrow-columns without role=gridcell on .slick-headerrow-column would introduce a new aria-required-children issue when showHeaderRow is enabled

aria-colcount and aria-rowcount behavior remains unchanged.

### How to reproduce

Run an a11y audit (axe or Lighthouse) on any page with a grid.

Before:
- aria-required-parent on header columns
- aria-required-children on grid ownership

After:
- header and filter-row hierarchy is exposed as rowgroup > row > columnheader or gridcell
- focus sinks are excluded from grid ownership by DOM placement, not aria-hidden

### Verification

Updated unit tests in slickGrid.spec.ts verify:

- rowgroup > row > columnheader and rowgroup > row > gridcell structure
- focus sinks are outside the grid subtree
- focus sinks remain focusable with tabindex -1 and have no aria-hidden
- external focus sinks are removed on destroy
- role structure remains correct with frozenColumn enabled

Targeted test run passed:

- vitest run --config vitest.config.mts slickGrid.spec.ts
- Result: PASS (415), FAIL (0)

### Attribution

- supersedes #2680 after original head branch deletion
- preserves and extends original contribution intent from @hjaewon with a standards-safe focus sink approach

### Caveat

One caveat worth knowing (not a bug, just a limitation):

If a consumer moves `_container` to a different DOM parent after grid init, the focus sinks stay attached to the original parent reference, not wherever the container moved to. This is a narrow edge case — SlickGrid doesn't support post-init container relocation elsewhere either, so it's consistent with existing assumptions, not a new regression.