### PR TITLE
perf(slickgrid): stabilize paged scrolling edges and clarify paging path

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -6238,6 +6238,40 @@ describe('SlickGrid core file', () => {
       expect(testGrid.getRowPosition(3)).toBe(row0Height + row1Height + row2Height);
     });
 
+    it('should cover legacy and interior branch paths in virtual page mapping helpers', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, rowHeight: 25 });
+      const testGrid = grid as any;
+
+      // getPageOffset(): legacy mapping when page count is tiny (n <= 3)
+      testGrid.n = 3;
+      testGrid.th = 1000;
+      testGrid.h = 500;
+      testGrid.cj = 123;
+      expect(testGrid.getPageOffset(1)).toBe(123);
+
+      // getPageOffset(): legacy fallback when computed lastOffset is non-positive
+      testGrid.n = 5;
+      testGrid.th = 400;
+      testGrid.h = 500;
+      testGrid.cj = 47;
+      expect(testGrid.getPageOffset(1)).toBe(47);
+
+      // getPageFromLargeScrollDelta(): no-interior-pages legacy page selection path
+      testGrid.n = 3;
+      testGrid.ph = 100;
+      testGrid.h = 500;
+      testGrid.viewportH = 50;
+      expect(testGrid.getPageFromLargeScrollDelta(150)).toBe(1);
+
+      // getPageFromLargeScrollDelta(): interior-page scale-factor path
+      testGrid.n = 6;
+      testGrid.ph = 100;
+      testGrid.h = 500;
+      testGrid.th = 1200;
+      testGrid.viewportH = 50;
+      expect(testGrid.getPageFromLargeScrollDelta(250)).toBe(4);
+    });
+
     it('should do page up when calling scrollRowIntoView() and we are further than row index that we want to scroll to', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, frozenRow: 0 });
       const scrollToSpy = vi.spyOn(grid, 'scrollTo');

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -6210,6 +6210,34 @@ describe('SlickGrid core file', () => {
       expect(renderSpy).toHaveBeenCalled();
     });
 
+    it('should keep page-boundary mapping stable with variable row height enabled', () => {
+      const manyRows = Array.from({ length: 700 }, (_, i) => ({ id: i, firstName: `name-${i}`, lastName: 'L', age: i }));
+      const variableRowHeightProvider = (_grid: SlickGrid, row: number) => 2200 + (row % 3) * 200;
+
+      grid = new SlickGrid<any, Column>(container, manyRows, columns, {
+        ...defaultOptions,
+        enableVariableRowHeight: true,
+        rowHeight: 2200,
+        rowHeightProvider: variableRowHeightProvider,
+      });
+
+      const testGrid = grid as any;
+      const lastPage = testGrid.n - 1;
+
+      expect(testGrid.n).toBeGreaterThan(3);
+      expect(testGrid.getPageOffset(0)).toBe(0);
+      expect(testGrid.getPageOffset(1)).toBe(0);
+      expect(testGrid.getPageOffset(lastPage)).toBe(Math.max(0, testGrid.th - testGrid.h));
+
+      expect(testGrid.getPageFromLargeScrollDelta(testGrid.ph - 1)).toBe(0);
+      expect(testGrid.getPageFromLargeScrollDelta(testGrid.h - testGrid.ph)).toBe(lastPage);
+
+      const row0Height = grid.getRowHeight(0);
+      const row1Height = grid.getRowHeight(1);
+      const row2Height = grid.getRowHeight(2);
+      expect(testGrid.getRowPosition(3)).toBe(row0Height + row1Height + row2Height);
+    });
+
     it('should do page up when calling scrollRowIntoView() and we are further than row index that we want to scroll to', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, { ...defaultOptions, frozenRow: 0 });
       const scrollToSpy = vi.spyOn(grid, 'scrollTo');

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -4112,6 +4112,51 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   }
 
   /**
+   * Map a virtual page index to its render offset in scroll-container space.
+   * First and last pages are pinned to container edges; interior pages are spread
+   * evenly between them to avoid browser edge clamping/jank near boundaries.
+   */
+  protected getPageOffset(page: number): number {
+    if (this.n <= 1 || page <= 0) {
+      return 0;
+    }
+
+    const lastOffset = Math.max(0, this.th - this.h);
+    if (page >= this.n - 1) {
+      return lastOffset;
+    }
+
+    // With no interior pages, keep legacy linear mapping.
+    if (this.n <= 3 || lastOffset <= 0) {
+      return Math.round(page * (this.cj || 0));
+    }
+
+    return Math.round(((page - 1) * lastOffset) / (this.n - 3));
+  }
+
+  /**
+   * Infer page index from large-scale scroll movement in container space.
+   * This mirrors page pinning logic used by getPageOffset().
+   */
+  protected getPageFromLargeScrollDelta(scrollTop: number): number {
+    if (this.n <= 1 || this.ph <= 0 || this.h <= this.viewportH || scrollTop < this.ph) {
+      return 0;
+    }
+
+    if (scrollTop >= this.h - this.ph) {
+      return this.n - 1;
+    }
+
+    // With no interior pages, keep legacy page selection behavior.
+    if (this.n <= 3 || this.h <= this.ph * 2) {
+      return Math.min(this.n - 1, Math.floor(scrollTop / this.ph));
+    }
+
+    const scaleFactor = (this.th - this.ph * 2) / (this.h - this.ph * 2);
+    return Math.min(this.n - 3, Math.floor(((scrollTop - this.ph) * scaleFactor) / this.ph)) + 1;
+  }
+
+  /**
    * Scroll to an Y coordinate position in the grid
    * @param {Number} y
    */
