### PR TITLE
refactor: single scrollbar add and named slack in getHeadersWidth

### DIFF
--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -108,6 +108,10 @@ import type { SlickDataView } from './slickDataview.js';
 import { Draggable, MouseWheel, Resizable } from './slickInteractions.js';
 import { applyHtmlToElement, runOptionalHtmlSanitizer } from './utils.js';
 
+// slack added beyond the summed column widths so the header band always exceeds the
+// body scroll range (header width is the header/body scroll-sync floor) and column
+// drag-reorder has room past the last column
+const HEADER_WIDTH_SLACK = 1000;
 const RESIZE_AUTOSCROLL_MIN_INTERVAL_MS = 30;
 const RESIZE_AUTOSCROLL_MAX_INTERVAL_MS = 600;
 const RESIZE_AUTOSCROLL_ACCELERATE_INTERVAL = 5;
@@ -1264,16 +1268,14 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     }
 
     if (this.hasFrozenColumns()) {
-      this.headersWidthL = this.headersWidthL + 1000;
+      this.headersWidthL = this.headersWidthL + HEADER_WIDTH_SLACK;
       this.headersWidthR = Math.max(this.headersWidthR, this.viewportW) + this.headersWidthL;
-      this.headersWidthR += this.scrollbarDimensions?.width || 0;
     } else {
-      this.headersWidthL += this.scrollbarDimensions?.width || 0;
-      this.headersWidthL = Math.max(this.headersWidthL, this.viewportW) + 1000;
+      this.headersWidthL = Math.max(this.headersWidthL, this.viewportW) + HEADER_WIDTH_SLACK;
     }
 
     this.headersWidth = this.headersWidthL + this.headersWidthR;
-    return Math.max(this.headersWidth, this.viewportW) + 1000;
+    return Math.max(this.headersWidth, this.viewportW) + HEADER_WIDTH_SLACK;
   }
 
   /** Get the grid canvas width */


### PR DESCRIPTION
_verified by Copilot using GPT-5.3-Codex_

Port bug fix from 6pac/SlickGrid PR https://github.com/6pac/SlickGrid/pull/1274 into slickgrid-universal

> Resolves the Q16 investigation item from the quirks triage (discussion https://github.com/6pac/SlickGrid/discussions/1247): `getHeadersWidth()` added the vertical-scrollbar width to the active band **twice** — once in the conditional gutter-attribution block (from https://github.com/6pac/SlickGrid/pull/1260, gated on `!autoHeight`), and once more, unconditionally, in the band-finalization block. Two generations of code expressing the same intent.
> 
> ### Why the duplicate add contributes nothing
> The band widths already carry the classic **`+1000` fixed slack** (applied to the left band and again to the return value), which is what actually guarantees the two invariants the header width serves:
> 
> 1. the header band's scroll range covers the body viewport's scroll range (header width is the header/body scroll-sync floor), and
> 2. column drag-reorder has room past the last column.
> 
> A second ≤17px scrollbar term riding on a 1000px slack cannot be load-bearing. It was also wrong-shaped: the conditional add correctly skips `autoHeight` grids (which have no vertical scrollbar), while the unconditional one gave them a gutter for a scrollbar that doesn't exist.
> 
> ### The change
> * Exactly **one** scrollbar add remains — the documented, conditional gutter attribution.
> * The two unconditional duplicate adds are deleted.
> * The `1000` literals are promoted to a named module constant, **`HEADER_WIDTH_SLACK`**, with a comment stating what the slack is for — the intent is now explicit rather than folklore.
> 
> Net effect on computed widths: the header container gets ≤17px narrower (and autoHeight grids lose the phantom gutter). The container is clipped, and both scroll-range floors retain the full 1000px slack, so nothing is user-visible.
> 
> This also simplifies the #1238 rework: the ViewportMgr's `computeHeaderWidths` currently mirrors the double-add bit-for-bit; after this lands it mirrors one sane formula.
> 
> ### Test
> `cypress/e2e/headers-width-scroll-sync.cy.ts` — a **regression pin**, not a bug repro (there is no fail-on-unfixed leg, and per that, no temporary example page). Self-hosting harness with three grids — plain, `frozenColumn: 1` (right band scrolls), and `autoHeight` — asserting for each: header scroll range ≥ body scroll range, header scroller reaches the body's `scrollLeft` at full right scroll (no clamping), and the last column's header stays pixel-aligned with its body cells there. Verified to pass on the **pre-change** build (baseline) and on the refactored build, so any future width-formula change that breaks scroll sync fails this spec.
> 
> Full cypress suite: all specs passed — 652 tests, 650 passing, 2 pre-existing skips (4m51s).
> 
> (Quirks-triage follow-up: with this, every actionable item from discussion https://github.com/6pac/SlickGrid/discussions/1247 is resolved on master — remaining entries are the documented keep-as-is decisions and the Q32 product call.)
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

