### PR TITLE
fix(core): sync plugin-added columns to Aurelia & Vue bindings

### DIFF
--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -718,8 +718,10 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     // save reference for all columns before they optionally become hidden/visible
     this.sharedService.allColumns = this._columns;
 
-    // before certain extentions/plugins potentially adds extra columns not created by the user itself (RowMove, RowDetail, RowSelections)
-    // we'll subscribe to the event and push back the change to the user so they always use full column defs array including extra cols
+    // certain extensions/plugins add extra columns not created by the user itself (RowMove, RowDetail, RowSelections),
+    // we notify the user via the `columns` 2-way binding so they always get the full column defs array including extra cols.
+    // NOTE: assign the private field directly, going through the `columns` setter would re-run the column
+    // arrangement pipeline mid-init and conflict with Grid State & Presets.
     this.subscriptions.push(
       this._eventPubSubService.subscribe<{ columns: Column[]; grid: SlickGrid }>('onPluginColumnsChanged', (data) => {
         this._columns = data.columns;
@@ -727,8 +729,8 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
       })
     );
 
-    // after subscribing to potential columns changed, we are ready to create these optional extensions
-    // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)
+    // create optional extensions (RowMove, RowDetail, RowSelections), they splice their extra columns
+    // directly into the array below, which also triggers the `onPluginColumnsChanged` subscription above
     this.extensionService.createExtensionsBeforeGridCreation(this._columns, this.options);
 
     // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -369,18 +369,18 @@ export class AureliaSlickgridCustomElement {
     // save reference for all columns before they optionally become hidden/visible
     this.sharedService.allColumns = this._columns;
 
-    // TODO: revisit later, this conflicts with Grid State (Example 15)
-    // before certain extentions/plugins potentially adds extra columns not created by the user itself (RowMove, RowDetail, RowSelections)
-    // we'll subscribe to the event and push back the change to the user so they always use full column defs array including extra cols
-    // this.subscriptions.push(
-    //   this._eventPubSubService.subscribe<{ columns: Column[]; grid: SlickGrid }>('onPluginColumnsChanged', data => {
-    //     this.columns = data.columns;
-    //     this.columnsChanged();
-    //   })
-    // );
+    // certain extensions/plugins add extra columns not created by the user itself (RowMove, RowDetail, RowSelections),
+    // push them back through the 2-way `columns` bindable so the user always sees the full column defs array.
+    // the assignment below re-enters `columnsChanged()`, which is safe only because the grid isn't initialized
+    // yet at this point and it therefore skips `updateColumnDefinitionsList()` (which would clash with Grid State & Presets)
+    this.subscriptions.push(
+      this._eventPubSubService.subscribe<{ columns: Column[]; pluginName: string }>('onPluginColumnsChanged', (data) => {
+        this.columns = data.columns;
+      })
+    );
 
-    // after subscribing to potential columns changed, we are ready to create these optional extensions
-    // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)
+    // create optional extensions (RowMove, RowDetail, RowSelections), they splice their extra columns
+    // directly into the array below, so both `_columns` & `sharedService.allColumns` stay in sync
     this.extensionService.createExtensionsBeforeGridCreation(this._columns, this.options);
 
     // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -514,8 +514,8 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
     // save reference for all columns before they optionally become hidden/visible
     this.sharedService.allColumns = this._columns;
 
-    // after subscribing to potential columns changed, we are ready to create these optional extensions
-    // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)
+    // create optional extensions (RowMove, RowDetail, RowSelections), they splice their extra columns
+    // directly into the array below, so both `_columns` & `sharedService.allColumns` stay in sync
     this.extensionService.createExtensionsBeforeGridCreation(this._columns, this._options);
 
     // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -357,11 +357,18 @@ function columnsChanged(columns?: Column[]) {
   if (columns) {
     _columns.value = columns;
   }
