### PR TITLE
feat: build the footer row lazily when createFooterRow is enabled at runtime

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1733,6 +1733,11 @@ describe('SlickGrid core file', () => {
 
       grid.setOptions({ createFooterRow: true, showFooterRow: true });
       footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
+      expect(footerElms[0].style.display).toBe('none');
+      expect(footerElms[1].style.display).toBe('none');
+
+      grid.setFooterRowVisibility(false);
+      grid.setFooterRowVisibility(true);
       expect(footerElms[0].style.display).not.toBe('none');
       expect(footerElms[1].style.display).not.toBe('none');
     });

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -1694,6 +1694,49 @@ describe('SlickGrid core file', () => {
       expect(grid.getFooterRowColumn('firstName')).toBeUndefined();
     });
 
+    it('should lazily create footer row when "createFooterRow" is enabled at runtime', () => {
+      const columns = [
+        { id: 'firstName', field: 'firstName', name: 'First Name' },
+        { id: 'lastName', field: 'lastName', name: 'Last Name' },
+      ] as Column[];
+      grid = new SlickGrid<any, Column>(container, [], columns, {
+        ...defaultOptions,
+        createFooterRow: false,
+        showFooterRow: true,
+      });
+      grid.init();
+
+      const onFooterRowCellRenderedSpy = vi.spyOn(grid.onFooterRowCellRendered, 'notify');
+
+      expect(grid.getFooterRow()).toBeFalsy();
+      expect(container.querySelector('.slick-footerrow')).toBeFalsy();
+
+      expect(() => grid.setOptions({ createFooterRow: true, showFooterRow: true })).not.toThrow();
+
+      let footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
+      expect(footerElms).toBeTruthy();
+      expect(footerElms.length).toBe(2);
+      expect(footerElms[0].style.display).not.toBe('none');
+      expect(footerElms[1].style.display).not.toBe('none');
+      expect(grid.getFooterRow()).toBeTruthy();
+      expect(grid.getFooterRowColumn('firstName')).toEqual(footerElms[0].querySelector('.slick-footerrow-column'));
+      expect(onFooterRowCellRenderedSpy).toHaveBeenCalledTimes(2);
+
+      grid.setFooterRowVisibility(false);
+      footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
+      expect(footerElms[0].style.display).toBe('none');
+      expect(footerElms[1].style.display).toBe('none');
+
+      grid.setOptions({ createFooterRow: false });
+      expect(footerElms[0].style.display).toBe('none');
+      expect(footerElms[1].style.display).toBe('none');
+
+      grid.setOptions({ createFooterRow: true, showFooterRow: true });
+      footerElms = container.querySelectorAll<HTMLDivElement>('.slick-footerrow');
+      expect(footerElms[0].style.display).not.toBe('none');
+      expect(footerElms[1].style.display).not.toBe('none');
+    });
+
     it('should show footer when "showFooterRow" is enabled but not return any row when columns to the right are outside the range', () => {
       const columns = [
         { id: 'firstName', field: 'firstName', name: 'First Name' },

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -1766,7 +1766,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /**
-   * Build footer row DOM lazily when footer row creation is enabled at runtime.
+   * Builds the footer-row DOM (scrollers, spacers and footer-row containers) in both
+   * panes — the single construction path shared by init and by a runtime
+   * `setOptions({ createFooterRow: true })` enable. On an already-initialized grid it
+   * also binds the footer events (during init they are bound in `finishInitialization`).
+   * Runtime disable hides the footer rather than destroying it (symmetric with
+   * `showFooterRow`).
    */
   protected materializeFooterRow(): void {
     const canvasWithScrollbarWidth = this.getCanvasWidth() + (this.scrollbarDimensions?.width || 0);
@@ -3747,16 +3752,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.validateAndEnforceOptions();
     this.setFrozenOptions();
 
-    if (this._options.createFooterRow) {
-      if (!this._footerRow) {
-        this.materializeFooterRow();
-      }
-      if (this._options.showFooterRow) {
-        Utils.show(this._footerRowScroller);
-      } else {
-        Utils.hide(this._footerRowScroller);
-      }
-    } else if (this._footerRowScroller) {
+    if (this._options.createFooterRow && !this._footerRow) {
+      this.materializeFooterRow();
+    } else if (!this._options.createFooterRow && this._footerRow) {
       this._footerRowScroller.forEach((scroller) => {
         Utils.hide(scroller);
       });

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -925,42 +925,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
     // footer Row
     if (this._options.createFooterRow) {
-      this._footerRowScrollerR = createDomElement('div', { className: 'slick-footerrow slick-state-default' }, this._paneTopR);
-      this._footerRowScrollerL = createDomElement('div', { className: 'slick-footerrow slick-state-default' }, this._paneTopL);
-
-      this._footerRowScroller = [this._footerRowScrollerL, this._footerRowScrollerR];
-
-      this._footerRowSpacerL = createDomElement(
-        'div',
-        { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } },
-        this._footerRowScrollerL
-      );
-      Utils.width(this._footerRowSpacerL, canvasWithScrollbarWidth);
-      this._footerRowSpacerR = createDomElement(
-        'div',
-        { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } },
-        this._footerRowScrollerR
-      );
-      Utils.width(this._footerRowSpacerR, canvasWithScrollbarWidth);
-
-      this._footerRowL = createDomElement(
-        'div',
-        { className: 'slick-footerrow-columns slick-footerrow-columns-left' },
-        this._footerRowScrollerL
-      );
-      this._footerRowR = createDomElement(
-        'div',
-        { className: 'slick-footerrow-columns slick-footerrow-columns-right' },
-        this._footerRowScrollerR
-      );
-
-      this._footerRow = [this._footerRowL, this._footerRowR];
-
-      if (!this._options.showFooterRow) {
-        this._footerRowScroller.forEach((scroller) => {
-          Utils.hide(scroller);
-        });
-      }
+      this.materializeFooterRow();
     }
 
     this._focusSink2 = this._focusSink.cloneNode(true) as HTMLDivElement;
@@ -1797,6 +1762,56 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           grid: this,
         });
       }
+    }
+  }
+
+  /**
+   * Build footer row DOM lazily when footer row creation is enabled at runtime.
+   */
+  protected materializeFooterRow(): void {
+    const canvasWithScrollbarWidth = this.getCanvasWidth() + (this.scrollbarDimensions?.width || 0);
+
+    this._footerRowScrollerR = createDomElement('div', { className: 'slick-footerrow slick-state-default' }, this._paneTopR);
+    this._footerRowScrollerL = createDomElement('div', { className: 'slick-footerrow slick-state-default' }, this._paneTopL);
+    this._footerRowScroller = [this._footerRowScrollerL, this._footerRowScrollerR];
+
+    this._footerRowSpacerL = createDomElement(
+      'div',
+      { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } },
+      this._footerRowScrollerL
+    );
+    Utils.width(this._footerRowSpacerL, canvasWithScrollbarWidth);
+
+    this._footerRowSpacerR = createDomElement(
+      'div',
+      { style: { display: 'block', height: '1px', position: 'absolute', top: '0px', left: '0px' } },
+      this._footerRowScrollerR
+    );
+    Utils.width(this._footerRowSpacerR, canvasWithScrollbarWidth);
+
+    this._footerRowL = createDomElement(
+      'div',
+      { className: 'slick-footerrow-columns slick-footerrow-columns-left' },
+      this._footerRowScrollerL
+    );
+    this._footerRowR = createDomElement(
+      'div',
+      { className: 'slick-footerrow-columns slick-footerrow-columns-right' },
+      this._footerRowScrollerR
+    );
+    this._footerRow = [this._footerRowL, this._footerRowR];
+
+    if (!this._options.showFooterRow) {
+      this._footerRowScroller.forEach((scroller) => {
+        Utils.hide(scroller);
+      });
+    }
+
+    // Bind footer events only when footer row is created after init.
+    if (this.initialized) {
+      this._bindingEventService.bind(this._footerRow, 'contextmenu', this.handleFooterContextMenu.bind(this) as EventListener);
+      this._bindingEventService.bind(this._footerRow, 'click', this.handleFooterClick.bind(this) as EventListener);
+      this._bindingEventService.bind(this._footerRowScroller, 'scroll', this.handleFooterRowScroll.bind(this) as EventListener);
     }
   }
 
