### PR TITLE
chore(tests): add basic Excel export Cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ jest-coverage
 **/coverage
 **/vitest-coverage
 **/cypress-report
+**/cypress/downloads
 **/dist
 **/*.tgz
 test/cypress/screenshots/*.png

--- a/demos/vanilla/src/examples/example37.html
+++ b/demos/vanilla/src/examples/example37.html
@@ -44,6 +44,10 @@
       </span>
     </h5>
     <button class="button is-small mb-3" onclick.trigger="gridFocus()">Grid Focus</button>
+    <button class="button is-small" data-test="export-excel-btn" onclick.trigger="exportGrid1ToExcel()">
+      <span class="mdi mdi-file-excel-outline"></span>
+      <span>Export to Excel</span>
+    </button>
   </div>
 </div>
 <div class="grid37-1"></div>

--- a/demos/vanilla/src/examples/example37.ts
+++ b/demos/vanilla/src/examples/example37.ts
@@ -4,7 +4,7 @@ import { Slicker, type SlickVanillaGridBundle } from '@slickgrid-universal/vanil
 import { ExampleGridOptions } from './example-grid-options.js';
 import './example37.scss';
 
-const NB_ITEMS = 1000;
+const NB_ITEMS = 400;
 
 export default class Example37 {
   protected _eventHandler: SlickEventHandler;
@@ -17,6 +17,7 @@ export default class Example37 {
   dataset2!: any[];
   sgb1!: SlickVanillaGridBundle;
   sgb2!: SlickVanillaGridBundle;
+  excelExportService = new ExcelExportService();
 
   gridFocus() {
     this.sgb1.slickGrid?.focus();
@@ -149,7 +150,7 @@ export default class Example37 {
       excelExportOptions: {
         exportWithFormatter: true,
       },
-      externalResources: [new ExcelExportService()],
+      externalResources: [this.excelExportService],
 
       // enable new hybrid selection model (rows & cells)
       enableSelection: true,
@@ -222,5 +223,9 @@ export default class Example37 {
       };
     }
     return data;
+  }
+
+  exportGrid1ToExcel() {
+    this.excelExportService.exportToExcel({ filename: 'export', format: 'xlsx' });
   }
 }

--- a/test/cypress.config.ts
+++ b/test/cypress.config.ts
@@ -1,4 +1,211 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
 import { defineConfig } from 'cypress';
+
+interface ReadLatestXlsxTaskOptions {
+  downloadsFolder: string;
+  minModifiedTime?: number;
+  timeoutMs?: number;
+  maxDataRows?: number;
+}
+
+interface ParsedXlsxExport {
+  fileName: string;
+  sheetName: string;
+  rowCount: number;
+  header: string[];
+  firstDataRow: string[];
+  dataRows: string[][];
+}
+
+function isExcelExportFile(fileName: string): boolean {
+  const lowerFileName = fileName.toLowerCase();
+  return lowerFileName.endsWith('.xlsx') || lowerFileName.endsWith('.xlxs');
+}
+
+function decodeXmlEntities(input: string): string {
+  return input.replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&quot;', '"').replaceAll('&apos;', "'");
+}
+
+function extractZipEntries(buffer: Buffer): Map<string, Buffer> {
+  const entries = new Map<string, Buffer>();
+  const eocdSignature = 0x06054b50;
+  const centralSignature = 0x02014b50;
+  const localSignature = 0x04034b50;
+
+  let eocdOffset = -1;
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === eocdSignature) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset < 0) {
+    throw new Error('Invalid XLSX file: end of central directory not found');
+  }
+
+  const totalEntries = buffer.readUInt16LE(eocdOffset + 10);
+  const centralDirectoryOffset = buffer.readUInt32LE(eocdOffset + 16);
+  let cursor = centralDirectoryOffset;
+
+  for (let i = 0; i < totalEntries; i++) {
+    if (buffer.readUInt32LE(cursor) !== centralSignature) {
+      throw new Error('Invalid XLSX file: central directory entry signature mismatch');
+    }
+
+    const compressionMethod = buffer.readUInt16LE(cursor + 10);
+    const compressedSize = buffer.readUInt32LE(cursor + 20);
+    const fileNameLength = buffer.readUInt16LE(cursor + 28);
+    const extraLength = buffer.readUInt16LE(cursor + 30);
+    const commentLength = buffer.readUInt16LE(cursor + 32);
+    const localHeaderOffset = buffer.readUInt32LE(cursor + 42);
+    const fileName = buffer.toString('utf8', cursor + 46, cursor + 46 + fileNameLength);
+
+    if (buffer.readUInt32LE(localHeaderOffset) !== localSignature) {
+      throw new Error(`Invalid XLSX file: local header signature mismatch for "${fileName}"`);
+    }
+
+    const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+    const compressedData = buffer.subarray(dataStart, dataStart + compressedSize);
+
+    let fileData: Buffer;
+    if (compressionMethod === 0) {
+      fileData = Buffer.from(compressedData);
+    } else if (compressionMethod === 8) {
+      fileData = zlib.inflateRawSync(compressedData);
+    } else {
+      throw new Error(`Unsupported XLSX compression method "${compressionMethod}" in "${fileName}"`);
+    }
+
+    entries.set(fileName, fileData);
+    cursor += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function parseSharedStrings(sharedStringsXml: string): string[] {
+  const output: string[] = [];
+  const regex = /<si[\s\S]*?<\/si>/g;
+  const textRegex = /<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/g;
+  const stringItems = sharedStringsXml.match(regex) || [];
+
+  for (const item of stringItems) {
+    const textParts: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = textRegex.exec(item)) !== null) {
+      textParts.push(decodeXmlEntities(match[1]));
+    }
+    output.push(textParts.join(''));
+  }
+
+  return output;
+}
+
+function parseSheetRowValues(sheetXml: string, sharedStrings: string[], rowNumber: number): string[] {
+  const rowRegex = new RegExp(`<row[^>]*r="${rowNumber}"[^>]*>([\\s\\S]*?)<\\/row>`);
+  const rowMatch = sheetXml.match(rowRegex);
+  if (!rowMatch) {
+    return [];
+  }
+
+  const rowBody = rowMatch[1];
+  const cellRegex = /<c([^>]*)>([\s\S]*?)<\/c>/g;
+  const values: string[] = [];
+  let cellMatch: RegExpExecArray | null;
+
+  while ((cellMatch = cellRegex.exec(rowBody)) !== null) {
+    const attrs = cellMatch[1] || '';
+    const body = cellMatch[2] || '';
+    const cellTypeMatch = attrs.match(/\st="([^"]+)"/);
+    const cellType = cellTypeMatch?.[1] || '';
+
+    if (cellType === 's') {
+      const valueMatch = body.match(/<v>(\d+)<\/v>/);
+      const stringIndex = valueMatch ? Number(valueMatch[1]) : NaN;
+      values.push(Number.isFinite(stringIndex) ? sharedStrings[stringIndex] || '' : '');
+      continue;
+    }
+
+    if (cellType === 'inlineStr') {
+      const inlineMatch = body.match(/<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/);
+      values.push(inlineMatch ? decodeXmlEntities(inlineMatch[1]) : '');
+      continue;
+    }
+
+    if (cellType === 'b') {
+      const boolValueMatch = body.match(/<v>([01])<\/v>/);
+      values.push(boolValueMatch?.[1] === '1' ? 'TRUE' : 'FALSE');
+      continue;
+    }
+
+    const rawValueMatch = body.match(/<v>([\s\S]*?)<\/v>/);
+    values.push(rawValueMatch ? decodeXmlEntities(rawValueMatch[1]) : '');
+  }
+
+  return values;
+}
+
+function parseXlsxExport(filePath: string, maxDataRows = 10): ParsedXlsxExport {
+  const zipBuffer = fs.readFileSync(filePath);
+  const entries = extractZipEntries(zipBuffer);
+
+  const workbookXml = entries.get('xl/workbook.xml')?.toString('utf8') || '';
+  const sheetNameMatch = workbookXml.match(/<sheet[^>]*name="([^"]+)"/);
+  const sheetName = decodeXmlEntities(sheetNameMatch?.[1] || '');
+  if (!sheetName) {
+    throw new Error(`No worksheet found in exported file "${path.basename(filePath)}"`);
+  }
+
+  const firstSheetXml = entries.get('xl/worksheets/sheet1.xml')?.toString('utf8') || '';
+  if (!firstSheetXml) {
+    throw new Error(`Missing worksheet payload "xl/worksheets/sheet1.xml" in "${path.basename(filePath)}"`);
+  }
+
+  const sharedStringsXml = entries.get('xl/sharedStrings.xml')?.toString('utf8') || '';
+  const sharedStrings = sharedStringsXml ? parseSharedStrings(sharedStringsXml) : [];
+
+  const header = parseSheetRowValues(firstSheetXml, sharedStrings, 1);
+  const firstDataRow = parseSheetRowValues(firstSheetXml, sharedStrings, 2);
+  const rowCountMatches = [...firstSheetXml.matchAll(/<row\b/g)];
+  const dataRows = Array.from({ length: Math.max(0, maxDataRows) }, (_unused, index) =>
+    parseSheetRowValues(firstSheetXml, sharedStrings, index + 2)
+  );
+
+  return {
+    fileName: path.basename(filePath),
+    sheetName,
+    rowCount: rowCountMatches.length,
+    header,
+    firstDataRow,
+    dataRows,
+  };
+}
+
+function getLatestXlsxFile(downloadsFolder: string, minModifiedTime = 0): string | undefined {
+  if (!fs.existsSync(downloadsFolder)) {
+    return undefined;
+  }
+
+  const xlsxEntries = fs
+    .readdirSync(downloadsFolder, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && isExcelExportFile(entry.name))
+    .map((entry) => {
+      const filePath = path.join(downloadsFolder, entry.name);
+      return {
+        filePath,
+        mtimeMs: fs.statSync(filePath).mtimeMs,
+      };
+    })
+    .filter((entry) => entry.mtimeMs >= minModifiedTime)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  return xlsxEntries[0]?.filePath;
+}
 
 export default defineConfig({
   allowCypressEnv: false,
@@ -35,6 +242,55 @@ export default defineConfig({
     specPattern: 'test/cypress/e2e/**/*.cy.ts',
     testIsolation: false,
     setupNodeEvents(on) {
+      on('task', {
+        clearXlsxDownloads({ downloadsFolder }: { downloadsFolder: string }) {
+          if (!fs.existsSync(downloadsFolder)) {
+            return 0;
+          }
+
+          let removedCount = 0;
+          const files = fs.readdirSync(downloadsFolder, { withFileTypes: true });
+          for (const file of files) {
+            if (file.isFile() && isExcelExportFile(file.name)) {
+              try {
+                fs.unlinkSync(path.join(downloadsFolder, file.name));
+                removedCount += 1;
+              } catch (error) {
+                const errorCode = (error as NodeJS.ErrnoException)?.code;
+                if (errorCode !== 'EBUSY' && errorCode !== 'EPERM') {
+                  throw error;
+                }
+              }
+            }
+          }
+
+          return removedCount;
+        },
+
+        async readLatestXlsxExport({
+          downloadsFolder,
+          minModifiedTime = 0,
+          timeoutMs = 10000,
+          maxDataRows = 10,
+        }: ReadLatestXlsxTaskOptions): Promise<ParsedXlsxExport> {
+          const startTime = Date.now();
+
+          while (Date.now() - startTime <= timeoutMs) {
+            const latestFilePath =
+              getLatestXlsxFile(downloadsFolder, minModifiedTime) ||
+              // Fallback for Windows/CI timestamp precision or delayed metadata updates.
+              getLatestXlsxFile(downloadsFolder, 0);
+            if (latestFilePath) {
+              return parseXlsxExport(latestFilePath, maxDataRows);
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 250));
+          }
+
+          throw new Error(`No .xlsx export found in "${downloadsFolder}" within ${timeoutMs}ms`);
+        },
+      });
+
       on('before:browser:launch', (browser, launchOptions) => {
         if (['chrome', 'edge'].includes(browser.name)) {
           if (browser.isHeadless) {

--- a/test/cypress/e2e/example07.cy.ts
+++ b/test/cypress/e2e/example07.cy.ts
@@ -860,6 +860,34 @@ describe('Example 07 - Row Move & Checkbox Selector Selector Plugins', () => {
       cy.get('.slick-context-menu .slick-menu-command-list').should('not.exist');
     });
 
+    it('should export to Excel and contain expected worksheet content', () => {
+      const downloadsFolder = Cypress.config('downloadsFolder');
+
+      cy.get('.grid7').find('.slick-row .slick-cell:nth(2)').rightclick({ force: true });
+      cy.get('.slick-context-menu.dropright .slick-menu-command-list')
+        .find('.slick-menu-item:nth(1)')
+        .find('.slick-menu-content')
+        .contains('Export to Excel')
+        .click();
+
+      cy.task('readLatestXlsxExport', { downloadsFolder, timeoutMs: 15000 }).then((xlsx: any) => {
+        expect(xlsx.fileName).to.match(/\.xlsx$/i);
+        expect(xlsx.sheetName).to.be.a('string').and.not.be.empty;
+        expect(xlsx.rowCount).to.be.gte(3);
+
+        const normalizedHeaders = xlsx.header.map((header: string) => `${header}`.replace(/\s+/g, ' ').trim());
+        expect(normalizedHeaders).to.deep.equal(['Title', '% Complete', 'Duration', 'Completed', 'Start', 'Prerequisites', 'Title']);
+
+        expect(xlsx.firstDataRow[0]).to.equal('Task 4');
+        expect(Number(xlsx.firstDataRow[1])).to.be.a('number');
+        expect(xlsx.firstDataRow[2]).to.equal('0');
+        expect(`${xlsx.firstDataRow[3]}`.toUpperCase()).to.equal('FALSE');
+        expect(xlsx.firstDataRow[4]).to.equal('2009-01-01');
+        expect(xlsx.firstDataRow[5]).to.contain('Task 4');
+        expect(xlsx.firstDataRow[6]).to.equal('Task 4');
+      });
+    });
+
     it('should switch language', () => {
       cy.get('[data-test="language-button"]').click();
 

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -38,14 +38,25 @@ describe('Example 37 - Hybrid Selection Model', () => {
         });
     });
 
-    it('should export Grid 1 to Excel and keep static columns with expected data shapes', () => {
+    it('should export Grid 1 to Excel without hidden columns and keep expected data shapes', () => {
       const downloadsFolder = Cypress.config('downloadsFolder');
 
       cy.get('[data-test="export-excel-btn"]').click();
 
       cy.task('readLatestXlsxExport', { downloadsFolder, timeoutMs: 15000, maxDataRows: 11 }).then((xlsx: any) => {
         expect(xlsx.fileName).to.match(/\.xlsx$/i);
-        expect(xlsx.header).to.deep.equal(['#', 'Title', '% Complete', 'Start', 'Finish', 'Priority', 'Effort Driven']);
+
+        const normalizedHeader = xlsx.header.map((columnName: string) =>
+          `${columnName}`
+            .replace(/\u00a0/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase()
+        );
+
+        expect(normalizedHeader).to.deep.equal(['#', 'title', '% complete', 'start', 'finish', 'priority', 'effort driven']);
+        expect(normalizedHeader).to.have.length(7);
+        expect(normalizedHeader).to.not.include('last column / hidden column');
         expect(xlsx.rowCount - 1).to.equal(400);
 
         expect(xlsx.dataRows).to.be.an('array');

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -38,6 +38,31 @@ describe('Example 37 - Hybrid Selection Model', () => {
         });
     });
 
+    it('should export Grid 1 to Excel and keep static columns with expected data shapes', () => {
+      const downloadsFolder = Cypress.config('downloadsFolder');
+
+      cy.get('[data-test="export-excel-btn"]').click();
+
+      cy.task('readLatestXlsxExport', { downloadsFolder, timeoutMs: 15000, maxDataRows: 11 }).then((xlsx: any) => {
+        expect(xlsx.fileName).to.match(/\.xlsx$/i);
+        expect(xlsx.header).to.deep.equal(['#', 'Title', '% Complete', 'Start', 'Finish', 'Priority', 'Effort Driven']);
+        expect(xlsx.rowCount - 1).to.equal(400);
+
+        expect(xlsx.dataRows).to.be.an('array');
+        expect(xlsx.dataRows.length).to.equal(11);
+
+        xlsx.dataRows.forEach((row: string[], index: number) => {
+          expect(row[0]).to.equal(`${index}`);
+          expect(row[1]).to.equal(`Task ${index}`);
+          expect(Number(row[2])).to.be.within(0, 99);
+          expect(row[3]).to.match(/^\d{2}\/\d{2}\/\d{4}$/);
+          expect(row[4]).to.match(/^\d{2}\/\d{2}\/\d{4}$/);
+          expect(row[5]).to.match(/^(Low|Medium|High)$/);
+          expect(row[6]).to.match(/^(Yes|No)$/);
+        });
+      });
+    });
+
     it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
       cy.get('.grid37-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
       cy.get('@task1').should('contain', 'Task 1');


### PR DESCRIPTION
## PR Description

This PR adds basic end-to-end regression coverage for Excel export behavior in Cypress, focused on validating exported workbook structure and data shape instead of only validating UI command clicks.

### Why
Major-version regressions can slip through when tests only verify menu actions and not the exported file contents. This change adds practical checks that verify the Excel output contract.

### What’s included
1. Added Cypress Excel export tests that trigger real exports and assert workbook content at a high level.
2. Validated stable fields directly (for example row identity/task labels) and validated variable fields by type/shape (for example numeric/date/enum-style values).
3. Added/updated Cypress-side export parsing helpers so tests can inspect exported `.xlsx` content without introducing heavy external reader dependencies.
4. Reduced flakiness around local file handling/timing by hardening export file discovery and Windows lock edge cases.

### Outcome
These tests provide meaningful regression protection for Excel export workflows while staying resilient to expected random dataset values.

### Context
  This addresses a past regression where hidden columns were exported in Excel even though exports are expected to be WYSIWYG.
- What changed:
  Added Cypress Excel export regression coverage that validates exported workbook headers and row data contracts.
- Regression guard:
  Example 37 now explicitly asserts that hidden columns (for example Last Column / Hidden Column) are excluded from Excel export output.
- Data validation:
  Test verifies static columns deterministically and validates randomized columns by type/shape.
- Result:
  Prevents hidden-column leakage regressions in future releases.

### LLM model attribution
This PR was assisted by GitHub Copilot using GPT-5.3-Codex.