### PR TITLE
fix: treat frozenRow: 0 as no freeze (input clamp)

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1412,8 +1412,8 @@ describe('SlickGrid core file', () => {
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');
       expect(grid.getFooterRowColumn('firstName')).toEqual(footerElms[0].querySelector('.slick-footerrow-column'));
-      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement).style.display).not.toBe('none'); // frozenRow: 0
-      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement).style.display).not.toBe('none'); // frozenRow: 0
+      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement).style.display).toBe('none'); // frozenRow: 0 -> no freeze
+      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement).style.display).toBe('none'); // frozenRow: 0 -> no freeze
     });
 
     it('should define colspan and rowspan then expect to cleanup rendered cells when SlickDataView and cell metadata are defined', () => {
@@ -1616,8 +1616,8 @@ describe('SlickGrid core file', () => {
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');
       expect(grid.getFooterRowColumn('firstName')).toEqual(footerElms[0].querySelector('.slick-footerrow-column'));
-      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement).style.display).not.toBe('none'); // frozenRow: 0
-      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement).style.display).not.toBe('none'); // frozenRow: 0
+      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement).style.display).toBe('none'); // frozenRow: 0 -> no freeze
+      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement).style.display).toBe('none'); // frozenRow: 0 -> no freeze
     });
 
     it('should hide/show column headers div when "showFooterRow" is disabled (with frozenColumn/frozenRow/frozenBottom) and expect footer row column exists', () => {
@@ -1648,8 +1648,8 @@ describe('SlickGrid core file', () => {
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');
       expect(grid.getFooterRowColumn('firstName')).toEqual(footerElms[0].querySelector('.slick-footerrow-column'));
-      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement).style.display).not.toBe('none'); // frozenRow: 0
-      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement).style.display).not.toBe('none'); // frozenRow: 0
+      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement).style.display).toBe('none'); // frozenRow: 0 -> no freeze
+      expect((container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement).style.display).toBe('none'); // frozenRow: 0 -> no freeze
     });
 
     it('should hide column headers div when "showFooterRow" is disabled and expect undefined footer row column', () => {
@@ -5796,14 +5796,14 @@ describe('SlickGrid core file', () => {
       Object.defineProperty(viewportLeftElm, 'scrollLeft', { writable: true, value: 88 });
       viewportLeftElm.dispatchEvent(mouseEvent);
 
-      expect(viewportTopLeftElm.scrollLeft).toBe(88);
-      expect(preHeaderElm[0].scrollLeft).toBe(88);
-      expect(footerRowElm[0].scrollLeft).toBe(88);
+      expect(viewportTopLeftElm.scrollLeft).toBe(160);
+      expect(preHeaderElm[0].scrollLeft).toBe(0);
+      expect(footerRowElm[0].scrollLeft).toBe(0);
       expect(viewportLeftElm.scrollLeft).toBe(88);
-      expect(viewportLeftElm.scrollTop).toBe(25);
-      expect(viewportBottomRightElm.scrollTop).toBe(25);
-      expect(onViewportChangedSpy).toHaveBeenCalled();
-      expect(mousePreventSpy).toHaveBeenCalled();
+      expect(viewportLeftElm.scrollTop).toBe(0);
+      expect(viewportBottomRightElm.scrollTop).toBe(0);
+      expect(onViewportChangedSpy).not.toHaveBeenCalled();
+      expect(mousePreventSpy).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(1);
       viewportLeftElm.dispatchEvent(mouseEvent);
@@ -5842,14 +5842,37 @@ describe('SlickGrid core file', () => {
       Object.defineProperty(viewportBottomLeftElm, 'scrollLeft', { writable: true, value: 88 });
       viewportBottomLeftElm.dispatchEvent(mouseEvent);
 
-      expect(viewportTopLeftElm.scrollLeft).toBe(88);
-      expect(preHeaderElm[0].scrollLeft).toBe(88);
-      expect(footerRowElm[0].scrollLeft).toBe(88);
+      expect(viewportTopLeftElm.scrollLeft).toBe(160);
+      expect(preHeaderElm[0].scrollLeft).toBe(0);
+      expect(footerRowElm[0].scrollLeft).toBe(0);
       expect(viewportBottomLeftElm.scrollLeft).toBe(88);
       expect(viewportBottomLeftElm.scrollTop).toBe(50);
       expect(viewportBottomLeftElm.scrollTop).toBe(50);
-      expect(onViewportChangedSpy).toHaveBeenCalled();
-      expect(mousePreventSpy).toHaveBeenCalled();
+      expect(onViewportChangedSpy).not.toHaveBeenCalled();
+      expect(mousePreventSpy).not.toHaveBeenCalled();
+    });
+
+    it('should treat frozenRow 0 as no freeze and render rows in top canvas only', () => {
+      const dv = new SlickDataView();
+      dv.setItems(data);
+      grid = new SlickGrid<any, Column>(container, dv, columns, {
+        ...defaultOptions,
+        frozenRow: 0,
+        createFooterRow: true,
+        createPreHeaderPanel: true,
+      });
+
+      const topPaneLeft = container.querySelector('.slick-pane.slick-pane-top.slick-pane-left') as HTMLDivElement;
+      const bottomPaneLeft = container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-left') as HTMLDivElement;
+      const bottomPaneRight = container.querySelector('.slick-pane.slick-pane-bottom.slick-pane-right') as HTMLDivElement;
+      const topCanvasRows = container.querySelectorAll('.grid-canvas-top .slick-row');
+      const bottomCanvasRows = container.querySelectorAll('.grid-canvas-bottom .slick-row');
+
+      expect(topPaneLeft.style.display).not.toBe('none');
+      expect(bottomPaneLeft.style.display).toBe('none');
+      expect(bottomPaneRight.style.display).toBe('none');
+      expect(topCanvasRows.length).toBe(data.length);
+      expect(bottomCanvasRows.length).toBe(0);
     });
 
     it('should scroll all elements shown when triggered by mousewheel and preHeader/footer/frozenColumn/frozenRow are enabled', () => {
@@ -5917,13 +5940,13 @@ describe('SlickGrid core file', () => {
       Object.defineProperty(viewportLeftElm, 'scrollLeft', { writable: true, value: 88 });
       viewportLeftElm.dispatchEvent(mouseEvent);
 
-      expect(preHeaderElm[1].scrollLeft).toBe(0);
-      expect(footerRowElm[1].scrollLeft).toBe(0);
+      expect(preHeaderElm[1].scrollLeft).toBe(80);
+      expect(footerRowElm[1].scrollLeft).toBe(80);
       expect(viewportLeftElm.scrollLeft).toBe(88);
       expect(viewportLeftElm.scrollTop).toBe(25);
-      expect(viewportTopRightElm.scrollTop).toBe(0);
-      expect(onViewportChangedSpy).not.toHaveBeenCalled();
-      expect(mousePreventSpy).not.toHaveBeenCalled();
+      expect(viewportTopRightElm.scrollTop).toBe(25);
+      expect(onViewportChangedSpy).toHaveBeenCalled();
+      expect(mousePreventSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -2708,7 +2708,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
         ? parseInt(this._options.frozenColumn as unknown as string, 10)
         : -1;
 
-    if (this._options.frozenRow! > -1) {
+    if (this._options.frozenRow! > 0) {
       this.hasFrozenRows = true;
       const dataLength = this.getDataLength();
       this.actualFrozenRow = this._options.frozenBottom ? dataLength - this._options.frozenRow! : this._options.frozenRow!;


### PR DESCRIPTION
_verified by Copilot using GPT-5.3-Codex_

Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1266 into slickgrid-universal

> ## The bug (Q23/Q24 in discussion https://github.com/6pac/SlickGrid/discussions/1247)
> `frozenRow` is a **count**, but `setFrozenOptions` gated on `frozenRow > -1`, so `frozenRow: 0` activated the full frozen-row machinery around an **empty band**:
> 
> * `hasFrozenRows = true`, split panes shown — a visible empty band strip;
> * `actualFrozenRow` computed to `0`, so **every row rendered in the bottom canvas** in top mode;
> * with `frozenBottom: true`, `actualFrozenRow = dataLength` — the whole body rendered in the top canvas while bottom-mode offset math measured it (the degenerate case behind several downstream contortions).
> 
> ## The fix
> One-line clamp: the gate is now `frozenRow > 0`. Zero pinned rows **is** no freeze. A repo-wide grep (examples/, cypress/, src/) confirms nothing passes `frozenRow: 0` today, so no exercised behavior changes.
> 
> ## Repro
> `new Slick.Grid('#c', data, cols, { frozenRow: 0 })` → pre-fix: all rows live in `.grid-canvas-bottom` under a visible empty band; post-fix: identical to an unfrozen grid.
> 
> ## Test
> `cypress/e2e/quirk-frozen-row-zero.cy.ts` — **self-hosting** (the two-variant harness is served from within the spec via `cy.intercept`; the spec does not depend on any example page). Asserts both `frozenRow: 0` variants are observably identical to an unfrozen grid (all rows in the top canvas, no bottom pane visible). Verified to **fail pre-fix** (`top=0 bottom=12`, phantom panes visible) **and pass with the fix**; frozen suites ran green as a regression gate.
> 
> ## ⚠️ Temporary example page
> `examples/example-quirk-frozen-row-zero.html` is a human-review repro (three grids: both variants + an unfrozen control) **intended to be deleted before merge**. The cypress test is fully independent of it.
> 
> (Part of the quirks-triage series — remaining-items wave: see discussion https://github.com/6pac/SlickGrid/discussions/1247.)

