### PR TITLE
fix: route off-viewport alwaysRenderColumn cells to their own column band

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -5581,6 +5581,28 @@ describe('SlickGrid core file', () => {
       expect(renderSpy).toHaveBeenCalledTimes(3);
     });
 
+    it('should route off-viewport alwaysRenderColumn cell to right canvas when frozen columns are enabled', () => {
+      const columnsWithAlwaysRender = [
+        { id: 'c0', field: 'c0', name: 'Col 0' },
+        { id: 'c1', field: 'c1', name: 'Col 1' },
+        { id: 'c2', field: 'c2', name: 'Col 2', alwaysRenderColumn: true },
+      ] as Column[];
+      const dataWithSingleRow = [{ id: 0, c0: '0', c1: '1', c2: '2' }];
+      grid = new SlickGrid<any, Column>(container, dataWithSingleRow, columnsWithAlwaysRender, { ...defaultOptions, frozenColumn: 0 });
+
+      vi.spyOn(grid, 'getRenderedRange').mockReturnValue({ leftPx: 260, rightPx: 340, bottom: 20, top: 0 });
+      grid.render();
+
+      const alwaysRenderNode = grid.getCellNode(0, 2);
+      const alwaysRenderCanvas = alwaysRenderNode?.closest('.grid-canvas');
+      const frozenNode = grid.getCellNode(0, 0);
+      const frozenCanvas = frozenNode?.closest('.grid-canvas');
+
+      expect(alwaysRenderNode).toBeTruthy();
+      expect(alwaysRenderCanvas?.classList.contains('grid-canvas-right')).toBeTruthy();
+      expect(frozenCanvas?.classList.contains('grid-canvas-left')).toBeTruthy();
+    });
+
     it('should scroll when calling scrollCellIntoView() with row having colspan returned from DataView getItemMetadata()', () => {
       const columnsCopy = [...columns];
       columnsCopy[1].colspan = '*';

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4295,7 +4295,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
             this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
           }
         } else if (m.alwaysRenderColumn || (this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
-          this.appendCellHtml(rowDiv, row, i, ncolspan, rowspan, columnData, d);
+          const targetedRowDiv = this.hasFrozenColumns() && i > this._options.frozenColumn! ? rowDivR! : rowDiv;
+          this.appendCellHtml(targetedRowDiv, row, i, ncolspan, rowspan, columnData, d);
         }
 
         if (ncolspan > 1) {


### PR DESCRIPTION
_verified by Copilot using GPT-5.3-Codex_

Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1267 into slickgrid-universal

> ## The bug (Q4 in discussion https://github.com/6pac/SlickGrid/discussions/1247)
> `appendRowHtml` has two cell-routing branches. The in-viewport branch routes by column band. The **off-viewport** branch — taken when a column has scrolled out past the left edge — appended `alwaysRenderColumn` cells to the left fragment unconditionally:
> 
> ```ts
> } else if (m.alwaysRenderColumn || (this.hasFrozenColumns() && i <= this._options.frozenColumn!)) {
>   this.appendCellHtml(rowDiv, row, i, …);   // LEFT fragment — wrong for a right-band column
> }
> ```
> 
> So an `alwaysRenderColumn` column **right of the freeze** (e.g. an action/checkbox column at the right edge of a frozen grid) rendered its off-viewport cells into the clipped **left** canvas: mispositioned/invisible, and — worse — its `cellNodesByColumnIdx` entry mapped to a node in the wrong pane, which `getCellNode`, editors and plugins all consume.
> 
> ## The fix
> The off-viewport branch now uses the same band pick as the in-viewport branch. Left-frozen and plain-grid cells keep landing in the left fragment exactly as before — the change is strictly narrowing.
> 
> ## Repro subtlety (worth knowing for review)
> The misroute only manifests on a row rendered **fresh while the horizontal position is already far-right**: a combined `scrollCellIntoView(row, col)` scrolls vertically first (synchronously, while the cached `scrollLeft` is still stale) so the fresh row routes in-viewport — and `cleanUpCells` deliberately never removes `alwaysRenderColumn` cells, so already-rendered rows never repro. Discovered while validating the spec; the test therefore scrolls horizontally, lets the async scroll handler settle, then scrolls a never-rendered row in.
> 
> ## Test
> `cypress/e2e/quirk-always-render-column-routing.cy.ts` — **self-hosting** (harness served from within the spec via `cy.intercept`; no dependency on any example page), with a frozen-left control cell. Verified to **fail pre-fix** (`canvas=grid-canvas-left`) **and pass with the fix**; frozen + rowspan + checkbox suites ran 75/75 as a regression gate.
> 
> ## ⚠️ Temporary example page
> `examples/example-quirk-always-render-column-routing.html` is a human-review repro (highlighted "Sticky" column, three-step buttons mirroring the settle-then-fresh-render recipe) **intended to be deleted before merge**. The cypress test is fully independent of it.
> 
> (Part of the quirks-triage series — remaining-items wave: see discussion https://github.com/6pac/SlickGrid/discussions/1247; sibling PR https://github.com/6pac/SlickGrid/pull/1266.)