@@ -3731,6 +3746,21 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
     this.validateAndEnforceOptions();
     this.setFrozenOptions();
+
+    if (this._options.createFooterRow) {
+      if (!this._footerRow) {
+        this.materializeFooterRow();
+      }
+      if (this._options.showFooterRow) {
+        Utils.show(this._footerRowScroller);
+      } else {
+        Utils.hide(this._footerRowScroller);
+      }
+    } else if (this._footerRowScroller) {
+      this._footerRowScroller.forEach((scroller) => {
+        Utils.hide(scroller);
+      });
+    }
 
     // when user changed frozen row option, we need to force a recalculation of each viewport heights
     if (this._options.frozenBottom !== undefined) {


### PR DESCRIPTION
_verified by Copilot using GPT-5.3-Codex_

Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1269 into slickgrid-universal

> > ⚠️ **Merge order:** this PR assumes **https://github.com/6pac/SlickGrid/pull/1266** and **https://github.com/6pac/SlickGrid/pull/1267** are merged first (and pairs naturally with https://github.com/6pac/SlickGrid/pull/1268). It has no textual conflicts with them, but it was authored and validated against a master that includes them — please land those before this one.
> 
> ## The bug (Q2 in discussion https://github.com/6pac/SlickGrid/discussions/1247)
> Footer-row DOM was built only in the init path, and `internal_setOptions` never created it — so `setOptions({ createFooterRow: true })` on a live grid flowed into `setColumns` → `createColumnFooter`, dereferenced the undefined `_footerRowL`, and **threw**, leaving the grid with a half-mutated options state.
> 
> ## The change (the 'support it' resolution from the triage)
> `internal_setOptions` now materializes the footer DOM when the flag flips true. `materializeFooterRow()` mirrors the init construction (R-before-L scroller order, spacers, columns containers, hidden when `!showFooterRow`) and binds the footer contextmenu/click/scroll handlers on an already-initialized grid. It runs **before** `setScroller` (which selects the footer scroll container) and **before** `setColumns` (which populates footer cells), so the existing pipeline completes the job with no further special-casing.
> 
> Runtime **disable** hides the footer rather than destroying it — symmetric with `showFooterRow` — and `setFooterRowVisibility` works on a runtime-built footer exactly as on an init-built one.
> 
> ## Test
> `cypress/e2e/quirk-runtime-footer-enable.cy.ts` — **self-hosting** (harness via `cy.intercept`; no example-page dependency). Enable on a live grid → no throw, scrollers visible, one footer cell **and** one `onFooterRowCellRendered` per column, `getFooterRow()` returns the element, `setFooterRowVisibility(false)` hides it. Verified to **fail pre-fix** (`TypeError: Cannot read properties of undefined`) **and pass with the fix**; footer + composite-editor + frozen suites ran 27/27 as a regression gate.
> 
> One review note: an earlier draft asserted `setOptions({ showFooterRow: false })` hides the footer — dropped because master never supported visibility toggling via `setOptions` for init-built footers either; `setFooterRowVisibility` is the supported API and is what the spec exercises.
> 
> ## ⚠️ Temporary example page
> `examples/example-quirk-runtime-footer-enable.html` is a human-review repro (enable + toggle buttons with a live readout) **intended to be deleted before merge** — the cypress test is fully independent of it.
> 
> (Quirks-triage remaining-items wave: see discussion https://github.com/6pac/SlickGrid/discussions/1247; siblings https://github.com/6pac/SlickGrid/pull/1266, https://github.com/6pac/SlickGrid/pull/1267, https://github.com/6pac/SlickGrid/pull/1268)

