### PR TITLE
chore(deps): migrate from pnpm/setup-action to pnpm/setup for pnpm@11

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -37,9 +37,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,9 @@ jobs:
           exit 1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/test-angular.yml
+++ b/.github/workflows/test-angular.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/test-aurelia.yml
+++ b/.github/workflows/test-aurelia.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: true
+          install: true
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/test-react.yml
+++ b/.github/workflows/test-react.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/test-vanilla.yml
+++ b/.github/workflows/test-vanilla.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/test-vue.yml
+++ b/.github/workflows/test-vue.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2
         with:
-          run_install: false
+          install: false
 
       - name: Set NodeJS
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7


### PR DESCRIPTION
## Description

migrate from `pnpm/setup-action` to `pnpm/setup` for pnpm@11

## Motivation and Context

as per pnpm docs:

> [!IMPORTANT]
> **This action has a successor: [`pnpm/setup`](https://github.com/pnpm/setup).**
>
> For pnpm v11 and newer, use [`pnpm/setup`](https://github.com/pnpm/setup) instead. It downloads pnpm's self-contained release binary (no Node.js or npm required) and can install a JavaScript runtime (Node.js, Bun, or Deno) in the same step, replacing `actions/setup-node`.
>
> `pnpm/action-setup` remains the action to use for installing pnpm v10 and older. See [Migrating to pnpm/setup](#migrating-to-pnpmsetup) below.
