### PR TITLE
fix(slickgrid): prevent native wheel drift with frozen columns

### DIFF
--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -6116,6 +6116,7 @@ describe('SlickGrid core file', () => {
 
       const mouseEvent = new Event('mousewheel');
       const mousePreventSpy = vi.spyOn(mouseEvent, 'stopPropagation');
+      const nativeScrollPreventSpy = vi.spyOn(mouseEvent, 'preventDefault');
       const onViewportChangedSpy = vi.spyOn(grid.onViewportChanged, 'notify');
       const viewportBottomRightElm = container.querySelector('.slick-viewport-bottom.slick-viewport-right') as HTMLDivElement;
       Object.defineProperty(viewportBottomRightElm, 'scrollHeight', { writable: true, value: DEFAULT_GRID_HEIGHT });
@@ -6136,6 +6137,7 @@ describe('SlickGrid core file', () => {
       expect(viewportBottomRightElm.scrollTop).toBe(0);
       expect(onViewportChangedSpy).toHaveBeenCalled();
       expect(mousePreventSpy).toHaveBeenCalled();
+      expect(nativeScrollPreventSpy).toHaveBeenCalled();
     });
 
     it('should scroll all elements shown when triggered by mousewheel and preHeader/footer/frozenColumn are enabled', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -6318,6 +6318,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     const handled = this._handleScroll('mousewheel');
     if (handled) {
       e.stopPropagation();
+      // Frozen columns use a second viewport whose vertical position is mirrored
+      // from the scrolling pane. Letting the browser also process this wheel event
+      // advances the source pane a second time, briefly putting it ahead of the
+      // frozen viewport until its subsequent scroll event is handled.
+      if (this.hasFrozenColumns()) {
+        e.preventDefault();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fix wheel-scroll drift when using frozen columns.

When SlickGrid handles a wheel event, it updates the scrolling viewport and mirrors the vertical position to the frozen-column pane. The browser could then apply its native wheel scroll as well, briefly advancing the main viewport ahead of the frozen pane.

## Changes

- Prevent the native wheel default only after SlickGrid has handled the event and frozen columns are enabled.
- Keep existing event propagation behavior.
- Leave regular, non-frozen grid scrolling unchanged.

## Test Coverage

- Updated the frozen columns/rows mousewheel regression test to verify that the handled wheel event calls `preventDefault()`.
- `slickGrid.spec.ts`: 428 tests passing.

## Scope

This fixes wheel and touchpad scrolling handled by SlickGrid. Native scrollbar-thumb dragging remains unchanged.

### LLM model attribution
This PR was assisted by Codex GPT-5.6-Terra.

#### bug demo

[Screencast_20260817_193846.webm](https://github.com/user-attachments/assets/575e9ef1-811a-423c-8db3-b06624353c48)


#### with fix

[Screencast_20260817_193728.webm](https://github.com/user-attachments/assets/3fec9a9a-309a-423c-86de-fb94ab2ddad7)
