### PR TITLE
fix: fractional grid height leaves the bottom rows unrendered

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4068,7 +4068,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     if (this.prevScrollTop !== newScrollTop) {
       this.vScrollDir = this.prevScrollTop + oldOffset < newScrollTop + this.offset ? 1 : -1;
-      this.lastRenderedScrollTop = this.scrollTop = this.prevScrollTop = newScrollTop;
+      this.scrollTop = this.prevScrollTop = newScrollTop;
 
       if (this.hasFrozenColumns()) {
         this._viewportTopL.scrollTop = newScrollTop;


### PR DESCRIPTION
Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1263 into slickgrid-universal

> Fixes https://github.com/6pac/SlickGrid/issues/1262.
> 
> ### Root cause
> Two different "maximum scrollTop" values disagree by a sub-pixel amount:
> 
> value at the bottom (`height: 430.1px`, rowHeight 20, 100 rows)
> `_handleScroll()` ceiling — `scrollHeight - clientHeight` (integer, and equal to the browser's real max)	`1611`
> `scrollTo()` ceiling — `th - getBoundingClientRect().height + scrollbarH` (fractional)	`1610.90625`
> `clientHeight` is **rounded**, so when the height's decimal part is below `.5` it rounds _down_ and the browser's real maximum scrollTop ends up _above_ the ceiling `scrollTo()` clamps to. At `.5` or above — and on integer heights — it rounds up, the gap disappears, and nothing goes wrong. That is exactly the threshold reported in the issue.
> 
> A mouse wheel that overshoots the bottom is clamped to `1611` by `_handleScroll()`, and `scrollTo()` then lowers it to `1610.90625`. Because `newScrollTop !== prevScrollTop`, `scrollTo()` takes its "the position moved" branch — which assigned `lastRenderedScrollTop` as if a render had happened:
> 
> ```js
> this.lastRenderedScrollTop = (this.scrollTop = this.prevScrollTop = newScrollTop);
> ```
> 
> Back in `_handleScroll()`, `dy = Math.abs(this.lastRenderedScrollTop - this.scrollTop)` is therefore `0`, the `dy > 20` gate fails, and `render()` is never called. Rows that the _previous_ render had cleaned up stay missing, and the bare viewport shows through at the bottom of the grid. Continued scrolling repeats the same path, which is why the issue reports that scrolling does not restore the grid — only an unrelated re-render (resizing a column, selecting a row) does.
> 
> ### Fix
> `scrollTo()` no longer claims a render it did not do — `lastRenderedScrollTop` is now set only by `render()`:
> 
> ```diff
> -      this.lastRenderedScrollTop = (this.scrollTop = this.prevScrollTop = newScrollTop);
> +      this.scrollTop = this.prevScrollTop = newScrollTop;
> ```
> 
> Every other `scrollTo()` caller (`scrollRowIntoView`, `scrollRowToTop`, `scrollPage`) calls `render()` immediately afterwards, so no render is lost. The branch this touches is only entered when `scrollTo()` genuinely moves the position — the fractional-height case above and virtual paging (`offset` change) — where a render was needed and was wrongly suppressed in both.
> 
> ### Regression test
> `cypress/e2e/quirk-fractional-height-bottom-render.cy.ts` is self-hosting (harness served via `cy.intercept`, no page added to `examples/`), following the `quirk-frozen-bottom-cell-cleanup` precedent. It reproduces the issue's exact geometry, and asserts two preconditions before the real check so it cannot silently pass for the wrong reason:
> 
> 1. the DOM's maximum scrollTop really is greater than the position `scrollTo()` settles on;
> 2. the wheel-up really did clean up the bottom rows.
> 
> Then it wheels back down past the bottom in a single event and asserts no visible row is left unrendered.
> 
> ### Verification
> * **Fails on the unfixed build** (both retry attempts): `[94, 95, 96, 97, 98, 99]` missing — the Cypress failure screenshot shows the bare viewport band below row 93. **Passes with the fix.**
> * Height sweep in Chrome (`430`, `430.1`, `430.25`, `430.49`, `430.5`, `430.6`, `430.75`, `430.9`, `429.3`, `431.4`): 0 missing rows on all; before the fix every sub-`.5` height lost 6 rows.
> * Full Cypress suite: **640 tests, 638 passing, 2 pending, 0 failing**. `tsc` and `eslint` clean.
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