@@ -4128,7 +4173,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     // determine the page for the target position first, then derive the offset from that page
     // (computing the offset from the previous page would lag one scroll event behind on jumps)
     this.page = this.ph ? Math.min((this.n || 0) - 1, Math.floor(y / this.ph)) : 0;
-    this.offset = Math.round(this.page * (this.cj || 0));
+    this.offset = this.getPageOffset(this.page);
     const newScrollTop = (y - this.offset) as number;
 
     if (this.offset !== oldOffset) {
@@ -5875,15 +5920,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       if (vScrollDist < this.viewportH) {
         this.scrollTo(this.scrollTop + this.offset);
       } else {
-        if (this.h === this.viewportH) {
-          this.page = 0;
-        } else {
-          this.page = Math.min(
-            this.n - 1,
-            Math.floor(this.scrollTop * ((this.th - this.viewportH) / (this.h - this.viewportH)) * (1 / this.ph))
-          );
-        }
-        this.offset = Math.round(this.page * this.cj);
+        this.page = this.getPageFromLargeScrollDelta(this.scrollTop);
+        this.offset = this.getPageOffset(this.page);
       }
     }
 


### PR DESCRIPTION
## Summary
This PR improves SlickGrid virtual paging to reduce boundary jank on very large datasets while preserving variable row height behavior and existing scroll semantics.

## Technical Changes
- Updated virtual page offset mapping in slickGrid.ts:
  - First page pinned to offset 0
  - Last page pinned to end offset
  - Interior pages evenly distributed between first and last
- Updated large-scroll page selection in slickGrid.ts:
  - Explicit first/last page handling near boundaries
  - Interior scaling only within interior range
- Integrated the new helpers into existing vertical scroll flow:
  - Used by scroll-to logic
  - Used by large scroll-delta branch in scroll handling
- Kept compatibility fallback paths for small/degenerate page regimes:
  - Small page count and non-interior scenarios still use stable fallback calculations
  - This is intentional to avoid edge-case regressions
- Minor readability/minimal-code cleanup:
  - Merged equivalent early-return guards
  - Removed redundant temporary variable usage
  - Renamed helper for clarity:
    - getPageFromLargeScrollPosition -> getPageFromLargeScrollDelta

## Test Coverage ✅ 
- Added regression tests in slickGrid.spec.ts:
  - Boundary page mapping with variable row height enabled
  - Variable row position accumulation remains correct
  - Explicit branch coverage for fallback and interior mapping paths in paging helpers

## What Was Reused From the Blog Posts
- Reused from Modern React Virtual Scroll Grid 9:
  - Pin first/last pages to container edges
  - Distribute interior pages between them
  - Separate boundary handling from interior scaling during large-scroll page selection
  - Source: https://www.thecandidstartup.org/2024/04/29/modern-react-virtual-scroll-grid-9.html
- Validated against Modern React Virtual Scroll Grid 8:
  - Original linear page spacing near boundaries can cause sticky/janky behavior at scale
  - Source: https://www.thecandidstartup.org/2024/04/22/modern-react-virtual-scroll-grid-8.html
- Confirmed compatibility with Modern React Virtual Scroll Grid 3:
  - Variable row height row-index/row-offset mapping remains owned by row position indexing
  - Paging remap is orthogonal and does not replace variable row offset mapping
  - Source: https://www.thecandidstartup.org/2024/02/12/modern-react-virtual-scroll-grid-3.html

## Other References 🔗 
GitHub project related to the same blog post
- https://github.com/TheCandidStartup/infinisheet/tree/main/packages/react-virtual-scroll

## Performance Improvements 🚀 
- Reduced large-dataset boundary jank by replacing linear virtual-page spacing with pinned-edge mapping:
  - first page pinned to 0
  - last page pinned to end offset
  - interior pages distributed across interior space
- Improved large-scroll page resolution by separating boundary and interior logic:
  - fast boundary routing near top and bottom
  - interior scaling only in interior range
- Wired both changes into active scroll paths:
  - getPageOffset now used by scrollTo page-to-offset mapping
  - getPageFromLargeScrollDelta now used by large scroll-delta page selection
- Preserved low-risk behavior in small/degenerate regimes through compatibility fallbacks, avoiding regressions while improving smoothness at scale.

### LLM model attribution
This PR was assisted by GitHub Copilot using GPT-5.3-Codex.