### PR TITLE
fix(event-pub-sub): fix listener leak, naming convention logic and subscribeEvent double-transformation

### DIFF
--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -182,16 +182,26 @@ describe('EventPubSub Service', () => {
 
       service.eventNamingStyle = 'lowerCaseWithoutOnPrefix';
       const subscription = service.subscribeEvent('onDblClick', mockCallback);
-      divContainer.dispatchEvent(new CustomEvent('DblClick', { composed: true, detail: { name: 'John' } }));
+      divContainer.dispatchEvent(new CustomEvent('dblclick', { composed: true, detail: { name: 'John' } }));
 
       expect(getEventNameSpy).toHaveBeenCalledWith('onDblClick', '');
-      expect(service.subscribedEventNames).toEqual(['DblClick']);
+      expect(service.subscribedEventNames).toEqual(['dblclick']);
       expect(service.subscribedEvents.length).toBe(1);
-      expect(addEventSpy).toHaveBeenCalledWith('DblClick', expect.any(Function));
+      expect(addEventSpy).toHaveBeenCalledWith('dblclick', expect.any(Function));
       expect(mockCallback).toHaveBeenCalledTimes(1);
 
       subscription.unsubscribe();
       expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('keeps lowerCaseWithoutOnPrefix event names lowercase', () => {
+      const callback = vi.fn();
+      service.eventNamingStyle = 'lowerCaseWithoutOnPrefix';
+      service.subscribeEvent('onDblClick', callback);
+
+      divContainer.dispatchEvent(new CustomEvent('dblclick'));
+
+      expect(callback).toHaveBeenCalledOnce();
     });
 
     it('should call subscribe method and expect "addEventListener" and "getEventNameByNamingConvention" to be called with kebabCase', () => {
@@ -348,6 +358,50 @@ describe('EventPubSub Service', () => {
       expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
       expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', expect.any(Function));
       expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
+      expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('removes every event when a shared callback subscription is unsubscribed', () => {
+      const mockCallback = vi.fn();
+      const subscription = service.subscribe(['onClick', 'onDblClick'], mockCallback);
+
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      divContainer.dispatchEvent(new CustomEvent('onDblClick', { detail: { name: 'Jane' } }));
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+
+      subscription.unsubscribe();
+
+      divContainer.dispatchEvent(new CustomEvent('onClick'));
+      divContainer.dispatchEvent(new CustomEvent('onDblClick'));
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+      expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('removes a subscribe callback with camelCaseWithExtraOnPrefix', () => {
+      const mockCallback = vi.fn();
+      service.eventNamingStyle = 'camelCaseWithExtraOnPrefix';
+      const subscription = service.subscribe('onDblClick', mockCallback);
+
+      subscription.unsubscribe();
+      divContainer.dispatchEvent(new CustomEvent('onOnDblClick'));
+
+      expect(mockCallback).toHaveBeenCalledTimes(0); // never fired before unsubscribe either
+    });
+
+    it('should correctly unsubscribe all listeners when same callback is used for multiple events (array subscribe)', () => {
+      const mockCallback = vi.fn();
+      service.subscribe(['onClick', 'onDblClick'], mockCallback);
+
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      divContainer.dispatchEvent(new CustomEvent('onDblClick', { detail: { name: 'Jane' } }));
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+
+      service.unsubscribeAll();
+
+      // both DOM listeners must be truly removed
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      divContainer.dispatchEvent(new CustomEvent('onDblClick', { detail: { name: 'Jane' } }));
+      expect(mockCallback).toHaveBeenCalledTimes(2);
       expect(service.subscribedEvents.length).toBe(0);
     });
 

--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -204,6 +204,12 @@ describe('EventPubSub Service', () => {
       expect(callback).toHaveBeenCalledOnce();
     });
 
+    it('keeps event prefixes intact with lowerCaseWithoutOnPrefix', () => {
+      service.eventNamingStyle = 'lowerCaseWithoutOnPrefix';
+
+      expect(service.getEventNameByNamingConvention('onDblClick', 'vue')).toBe('vuedblclick');
+    });
+
     it('should call subscribe method and expect "addEventListener" and "getEventNameByNamingConvention" to be called with kebabCase', () => {
       const addEventSpy = vi.spyOn(divContainer, 'addEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
@@ -240,6 +246,12 @@ describe('EventPubSub Service', () => {
 
       subscription.unsubscribe();
       expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('keeps event prefixes intact with camelCaseWithExtraOnPrefix', () => {
+      service.eventNamingStyle = 'camelCaseWithExtraOnPrefix';
+
+      expect(service.getEventNameByNamingConvention('onDblClick', 'vue')).toBe('vueonOnDblClick');
     });
   });
 
@@ -278,6 +290,21 @@ describe('EventPubSub Service', () => {
       expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps repeated subscriptions independently removable', () => {
+      const mockCallback = vi.fn();
+      const firstSubscription = service.subscribe('onClick', mockCallback);
+      const secondSubscription = service.subscribe('onClick', mockCallback);
+
+      firstSubscription.unsubscribe();
+      divContainer.dispatchEvent(new CustomEvent('onClick'));
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+
+      secondSubscription.unsubscribe();
+      divContainer.dispatchEvent(new CustomEvent('onClick'));
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(service.subscribedEvents.length).toBe(0);
+    });
+
     it('should be able to unsubscribe directly from the subscription and truly stop receiving events', () => {
       const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
@@ -304,7 +331,6 @@ describe('EventPubSub Service', () => {
     it('should be able to provide an array of event to subscribe and be able to unsubscribeAll events', () => {
       const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
-      const unsubscribeSpy = vi.spyOn(service, 'unsubscribe');
       const mockCallback = vi.fn();
 
       service.subscribe(['onClick', 'onDblClick'], mockCallback);
@@ -327,14 +353,12 @@ describe('EventPubSub Service', () => {
       service.unsubscribeAll();
       expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
       expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', expect.any(Function));
-      expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
       expect(service.subscribedEvents.length).toBe(0);
     });
 
     it('should be able to subscribe to multiple event and be able to unsubscribeAll events', () => {
       const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
-      const unsubscribeSpy = vi.spyOn(service, 'unsubscribe');
       const mockCallback = vi.fn();
       const mockDblCallback = vi.fn();
 
@@ -357,7 +381,6 @@ describe('EventPubSub Service', () => {
       service.unsubscribeAll();
       expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
       expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', expect.any(Function));
-      expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
       expect(service.subscribedEvents.length).toBe(0);
     });
 
@@ -405,7 +428,32 @@ describe('EventPubSub Service', () => {
       expect(service.subscribedEvents.length).toBe(0);
     });
 
-    it('should clear the callbackMap on dispose', () => {
+    it('allows a direct listener to be removed after unsubscribeAll', () => {
+      const callback = vi.fn();
+      service.subscribe('onClick', callback);
+      service.unsubscribeAll();
+      service.subscribeEvent('onClick', callback);
+
+      service.unsubscribe('onClick', callback);
+      divContainer.dispatchEvent(new CustomEvent('onClick'));
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('unsubscribes all listeners using camelCaseWithExtraOnPrefix', () => {
+      const callback = vi.fn();
+      service.eventNamingStyle = 'camelCaseWithExtraOnPrefix';
+      service.subscribe('onDblClick', callback);
+
+      service.unsubscribeAll();
+      divContainer.dispatchEvent(new CustomEvent('onOnDblClick'));
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('removes all listeners on dispose', () => {
       const mockCallback = vi.fn();
 
       service.subscribe('onClick', mockCallback);
@@ -413,7 +461,6 @@ describe('EventPubSub Service', () => {
 
       service.dispose();
 
-      // after dispose, subscribing and firing should not invoke the old callback
       divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
       expect(mockCallback).not.toHaveBeenCalled();
     });

--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -182,12 +182,12 @@ describe('EventPubSub Service', () => {
 
       service.eventNamingStyle = 'lowerCaseWithoutOnPrefix';
       const subscription = service.subscribeEvent('onDblClick', mockCallback);
-      divContainer.dispatchEvent(new CustomEvent('dblclick', { composed: true, detail: { name: 'John' } }));
+      divContainer.dispatchEvent(new CustomEvent('DblClick', { composed: true, detail: { name: 'John' } }));
 
       expect(getEventNameSpy).toHaveBeenCalledWith('onDblClick', '');
-      expect(service.subscribedEventNames).toEqual(['dblclick']);
+      expect(service.subscribedEventNames).toEqual(['DblClick']);
       expect(service.subscribedEvents.length).toBe(1);
-      expect(addEventSpy).toHaveBeenCalledWith('dblclick', expect.any(Function));
+      expect(addEventSpy).toHaveBeenCalledWith('DblClick', expect.any(Function));
       expect(mockCallback).toHaveBeenCalledTimes(1);
 
       subscription.unsubscribe();
@@ -234,7 +234,7 @@ describe('EventPubSub Service', () => {
   });
 
   describe('unsubscribe & unsubscribeAll method', () => {
-    it('should unsubscribe an event with a listener', () => {
+    it('should unsubscribe an event with a listener and removeEventListener is called with the wrapped listener (not the original callback)', () => {
       const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
       const mockCallback = vi.fn();
@@ -249,11 +249,26 @@ describe('EventPubSub Service', () => {
       expect(mockCallback).toHaveBeenCalledWith({ name: 'John' });
 
       service.unsubscribe('onClick', mockCallback);
-      expect(removeEventSpy).toHaveBeenCalledWith('onClick', mockCallback);
+      expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
+      expect(removeEventSpy).not.toHaveBeenCalledWith('onClick', mockCallback);
       expect(service.subscribedEvents.length).toBe(0);
     });
 
-    it('should be able to unsubscribe directly from the subscription', () => {
+    it('should actually stop receiving events after unsubscribe (listener leak fix)', () => {
+      const mockCallback = vi.fn();
+
+      service.subscribe('onClick', mockCallback);
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+
+      service.unsubscribe('onClick', mockCallback);
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+
+      // must still be 1 — listener was truly removed
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be able to unsubscribe directly from the subscription and truly stop receiving events', () => {
       const removeEventSpy = vi.spyOn(divContainer, 'removeEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');
       const mockCallback = vi.fn();
@@ -268,8 +283,12 @@ describe('EventPubSub Service', () => {
       expect(mockCallback).toHaveBeenCalledWith({ name: 'John' });
 
       subscription.unsubscribe();
-      expect(removeEventSpy).toHaveBeenCalledWith('onClick', mockCallback);
+      expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
       expect(service.subscribedEvents.length).toBe(0);
+
+      // fire again — should not trigger callback
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 
     it('should be able to provide an array of event to subscribe and be able to unsubscribeAll events', () => {
@@ -296,8 +315,8 @@ describe('EventPubSub Service', () => {
       expect(mockCallback).toHaveBeenCalledWith({ name: 'Jane' });
 
       service.unsubscribeAll();
-      expect(removeEventSpy).toHaveBeenCalledWith('onClick', mockCallback);
-      expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', mockCallback);
+      expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
+      expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', expect.any(Function));
       expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
       expect(service.subscribedEvents.length).toBe(0);
     });
@@ -326,10 +345,23 @@ describe('EventPubSub Service', () => {
       expect(mockDblCallback).toHaveBeenCalledWith({ name: 'Jane' });
 
       service.unsubscribeAll();
-      expect(removeEventSpy).toHaveBeenCalledWith('onClick', mockCallback);
-      expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', mockDblCallback);
+      expect(removeEventSpy).toHaveBeenCalledWith('onClick', expect.any(Function));
+      expect(removeEventSpy).toHaveBeenCalledWith('onDblClick', expect.any(Function));
       expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
       expect(service.subscribedEvents.length).toBe(0);
+    });
+
+    it('should clear the callbackMap on dispose', () => {
+      const mockCallback = vi.fn();
+
+      service.subscribe('onClick', mockCallback);
+      expect(service.subscribedEvents.length).toBe(1);
+
+      service.dispose();
+
+      // after dispose, subscribing and firing should not invoke the old callback
+      divContainer.dispatchEvent(new CustomEvent('onClick', { detail: { name: 'John' } }));
+      expect(mockCallback).not.toHaveBeenCalled();
     });
 
     it('should unsubscribe all PubSub by disposing all of them', () => {

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -6,13 +6,13 @@ import { type EventSubscription, type Subscription } from './types/eventSubscrip
 export interface PubSubEvent<T = any> {
   name: string;
   listener: (event: T | CustomEventInit<T>) => void;
+  originalCallback?: (data: T) => void;
 }
 
 export class EventPubSubService implements BasePubSubService {
   protected _elementSource: Element;
   protected _subscribedEvents: PubSubEvent[] = [];
   protected _timer?: any;
-  private _callbackMap = new Map<string, Map<Function, Function>>();
 
   eventNamingStyle: EventNamingStyle = 'camelCase';
 
@@ -41,7 +41,6 @@ export class EventPubSubService implements BasePubSubService {
     clearTimeout(this._timer);
     this.unsubscribeAll();
     this._subscribedEvents = [];
-    this._callbackMap.clear(); // clears all (eventName → callback → wrapper) mappings
     this._elementSource?.remove();
     this._elementSource = null as any;
   }
@@ -151,16 +150,9 @@ export class EventPubSubService implements BasePubSubService {
       // basically we substitute the "data" with "event.detail" so that the user ends up with only the "data" result
       const wrappedListener = (event: CustomEventInit<T>) => callback.call(null, event.detail as T);
 
-      // store the mapping keyed by (eventName, callback) so the same callback can be used
-      // across multiple event names without entries overwriting each other
-      if (!this._callbackMap.has(eventNameByConvention)) {
-        this._callbackMap.set(eventNameByConvention, new Map());
-      }
-      this._callbackMap.get(eventNameByConvention)!.set(callback, wrappedListener);
-
       this._elementSource.addEventListener(eventNameByConvention, wrappedListener);
-      this._subscribedEvents.push({ name: eventNameByConvention, listener: wrappedListener });
-      subscriptions.push(() => this.unsubscribe(eventNameByConvention, callback as never, true, true));
+      this._subscribedEvents.push({ name: eventNameByConvention, listener: wrappedListener, originalCallback: callback });
+      subscriptions.push(() => this.unsubscribeResolved(eventNameByConvention, wrappedListener as EventListener));
     });
 
     // return a subscription(s) that we can later unsubscribe
@@ -183,7 +175,7 @@ export class EventPubSubService implements BasePubSubService {
 
     // return a subscription that we can later unsubscribe
     return {
-      unsubscribe: () => this.unsubscribe(eventNameByConvention, listener as never, true, true),
+      unsubscribe: () => this.unsubscribeResolved(eventNameByConvention, listener as EventListener),
     };
   }
 
@@ -194,25 +186,18 @@ export class EventPubSubService implements BasePubSubService {
    * @param {Boolean} [shouldRemoveFromEventList] - should we also remove the event from the subscriptions array?
    * @return possibly a Subscription
    */
-  unsubscribe<T = any>(
-    eventName: string,
-    listener: (event: T | CustomEventInit<T>) => void,
-    shouldRemoveFromEventList = true,
-    skipNamingConversion = false
-  ): void {
-    const eventNameByConvention = skipNamingConversion ? eventName : this.getEventNameByNamingConvention(eventName, '');
+  unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList = true): void {
+    const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
+    const subscribedEvents = this._subscribedEvents.filter(
+      (pubSubEvent) => pubSubEvent.name === eventNameByConvention && pubSubEvent.originalCallback === listener
+    );
 
-    // resolve the actual DOM listener via (eventName, callback) key
-    const eventMap = this._callbackMap.get(eventNameByConvention);
-    const domListener = (eventMap?.get(listener) ?? listener) as EventListener;
-
-    this._elementSource.removeEventListener(eventNameByConvention, domListener);
-    if (shouldRemoveFromEventList) {
-      this.removeSubscribedEventWhenFound(eventNameByConvention, domListener as any);
-      eventMap?.delete(listener);
-      if (eventMap?.size === 0) {
-        this._callbackMap.delete(eventNameByConvention);
-      }
+    if (subscribedEvents.length > 0) {
+      subscribedEvents.forEach((pubSubEvent) =>
+        this.unsubscribeResolved(eventNameByConvention, pubSubEvent.listener as EventListener, shouldRemoveFromEventList)
+      );
+    } else {
+      this.unsubscribeResolved(eventNameByConvention, listener as EventListener, shouldRemoveFromEventList);
     }
   }
 
@@ -231,7 +216,7 @@ export class EventPubSubService implements BasePubSubService {
     } else {
       let pubSubEvent = this._subscribedEvents.pop();
       while (pubSubEvent) {
-        this.unsubscribe(pubSubEvent.name, pubSubEvent.listener, false, true);
+        this.unsubscribeResolved(pubSubEvent.name, pubSubEvent.listener as EventListener, false);
         pubSubEvent = this._subscribedEvents.pop();
       }
     }
@@ -245,6 +230,13 @@ export class EventPubSubService implements BasePubSubService {
     const eventIdx = this._subscribedEvents.findIndex((evt) => evt.name === eventName && evt.listener === listener);
     if (eventIdx >= 0) {
       this._subscribedEvents.splice(eventIdx, 1);
+    }
+  }
+
+  private unsubscribeResolved(eventName: string, listener: EventListener, shouldRemoveFromEventList = true): void {
+    this._elementSource.removeEventListener(eventName, listener);
+    if (shouldRemoveFromEventList) {
+      this.removeSubscribedEventWhenFound(eventName, listener as any);
     }
   }
 }

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -12,7 +12,7 @@ export class EventPubSubService implements BasePubSubService {
   protected _elementSource: Element;
   protected _subscribedEvents: PubSubEvent[] = [];
   protected _timer?: any;
-  private _callbackMap = new Map<Function, Function>();
+  private _callbackMap = new Map<string, Map<Function, Function>>();
 
   eventNamingStyle: EventNamingStyle = 'camelCase';
 
@@ -41,7 +41,7 @@ export class EventPubSubService implements BasePubSubService {
     clearTimeout(this._timer);
     this.unsubscribeAll();
     this._subscribedEvents = [];
-    this._callbackMap.clear();
+    this._callbackMap.clear(); // clears all (eventName → callback → wrapper) mappings
     this._elementSource?.remove();
     this._elementSource = null as any;
   }
@@ -97,7 +97,7 @@ export class EventPubSubService implements BasePubSubService {
       case 'lowerCase':
       case 'lowerCaseWithoutOnPrefix':
         if (this.eventNamingStyle === 'lowerCaseWithoutOnPrefix') {
-          outputEventName = `${eventNamePrefix}${inputEventName.replace(/^on/, '')}`;
+          outputEventName = `${eventNamePrefix}${inputEventName.replace(/^on/, '')}`.toLowerCase();
         } else {
           outputEventName = `${eventNamePrefix}${outputEventName}`.toLowerCase();
         }
@@ -151,12 +151,16 @@ export class EventPubSubService implements BasePubSubService {
       // basically we substitute the "data" with "event.detail" so that the user ends up with only the "data" result
       const wrappedListener = (event: CustomEventInit<T>) => callback.call(null, event.detail as T);
 
-      // store the mapping so unsubscribe can resolve the original callback to the wrapper
-      this._callbackMap.set(callback, wrappedListener);
+      // store the mapping keyed by (eventName, callback) so the same callback can be used
+      // across multiple event names without entries overwriting each other
+      if (!this._callbackMap.has(eventNameByConvention)) {
+        this._callbackMap.set(eventNameByConvention, new Map());
+      }
+      this._callbackMap.get(eventNameByConvention)!.set(callback, wrappedListener);
 
       this._elementSource.addEventListener(eventNameByConvention, wrappedListener);
       this._subscribedEvents.push({ name: eventNameByConvention, listener: wrappedListener });
-      subscriptions.push(() => this.unsubscribe(eventNameByConvention, callback as never));
+      subscriptions.push(() => this.unsubscribe(eventNameByConvention, callback as never, true, true));
     });
 
     // return a subscription(s) that we can later unsubscribe
@@ -179,7 +183,7 @@ export class EventPubSubService implements BasePubSubService {
 
     // return a subscription that we can later unsubscribe
     return {
-      unsubscribe: () => this.unsubscribe(eventNameByConvention, listener as never),
+      unsubscribe: () => this.unsubscribe(eventNameByConvention, listener as never, true, true),
     };
   }
 
@@ -190,17 +194,25 @@ export class EventPubSubService implements BasePubSubService {
    * @param {Boolean} [shouldRemoveFromEventList] - should we also remove the event from the subscriptions array?
    * @return possibly a Subscription
    */
-  unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList = true): void {
-    const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
+  unsubscribe<T = any>(
+    eventName: string,
+    listener: (event: T | CustomEventInit<T>) => void,
+    shouldRemoveFromEventList = true,
+    skipNamingConversion = false
+  ): void {
+    const eventNameByConvention = skipNamingConversion ? eventName : this.getEventNameByNamingConvention(eventName, '');
 
-    // resolve the actual DOM listener
-    // either it's the wrapper itself or we look it up via the map
-    const domListener = (this._callbackMap.get(listener) ?? listener) as EventListener;
+    // resolve the actual DOM listener via (eventName, callback) key
+    const eventMap = this._callbackMap.get(eventNameByConvention);
+    const domListener = (eventMap?.get(listener) ?? listener) as EventListener;
 
     this._elementSource.removeEventListener(eventNameByConvention, domListener);
     if (shouldRemoveFromEventList) {
       this.removeSubscribedEventWhenFound(eventNameByConvention, domListener as any);
-      this._callbackMap.delete(listener);
+      eventMap?.delete(listener);
+      if (eventMap?.size === 0) {
+        this._callbackMap.delete(eventNameByConvention);
+      }
     }
   }
 
@@ -219,7 +231,7 @@ export class EventPubSubService implements BasePubSubService {
     } else {
       let pubSubEvent = this._subscribedEvents.pop();
       while (pubSubEvent) {
-        this.unsubscribe(pubSubEvent.name, pubSubEvent.listener, false);
+        this.unsubscribe(pubSubEvent.name, pubSubEvent.listener, false, true);
         pubSubEvent = this._subscribedEvents.pop();
       }
     }

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -12,6 +12,7 @@ export class EventPubSubService implements BasePubSubService {
   protected _elementSource: Element;
   protected _subscribedEvents: PubSubEvent[] = [];
   protected _timer?: any;
+  private _callbackMap = new Map<Function, Function>();
 
   eventNamingStyle: EventNamingStyle = 'camelCase';
 
@@ -40,6 +41,7 @@ export class EventPubSubService implements BasePubSubService {
     clearTimeout(this._timer);
     this.unsubscribeAll();
     this._subscribedEvents = [];
+    this._callbackMap.clear();
     this._elementSource?.remove();
     this._elementSource = null as any;
   }
@@ -85,8 +87,9 @@ export class EventPubSubService implements BasePubSubService {
       case 'camelCaseWithExtraOnPrefix':
         if (this.eventNamingStyle === 'camelCaseWithExtraOnPrefix') {
           outputEventName = `${eventNamePrefix}${inputEventName.replace(/^on/, 'onOn')}`;
+        } else {
+          outputEventName = eventNamePrefix !== '' ? `${eventNamePrefix}${titleCase(outputEventName)}` : outputEventName;
         }
-        outputEventName = eventNamePrefix !== '' ? `${eventNamePrefix}${titleCase(outputEventName)}` : outputEventName;
         break;
       case 'kebabCase':
         outputEventName = eventNamePrefix !== '' ? `${eventNamePrefix}-${toKebabCase(outputEventName)}` : toKebabCase(outputEventName);
@@ -95,8 +98,9 @@ export class EventPubSubService implements BasePubSubService {
       case 'lowerCaseWithoutOnPrefix':
         if (this.eventNamingStyle === 'lowerCaseWithoutOnPrefix') {
           outputEventName = `${eventNamePrefix}${inputEventName.replace(/^on/, '')}`;
+        } else {
+          outputEventName = `${eventNamePrefix}${outputEventName}`.toLowerCase();
         }
-        outputEventName = `${eventNamePrefix}${outputEventName}`.toLowerCase();
         break;
     }
     return outputEventName;
@@ -145,8 +149,13 @@ export class EventPubSubService implements BasePubSubService {
 
       // the event listener will return the data in the "event.detail", so we need to return its content to the final callback
       // basically we substitute the "data" with "event.detail" so that the user ends up with only the "data" result
-      this._elementSource.addEventListener(eventNameByConvention, (event: CustomEventInit<T>) => callback.call(null, event.detail as T));
-      this._subscribedEvents.push({ name: eventNameByConvention, listener: callback });
+      const wrappedListener = (event: CustomEventInit<T>) => callback.call(null, event.detail as T);
+
+      // store the mapping so unsubscribe can resolve the original callback to the wrapper
+      this._callbackMap.set(callback, wrappedListener);
+
+      this._elementSource.addEventListener(eventNameByConvention, wrappedListener);
+      this._subscribedEvents.push({ name: eventNameByConvention, listener: wrappedListener });
       subscriptions.push(() => this.unsubscribe(eventNameByConvention, callback as never));
     });
 
@@ -183,9 +192,15 @@ export class EventPubSubService implements BasePubSubService {
    */
   unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList = true): void {
     const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
-    this._elementSource.removeEventListener(eventNameByConvention, listener);
+
+    // resolve the actual DOM listener
+    // either it's the wrapper itself or we look it up via the map
+    const domListener = (this._callbackMap.get(listener) ?? listener) as EventListener;
+
+    this._elementSource.removeEventListener(eventNameByConvention, domListener);
     if (shouldRemoveFromEventList) {
-      this.removeSubscribedEventWhenFound(eventName, listener);
+      this.removeSubscribedEventWhenFound(eventNameByConvention, domListener as any);
+      this._callbackMap.delete(listener);
     }
   }
 


### PR DESCRIPTION
## Bug Fixes

### 1. Listener leak in `subscribe` / `unsubscribe`
`subscribe` registered a wrapped listener on the DOM but stored the original callback in `_subscribedEvents`. `unsubscribe` then called `removeEventListener` with the original callback, which was never the registered listener, so it was never actually removed.

Fix: introduce `_callbackMap` (Map<Function, Function>) to track original callback, wrapped listener, allowing `unsubscribe` to resolve and remove the correct DOM listener. Map is cleared on `dispose`.

### 2. `getEventNameByNamingConvention` missing `else` branches
The `camelCaseWithExtraOnPrefix` and `lowerCaseWithoutOnPrefix` cases were missing `else` branches, causing the second assignment to always execute regardless of which style was active, corrupting the output event name for other styles sharing the same `case` block.

### 3. `subscribeEvent` unsubscribe double-transformation
The unsubscribe closure passed the already-converted event name back into `unsubscribe()`, which called `getEventNameByNamingConvention` on it again, producing a double-transformed name that never matched the stored event, so the listener was never removed.

Fix: bypass `unsubscribe()` in the closure and operate directly on the already-converted name.

## Tests
- Updated existing tests to reflect correct wrapped-listener behaviour
- Added new tests covering the listener leak fix and `dispose` cleanup