-  // the watcher flushes async, so this can land after the grid is initialized even though the pushback happened before it
-  if (isGridInitialized && !isPushingBackPluginColumns) {
+
+  // this watcher flushes async, so the plugin columns pushback lands after the grid is initialized and its columns
+  // already have computed widths, re-running the below would clash with Grid State/Presets and would also stamp
+  // those computed widths as `originalWidth`, which the resize-by-content then treats as user-provided widths
+  if (isPushingBackPluginColumns) {
+    isPushingBackPluginColumns = false;
+    return;
+  }
+
+  if (isGridInitialized) {
     updateColumnsList(_columns.value);
   }
-  isPushingBackPluginColumns = false;
   if (_columns.value!.length > 0) {
     copyColumnWidthsReference(_columns.value);
   }

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -104,6 +104,7 @@ let isGridInitialized = false;
 let isDatasetInitialized = false;
 let isDatasetHierarchicalInitialized = false;
 let isPaginationInitialized = false;
+let isPushingBackPluginColumns = false;
 let isLocalGrid = true;
 let metrics: Metrics | undefined;
 let registeredResources: Array<ExternalResource | ExternalResourceConstructor> = [];
@@ -356,9 +357,11 @@ function columnsChanged(columns?: Column[]) {
   if (columns) {
     _columns.value = columns;
   }
-  if (isGridInitialized) {
+  // the watcher flushes async, so this can land after the grid is initialized even though the pushback happened before it
+  if (isGridInitialized && !isPushingBackPluginColumns) {
     updateColumnsList(_columns.value);
   }
+  isPushingBackPluginColumns = false;
   if (_columns.value!.length > 0) {
     copyColumnWidthsReference(_columns.value);
   }
@@ -446,18 +449,19 @@ function initialization() {
   // save reference for all columns before they optionally become hidden/visible
   sharedService.allColumns = _columns.value as Column[];
 
-  // TODO: revisit later, this conflicts with Grid State (Example 15)
-  // before certain extentions/plugins potentially adds extra columns not created by the user itself (RowMove, RowDetail, RowSelections)
-  // we'll subscribe to the event and push back the change to the user so they always use full column defs array including extra cols
-  // subscriptions.push(
-  //   _eventPubSubService.subscribe<{ columns: Column<any>[]; grid: SlickGrid }>('onPluginColumnsChanged', data => {
-  //     columns = data.columns;
-  //     columnsChanged();
-  //   })
-  // );
+  // certain extensions/plugins add extra columns not created by the user itself (RowMove, RowDetail, RowSelections),
+  // push them back through the `v-model:columns` binding so the user always sees the full column defs array.
+  // `_columns` already holds them, so the flag tells `columnsChanged()` to skip the grid re-render
+  // that would otherwise clash with Grid State & Presets
+  subscriptions.push(
+    eventPubSubService.subscribe<{ columns: Column[]; pluginName: string }>('onPluginColumnsChanged', (data) => {
+      isPushingBackPluginColumns = true;
+      columnsModel.value = data.columns;
+    })
+  );
 
-  // after subscribing to potential columns changed, we are ready to create these optional extensions
-  // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)
+  // create optional extensions (RowMove, RowDetail, RowSelections), they splice their extra columns
+  // directly into the array below, so both `_columns` & `sharedService.allColumns` stay in sync
   extensionService.createExtensionsBeforeGridCreation(_columns.value as Column[], _gridOptions.value as GridOption);
 
   // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -472,23 +472,6 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
     expect(pubSubSpy).toHaveBeenNthCalledWith(5, 'onBeforeGridDestroy', expect.any(Object));
   });
 
-  // TODO: revisit later, this is conflicting with Grid State & Presets
-  // oxlint-disable-next-line no-disabled-tests
-  it.skip('should update column definitions when onPluginColumnsChanged event is triggered with updated columns', () => {
-    const columnsMock = [
-      { id: 'firstName', field: 'firstName', editor: undefined, editorClass: {} },
-      { id: 'lastName', field: 'lastName', editor: undefined, editorClass: {} },
-    ];
-    eventPubSubService.publish('onPluginColumnsChanged', {
-      columns: columnsMock,
-      pluginName: 'RowMoveManager',
-    });
-
-    component.initialization(divContainer, slickEventHandler);
-
-    expect(component.columnDefinitions).toEqual(columnsMock);
-  });
-
   describe('initialization method', () => {
     const customEditableInputFormatter: Formatter = (_row, _cell, value, columnDef) => {
       const isEditableItem = !!columnDef.editor;

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -552,17 +552,8 @@ export class SlickVanillaGridBundle<TData = any> {
     // save reference for all columns before they optionally become hidden/visible
     this.sharedService.allColumns = this._columns;
 
-    // TODO: revisit later, this is conflicting with Grid State & Presets
-    // before certain extentions/plugins potentially adds extra columns not created by the user itself (RowMove, RowDetail, RowSelections)
-    // we'll subscribe to the event and push back the change to the user so they always use full column defs array including extra cols
-    // this.subscriptions.push(
-    //   this._eventPubSubService.subscribe<{ columns: Column[]; pluginName: string }>('onPluginColumnsChanged', data => {
-    //     this._columnDefinitions = this.columnDefinitions = data.columns;
-    //   })
-    // );
-
-    // after subscribing to potential columns changed, we are ready to create these optional extensions
-    // when we did find some to create (RowMove, RowDetail, RowSelections), it will automatically modify column definitions (by previous subscribe)
+    // create optional extensions (RowMove, RowDetail, RowSelections), they splice their extra columns
+    // directly into the array below, so both `_columns` & `sharedService.allColumns` stay in sync
     this.extensionService.createExtensionsBeforeGridCreation(this._columns, this._gridOptions);
 
     // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options


### PR DESCRIPTION
### PR description

**What**

Plugins that inject their own column (RowMove, RowDetail, CheckboxSelector, RowBasedEdit) splice it directly into the internal column defs array and publish `onPluginColumnsChanged`. Only Angular acted on that event, so Aurelia and Vue consumers never saw those extra columns reflected back through their two-way `columns` binding, despite both advertising one.

**Changes**

- **Aurelia** — subscribe to `onPluginColumnsChanged` and assign through the `columns` two-way bindable. The re-entrant `columnsChanged()` call is safe here because the grid isn't initialized yet, so the heavy `updateColumnDefinitionsList()` path is skipped.
- **Vue** — same via `v-model:columns`, guarded by an internal flag. Vue's `watch` flushes asynchronously, so the pushback lands *after* grid init when columns already have computed widths. The flag short-circuits that one pass entirely — skipping both `updateColumnsList()` (which would clash with Grid State/Presets) and `copyColumnWidthsReference()`, which would otherwise stamp SlickGrid's computed widths onto `originalWidth` and cause resize-by-content to treat them as user-provided widths.
- **Angular** — unchanged behavior; clarified the comment explaining why the private field is assigned directly instead of going through the `columns` setter, so the working pattern isn't "tidied" into the broken one.
- **vanilla / React** — removed the long-dead commented-out block and its stale `TODO`. Neither has a consumer binding to push back to (React props are unidirectional; the vanilla getter already returns the plugin-inclusive array), and the plugins mutate the array in place, so the assignment was an identity no-op. Also corrected the misleading "by previous subscribe" comment, which was present in all five components including React, which never had a subscription.
- Dropped the permanently-skipped vanilla test and its `oxlint-disable no-disabled-tests` suppression.

**Why only Vue needed a guard**

Aurelia's bindable change handler fires synchronously, so its pushback completes before grid init while `col.width` is still undefined — harmless. Angular never enters that path at all, since its `@Output` emit is decoupled from the `@Input` setter. The async-flush hazard is Vue-specific, which is why `example32` (resize by content) failed there and nowhere else.

**Behavior change**

Aurelia and Vue consumers will now see plugin-injected columns (`_checkbox_selector`, `_move`, `_detail_selector`) appear in their bound `columns` array. This brings them in line with Angular's long-standing behavior, but it is observable — code that iterates, counts or persists that array will see the extra entries. React is deliberately excluded; giving it parity would require a new public callback prop.

| | Binding | Subscription |
|---|---|---|
| Angular | `@Input` + `@Output columnsChange` | kept (was already working) |
| Aurelia | `@bindable({ mode: twoWay })` | **added** |
| Vue | `defineModel('columns')` | **added** |
| React | plain prop, unidirectional | no — nowhere to push to |
| vanilla | no consumer binding at all | no — getter already returns the right array |

**Testing** — 905 vanilla + 131 Angular unit tests pass. Aurelia/Vue have no unit test infra; their Cypress suites pass, including `example32` (resize by content), which caught the `originalWidth` regression described above.

---

🤖 Investigated and implemented with GitHub Copilot using **Claude Opus 5**.