### PR TITLE
fix(grid): force top row offset for RowDetail in transform mode

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -182,9 +182,7 @@ describe('SlickGrid core file', () => {
     expect(styleElm?.getAttribute('nonce')).toBe('test-nonce');
   });
 
-  it('should display a console warning when Row Detail is enabled with `rowTopOffsetRenderType` is set to "transfrom"', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockReturnValue();
-
+  it('should auto-fallback to top when Row Detail is enabled with `rowTopOffsetRenderType` set to "transform"', () => {
     document.body.style.zoom = '90%';
     const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
     grid = new SlickGrid<any, Column>(
@@ -197,9 +195,7 @@ describe('SlickGrid core file', () => {
     grid.init();
 
     expect(grid).toBeTruthy();
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using either RowDetail and/or RowSpan')
-    );
+    expect(grid.getOptions().rowTopOffsetRenderType).toBe('top');
   });
 
   it('should display a console warning when RowSpan is enabled with `rowTopOffsetRenderType` is set to "transfrom"', () => {
@@ -218,7 +214,7 @@ describe('SlickGrid core file', () => {
 
     expect(grid).toBeTruthy();
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using either RowDetail and/or RowSpan')
+      expect.stringContaining('[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using RowSpan')
     );
   });
 

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -648,9 +648,9 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           'SlickGrid relies on the `rowHeight` grid option to do row positioning & calculation and when zoom is not 100% then calculation becomes all offset.'
       );
     }
-    if (this._options.rowTopOffsetRenderType === 'transform' && (this._options.enableCellRowSpan || this._options.enableRowDetailView)) {
+    if (this._options.rowTopOffsetRenderType === 'transform' && this._options.enableCellRowSpan) {
       console.warn(
-        '[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using either RowDetail and/or RowSpan since "transform" is known to have UI issues.'
+        '[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using RowSpan since "transform" is known to have UI issues.'
       );
     }
     this.finishInitialization();
@@ -3846,6 +3846,12 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this._options.autoHeight) {
       this._options.leaveSpaceForNewRows = false;
     }
+
+    // Row Detail relies on absolute top-based row positioning; force a safe fallback.
+    if (this._options.rowTopOffsetRenderType === 'transform' && this._options.enableRowDetailView) {
+      this._options.rowTopOffsetRenderType = 'top';
+    }
+
     // make sure the freeze is also valid without breaking the UI (e.g. we can't left freeze columns wider than visible left canvas width)
     if (!this.validateColumnFreezeWidth(this._options.frozenColumn)) {
       this._options.frozenColumn = this._prevFrozenColumnIdx < this._options.frozenColumn! ? this._prevFrozenColumnIdx : -1;


### PR DESCRIPTION
### Description
This change makes RowDetail rendering safer by automatically switching row offset rendering to top when transform is configured. The goal is to prevent known visual issues while keeping behavior stable and minimal.

### High-level updates:
1. Keep RowSpan warning behavior in init.
2. Enforce RowDetail fallback from transform to top during option validation.
3. Remove duplicate warning noise from the new fallback path.
4. Update and align unit tests with the final behavior.

### Validation:
1. Targeted core SlickGrid specs pass.