### PR TITLE
feat(export): add opt-in includeColumnWidth for Excel and PDF exports

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example55.html
+++ b/demos/aurelia/src/examples/slickgrid/example55.html
@@ -16,6 +16,12 @@
 
   <div class="row" style="margin-bottom: 6px">
     <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-excel-btn" click.trigger="exportToExcel()">
+        <i class="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-pdf-btn" click.trigger="exportToPdf()">
+        <i class="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+      </button>
       <button class="btn btn-outline-secondary btn-sm btn-icon" click.trigger="scrollToRow90()" data-test="scroll-row-90-example55">
         <span class="mdi mdi-arrow-down"></span>
         <span> Scroll To row 90</span>

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -18,6 +18,8 @@ export class Example55 {
   columns: Column[] = [];
   dataset: StoryItem[] = [];
   gridOptions!: GridOption;
+  excelExportService = new ExcelExportService();
+  pdfExportService = new PdfExportService();
 
   constructor() {
     this.defineGrid();
@@ -40,7 +42,15 @@ export class Example55 {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
-      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        exportWithFormatter: true,
+        formatter: (_row, _cell, value) => `${value}px`,
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 
@@ -48,7 +58,7 @@ export class Example55 {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [this.excelExportService, this.pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -94,5 +104,16 @@ export class Example55 {
       });
     }
     return data;
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({
+      filename: 'export',
+      format: 'xlsx',
+    });
+  }
+
+  exportToPdf() {
+    this.pdfExportService.exportToPdf({ filename: 'export' });
   }
 }

--- a/demos/aurelia/src/examples/slickgrid/example55.ts
+++ b/demos/aurelia/src/examples/slickgrid/example55.ts
@@ -53,9 +53,14 @@ export class Example55 {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       gridHeight: 560,

--- a/demos/aurelia/src/examples/slickgrid/example56.html
+++ b/demos/aurelia/src/examples/slickgrid/example56.html
@@ -19,6 +19,12 @@
 
   <div class="row" style="margin-bottom: 6px">
     <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-excel-btn" click.trigger="exportToExcel()">
+        <i class="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-pdf-btn" click.trigger="exportToPdf()">
+        <i class="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+      </button>
       <button class="btn btn-outline-secondary btn-sm btn-icon" click.trigger="toggleDensity()" data-test="toggle-density">
         <span class="mdi mdi-flip-vertical"></span>
         <span> Toggle Compact Density</span>

--- a/demos/aurelia/src/examples/slickgrid/example56.ts
+++ b/demos/aurelia/src/examples/slickgrid/example56.ts
@@ -67,9 +67,14 @@ export class Example56 {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       frozenRow: 2,

--- a/demos/aurelia/src/examples/slickgrid/example56.ts
+++ b/demos/aurelia/src/examples/slickgrid/example56.ts
@@ -18,6 +18,8 @@ export class Example56 {
   dataset: TaskItem[] = [];
   gridOptions!: GridOption;
   isCompact = false;
+  excelExportService = new ExcelExportService();
+  pdfExportService = new PdfExportService();
 
   constructor() {
     this.defineGrid();
@@ -49,6 +51,7 @@ export class Example56 {
         id: 'rowHeight',
         name: 'Height',
         field: 'rowHeight',
+        exportWithFormatter: true,
         formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
           return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
         },
@@ -62,7 +65,7 @@ export class Example56 {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [this.excelExportService, this.pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -123,5 +126,16 @@ export class Example56 {
       });
     }
     return data;
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({
+      filename: 'export',
+      format: 'xlsx',
+    });
+  }
+
+  exportToPdf() {
+    this.pdfExportService.exportToPdf({ filename: 'export' });
   }
 }

--- a/demos/react/src/examples/slickgrid/Example55.tsx
+++ b/demos/react/src/examples/slickgrid/Example55.tsx
@@ -18,6 +18,8 @@ const Example55: React.FC = () => {
   const [columns, setColumns] = useState<Column[]>([]);
   const [dataset, setDataset] = useState<StoryItem[]>([]);
   const [gridOptions, setGridOptions] = useState<GridOption | undefined>(undefined);
+  const [excelExportService] = useState(new ExcelExportService());
+  const [pdfExportService] = useState(new PdfExportService());
   const reactGridRef = useRef<SlickgridReactInstance | null>(null);
 
   useEffect(() => {
@@ -38,7 +40,15 @@ const Example55: React.FC = () => {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
-      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        exportWithFormatter: true,
+        formatter: (_row, _cell, value) => `${value}px`,
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 
@@ -46,7 +56,7 @@ const Example55: React.FC = () => {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [excelExportService, pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -97,6 +107,17 @@ const Example55: React.FC = () => {
     return data;
   }
 
+  function exportToExcel() {
+    excelExportService.exportToExcel({
+      filename: 'Export',
+      format: 'xlsx',
+    });
+  }
+
+  function exportToPdf() {
+    pdfExportService.exportToPdf({ filename: 'Export' });
+  }
+
   return !gridOptions ? (
     ''
   ) : (
@@ -121,6 +142,12 @@ const Example55: React.FC = () => {
 
         <div className="row" style={{ marginBottom: '6px' }}>
           <div className="col-md-12">
+            <button className="btn btn-outline-secondary btn-sm btn-icon me-1" data-test="export-excel-btn" onClick={() => exportToExcel()}>
+              <i className="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+            </button>
+            <button className="btn btn-outline-secondary btn-sm btn-icon" data-test="export-pdf-btn" onClick={() => exportToPdf()}>
+              <i className="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+            </button>
             <button className="btn btn-outline-secondary btn-sm btn-icon" onClick={scrollToRow90} data-test="scroll-row-90-example55">
               <span className="mdi mdi-arrow-down"></span>
               <span> Scroll To row 90</span>

--- a/demos/react/src/examples/slickgrid/Example55.tsx
+++ b/demos/react/src/examples/slickgrid/Example55.tsx
@@ -51,9 +51,14 @@ const Example55: React.FC = () => {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       gridHeight: 560,

--- a/demos/react/src/examples/slickgrid/Example56.tsx
+++ b/demos/react/src/examples/slickgrid/Example56.tsx
@@ -66,9 +66,14 @@ const Example56: React.FC = () => {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       frozenRow: 2,

--- a/demos/react/src/examples/slickgrid/Example56.tsx
+++ b/demos/react/src/examples/slickgrid/Example56.tsx
@@ -17,6 +17,8 @@ const Example56: React.FC = () => {
   const [columns, setColumns] = useState<Column[]>([]);
   const [dataset, setDataset] = useState<TaskItem[]>([]);
   const [gridOptions, setGridOptions] = useState<GridOption | undefined>(undefined);
+  const [excelExportService] = useState(new ExcelExportService());
+  const [pdfExportService] = useState(new PdfExportService());
 
   const reactGridRef = useRef<SlickgridReactInstance | null>(null);
   const compactRef = useRef(false);
@@ -48,6 +50,7 @@ const Example56: React.FC = () => {
         id: 'rowHeight',
         name: 'Height',
         field: 'rowHeight',
+        exportWithFormatter: true,
         formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
           return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
         },
@@ -61,7 +64,7 @@ const Example56: React.FC = () => {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [excelExportService, pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -127,6 +130,17 @@ const Example56: React.FC = () => {
     return data;
   }
 
+  function exportToExcel() {
+    excelExportService.exportToExcel({
+      filename: 'Export',
+      format: 'xlsx',
+    });
+  }
+
+  function exportToPdf() {
+    pdfExportService.exportToPdf({ filename: 'Export' });
+  }
+
   return !gridOptions ? (
     ''
   ) : (
@@ -152,6 +166,12 @@ const Example56: React.FC = () => {
 
         <div className="row" style={{ marginBottom: '6px' }}>
           <div className="col-md-12">
+            <button className="btn btn-outline-secondary btn-sm btn-icon me-1" data-test="export-excel-btn" onClick={() => exportToExcel()}>
+              <i className="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+            </button>
+            <button className="btn btn-outline-secondary btn-sm btn-icon" data-test="export-pdf-btn" onClick={() => exportToPdf()}>
+              <i className="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+            </button>
             <button className="btn btn-outline-secondary btn-sm btn-icon" onClick={toggleDensity} data-test="toggle-density">
               <span className="mdi mdi-flip-vertical"></span>
               <span> Toggle Compact Density</span>

--- a/demos/vanilla/src/examples/example44.html
+++ b/demos/vanilla/src/examples/example44.html
@@ -1,11 +1,5 @@
 <h3 class="title is-3">
   Example 44 - Variable Row Height (provider)
-  <span class="d-inline-flex">
-    <button class="button is-small" onclick.trigger="scrollToRow90()" data-test="scroll-row-90-example44">
-      <span class="mdi mdi-arrow-down"></span>
-      <span> Scroll To row 90</span>
-    </button>
-  </span>
 
   <div class="subtitle code-link">
     <span class="is-size-6">see</span>
@@ -22,5 +16,22 @@
 <h6 class="title is-6 italic">
   Variable row heights driven by <code>rowHeightProvider</code>. Short summaries stay compact while longer summaries grow.
 </h6>
+
+<section class="mb-2">
+  <div class="row mb-1">
+    <button class="button is-small" data-test="export-excel-btn" onclick.trigger="exportToExcel()">
+      <span class="mdi mdi-file-excel-outline"></span>
+      <span>Export to Excel</span>
+    </button>
+    <button class="button is-small" data-test="export-pdf-btn" onclick.trigger="exportToPdf()">
+      <span class="mdi mdi-file-pdf-outline"></span>
+      <span>Export to PDF</span>
+    </button>
+    <button class="button is-small" onclick.trigger="scrollToRow90()" data-test="scroll-row-90-example44">
+      <span class="mdi mdi-arrow-down"></span>
+      <span> Scroll To row 90</span>
+    </button>
+  </div>
+</section>
 
 <div class="grid44"></div>

--- a/demos/vanilla/src/examples/example44.ts
+++ b/demos/vanilla/src/examples/example44.ts
@@ -20,6 +20,8 @@ export default class Example44 {
   dataset: StoryItem[] = [];
   gridOptions!: GridOption;
   sgb!: SlickVanillaGridBundle;
+  excelExportService = new ExcelExportService();
+  pdfExportService = new PdfExportService();
 
   attached() {
     this.defineGrid();
@@ -45,7 +47,15 @@ export default class Example44 {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
-      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        exportWithFormatter: true,
+        formatter: (_row, _cell, value) => `${value}px`,
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 
@@ -53,7 +63,7 @@ export default class Example44 {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [this.excelExportService, this.pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -101,5 +111,13 @@ export default class Example44 {
       });
     }
     return data;
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({ filename: 'export', format: 'xlsx' });
+  }
+
+  exportToPdf() {
+    this.pdfExportService.exportToPdf({ filename: 'Export' });
   }
 }

--- a/demos/vanilla/src/examples/example44.ts
+++ b/demos/vanilla/src/examples/example44.ts
@@ -58,9 +58,14 @@ export default class Example44 {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       gridHeight: 560,

--- a/demos/vanilla/src/examples/example45.html
+++ b/demos/vanilla/src/examples/example45.html
@@ -1,15 +1,5 @@
 <h3 class="title is-3">
   Example 45 - Variable Row Height (item metadata)
-  <span class="d-inline-flex">
-    <button class="button is-small" onclick.trigger="toggleDensity()" data-test="toggle-density">
-      <span class="mdi mdi-flip-vertical"></span>
-      <span> Toggle Compact Density</span>
-    </button>
-    <button class="button is-small ml-2" onclick.trigger="scrollToRow90()" data-test="scroll-row-90-example45">
-      <span class="mdi mdi-arrow-down"></span>
-      <span> Scroll To row 90</span>
-    </button>
-  </span>
 
   <div class="subtitle code-link">
     <span class="is-size-6">see</span>
@@ -27,5 +17,26 @@
   Variable row heights via <code>ItemMetadata.height</code> fallback, with compact mode rebuilding heights through
   <code>invalidateRowHeights()</code>.
 </h6>
+
+<section class="mb-2">
+  <div class="row mb-1">
+    <button class="button is-small" data-test="export-excel-btn" onclick.trigger="exportToExcel()">
+      <span class="mdi mdi-file-excel-outline"></span>
+      <span>Export to Excel</span>
+    </button>
+    <button class="button is-small" data-test="export-pdf-btn" onclick.trigger="exportToPdf()">
+      <span class="mdi mdi-file-pdf-outline"></span>
+      <span>Export to PDF</span>
+    </button>
+    <button class="button is-small" onclick.trigger="toggleDensity()" data-test="toggle-density">
+      <span class="mdi mdi-flip-vertical"></span>
+      <span> Toggle Compact Density</span>
+    </button>
+    <button class="button is-small" onclick.trigger="scrollToRow90()" data-test="scroll-row-90-example45">
+      <span class="mdi mdi-arrow-down"></span>
+      <span> Scroll To row 90</span>
+    </button>
+  </div>
+</section>
 
 <div class="grid45"></div>

--- a/demos/vanilla/src/examples/example45.ts
+++ b/demos/vanilla/src/examples/example45.ts
@@ -20,6 +20,8 @@ export default class Example45 {
   gridOptions!: GridOption;
   sgb!: SlickVanillaGridBundle;
   isCompact = false;
+  excelExportService = new ExcelExportService();
+  pdfExportService = new PdfExportService();
 
   attached() {
     this.defineGrid();
@@ -55,6 +57,7 @@ export default class Example45 {
         id: 'rowHeight',
         name: 'Height',
         field: 'rowHeight',
+        exportWithFormatter: true,
         formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
           return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
         },
@@ -68,7 +71,7 @@ export default class Example45 {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [this.excelExportService, this.pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -131,5 +134,13 @@ export default class Example45 {
       });
     }
     return data;
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({ filename: 'export', format: 'xlsx' });
+  }
+
+  exportToPdf() {
+    this.pdfExportService.exportToPdf({ filename: 'Export' });
   }
 }

--- a/demos/vanilla/src/examples/example45.ts
+++ b/demos/vanilla/src/examples/example45.ts
@@ -73,9 +73,14 @@ export default class Example45 {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       frozenRow: 2,

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -50,9 +50,14 @@ function defineGrid() {
       // export variable row height will also be reflected in the export
       // but it can be disabled by setting `includeVariableRowHeight` to false
       // includeVariableRowHeight: false, // export all rows at default height
+
+      // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+      includeColumnWidth: true,
     },
     pdfExportOptions: {
       pageOrientation: 'landscape',
+      // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+      includeColumnWidth: true,
     },
     rowHeight: 40,
     gridHeight: 560,

--- a/demos/vue/src/components/Example55.vue
+++ b/demos/vue/src/components/Example55.vue
@@ -17,6 +17,8 @@ interface StoryItem {
 const gridOptions = ref<GridOption>();
 const columns: Ref<Column[]> = ref([]);
 const dataset = ref<StoryItem[]>([]);
+const excelExportService = new ExcelExportService();
+const pdfExportService = new PdfExportService();
 let vueGrid!: SlickgridVueInstance;
 
 onBeforeMount(() => {
@@ -37,7 +39,15 @@ function defineGrid() {
     { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
     { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
     { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
-    { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
+    {
+      id: 'rowHeight',
+      name: 'Height',
+      field: 'rowHeight',
+      exportWithFormatter: true,
+      formatter: (_row, _cell, value) => `${value}px`,
+      minWidth: 90,
+      width: 90,
+    },
     { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
   ];
 
@@ -45,7 +55,7 @@ function defineGrid() {
     enableCellNavigation: true,
     enableTextSelectionOnCells: true,
     enableVariableRowHeight: true,
-    externalResources: [new ExcelExportService(), new PdfExportService()],
+    externalResources: [excelExportService, pdfExportService],
     excelExportOptions: {
       // export variable row height will also be reflected in the export
       // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -92,6 +102,17 @@ function getData(itemCount: number): StoryItem[] {
   }
   return data;
 }
+
+function exportToExcel() {
+  excelExportService.exportToExcel({
+    filename: 'Export',
+    format: 'xlsx',
+  });
+}
+
+function exportToPdf() {
+  pdfExportService.exportToPdf({ filename: 'Export' });
+}
 </script>
 
 <template>
@@ -112,6 +133,12 @@ function getData(itemCount: number): StoryItem[] {
 
   <div class="row" style="margin-bottom: 6px">
     <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon mx-1" data-test="export-excel-btn" @click="exportToExcel()">
+        <i class="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-outline-secondary btn-sm btn-icon mx-1" data-test="export-pdf-btn" @click="exportToPdf()">
+        <i class="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+      </button>
       <button class="btn btn-outline-secondary btn-sm btn-icon" @click="scrollToRow90()" data-test="scroll-row-90-example55">
         <span class="mdi mdi-arrow-down"></span>
         <span> Scroll To row 90</span>

--- a/demos/vue/src/components/Example56.vue
+++ b/demos/vue/src/components/Example56.vue
@@ -65,9 +65,14 @@ function defineGrid() {
       // export variable row height will also be reflected in the export
       // but it can be disabled by setting `includeVariableRowHeight` to false
       // includeVariableRowHeight: false, // export all rows at default height
+
+      // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+      includeColumnWidth: true,
     },
     pdfExportOptions: {
       pageOrientation: 'landscape',
+      // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+      includeColumnWidth: true,
     },
     frozenRow: 2,
     gridHeight: 560,

--- a/demos/vue/src/components/Example56.vue
+++ b/demos/vue/src/components/Example56.vue
@@ -17,6 +17,8 @@ const gridOptions = ref<GridOption>();
 const columns: Ref<Column[]> = ref([]);
 const dataset = ref<TaskItem[]>([]);
 const isCompact = ref(false);
+const excelExportService = new ExcelExportService();
+const pdfExportService = new PdfExportService();
 let vueGrid!: SlickgridVueInstance;
 
 onBeforeMount(() => {
@@ -46,6 +48,7 @@ function defineGrid() {
       id: 'rowHeight',
       name: 'Height',
       field: 'rowHeight',
+      exportWithFormatter: true,
       formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
         return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
       },
@@ -60,7 +63,7 @@ function defineGrid() {
     enableTextSelectionOnCells: true,
     enableVariableRowHeight: true,
     rowHeight: 40,
-    externalResources: [new ExcelExportService(), new PdfExportService()],
+    externalResources: [excelExportService, pdfExportService],
     excelExportOptions: {
       // export variable row height will also be reflected in the export
       // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -121,6 +124,17 @@ function getData(itemCount: number): TaskItem[] {
   }
   return data;
 }
+
+function exportToExcel() {
+  excelExportService.exportToExcel({
+    filename: 'Export',
+    format: 'xlsx',
+  });
+}
+
+function exportToPdf() {
+  pdfExportService.exportToPdf({ filename: 'Export' });
+}
 </script>
 
 <template>
@@ -144,6 +158,12 @@ function getData(itemCount: number): TaskItem[] {
 
   <div class="row" style="margin-bottom: 6px">
     <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon mx-1" data-test="export-excel-btn" @click="exportToExcel()">
+        <i class="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-outline-secondary btn-sm btn-icon mx-1" data-test="export-pdf-btn" @click="exportToPdf()">
+        <i class="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+      </button>
       <button class="btn btn-outline-secondary btn-sm btn-icon" @click="toggleDensity()" data-test="toggle-density">
         <span class="mdi mdi-flip-vertical"></span>
         <span> Toggle Compact Density</span>

--- a/docs/grid-functionalities/export-to-excel.md
+++ b/docs/grid-functionalities/export-to-excel.md
@@ -77,6 +77,7 @@ Inside the column definition there are couple of flags you can set in `excelExpo
 - `sheetName` allows you to change the Excel Sheet Name (defaults to "Sheet1")
 - `groupingColumnHeaderTitle` The column header title (at A0 in Excel) of the Group by. If nothing is provided it will use "Group By"
 - `groupingAggregatorRowText` The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator
+- `includeColumnWidth` defaults to `false`, when enabled it will use each column `width` in the Excel export when `excelExportOptions.width` is not defined on the column.
 - set `sanitizeDataExport` to remove any HTML/Script code from being export. For example if your value is `<span class="mdi mdi-check">True</span>` will export `True` without any HTML (data is sanitized).
    - this flag can be used in the Grid Options (all columns) or in a Column Definition (per column).
 - `customExcelHeader` is a callback method that can be used to provide a custom Header Title to your Excel File
@@ -136,6 +137,24 @@ this.gridOptions = {
 ### Custom Column Width
 
 See [Custom Cell Styling](#custom-cell-styling) to define cell width.
+
+#### Width Precedence
+When exporting a column width, the library uses this order of precedence.
+
+1. Column `excelExportOptions.width`
+2. Column `width` when `includeColumnWidth: true`
+3. Grid `customColumnWidth`
+4. Internal fallback width (`10`)
+
+```ts
+this.gridOptions = {
+  excelExportOptions: {
+    includeColumnWidth: true,
+    customColumnWidth: 15,
+  },
+  externalResources: [new ExcelExportService()],
+};
+```
 
 ### Styling the Header Titles
 By default the header titles (first row) will be styled as Bold text, however you can choose to style them differently with custom styles as shown below. To find out what styling you can use, you can take a look at Excel Builder-Vanilla [Documentation](https://ghiscoding.gitbook.io/excel-builder-vanilla/cookbook/fonts-and-colors) website. The code shown below is used in [Aurelia-Slickgrid - Example 24](https://ghiscoding.github.io/aurelia-slickgrid-demos/#/slickgrid/example24) if you wish to see the result.

--- a/docs/grid-functionalities/export-to-excel.md
+++ b/docs/grid-functionalities/export-to-excel.md
@@ -141,10 +141,10 @@ See [Custom Cell Styling](#custom-cell-styling) to define cell width.
 #### Width Precedence
 When exporting a column width, the library uses this order of precedence.
 
-1. Column `excelExportOptions.width`
-2. Column `width` when `includeColumnWidth: true`
-3. Grid `customColumnWidth`
-4. Internal fallback width (`10`)
+1. Column `excelExportOptions.width` (when defined on the column)
+2. Column `width` when `includeColumnWidth` is enabled in `excelExportOptions`
+3. Grid `customColumnWidth` (when defined)
+4. Internal fallback width (`10` Excel width units, not pixels)
 
 ```ts
 this.gridOptions = {

--- a/docs/grid-functionalities/export-to-pdf.md
+++ b/docs/grid-functionalities/export-to-pdf.md
@@ -66,6 +66,9 @@ initializeGrid() {
 - `sanitizeDataExport`: remove HTML/script from exported data
 - `pdfExportOptions`: per-column PDF export options (see interface for details)
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
+  - `width`: per-column width override in PDF points (`pt`)
+- `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
+  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/docs/grid-functionalities/export-to-pdf.md
+++ b/docs/grid-functionalities/export-to-pdf.md
@@ -68,7 +68,7 @@ initializeGrid() {
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
   - `width`: per-column width override in PDF points (`pt`)
 - `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
-  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
+  - width precedence is: column `pdfExportOptions.width` (when defined) ➜ column `width` when `includeColumnWidth: true` is enabled (grid px converted to PDF points) ➜ default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-excel.md
@@ -149,10 +149,10 @@ this.gridOptions = {
 #### Width Precedence
 When exporting a column width, the library uses this order of precedence.
 
-1. Column `excelExportOptions.width`
-2. Column `width` when `includeColumnWidth: true`
-3. Grid `customColumnWidth`
-4. Internal fallback width (`10`)
+1. Column `excelExportOptions.width` (when defined on the column)
+2. Column `width` when `includeColumnWidth` is enabled in `excelExportOptions`
+3. Grid `customColumnWidth` (when defined)
+4. Internal fallback width (`10` Excel width units, not pixels)
 
 ```ts
 this.gridOptions = {

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-excel.md
@@ -76,6 +76,7 @@ Inside the column definition there are couple of flags you can set in `excelExpo
 - `sheetName` allows you to change the Excel Sheet Name (defaults to "Sheet1")
 - `groupingColumnHeaderTitle` The column header title (at A0 in Excel) of the Group by. If nothing is provided it will use "Group By"
 - `groupingAggregatorRowText` The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator
+- `includeColumnWidth` defaults to `false`, when enabled it will use each column `width` in the Excel export when `excelExportOptions.width` is not defined on the column.
 - set `sanitizeDataExport` to remove any HTML/Script code from being export. For example if your value is `<span class="mdi mdi-check">True</span>` will export `True` without any HTML (data is sanitized).
    - this flag can be used in the Grid Options (all columns) or in a Column Definition (per column).
 - `customExcelHeader` is a callback method that can be used to provide a custom Header Title to your Excel File
@@ -139,6 +140,24 @@ You could also set a custom width for the entire grid export via the `excelExpor
 this.gridOptions = {
   // set at the grid option level, meaning all column will evaluate the Formatter (when it has a Formatter defined)
   excelExportOptions: {
+    customColumnWidth: 15,
+  },
+  externalResources: [new ExcelExportService()],
+};
+```
+
+#### Width Precedence
+When exporting a column width, the library uses this order of precedence.
+
+1. Column `excelExportOptions.width`
+2. Column `width` when `includeColumnWidth: true`
+3. Grid `customColumnWidth`
+4. Internal fallback width (`10`)
+
+```ts
+this.gridOptions = {
+  excelExportOptions: {
+    includeColumnWidth: true,
     customColumnWidth: 15,
   },
   externalResources: [new ExcelExportService()],

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-pdf.md
@@ -65,6 +65,9 @@ defineGrid() {
 - `sanitizeDataExport`: remove HTML/script from exported data
 - `pdfExportOptions`: per-column PDF export options (see interface for details)
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
+  - `width`: per-column width override in PDF points (`pt`)
+- `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
+  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/export-to-pdf.md
@@ -67,7 +67,7 @@ defineGrid() {
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
   - `width`: per-column width override in PDF points (`pt`)
 - `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
-  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
+  - width precedence is: column `pdfExportOptions.width` (when defined) ➜ column `width` when `includeColumnWidth: true` is enabled (grid px converted to PDF points) ➜ default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.html
@@ -16,6 +16,12 @@
 
   <div class="row" style="margin-bottom: 6px">
     <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-excel-btn" (click)="exportToExcel()">
+        <i class="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-pdf-btn" (click)="exportToPdf()">
+        <i class="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+      </button>
       <button class="btn btn-outline-secondary btn-sm btn-icon" (click)="scrollToRow90()" data-test="scroll-row-90-example55">
         <span class="mdi mdi-arrow-down"></span>
         <span> Scroll To row 90</span>

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
@@ -56,9 +56,14 @@ export class Example55Component implements OnInit {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       gridHeight: 560,

--- a/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example55.component.ts
@@ -24,6 +24,8 @@ export class Example55Component implements OnInit {
   columns: Column[] = [];
   dataset: StoryItem[] = [];
   gridOptions!: GridOption;
+  excelExportService = new ExcelExportService();
+  pdfExportService = new PdfExportService();
 
   angularGridReady(angularGrid: AngularGridInstance) {
     this.angularGrid = angularGrid;
@@ -43,7 +45,15 @@ export class Example55Component implements OnInit {
       { id: 'id', name: '#', field: 'id', minWidth: 60, maxWidth: 70 },
       { id: 'title', name: 'Story', field: 'title', minWidth: 180, width: 220 },
       { id: 'owner', name: 'Owner', field: 'owner', minWidth: 110, width: 130 },
-      { id: 'rowHeight', name: 'Height', field: 'rowHeight', formatter: (_row, _cell, value) => `${value}px`, minWidth: 90, width: 90 },
+      {
+        id: 'rowHeight',
+        name: 'Height',
+        field: 'rowHeight',
+        exportWithFormatter: true,
+        formatter: (_row, _cell, value) => `${value}px`,
+        minWidth: 90,
+        width: 90,
+      },
       { id: 'summary', name: 'Summary', field: 'summary', cssClass: 'cell-wrap', minWidth: 360, width: 500, maxWidth: 620 },
     ];
 
@@ -51,7 +61,7 @@ export class Example55Component implements OnInit {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [this.excelExportService, this.pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -97,5 +107,16 @@ export class Example55Component implements OnInit {
       });
     }
     return data;
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({
+      filename: 'export',
+      format: 'xlsx',
+    });
+  }
+
+  exportToPdf() {
+    this.pdfExportService.exportToPdf({ filename: 'export' });
   }
 }

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.html
@@ -19,6 +19,12 @@
 
   <div class="row" style="margin-bottom: 6px">
     <div class="col-md-12">
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-excel-btn" (click)="exportToExcel()">
+        <i class="mdi mdi-file-excel-outline text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-outline-secondary btn-sm btn-icon" data-test="export-pdf-btn" (click)="exportToPdf()">
+        <i class="mdi mdi-file-pdf-outline text-danger"></i> Export to PDF
+      </button>
       <button class="btn btn-outline-secondary btn-sm btn-icon" (click)="toggleDensity()" data-test="toggle-density">
         <span class="mdi mdi-flip-vertical"></span>
         <span> Toggle Compact Density</span>

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
@@ -70,9 +70,14 @@ export class Example56Component implements OnInit {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
         // includeVariableRowHeight: false, // export all rows at default height
+
+        // we can opt-in to also use same column width grid vs Excel export (it's disabled by default)
+        includeColumnWidth: true,
       },
       pdfExportOptions: {
         pageOrientation: 'landscape',
+        // we can opt-in to also use same column width grid vs PDF export (it's disabled by default)
+        includeColumnWidth: true,
       },
       rowHeight: 40,
       frozenRow: 2,

--- a/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example56.component.ts
@@ -24,6 +24,8 @@ export class Example56Component implements OnInit {
   dataset: TaskItem[] = [];
   gridOptions!: GridOption;
   isCompact = false;
+  excelExportService = new ExcelExportService();
+  pdfExportService = new PdfExportService();
 
   angularGridReady(angularGrid: AngularGridInstance) {
     this.angularGrid = angularGrid;
@@ -52,6 +54,7 @@ export class Example56Component implements OnInit {
         id: 'rowHeight',
         name: 'Height',
         field: 'rowHeight',
+        exportWithFormatter: true,
         formatter: (row, _cell, _value, _coldef, _dataContext, grid) => {
           return `${grid.getItemMetadaWhenExists(row)?.height ?? 0}px`;
         },
@@ -65,7 +68,7 @@ export class Example56Component implements OnInit {
       enableCellNavigation: true,
       enableTextSelectionOnCells: true,
       enableVariableRowHeight: true,
-      externalResources: [new ExcelExportService(), new PdfExportService()],
+      externalResources: [this.excelExportService, this.pdfExportService],
       excelExportOptions: {
         // export variable row height will also be reflected in the export
         // but it can be disabled by setting `includeVariableRowHeight` to false
@@ -126,5 +129,16 @@ export class Example56Component implements OnInit {
       });
     }
     return data;
+  }
+
+  exportToExcel() {
+    this.excelExportService.exportToExcel({
+      filename: 'export',
+      format: 'xlsx',
+    });
+  }
+
+  exportToPdf() {
+    this.pdfExportService.exportToPdf({ filename: 'export' });
   }
 }

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-excel.md
@@ -144,10 +144,10 @@ this.gridOptions = {
 #### Width Precedence
 When exporting a column width, the library uses this order of precedence.
 
-1. Column `excelExportOptions.width`
-2. Column `width` when `includeColumnWidth: true`
-3. Grid `customColumnWidth`
-4. Internal fallback width (`10`)
+1. Column `excelExportOptions.width` (when defined on the column)
+2. Column `width` when `includeColumnWidth` is enabled in `excelExportOptions`
+3. Grid `customColumnWidth` (when defined)
+4. Internal fallback width (`10` Excel width units, not pixels)
 
 ```ts
 this.gridOptions = {

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-excel.md
@@ -80,6 +80,7 @@ Inside the column definition there are couple of flags you can set in `excelExpo
 - `sheetName` allows you to change the Excel Sheet Name (defaults to "Sheet1")
 - `groupingColumnHeaderTitle` The column header title (at A0 in Excel) of the Group by. If nothing is provided it will use "Group By"
 - `groupingAggregatorRowText` The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator
+- `includeColumnWidth` defaults to `false`, when enabled it will use each column `width` in the Excel export when `excelExportOptions.width` is not defined on the column.
 - set `sanitizeDataExport` to remove any HTML/Script code from being export. For example if your value is `<span class="mdi mdi-check">True</span>` will export `True` without any HTML (data is sanitized).
    - this flag can be used in the Grid Options (all columns) or in a Column Definition (per column).
 - `customExcelHeader` is a callback method that can be used to provide a custom Header Title to your Excel File
@@ -134,6 +135,24 @@ You could also set a custom width for the entire grid export via the `excelExpor
 this.gridOptions = {
   // set at the grid option level, meaning all column will evaluate the Formatter (when it has a Formatter defined)
   excelExportOptions: {
+    customColumnWidth: 15,
+  },
+  externalResources: [new ExcelExportService()],
+};
+```
+
+#### Width Precedence
+When exporting a column width, the library uses this order of precedence.
+
+1. Column `excelExportOptions.width`
+2. Column `width` when `includeColumnWidth: true`
+3. Grid `customColumnWidth`
+4. Internal fallback width (`10`)
+
+```ts
+this.gridOptions = {
+  excelExportOptions: {
+    includeColumnWidth: true,
     customColumnWidth: 15,
   },
   externalResources: [new ExcelExportService()],

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-pdf.md
@@ -65,6 +65,9 @@ defineGrid() {
 - `sanitizeDataExport`: remove HTML/script from exported data
 - `pdfExportOptions`: per-column PDF export options (see interface for details)
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
+  - `width`: per-column width override in PDF points (`pt`)
+- `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
+  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/export-to-pdf.md
@@ -67,7 +67,7 @@ defineGrid() {
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
   - `width`: per-column width override in PDF points (`pt`)
 - `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
-  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
+  - width precedence is: column `pdfExportOptions.width` (when defined) ➜ column `width` when `includeColumnWidth: true` is enabled (grid px converted to PDF points) ➜ default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/slickgrid-react/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/export-to-excel.md
@@ -147,10 +147,10 @@ See [Custom Cell Styling](#custom-cell-styling) to define cell width.
 #### Width Precedence
 When exporting a column width, the library uses this order of precedence.
 
-1. Column `excelExportOptions.width`
-2. Column `width` when `includeColumnWidth: true`
-3. Grid `customColumnWidth`
-4. Internal fallback width (`10`)
+1. Column `excelExportOptions.width` (when defined on the column)
+2. Column `width` when `includeColumnWidth` is enabled in `excelExportOptions`
+3. Grid `customColumnWidth` (when defined)
+4. Internal fallback width (`10` Excel width units, not pixels)
 
 ```ts
 const gridOptions = {

--- a/frameworks/slickgrid-react/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/export-to-excel.md
@@ -86,6 +86,7 @@ Inside the column definition there are couple of flags you can set in `excelExpo
 - `sheetName` allows you to change the Excel Sheet Name (defaults to "Sheet1")
 - `groupingColumnHeaderTitle` The column header title (at A0 in Excel) of the Group by. If nothing is provided it will use "Group By"
 - `groupingAggregatorRowText` The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator
+- `includeColumnWidth` defaults to `false`, when enabled it will use each column `width` in the Excel export when `excelExportOptions.width` is not defined on the column.
 - set `sanitizeDataExport` to remove any HTML/Script code from being export. For example if your value is `<span class="mdi mdi-check">True</span>` will export `True` without any HTML (data is sanitized).
    - this flag can be used in the Grid Options (all columns) or in a Column Definition (per column).
 - `customExcelHeader` is a callback method that can be used to provide a custom Header Title to your Excel File
@@ -142,6 +143,24 @@ What we can see from the example, is that it will use all Formatters (when exist
 ### Custom Column Width
 
 See [Custom Cell Styling](#custom-cell-styling) to define cell width.
+
+#### Width Precedence
+When exporting a column width, the library uses this order of precedence.
+
+1. Column `excelExportOptions.width`
+2. Column `width` when `includeColumnWidth: true`
+3. Grid `customColumnWidth`
+4. Internal fallback width (`10`)
+
+```ts
+const gridOptions = {
+  excelExportOptions: {
+    includeColumnWidth: true,
+    customColumnWidth: 15,
+  },
+  externalResources: [new ExcelExportService()],
+};
+```
 
 ### Styling the Header Titles
 By default the header titles (first row) will be styled as Bold text, however you can choose to style them differently with custom styles as shown below. To find out what styling you can use, you can take a look at Excel Builder-Vanilla [Documentation](https://ghiscoding.gitbook.io/excel-builder-vanilla/cookbook/fonts-and-colors) website. The code shown below is used in [Example 24](https://ghiscoding.github.io/slickgrid-react-demos/#/Example24) if you wish to see the result.

--- a/frameworks/slickgrid-react/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/export-to-pdf.md
@@ -73,6 +73,9 @@ const Example: React.FC = () => {
 - `sanitizeDataExport`: remove HTML/script from exported data
 - `pdfExportOptions`: per-column PDF export options (see interface for details)
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
+  - `width`: per-column width override in PDF points (`pt`)
+- `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
+  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/slickgrid-react/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/export-to-pdf.md
@@ -75,7 +75,7 @@ const Example: React.FC = () => {
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
   - `width`: per-column width override in PDF points (`pt`)
 - `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
-  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
+  - width precedence is: column `pdfExportOptions.width` (when defined) ➜ column `width` when `includeColumnWidth: true` is enabled (grid px converted to PDF points) ➜ default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-excel.md
@@ -154,10 +154,10 @@ See [Custom Cell Styling](#custom-cell-styling) to define cell width.
 #### Width Precedence
 When exporting a column width, the library uses this order of precedence.
 
-1. Column `excelExportOptions.width`
-2. Column `width` when `includeColumnWidth: true`
-3. Grid `customColumnWidth`
-4. Internal fallback width (`10`)
+1. Column `excelExportOptions.width` (when defined on the column)
+2. Column `width` when `includeColumnWidth` is enabled in `excelExportOptions`
+3. Grid `customColumnWidth` (when defined)
+4. Internal fallback width (`10` Excel width units, not pixels)
 
 ```ts
 gridOptions.value = {

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-excel.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-excel.md
@@ -89,6 +89,7 @@ Inside the column definition there are couple of flags you can set in `excelExpo
 - `sheetName` allows you to change the Excel Sheet Name (defaults to "Sheet1")
 - `groupingColumnHeaderTitle` The column header title (at A0 in Excel) of the Group by. If nothing is provided it will use "Group By"
 - `groupingAggregatorRowText` The default text to display in 1st column of the File Export, which will identify that the current row is a Grouping Aggregator
+- `includeColumnWidth` defaults to `false`, when enabled it will use each column `width` in the Excel export when `excelExportOptions.width` is not defined on the column.
 - set `sanitizeDataExport` to remove any HTML/Script code from being export. For example if your value is `<span class="mdi mdi-check">True</span>` will export `True` without any HTML (data is sanitized).
    - this flag can be used in the Grid Options (all columns) or in a Column Definition (per column).
 - `customExcelHeader` is a callback method that can be used to provide a custom Header Title to your Excel File
@@ -149,6 +150,24 @@ What we can see from the example, is that it will use all Formatters (when exist
 ### Custom Column Width
 
 See [Custom Cell Styling](#custom-cell-styling) to define cell width.
+
+#### Width Precedence
+When exporting a column width, the library uses this order of precedence.
+
+1. Column `excelExportOptions.width`
+2. Column `width` when `includeColumnWidth: true`
+3. Grid `customColumnWidth`
+4. Internal fallback width (`10`)
+
+```ts
+gridOptions.value = {
+  excelExportOptions: {
+    includeColumnWidth: true,
+    customColumnWidth: 15,
+  },
+  externalResources: [new ExcelExportService()],
+};
+```
 
 #### For the entire Grid
 You could also set a custom width for the entire grid export via the `excelExportOptions`

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-pdf.md
@@ -70,6 +70,9 @@ function defineGrid() {
 - `sanitizeDataExport`: remove HTML/script from exported data
 - `pdfExportOptions`: per-column PDF export options (see interface for details)
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
+  - `width`: per-column width override in PDF points (`pt`)
+- `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
+  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-pdf.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/export-to-pdf.md
@@ -72,7 +72,7 @@ function defineGrid() {
   - `textAlign`: per-column horizontal text alignment (`'left'` \| `'center'` \| `'right'`), maps to AutoTable's `halign` style
   - `width`: per-column width override in PDF points (`pt`)
 - `includeColumnWidth`: grid-level option (defaults to `false`) that uses each column `width` when `pdfExportOptions.width` is not defined on the column
-  - width precedence is: column `pdfExportOptions.width` > column `width` when `includeColumnWidth: true` > default PDF layout distribution
+  - width precedence is: column `pdfExportOptions.width` (when defined) ➜ column `width` when `includeColumnWidth: true` is enabled (grid px converted to PDF points) ➜ default PDF layout distribution
 
 Example — right-aligning a numeric column:
 ```ts

--- a/packages/common/src/interfaces/columnExcelExportOption.interface.ts
+++ b/packages/common/src/interfaces/columnExcelExportOption.interface.ts
@@ -14,7 +14,7 @@ export interface ColumnExcelExportOption {
    */
   style?: ExcelStyleInstruction;
 
-  /** Excel column width */
+  /** Excel column width (Excel width units, not pixels). */
   width?: number;
 
   /** Cell data value parser callback function */

--- a/packages/common/src/interfaces/excelExportOption.interface.ts
+++ b/packages/common/src/interfaces/excelExportOption.interface.ts
@@ -11,7 +11,7 @@ export interface ExcelExportOption {
   /** When defined, this will override header titles styling, when undefined the default will be a bold style */
   columnHeaderStyle?: ExcelStyleInstruction;
 
-  /** If set then this will be used as column width for all columns */
+  /** If set then this will be used as Excel column width for all columns (Excel width units, not pixels). */
   customColumnWidth?: number;
 
   /** Defaults to false, which leads to all Formatters of the grid being evaluated on export. You can also override a column by changing the propery on the column itself */
@@ -25,6 +25,19 @@ export interface ExcelExportOption {
 
   /** Defaults to false, should we also include hidden properties in the export? */
   includeHidden?: boolean;
+
+  /**
+   * When true, include each grid column width in the Excel export when no `excelExportOptions.width` is provided on the column.
+   * This is disabled by default to preserve backward compatibility with `customColumnWidth` exports.
+   */
+  includeColumnWidth?: boolean;
+
+  /**
+   * When true (default), export row heights to Excel when enableVariableRowHeight is active.
+   * Set to false to ignore variable row heights and export all rows at default height.
+   * Heights are converted from pixels to Excel points (72 DPI) for proper rendering.
+   */
+  includeVariableRowHeight?: boolean;
 
   /**
    * file MIME type could be provided by the user.
@@ -61,13 +74,6 @@ export interface ExcelExportOption {
    * Useful for debugging, compatibility, or environments where streaming is not desired or supported.
    */
   useStreamingExport?: boolean;
-
-  /**
-   * When true (default), export row heights to Excel when enableVariableRowHeight is active.
-   * Set to false to ignore variable row heights and export all rows at default height.
-   * Heights are converted from pixels to Excel points (72 DPI) for proper rendering.
-   */
-  includeVariableRowHeight?: boolean;
 
   /** Add a Custom Excel Header on first row of the Excel Sheet */
   customExcelHeader?: (workbook: Workbook, sheet: Worksheet) => void;

--- a/packages/common/src/interfaces/pdfExportOption.interface.ts
+++ b/packages/common/src/interfaces/pdfExportOption.interface.ts
@@ -55,6 +55,12 @@ export interface PdfExportOption {
   cellPadding?: number;
   /** Defaults to false, should we also include hidden properties in the export? */
   includeHidden?: boolean;
+
+  /**
+   * When true, include each grid column `width` (pixels) in the PDF export when no `pdfExportOptions.width` is provided on the column.
+   * This is disabled by default to preserve backward compatibility with existing exports.
+   */
+  includeColumnWidth?: boolean;
   /**
    * Optional PDF document properties (metadata) set via `doc.setDocumentProperties()`.
    * These appear in the PDF viewer's "Document Properties" dialog.

--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -944,6 +944,22 @@ describe('Resizer Service', () => {
           }, 15);
         }));
 
+      it('should set "_cResizeCheckRequired" when grid is hidden from UI while auto-fix loop is running', () =>
+        new Promise((done: any) => {
+          mockGridOptions.autoFixResizeWhenBrokenStyleDetected = true;
+          mockGridOptions.autoFixResizeTimeout = 3;
+          service.intervalRetryDelay = 1;
+
+          vi.spyOn(service as any, 'isGridVisibleInUI').mockReturnValue(false);
+          service.init(gridStub, divContainer);
+
+          setTimeout(() => {
+            expect((service as any)._cResizeCheckRequired).toBe(true);
+            service.requestStopOfAutoFixResizeGrid(true);
+            done();
+          }, 5);
+        }));
+
       it('should try to resize grid when its UI is deemed broken by the 2nd condition check of "getRenderedRange"', () =>
         new Promise((done: any) => {
           const resizeSpy = vi.spyOn(service, 'resizeGrid').mockReturnValue(Promise.resolve({ height: 150, width: 350 }));

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -2625,7 +2625,7 @@ describe('ExcelExportService', () => {
       service.init(gridStub, container);
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120 } as Column]);
 
-      expect(styles[0]).toEqual(expect.objectContaining({ width: 120 }));
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 16.43 }));
     });
 
     it('getColumnStyles should prioritize excelExportOptions.width over includeColumnWidth and customColumnWidth', () => {
@@ -2637,13 +2637,39 @@ describe('ExcelExportService', () => {
       expect(styles[0]).toEqual(expect.objectContaining({ width: 40 }));
     });
 
-    it('getColumnStyles should use raw columnDef.width when includeColumnWidth is enabled', () => {
+    it('getColumnStyles should convert columnDef.width (px) to Excel width units when includeColumnWidth is enabled', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
       mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
       service.init(gridStub, container);
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120, minWidth: 130, maxWidth: 135 } as Column]);
 
-      expect(styles[0]).toEqual(expect.objectContaining({ width: 120 }));
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 16.43 }));
+    });
+
+    it('getColumnStyles should convert 70px to expected Excel width approximation', () => {
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
+      mockGridOptions.excelExportOptions = { includeColumnWidth: true } as any;
+      service.init(gridStub, container);
+      const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 70 } as Column]);
+
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 9.29 }));
+    });
+
+    it('getColumnStyles should return width 0 when includeColumnWidth is enabled and column width is Infinity', () => {
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
+      mockGridOptions.excelExportOptions = { includeColumnWidth: true } as any;
+      service.init(gridStub, container);
+      const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: Number.POSITIVE_INFINITY } as Column]);
+
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 0 }));
+    });
+
+    it('convertPixelToExcelWidth should return 0 for non-finite and non-positive values', () => {
+      service.init(gridStub, container);
+
+      expect((service as any).convertPixelToExcelWidth(0)).toBe(0);
+      expect((service as any).convertPixelToExcelWidth(-10)).toBe(0);
+      expect((service as any).convertPixelToExcelWidth(Number.NaN)).toBe(0);
     });
 
     it('getColumnHeaderData should prepend Group By title when grouping exists', () => {

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -2611,6 +2611,41 @@ describe('ExcelExportService', () => {
       expect(styles.length).toBeGreaterThanOrEqual(mockColumns.length);
     });
 
+    it('getColumnStyles should keep using customColumnWidth by default even when grid columns have widths', () => {
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
+      service.init(gridStub, container);
+      const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120 } as Column]);
+
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 12 }));
+    });
+
+    it('getColumnStyles should use grid column width when includeColumnWidth is enabled', () => {
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
+      mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
+      service.init(gridStub, container);
+      const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120 } as Column]);
+
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 120 }));
+    });
+
+    it('getColumnStyles should prioritize excelExportOptions.width over includeColumnWidth and customColumnWidth', () => {
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
+      mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
+      service.init(gridStub, container);
+      const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120, excelExportOptions: { width: 40 } } as Column]);
+
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 40 }));
+    });
+
+    it('getColumnStyles should use raw columnDef.width when includeColumnWidth is enabled', () => {
+      vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
+      mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
+      service.init(gridStub, container);
+      const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120, minWidth: 130, maxWidth: 135 } as Column]);
+
+      expect(styles[0]).toEqual(expect.objectContaining({ width: 120 }));
+    });
+
     it('getColumnHeaderData should prepend Group By title when grouping exists', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([{ getter: 'id' }] as any);
       service.init(gridStub, container);

--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -2137,6 +2137,7 @@ describe('ExcelExportService', () => {
         getColumns: vi.fn().mockReturnValue([{ id: 'id', field: 'id', width: 80 }]),
       };
       svc.init(grid, container);
+      (svc as any)._excelExportOptions = { customColumnWidth: 10 };
       const styles = (svc as any).getColumnStyles(grid.getColumns());
       expect(styles[0]).toEqual(expect.objectContaining({ bestFit: true }));
     });
@@ -2606,6 +2607,7 @@ describe('ExcelExportService', () => {
     it('getColumnStyles should include grouping width style when grouping is present', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([{ getter: 'id' }] as any);
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { customColumnWidth: 10 };
       const styles = (service as any).getColumnStyles(mockColumns);
       expect(styles[0]).toEqual(expect.objectContaining({ bestFit: true }));
       expect(styles.length).toBeGreaterThanOrEqual(mockColumns.length);
@@ -2614,6 +2616,7 @@ describe('ExcelExportService', () => {
     it('getColumnStyles should keep using customColumnWidth by default even when grid columns have widths', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { customColumnWidth: 12 };
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120 } as Column]);
 
       expect(styles[0]).toEqual(expect.objectContaining({ width: 12 }));
@@ -2621,8 +2624,8 @@ describe('ExcelExportService', () => {
 
     it('getColumnStyles should use grid column width when includeColumnWidth is enabled', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
-      mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true };
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120 } as Column]);
 
       expect(styles[0]).toEqual(expect.objectContaining({ width: 16.43 }));
@@ -2630,8 +2633,8 @@ describe('ExcelExportService', () => {
 
     it('getColumnStyles should prioritize excelExportOptions.width over includeColumnWidth and customColumnWidth', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
-      mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true };
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120, excelExportOptions: { width: 40 } } as Column]);
 
       expect(styles[0]).toEqual(expect.objectContaining({ width: 40 }));
@@ -2639,8 +2642,8 @@ describe('ExcelExportService', () => {
 
     it('getColumnStyles should convert columnDef.width (px) to Excel width units when includeColumnWidth is enabled', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
-      mockGridOptions.excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true } as any;
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { customColumnWidth: 12, includeColumnWidth: true };
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 120, minWidth: 130, maxWidth: 135 } as Column]);
 
       expect(styles[0]).toEqual(expect.objectContaining({ width: 16.43 }));
@@ -2648,8 +2651,8 @@ describe('ExcelExportService', () => {
 
     it('getColumnStyles should convert 70px to expected Excel width approximation', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
-      mockGridOptions.excelExportOptions = { includeColumnWidth: true } as any;
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { includeColumnWidth: true };
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: 70 } as Column]);
 
       expect(styles[0]).toEqual(expect.objectContaining({ width: 9.29 }));
@@ -2657,8 +2660,8 @@ describe('ExcelExportService', () => {
 
     it('getColumnStyles should return width 0 when includeColumnWidth is enabled and column width is Infinity', () => {
       vi.spyOn(dataViewStub, 'getGrouping').mockReturnValue([]);
-      mockGridOptions.excelExportOptions = { includeColumnWidth: true } as any;
       service.init(gridStub, container);
+      (service as any)._excelExportOptions = { includeColumnWidth: true };
       const styles = (service as any).getColumnStyles([{ id: 'title', field: 'title', width: Number.POSITIVE_INFINITY } as Column]);
 
       expect(styles[0]).toEqual(expect.objectContaining({ width: 0 }));

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -336,9 +336,8 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
   /** Get each column style including a style for the width of each column */
   protected getColumnStyles(columns: Column[]): any[] {
-    const exportOptions = this._excelExportOptions ?? this._gridOptions?.excelExportOptions ?? {};
-    const defaultColumnWidth = exportOptions.customColumnWidth ?? 10;
-    const includeColumnWidth = exportOptions.includeColumnWidth === true;
+    const defaultColumnWidth = this._excelExportOptions.customColumnWidth ?? 10;
+    const includeColumnWidth = this._excelExportOptions.includeColumnWidth === true;
     const grouping = this._dataView.getGrouping();
     const columnStyles = [];
     if (Array.isArray(grouping) && grouping.length > 0) {

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -352,7 +352,9 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
       const skippedField = columnDef.excludeFromExport ?? false;
       // if column width is 0, then we consider that field as a hidden field and should not be part of the export
       if ((columnDef.width === undefined || columnDef.width > 0) && !skippedField) {
-        const width = columnDef.excelExportOptions?.width ?? (includeColumnWidth ? columnDef.width : undefined);
+        const width =
+          columnDef.excelExportOptions?.width ??
+          (includeColumnWidth && typeof columnDef.width === 'number' ? this.convertPixelToExcelWidth(columnDef.width) : undefined);
 
         columnStyles.push({
           bestFit: true,
@@ -361,6 +363,27 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
       }
     });
     return columnStyles;
+  }
+
+  /** Convert grid column width in pixels to Excel column width units. */
+  protected convertPixelToExcelWidth(pixelWidth: number): number {
+    if (!Number.isFinite(pixelWidth) || pixelWidth <= 0) {
+      return 0;
+    }
+
+    // Excel width is not pixel-based. This approximation mirrors common Calibri 11 behavior.
+    const excelWidth = pixelWidth <= 12 ? pixelWidth / 12 : (pixelWidth - 5) / 7;
+    return this.roundTo2Decimals(excelWidth);
+  }
+
+  /** Convert pixels to Excel points (72 DPI / 96 DPI = 0.75). */
+  protected convertPixelToExcelPoint(pixelValue: number): number {
+    return this.roundTo2Decimals(pixelValue * 0.75);
+  }
+
+  /** Round numeric values to 2 decimal places for stable export output. */
+  protected roundTo2Decimals(value: number): number {
+    return Math.round(value * 100) / 100;
   }
 
   /**
@@ -677,8 +700,7 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
       return;
     }
 
-    // Convert pixels to Excel points: 72 DPI / 96 DPI = 0.75
-    const excelHeight = Math.round(pixelHeight * 0.75 * 100) / 100; // Round to 2 decimal places
+    const excelHeight = this.convertPixelToExcelPoint(pixelHeight);
     this._sheet.setRowInstructions(excelRowNumber, { height: excelHeight });
   }
 

--- a/packages/excel-export/src/excelExport.service.ts
+++ b/packages/excel-export/src/excelExport.service.ts
@@ -336,12 +336,15 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
 
   /** Get each column style including a style for the width of each column */
   protected getColumnStyles(columns: Column[]): any[] {
+    const exportOptions = this._excelExportOptions ?? this._gridOptions?.excelExportOptions ?? {};
+    const defaultColumnWidth = exportOptions.customColumnWidth ?? 10;
+    const includeColumnWidth = exportOptions.includeColumnWidth === true;
     const grouping = this._dataView.getGrouping();
     const columnStyles = [];
     if (Array.isArray(grouping) && grouping.length > 0) {
       columnStyles.push({
         bestFit: true,
-        columnStyles: this._gridOptions?.excelExportOptions?.customColumnWidth ?? 10,
+        columnStyles: defaultColumnWidth,
       });
     }
 
@@ -349,9 +352,11 @@ export class ExcelExportService implements ExternalResource, BaseExcelExportServ
       const skippedField = columnDef.excludeFromExport ?? false;
       // if column width is 0, then we consider that field as a hidden field and should not be part of the export
       if ((columnDef.width === undefined || columnDef.width > 0) && !skippedField) {
+        const width = columnDef.excelExportOptions?.width ?? (includeColumnWidth ? columnDef.width : undefined);
+
         columnStyles.push({
           bestFit: true,
-          width: columnDef.excelExportOptions?.width ?? this._gridOptions?.excelExportOptions?.customColumnWidth ?? 10,
+          width: width ?? defaultColumnWidth,
         });
       }
     });

--- a/packages/pdf-export/src/pdfExport.service.spec.ts
+++ b/packages/pdf-export/src/pdfExport.service.spec.ts
@@ -1232,6 +1232,53 @@ describe('PdfExportService', () => {
         expect(opts.columnStyles).toEqual({});
       });
 
+      it('should not include column width in autoTable by default', async () => {
+        const { PdfExportService: Svc, autoTableSpy } = await createAutoTableService();
+        const columns = [
+          { id: 'col1', field: 'col1', name: 'Col1', width: 120 },
+          { id: 'col2', field: 'col2', name: 'Col2', width: 180 },
+        ];
+        const { gridStub, container } = createStubs(columns);
+        const service = new Svc();
+        service.init(gridStub as any, container as any);
+        await service.exportToPdf({ filename: 'no-width-by-default' });
+
+        const opts = autoTableSpy.mock.calls[0][0];
+        expect(opts.columnStyles).toEqual({});
+      });
+
+      it('should include column width in autoTable when includeColumnWidth is enabled', async () => {
+        const { PdfExportService: Svc, autoTableSpy } = await createAutoTableService();
+        const columns = [
+          { id: 'col1', field: 'col1', name: 'Col1', width: 120 },
+          { id: 'col2', field: 'col2', name: 'Col2', width: 180 },
+        ];
+        const { gridStub, container } = createStubs(columns);
+        const service = new Svc();
+        service.init(gridStub as any, container as any);
+        await service.exportToPdf({ filename: 'with-grid-width', includeColumnWidth: true });
+
+        const opts = autoTableSpy.mock.calls[0][0];
+        expect(opts.columnStyles[0]).toEqual({ cellWidth: 120 });
+        expect(opts.columnStyles[1]).toEqual({ cellWidth: 180 });
+      });
+
+      it('should prioritize pdfExportOptions.width over includeColumnWidth in autoTable', async () => {
+        const { PdfExportService: Svc, autoTableSpy } = await createAutoTableService();
+        const columns = [
+          { id: 'col1', field: 'col1', name: 'Col1', width: 120, pdfExportOptions: { width: 80 } },
+          { id: 'col2', field: 'col2', name: 'Col2', width: 180 },
+        ];
+        const { gridStub, container } = createStubs(columns);
+        const service = new Svc();
+        service.init(gridStub as any, container as any);
+        await service.exportToPdf({ filename: 'width-precedence', includeColumnWidth: true });
+
+        const opts = autoTableSpy.mock.calls[0][0];
+        expect(opts.columnStyles[0]).toEqual({ cellWidth: 80 });
+        expect(opts.columnStyles[1]).toEqual({ cellWidth: 180 });
+      });
+
       it('should handle mixed column alignments correctly', async () => {
         const { PdfExportService: Svc, autoTableSpy } = await createAutoTableService();
         const columns = [

--- a/packages/pdf-export/src/pdfExport.service.spec.ts
+++ b/packages/pdf-export/src/pdfExport.service.spec.ts
@@ -1259,8 +1259,8 @@ describe('PdfExportService', () => {
         await service.exportToPdf({ filename: 'with-grid-width', includeColumnWidth: true });
 
         const opts = autoTableSpy.mock.calls[0][0];
-        expect(opts.columnStyles[0]).toEqual({ cellWidth: 120 });
-        expect(opts.columnStyles[1]).toEqual({ cellWidth: 180 });
+        expect(opts.columnStyles[0]).toEqual({ cellWidth: 90 });
+        expect(opts.columnStyles[1]).toEqual({ cellWidth: 135 });
       });
 
       it('should prioritize pdfExportOptions.width over includeColumnWidth in autoTable', async () => {
@@ -1276,7 +1276,7 @@ describe('PdfExportService', () => {
 
         const opts = autoTableSpy.mock.calls[0][0];
         expect(opts.columnStyles[0]).toEqual({ cellWidth: 80 });
-        expect(opts.columnStyles[1]).toEqual({ cellWidth: 180 });
+        expect(opts.columnStyles[1]).toEqual({ cellWidth: 135 });
       });
 
       it('should handle mixed column alignments correctly', async () => {
@@ -3025,6 +3025,61 @@ describe('PdfExportService', () => {
       // Percent header should be center-aligned
       const pctCall = headerCalls.find((c: any[]) => c[0] === 'Percent');
       expect(pctCall![3].align).toBe('center');
+    });
+
+    it('should use columnDef.width in manual fallback when includeColumnWidth is enabled', async () => {
+      vi.resetModules();
+      const textSpy = vi.fn();
+      function jsPDFMockManual(this: any) {
+        this.save = vi.fn();
+        this.setFontSize = vi.fn();
+        this.getTextWidth = vi.fn((txt: string) => txt.length * 6);
+        this.internal = {
+          pageSize: {
+            getWidth: () => 595.28,
+            getHeight: () => 841.89,
+          },
+        };
+        this.setFillColor = vi.fn();
+        this.setTextColor = vi.fn();
+        this.rect = vi.fn();
+        this.text = textSpy;
+        this.addPage = vi.fn();
+      }
+      vi.doMock('jspdf', () => ({ __esModule: true, default: jsPDFMockManual }));
+      const { PdfExportService: Svc } = await import('./pdfExport.service.js');
+
+      const columns = [
+        { id: 'first', field: 'first', name: 'FirstHdr', width: 200 },
+        { id: 'second', field: 'second', name: 'SecondHdr', width: 100 },
+      ];
+      const dataViewStub = {
+        getGrouping: () => [],
+        getLength: () => 1,
+        getItem: () => ({ id: 1, first: 'A', second: 'B' }),
+        getItemMetadata: vi.fn().mockReturnValue({}),
+      };
+      const gridStub = {
+        getVisibleColumns: () => columns,
+        getOptions: () => ({}),
+        getData: () => dataViewStub,
+      };
+      const pubSubService = { publish: vi.fn() };
+      const container = { get: () => pubSubService };
+      const service = new Svc();
+      service.init(gridStub as any, container as any);
+
+      await service.exportToPdf({ filename: 'manual-include-col-width', includeColumnWidth: true } as any);
+
+      const firstHeaderCall = textSpy.mock.calls.find((c: any[]) => c[0] === 'FirstHdr');
+      const secondHeaderCall = textSpy.mock.calls.find((c: any[]) => c[0] === 'SecondHdr');
+      expect(firstHeaderCall).toBeDefined();
+      expect(secondHeaderCall).toBeDefined();
+
+      // left alignment means header X equals current column start.
+      // with includeColumnWidth=true, first column width=200px converts to 150pt and second header starts at 40 + 150.
+      expect(firstHeaderCall![1]).toBe(40);
+      expect(secondHeaderCall![1]).toBe(190);
     });
 
     it('should call setDocumentProperties in manual fallback when documentProperties is provided', async () => {

--- a/packages/pdf-export/src/pdfExport.service.ts
+++ b/packages/pdf-export/src/pdfExport.service.ts
@@ -40,16 +40,14 @@ const DEFAULT_EXPORT_OPTIONS: PdfExportOption = {
   alternateRowColor: [245, 245, 245],
   cellPadding: 4,
 };
+const PX_TO_PT_CONVERSION_FACTOR = 0.75;
 
 export interface GroupedHeaderSpan {
   title: string;
   span: number;
 }
 
-const PX_TO_PT_CONVERSION_FACTOR = 0.75;
-
 // Utility to resolve and merge column/grid export options
-
 function resolveColumnExportOptions(columnDef: Column, globalOptions: PdfExportOption): PdfExportOption {
   const config = { ...globalOptions, ...(columnDef.pdfExportOptions || {}) };
 

--- a/packages/pdf-export/src/pdfExport.service.ts
+++ b/packages/pdf-export/src/pdfExport.service.ts
@@ -46,6 +46,8 @@ export interface GroupedHeaderSpan {
   span: number;
 }
 
+const PX_TO_PT_CONVERSION_FACTOR = 0.75;
+
 // Utility to resolve and merge column/grid export options
 
 function resolveColumnExportOptions(columnDef: Column, globalOptions: PdfExportOption): PdfExportOption {
@@ -70,6 +72,10 @@ export class PdfExportService implements ExternalResource, BasePdfExportService 
   protected _pubSubService!: PubSubService | null;
   protected _translaterService: TranslaterService | undefined;
   protected _timer?: any;
+
+  protected convertPixelToPdfPoint(pixelValue: number): number {
+    return Math.round(pixelValue * PX_TO_PT_CONVERSION_FACTOR * 100) / 100;
+  }
 
   /** PdfExportService class name which is use to find service instance in the external registered services */
   readonly pluginName = 'PdfExportService';
@@ -215,7 +221,7 @@ export class PdfExportService implements ExternalResource, BasePdfExportService 
 
             let cachedRowHeight = rowHeightByRowIndex.get(rowIdx);
             if (cachedRowHeight === undefined) {
-              cachedRowHeight = Math.round(this._grid.getRowHeight(rowIdx) * 0.75 * 100) / 100;
+              cachedRowHeight = this.convertPixelToPdfPoint(this._grid.getRowHeight(rowIdx));
               rowHeightByRowIndex.set(rowIdx, cachedRowHeight);
             }
 
@@ -236,7 +242,7 @@ export class PdfExportService implements ExternalResource, BasePdfExportService 
                 typeof colExportOpts.width === 'number' && colExportOpts.width > 0
                   ? colExportOpts.width
                   : includeColumnWidth && typeof col.width === 'number' && col.width > 0
-                    ? col.width
+                    ? this.convertPixelToPdfPoint(col.width)
                     : undefined;
 
               if (alignOverride || resolvedWidth !== undefined) {
@@ -363,7 +369,7 @@ export class PdfExportService implements ExternalResource, BasePdfExportService 
                 typeof colOpt?.width === 'number' && colOpt.width > 0
                   ? colOpt.width
                   : includeColumnWidth && typeof colDef?.width === 'number' && colDef.width > 0
-                    ? colDef.width
+                    ? this.convertPixelToPdfPoint(colDef.width)
                     : undefined;
 
               if (resolvedWidth !== undefined) {

--- a/packages/pdf-export/src/pdfExport.service.ts
+++ b/packages/pdf-export/src/pdfExport.service.ts
@@ -223,15 +223,32 @@ export class PdfExportService implements ExternalResource, BasePdfExportService 
           };
 
           // Add table (using jsPDF-AutoTable if available, else fallback to manual)
+          const includeColumnWidth = this._exportOptions.includeColumnWidth === true;
+          const visibleColumns = columns.filter((col: Column) => !col.excludeFromExport && (col.width === undefined || col.width > 0));
           if ((doc as any).autoTable) {
             // Build per-column styles for AutoTable from each column's pdfExportOptions
-            const visibleColumns = columns.filter((col: Column) => !col.excludeFromExport && (col.width === undefined || col.width > 0));
-            const columnStyles: Record<number, { halign: string }> = {};
+            const columnStyles: Record<number, { halign?: string; cellWidth?: number }> = {};
             const groupOffset = this._hasGroupedItems ? 1 : 0;
             for (const [idx, col] of visibleColumns.entries()) {
               const colExportOpts = resolveColumnExportOptions(col, this._exportOptions);
-              if (colExportOpts.textAlign && colExportOpts.textAlign !== (this._exportOptions.textAlign || 'left')) {
-                columnStyles[idx + groupOffset] = { halign: colExportOpts.textAlign };
+              const alignOverride = colExportOpts.textAlign && colExportOpts.textAlign !== (this._exportOptions.textAlign || 'left');
+              const resolvedWidth =
+                typeof colExportOpts.width === 'number' && colExportOpts.width > 0
+                  ? colExportOpts.width
+                  : includeColumnWidth && typeof col.width === 'number' && col.width > 0
+                    ? col.width
+                    : undefined;
+
+              if (alignOverride || resolvedWidth !== undefined) {
+                const styleIdx = idx + groupOffset;
+                const styleDef = columnStyles[styleIdx] ?? {};
+                if (alignOverride) {
+                  styleDef.halign = colExportOpts.textAlign;
+                }
+                if (resolvedWidth !== undefined) {
+                  styleDef.cellWidth = resolvedWidth;
+                }
+                columnStyles[styleIdx] = styleDef;
               }
             }
 
@@ -334,10 +351,23 @@ export class PdfExportService implements ExternalResource, BasePdfExportService 
             // Use custom width if provided, else equal width
             let colWidths = Array(colCount).fill(tableWidth / colCount);
             for (let i = 0; i < colCount; i++) {
-              const colId = columns[i]?.id;
+              if (this._hasGroupedItems && i === 0) {
+                continue;
+              }
+
+              const dataColIdx = this._hasGroupedItems ? i - 1 : i;
+              const colDef = visibleColumns[dataColIdx];
+              const colId = colDef?.id;
               const colOpt = colId ? columnExportOptionsCache[colId] : undefined;
-              if (colOpt && colOpt.width && typeof colOpt.width === 'number') {
-                colWidths[i] = colOpt.width;
+              const resolvedWidth =
+                typeof colOpt?.width === 'number' && colOpt.width > 0
+                  ? colOpt.width
+                  : includeColumnWidth && typeof colDef?.width === 'number' && colDef.width > 0
+                    ? colDef.width
+                    : undefined;
+
+              if (resolvedWidth !== undefined) {
+                colWidths[i] = resolvedWidth;
               }
             }
             // If any custom widths, adjust last column to fill remaining space so sum matches tableWidth


### PR DESCRIPTION
_vibe coded with Copilot using GPT-5.3-Codex_

after recently adding variable row height in Excel/PDF exports, I figured that we should also add the column width as well but as opt-in.

## Why
Exports were already handling row height fidelity, but column width fidelity was inconsistent:
- Excel width export mostly relied on export-specific width settings and global fallback.
- PDF had width support in parts of the flow, but not consistent parity across rendering paths.
- Because runtime grid columns typically end up with a width value (defaulted by grid internals), enabling width import by default would silently change many existing exports.

This change introduces an explicit, safe way to export using grid column widths without breaking current behavior.

## What changed (behavior)
A new option is introduced for both Excel and PDF:
- includeColumnWidth: boolean (default false)

When includeColumnWidth is false:
- Existing behavior is preserved.

When includeColumnWidth is true:
- Export uses column definition width as fallback source for each column width.

Width resolution precedence is now explicit:
1. Per-column export width (highest priority)
2. Column definition width when includeColumnWidth is true
3. Existing global/default fallback behavior

In plain terms:
- If you already set export-specific width, nothing changes.
- If you do not set export-specific width and opt in, export follows your grid column width.
- If you do not opt in, export keeps prior defaults.

## Why opt-in
This is intentionally opt-in for backward compatibility:
- Grid columns generally have a width at runtime (explicit or defaulted).
- A default-on approach would alter output for many users unexpectedly.
- Opt-in keeps existing exports stable while enabling fidelity for users who want WYSIWYG width behavior.

## Notes on units
- Excel width uses Excel column-width units (not pixels).
- PDF width uses points (pt), consistent with jsPDF defaults.
- includeColumnWidth uses the column width value as-is within each export pipeline’s existing unit semantics.

## Scope details
- Applied to Excel export width logic.
- Applied to PDF export width logic in both render paths:
1. jsPDF AutoTable path
2. Manual fallback rendering path

## Validation
- Targeted Excel export tests pass.
- Targeted PDF export tests pass.
- New tests cover default behavior, opt-in behavior, and precedence behavior.

## Summary
 We now have 2 new options in Excel/PDF exports for row height and column width:
- `includeVariableRowHeight` => default true **but only** when variable row height is enabled
- `includeColumnWidth` => default false (opt-in)

### Export Demo

<img width="1127" height="850" alt="image" src="https://github.com/user-attachments/assets/f9dc4dda-173a-44f8-ad58-81a4ca0b7af3" />
