### PR TITLE
fix(rowspan): support rowTopOffsetRenderType transform

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example43.ts
+++ b/demos/aurelia/src/examples/slickgrid/example43.ts
@@ -169,7 +169,7 @@ export class Example43 {
       gridMenu: {
         hideColumnPickerSection: true,
       },
-      rowTopOffsetRenderType: 'top', // RowDetail and/or RowSpan don't render well with "transform", you should use "top"
+      rowTopOffsetRenderType: 'top', // intentional top-positioning coverage; rowspan also supports 'transform'
     };
   }
 

--- a/demos/aurelia/src/examples/slickgrid/example44.ts
+++ b/demos/aurelia/src/examples/slickgrid/example44.ts
@@ -280,7 +280,7 @@ export class Example44 {
       },
       enableExcelExport: true,
       externalResources: [new ExcelExportService()],
-      rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
+      // rowTopOffsetRenderType: 'top', // no longer necessary with v10.10.0 and above; otherwise, uncomment this line
     };
   }
 

--- a/demos/aurelia/src/examples/slickgrid/example44.ts
+++ b/demos/aurelia/src/examples/slickgrid/example44.ts
@@ -280,7 +280,7 @@ export class Example44 {
       },
       enableExcelExport: true,
       externalResources: [new ExcelExportService()],
-      rowTopOffsetRenderType: 'top', // RowDetail and/or RowSpan don't render well with "transform", you should use "top"
+      rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
     };
   }
 

--- a/demos/aurelia/test/cypress/e2e/example44.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example44.cy.ts
@@ -39,7 +39,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   it('should drag Title column to swap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Task 0 to spread instead', () => {
     const expectedTitles = ['Revenue Growth', 'Title', 'Pricing Policy'];
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+    cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -51,11 +51,11 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Revenue Growth');
     cy.get('.slick-header-column:nth(1)').contains('Title');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l1.r1`).should('not.exist');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 3');
+    cy.get(`[data-row=0] > .slick-cell.l1.r1`).should('contain', 'Task 0');
+    cy.get(`[data-row=2] > .slick-cell.l1.r1`).should('not.exist');
+    cy.get(`[data-row=3] > .slick-cell.l1.r1`).should('contain', 'Task 3');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -69,7 +69,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   });
 
   it('should drag back Title column to reswap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Revenue Growth to now spread', () => {
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
     cy.get('.slick-header-columns')
@@ -80,10 +80,10 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Title');
     cy.get('.slick-header-column:nth(1)').contains('Revenue Growth');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 1');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 2');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l0.r0`).should('not.exist');
+    cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+    cy.get(`[data-row=1] > .slick-cell.l0.r0`).should('contain', 'Task 1');
+    cy.get(`[data-row=2] > .slick-cell.l0.r0`).should('contain', 'Task 2');
+    cy.get(`[data-row=3] > .slick-cell.l0.r0`).should('not.exist');
 
     const expectedTitles = ['Title', 'Revenue Growth', 'Pricing Policy'];
     cy.get('.slick-header-columns')
@@ -97,73 +97,65 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
 
   describe('spanning', () => {
     it('should expect first row to be regular rows without any spanning', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
 
       for (let i = 2; i <= 6; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l${i}.r${i}`).should('exist');
+        cy.get(`[data-row=0] > .slick-cell.l${i}.r${i}`).should('exist');
       }
     });
 
     it('should expect 1st row, second cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3);
       });
 
       for (let i = 2; i <= 14; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
+        cy.get(`[data-row=1] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
       }
     });
 
     it('should expect 3rd row first cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       for (let i = 2; i <= 5; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/);
+        cy.get(`[data-row=2] > .slick-cell:nth(${i})`).contains(/\d+$/);
       }
     });
 
     it('should expect 4th row to have 2 sections (blue, green) spanning across 3 rows (rowspan) and 2 columns (colspan)', () => {
       // blue rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l2.r2`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l2.r2`).should('exist').contains(/\d+$/);
 
       // green colspan/rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l3.r7`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l8.r8`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l9.r9`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l3.r7`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l8.r8`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l9.r9`).should('exist').contains(/\d+$/);
     });
 
     it('should click on "Toggle blue cell colspan..." and expect colspan to widen from 1 column to 2 columns and from 5 rows to 3 rowspan', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
 
       cy.get('[data-test="toggleSpans"]').click();
       cy.get('.slick-cell.l1.r1.rowspan').should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r2.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
     });
 
     it('should expect Task 8 on 2nd column to have rowspan spanning 80 cells', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
     });
@@ -171,36 +163,36 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     it('should scroll to the right and still expect spans without any extra texts', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(400, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(0).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       // next rows are regular cells
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l4.r4`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l4.r4`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
     });
 
     it('should scroll back to left and expect Task 8 to have 2 different spans (Revenue Grow: rowspan=80, Policy Index: rowspan=2000,colspan=2)', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(0, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(2)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l3.r4`).should('exist');
+      cy.get(`[data-row=8] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell:nth(2)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l3.r4`).should('exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 9}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 9');
+      cy.get(`[data-row=9] > .slick-cell.l0.r0`).should('contain', 'Task 9');
     });
 
     it('should scroll to row 85 and still expect 3 spans in the screen, "Revenue Growth" and "Policy Index" spans', () => {

--- a/demos/react/src/examples/slickgrid/Example43.tsx
+++ b/demos/react/src/examples/slickgrid/Example43.tsx
@@ -155,7 +155,7 @@ export default function Example43() {
     gridMenu: {
       hideColumnPickerSection: true,
     },
-    rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+    rowTopOffsetRenderType: 'top', // intentional top-positioning coverage; rowspan also supports 'transform'
   };
 
   function exportToExcel() {

--- a/demos/react/src/examples/slickgrid/Example44.tsx
+++ b/demos/react/src/examples/slickgrid/Example44.tsx
@@ -278,7 +278,7 @@ export default function Example44() {
     },
     enableExcelExport: true,
     externalResources: [new ExcelExportService()],
-    rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
+    // rowTopOffsetRenderType: 'top', // no longer necessary with v10.10.0 and above; otherwise, uncomment this line
   };
 
   function clearScrollTo() {

--- a/demos/react/src/examples/slickgrid/Example44.tsx
+++ b/demos/react/src/examples/slickgrid/Example44.tsx
@@ -278,7 +278,7 @@ export default function Example44() {
     },
     enableExcelExport: true,
     externalResources: [new ExcelExportService()],
-    rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+    rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
   };
 
   function clearScrollTo() {

--- a/demos/react/test/cypress/e2e/example44.cy.ts
+++ b/demos/react/test/cypress/e2e/example44.cy.ts
@@ -39,7 +39,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   it('should drag Title column to swap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Task 0 to spread instead', () => {
     const expectedTitles = ['Revenue Growth', 'Title', 'Pricing Policy'];
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+    cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -51,11 +51,11 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Revenue Growth');
     cy.get('.slick-header-column:nth(1)').contains('Title');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l1.r1`).should('not.exist');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 3');
+    cy.get(`[data-row=0] > .slick-cell.l1.r1`).should('contain', 'Task 0');
+    cy.get(`[data-row=2] > .slick-cell.l1.r1`).should('not.exist');
+    cy.get(`[data-row=3] > .slick-cell.l1.r1`).should('contain', 'Task 3');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -69,7 +69,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   });
 
   it('should drag back Title column to reswap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Revenue Growth to now spread', () => {
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
     cy.get('.slick-header-columns')
@@ -80,10 +80,10 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Title');
     cy.get('.slick-header-column:nth(1)').contains('Revenue Growth');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 1');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 2');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l0.r0`).should('not.exist');
+    cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+    cy.get(`[data-row=1] > .slick-cell.l0.r0`).should('contain', 'Task 1');
+    cy.get(`[data-row=2] > .slick-cell.l0.r0`).should('contain', 'Task 2');
+    cy.get(`[data-row=3] > .slick-cell.l0.r0`).should('not.exist');
 
     const expectedTitles = ['Title', 'Revenue Growth', 'Pricing Policy'];
     cy.get('.slick-header-columns')
@@ -97,73 +97,65 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
 
   describe('spanning', () => {
     it('should expect first row to be regular rows without any spanning', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
 
       for (let i = 2; i <= 6; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l${i}.r${i}`).should('exist');
+        cy.get(`[data-row=0] > .slick-cell.l${i}.r${i}`).should('exist');
       }
     });
 
     it('should expect 1st row, second cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3);
       });
 
       for (let i = 2; i <= 14; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
+        cy.get(`[data-row=1] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
       }
     });
 
     it('should expect 3rd row first cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       for (let i = 2; i <= 5; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/);
+        cy.get(`[data-row=2] > .slick-cell:nth(${i})`).contains(/\d+$/);
       }
     });
 
     it('should expect 4th row to have 2 sections (blue, green) spanning across 3 rows (rowspan) and 2 columns (colspan)', () => {
       // blue rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l2.r2`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l2.r2`).should('exist').contains(/\d+$/);
 
       // green colspan/rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l3.r7`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l8.r8`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l9.r9`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l3.r7`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l8.r8`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l9.r9`).should('exist').contains(/\d+$/);
     });
 
     it('should click on "Toggle blue cell colspan..." and expect colspan to widen from 1 column to 2 columns and from 5 rows to 3 rowspan', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
 
       cy.get('[data-test="toggleSpans"]').click();
       cy.get('.slick-cell.l1.r1.rowspan').should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r2.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
     });
 
     it('should expect Task 8 on 2nd column to have rowspan spanning 80 cells', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
     });
@@ -171,36 +163,36 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     it('should scroll to the right and still expect spans without any extra texts', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(400, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(0).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       // next rows are regular cells
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l4.r4`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l4.r4`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
     });
 
     it('should scroll back to left and expect Task 8 to have 2 different spans (Revenue Grow: rowspan=80, Policy Index: rowspan=2000,colspan=2)', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(0, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(2)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l3.r4`).should('exist');
+      cy.get(`[data-row=8] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell:nth(2)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l3.r4`).should('exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 9}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 9');
+      cy.get(`[data-row=9] > .slick-cell.l0.r0`).should('contain', 'Task 9');
     });
 
     it('should scroll to row 85 and still expect 3 spans in the screen, "Revenue Growth" and "Policy Index" spans', () => {

--- a/demos/vanilla/src/examples/example32.ts
+++ b/demos/vanilla/src/examples/example32.ts
@@ -189,7 +189,7 @@ export default class Example32 {
       gridMenu: {
         hideColumnPickerSection: true,
       },
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'top', // intentional top-positioning coverage; rowspan also supports 'transform'
     };
   }
 

--- a/demos/vanilla/src/examples/example33.ts
+++ b/demos/vanilla/src/examples/example33.ts
@@ -297,7 +297,7 @@ export default class Example33 {
       },
       enableExcelExport: true,
       externalResources: [new ExcelExportService()],
-      rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
+      // rowTopOffsetRenderType: 'top', // no longer necessary with v10.10.0 and above; otherwise, uncomment this line
     };
   }
 

--- a/demos/vanilla/src/examples/example33.ts
+++ b/demos/vanilla/src/examples/example33.ts
@@ -297,7 +297,7 @@ export default class Example33 {
       },
       enableExcelExport: true,
       externalResources: [new ExcelExportService()],
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
     };
   }
 

--- a/demos/vue/src/components/Example43.vue
+++ b/demos/vue/src/components/Example43.vue
@@ -163,7 +163,7 @@ function defineGrid() {
     gridMenu: {
       hideColumnPickerSection: true,
     },
-    rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+    rowTopOffsetRenderType: 'top', // intentional top-positioning coverage; rowspan also supports 'transform'
   };
 }
 

--- a/demos/vue/src/components/Example44.vue
+++ b/demos/vue/src/components/Example44.vue
@@ -274,7 +274,7 @@ function defineGrid() {
     },
     enableExcelExport: true,
     externalResources: [new ExcelExportService()],
-    rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+    rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
   };
 }
 

--- a/demos/vue/src/components/Example44.vue
+++ b/demos/vue/src/components/Example44.vue
@@ -274,7 +274,7 @@ function defineGrid() {
     },
     enableExcelExport: true,
     externalResources: [new ExcelExportService()],
-    rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
+    // rowTopOffsetRenderType: 'top', // no longer necessary with v10.10.0 and above; otherwise, uncomment this line
   };
 }
 

--- a/demos/vue/test/cypress/e2e/example44.cy.ts
+++ b/demos/vue/test/cypress/e2e/example44.cy.ts
@@ -39,7 +39,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   it('should drag Title column to swap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Task 0 to spread instead', () => {
     const expectedTitles = ['Revenue Growth', 'Title', 'Pricing Policy'];
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+    cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -51,11 +51,11 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Revenue Growth');
     cy.get('.slick-header-column:nth(1)').contains('Title');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l1.r1`).should('not.exist');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 3');
+    cy.get(`[data-row=0] > .slick-cell.l1.r1`).should('contain', 'Task 0');
+    cy.get(`[data-row=2] > .slick-cell.l1.r1`).should('not.exist');
+    cy.get(`[data-row=3] > .slick-cell.l1.r1`).should('contain', 'Task 3');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -69,7 +69,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   });
 
   it('should drag back Title column to reswap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Revenue Growth to now spread', () => {
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
     cy.get('.slick-header-columns')
@@ -80,10 +80,10 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Title');
     cy.get('.slick-header-column:nth(1)').contains('Revenue Growth');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 1');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 2');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l0.r0`).should('not.exist');
+    cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+    cy.get(`[data-row=1] > .slick-cell.l0.r0`).should('contain', 'Task 1');
+    cy.get(`[data-row=2] > .slick-cell.l0.r0`).should('contain', 'Task 2');
+    cy.get(`[data-row=3] > .slick-cell.l0.r0`).should('not.exist');
 
     const expectedTitles = ['Title', 'Revenue Growth', 'Pricing Policy'];
     cy.get('.slick-header-columns')
@@ -97,73 +97,65 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
 
   describe('spanning', () => {
     it('should expect first row to be regular rows without any spanning', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
 
       for (let i = 2; i <= 6; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l${i}.r${i}`).should('exist');
+        cy.get(`[data-row=0] > .slick-cell.l${i}.r${i}`).should('exist');
       }
     });
 
     it('should expect 1st row, second cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3);
       });
 
       for (let i = 2; i <= 14; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
+        cy.get(`[data-row=1] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
       }
     });
 
     it('should expect 3rd row first cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       for (let i = 2; i <= 5; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/);
+        cy.get(`[data-row=2] > .slick-cell:nth(${i})`).contains(/\d+$/);
       }
     });
 
     it('should expect 4th row to have 2 sections (blue, green) spanning across 3 rows (rowspan) and 2 columns (colspan)', () => {
       // blue rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l2.r2`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l2.r2`).should('exist').contains(/\d+$/);
 
       // green colspan/rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l3.r7`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l8.r8`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l9.r9`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l3.r7`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l8.r8`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l9.r9`).should('exist').contains(/\d+$/);
     });
 
     it('should click on "Toggle blue cell colspan..." and expect colspan to widen from 1 column to 2 columns and from 5 rows to 3 rowspan', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
 
       cy.get('[data-test="toggleSpans"]').click();
       cy.get('.slick-cell.l1.r1.rowspan').should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r2.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
     });
 
     it('should expect Task 8 on 2nd column to have rowspan spanning 80 cells', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
     });
@@ -171,36 +163,36 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     it('should scroll to the right and still expect spans without any extra texts', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(400, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(0).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       // next rows are regular cells
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l4.r4`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l4.r4`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
     });
 
     it('should scroll back to left and expect Task 8 to have 2 different spans (Revenue Grow: rowspan=80, Policy Index: rowspan=2000,colspan=2)', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(0, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(2)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l3.r4`).should('exist');
+      cy.get(`[data-row=8] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell:nth(2)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l3.r4`).should('exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 9}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 9');
+      cy.get(`[data-row=9] > .slick-cell.l0.r0`).should('contain', 'Task 9');
     });
 
     it('should scroll to row 85 and still expect 3 spans in the screen, "Revenue Growth" and "Policy Index" spans', () => {

--- a/docs/grid-functionalities/column-row-spanning.md
+++ b/docs/grid-functionalities/column-row-spanning.md
@@ -57,8 +57,10 @@ example class MyExample {
           },
         },
       },
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'transform', // default; RowSpan is supported with v10.10.x+
     };
   }
 }
 ```
+
+**v11 transition:** RowSpan uses hybrid positioning in v10.10.x+ so that `rowTopOffsetRenderType: 'transform'` works without requiring the legacy `top` workaround. In v11, transform-based row positioning is planned to be the only supported mode, so `rowTopOffsetRenderType: 'top'` will no longer be necessary and the `'top'` value may be removed from the API.

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/column-row-spanning.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/column-row-spanning.md
@@ -67,8 +67,10 @@ export class Grid43Component implements OnInit {
           },
         },
       },
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'transform', // default; RowSpan is supported with v10.10.x+
     };
   }
 }
 ```
+
+**v11 transition:** RowSpan uses hybrid positioning in v10.10.x+ so that `rowTopOffsetRenderType: 'transform'` works without requiring the legacy `top` workaround. In v11, transform-based row positioning is planned to be the only supported mode, so `rowTopOffsetRenderType: 'top'` will no longer be necessary and the `'top'` value may be removed from the API.

--- a/frameworks/angular-slickgrid/src/demos/examples/example43.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example43.component.ts
@@ -182,7 +182,7 @@ export class Example43Component implements OnInit {
       gridMenu: {
         hideColumnPickerSection: true,
       },
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'top', // intentional top-positioning coverage; rowspan also supports 'transform'
     };
   }
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example44.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example44.component.ts
@@ -294,7 +294,7 @@ export class Example44Component implements OnInit {
       },
       enableExcelExport: true,
       externalResources: [new ExcelExportService()],
-      rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
+      // rowTopOffsetRenderType: 'top', // no longer necessary with v10.10.0 and above; otherwise, uncomment this line
     };
   }
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example44.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example44.component.ts
@@ -294,7 +294,7 @@ export class Example44Component implements OnInit {
       },
       enableExcelExport: true,
       externalResources: [new ExcelExportService()],
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'transform', // RowSpan host rows use hybrid top positioning
     };
   }
 

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example44.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example44.cy.ts
@@ -39,7 +39,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   it('should drag Title column to swap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Task 0 to spread instead', () => {
     const expectedTitles = ['Revenue Growth', 'Title', 'Pricing Policy'];
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+    cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -51,11 +51,11 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Revenue Growth');
     cy.get('.slick-header-column:nth(1)').contains('Title');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l1.r1`).should('not.exist');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 3');
+    cy.get(`[data-row=0] > .slick-cell.l1.r1`).should('contain', 'Task 0');
+    cy.get(`[data-row=2] > .slick-cell.l1.r1`).should('not.exist');
+    cy.get(`[data-row=3] > .slick-cell.l1.r1`).should('contain', 'Task 3');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -69,7 +69,7 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
   });
 
   it('should drag back Title column to reswap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Revenue Growth to now spread', () => {
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
     cy.get('.slick-header-columns')
@@ -80,10 +80,10 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Title');
     cy.get('.slick-header-column:nth(1)').contains('Revenue Growth');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 1');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 2');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l0.r0`).should('not.exist');
+    cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+    cy.get(`[data-row=1] > .slick-cell.l0.r0`).should('contain', 'Task 1');
+    cy.get(`[data-row=2] > .slick-cell.l0.r0`).should('contain', 'Task 2');
+    cy.get(`[data-row=3] > .slick-cell.l0.r0`).should('not.exist');
 
     const expectedTitles = ['Title', 'Revenue Growth', 'Pricing Policy'];
     cy.get('.slick-header-columns')
@@ -97,73 +97,65 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
 
   describe('spanning', () => {
     it('should expect first row to be regular rows without any spanning', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
 
       for (let i = 2; i <= 6; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l${i}.r${i}`).should('exist');
+        cy.get(`[data-row=0] > .slick-cell.l${i}.r${i}`).should('exist');
       }
     });
 
     it('should expect 1st row, second cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3);
       });
 
       for (let i = 2; i <= 14; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
+        cy.get(`[data-row=1] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
       }
     });
 
     it('should expect 3rd row first cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       for (let i = 2; i <= 5; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/);
+        cy.get(`[data-row=2] > .slick-cell:nth(${i})`).contains(/\d+$/);
       }
     });
 
     it('should expect 4th row to have 2 sections (blue, green) spanning across 3 rows (rowspan) and 2 columns (colspan)', () => {
       // blue rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l2.r2`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l2.r2`).should('exist').contains(/\d+$/);
 
       // green colspan/rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l3.r7`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l8.r8`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l9.r9`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l3.r7`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l8.r8`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l9.r9`).should('exist').contains(/\d+$/);
     });
 
     it('should click on "Toggle blue cell colspan..." and expect colspan to widen from 1 column to 2 columns and from 5 rows to 3 rowspan', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
 
       cy.get('[data-test="toggleSpans"]').click();
       cy.get('.slick-cell.l1.r1.rowspan').should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r2.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
     });
 
     it('should expect Task 8 on 2nd column to have rowspan spanning 80 cells', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
     });
@@ -171,36 +163,36 @@ describe('Example 44 - Column & Row Span', { retries: 0 }, () => {
     it('should scroll to the right and still expect spans without any extra texts', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(400, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(0).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       // next rows are regular cells
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l4.r4`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l4.r4`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
     });
 
     it('should scroll back to left and expect Task 8 to have 2 different spans (Revenue Grow: rowspan=80, Policy Index: rowspan=2000,colspan=2)', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(0, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(2)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l3.r4`).should('exist');
+      cy.get(`[data-row=8] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell:nth(2)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l3.r4`).should('exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 9}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 9');
+      cy.get(`[data-row=9] > .slick-cell.l0.r0`).should('contain', 'Task 9');
     });
 
     it('should scroll to row 85 and still expect 3 spans in the screen, "Revenue Growth" and "Policy Index" spans', () => {

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/column-row-spanning.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/column-row-spanning.md
@@ -57,8 +57,10 @@ example class MyExample {
           },
         },
       },
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'transform', // default; RowSpan is supported with v10.10.x+
     };
   }
 }
 ```
+
+**v11 transition:** RowSpan uses hybrid positioning in v10.10.x+ so that `rowTopOffsetRenderType: 'transform'` works without requiring the legacy `top` workaround. In v11, transform-based row positioning is planned to be the only supported mode, so `rowTopOffsetRenderType: 'top'` will no longer be necessary and the `'top'` value may be removed from the API.

--- a/frameworks/slickgrid-react/docs/grid-functionalities/column-row-spanning.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/column-row-spanning.md
@@ -72,8 +72,10 @@ const Example: React.FC = () => {
           },
         },
       },
-      rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+      rowTopOffsetRenderType: 'transform', // default; RowSpan is supported with v10.10.x+
     });
   }
 }
 ```
+
+**v11 transition:** RowSpan uses hybrid positioning in v10.10.x+ so that `rowTopOffsetRenderType: 'transform'` works without requiring the legacy `top` workaround. In v11, transform-based row positioning is planned to be the only supported mode, so `rowTopOffsetRenderType: 'top'` will no longer be necessary and the `'top'` value may be removed from the API.

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/column-row-spanning.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/column-row-spanning.md
@@ -63,7 +63,7 @@ function defineGrid() {
         },
       },
     },
-    rowTopOffsetRenderType: 'top', // rowspan doesn't render well with 'transform', default is 'top'
+    rowTopOffsetRenderType: 'transform', // default; RowSpan is supported with v10.10.x+
   };
 }
 </script>
@@ -77,3 +77,5 @@ function defineGrid() {
   />
 </script>
 ```
+
+**v11 transition:** RowSpan uses hybrid positioning in v10.10.x+ so that `rowTopOffsetRenderType: 'transform'` works without requiring the legacy `top` workaround. In v11, transform-based row positioning is planned to be the only supported mode, so `rowTopOffsetRenderType: 'top'` will no longer be necessary and the `'top'` value may be removed from the API.

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -244,7 +244,7 @@ describe('SlickGrid core file', () => {
         rowTopOffsetRenderType: 'transform',
         enableRowDetailView: true,
         rowDetailView: { renderMode: 'overlay' },
-      },
+      } as GridOption,
       pubSubServiceStub
     );
     grid.init();
@@ -252,24 +252,39 @@ describe('SlickGrid core file', () => {
     expect(grid.getOptions().rowTopOffsetRenderType).toBe('transform');
   });
 
-  it('should display a console warning when RowSpan is enabled with `rowTopOffsetRenderType` is set to "transfrom"', () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockReturnValue();
-
-    document.body.style.zoom = '90%';
-    const columns = [{ id: 'firstName', field: 'firstName', name: 'First Name' }] as Column[];
+  it('should keep RowSpan host rows top-positioned while other rows use transforms', () => {
+    const columns = [
+      { id: 'firstName', field: 'firstName', name: 'First Name' },
+      { id: 'lastName', field: 'lastName', name: 'Last Name' },
+    ] as Column[];
+    const data = [
+      { id: 0, firstName: 'Jane', lastName: 'Doe' },
+      { id: 1, firstName: 'John', lastName: 'Doe' },
+    ];
+    const dataView = new SlickDataView({
+      globalItemMetadataProvider: { getRowMetadata: (_item, row) => (row === 0 ? { columns: { 0: { rowspan: 2 } } } : undefined) },
+    });
+    dataView.setItems(data);
     grid = new SlickGrid<any, Column>(
       '#myGrid',
-      [],
+      dataView,
       columns,
       { ...defaultOptions, rowTopOffsetRenderType: 'transform', enableCellRowSpan: true },
       pubSubServiceStub
     );
     grid.init();
 
-    expect(grid).toBeTruthy();
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using RowSpan')
-    );
+    const spanRow = container.querySelector<HTMLElement>('.slick-row[data-row="0"]')!;
+    const regularRow = container.querySelector<HTMLElement>('.slick-row[data-row="1"]')!;
+    expect(grid.getOptions().rowTopOffsetRenderType).toBe('transform');
+    expect(spanRow.style.top).toBe('0px');
+    expect(spanRow.style.transform).toBe('');
+    expect(spanRow.classList).toContain('slick-rowspan');
+    expect(regularRow.style.top).toBe('');
+    expect(regularRow.style.transform).toBe(`translateY(${grid.getOptions().rowHeight}px)`);
+    const spanCell = spanRow.querySelector<HTMLElement>('.slick-cell.rowspan')!;
+    expect(spanCell).toBeTruthy();
+    expect(grid.getCellFromEvent({ target: spanCell } as unknown as Event)).toEqual({ row: 0, cell: 0 });
   });
 
   it('should be able to instantiate SlickGrid and get columns', () => {

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -650,11 +650,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           'SlickGrid relies on row positioning calculations that can drift with browser zoom.'
       );
     }
-    if (this._options.rowTopOffsetRenderType === 'transform' && this._options.enableCellRowSpan) {
-      console.warn(
-        '[Slickgrid-Universal] `rowTopOffsetRenderType` should be set to "top" when using RowSpan since "transform" is known to have UI issues.'
-      );
-    }
     this.finishInitialization();
   }
 
@@ -4344,14 +4339,6 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
       role: 'row',
       dataset: { row: `${row}` },
     });
-    const frozenRowOffset = this.getFrozenRowOffset(row);
-    const topOffset = this.getRowTop(row) - frozenRowOffset;
-    if (this._options.rowTopOffsetRenderType === 'transform') {
-      rowDiv.style.transform = `translateY(${topOffset}px)`;
-    } else {
-      rowDiv.style.top = `${topOffset}px`; // default to `top: {offset}px`
-    }
-
     if (this._options.enableVariableRowHeight) {
       // only rows with a non-default height get an inline height so that rows with
       // the default height can be sized by the stylesheet rule
@@ -4437,6 +4424,26 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           i += ncolspan - 1;
         }
       }
+    }
+
+    this.applyRowTopOffset(rowDiv, row);
+    if (rowDivR) {
+      this.applyRowTopOffset(rowDivR, row);
+    }
+  }
+
+  /** Keep RowSpan host rows top-positioned so their cells escape transformed sibling stacking contexts. */
+  protected applyRowTopOffset(rowNode: HTMLElement, row: number): void {
+    const top = this.getRowTop(row) - this.getFrozenRowOffset(row);
+    const isTransform = this._options.rowTopOffsetRenderType === 'transform';
+    const hasRowSpan = this._options.enableCellRowSpan && !!rowNode.querySelector('.slick-cell.rowspan');
+    rowNode.classList.toggle('slick-rowspan', isTransform && hasRowSpan);
+    if (isTransform && !hasRowSpan) {
+      rowNode.style.top = '';
+      rowNode.style.transform = `translateY(${top}px)`;
+    } else {
+      rowNode.style.top = `${top}px`;
+      rowNode.style.transform = '';
     }
   }
 
@@ -5642,6 +5649,7 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
           cacheEntry.cellNodesByColumnIdx![columnIdx] = node;
         }
       }
+      cacheEntry.rowNode?.forEach((rowNode) => this.applyRowTopOffset(rowNode, processedRow!));
     }
   }
 
@@ -5801,14 +5809,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     if (this.rowsCache && typeof this.rowsCache === 'object') {
       Object.keys(this.rowsCache).forEach((row) => {
         const rowNumber = row ? parseInt(row, 10) : 0;
-        // same formula appendRowHtml uses to place rows initially
-        const top = this.getRowTop(rowNumber) - this.getFrozenRowOffset(rowNumber);
         this.rowsCache[rowNumber].rowNode!.forEach((rowNode) => {
-          if (this._options.rowTopOffsetRenderType === 'transform') {
-            rowNode.style.transform = `translateY(${top}px)`;
-          } else {
-            rowNode.style.top = `${top}px`; // default to `top: {offset}px`
-          }
+          this.applyRowTopOffset(rowNode, rowNumber);
         });
       });
     }

--- a/packages/common/src/interfaces/gridOption.interface.ts
+++ b/packages/common/src/interfaces/gridOption.interface.ts
@@ -875,7 +875,7 @@ export interface GridOption<C extends Column = Column> {
   /**
    * Defaults to "transform", what CSS style to we want to use to render each row top offset (choose between "top" and "transform").
    * For example, with a default `rowHeight: 22`, the 2nd row will have a `top` offset of 44px and by default have a CSS style of `transform: translateY(44px)`.
-   * NOTE: use `top` with the legacy inline Row Detail renderer and/or RowSpan. Row Detail can use `rowDetailView.renderMode: 'overlay'` for transform compatibility.
+   * NOTE: use `top` with the legacy inline Row Detail renderer. Row Detail uses an overlay and RowSpan uses hybrid positioning for transform compatibility.
    */
   rowTopOffsetRenderType?: 'top' | 'transform';
 

--- a/packages/common/src/styles/slick-grid.scss
+++ b/packages/common/src/styles/slick-grid.scss
@@ -260,6 +260,16 @@
     }
   }
 
+  // Active-row padding changes the containing box and can clip the fixed-height RowSpan cell.
+  .slick-row.active.slick-rowspan {
+    padding: 0;
+  }
+
+  // Keep the complete RowSpan host row above selected/hovered transformed rows.
+  .slick-row.slick-rowspan {
+    z-index: var(--slick-rowspan-z-index, 10);
+  }
+
   .slick-group-header-columns {
     position: relative;
     white-space: nowrap;

--- a/test/cypress/e2e/example33.cy.ts
+++ b/test/cypress/e2e/example33.cy.ts
@@ -39,7 +39,7 @@ describe('Example 33 - Column & Row Span', { retries: 0 }, () => {
   it('should drag Title column to swap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Task 0 to spread instead', () => {
     const expectedTitles = ['Revenue Growth', 'Title', 'Pricing Policy'];
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+    cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -51,11 +51,11 @@ describe('Example 33 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Revenue Growth');
     cy.get('.slick-header-column:nth(1)').contains('Title');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l1.r1`).should('not.exist');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1`).should('contain', 'Task 3');
+    cy.get(`[data-row=0] > .slick-cell.l1.r1`).should('contain', 'Task 0');
+    cy.get(`[data-row=2] > .slick-cell.l1.r1`).should('not.exist');
+    cy.get(`[data-row=3] > .slick-cell.l1.r1`).should('contain', 'Task 3');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
 
@@ -69,7 +69,7 @@ describe('Example 33 - Column & Row Span', { retries: 0 }, () => {
   });
 
   it('should drag back Title column to reswap with 2nd column "Revenue Growth" in the grid and expect rowspan to stay at same position with Revenue Growth to now spread', () => {
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+    cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) =>
       expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
     );
     cy.get('.slick-header-columns')
@@ -80,10 +80,10 @@ describe('Example 33 - Column & Row Span', { retries: 0 }, () => {
     cy.get('.slick-header-column:nth(0)').contains('Title');
     cy.get('.slick-header-column:nth(1)').contains('Revenue Growth');
 
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 1');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 2');
-    cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l0.r0`).should('not.exist');
+    cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+    cy.get(`[data-row=1] > .slick-cell.l0.r0`).should('contain', 'Task 1');
+    cy.get(`[data-row=2] > .slick-cell.l0.r0`).should('contain', 'Task 2');
+    cy.get(`[data-row=3] > .slick-cell.l0.r0`).should('not.exist');
 
     const expectedTitles = ['Title', 'Revenue Growth', 'Pricing Policy'];
     cy.get('.slick-header-columns')
@@ -97,73 +97,65 @@ describe('Example 33 - Column & Row Span', { retries: 0 }, () => {
 
   describe('spanning', () => {
     it('should expect first row to be regular rows without any spanning', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
 
       for (let i = 2; i <= 6; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l${i}.r${i}`).should('exist');
+        cy.get(`[data-row=0] > .slick-cell.l${i}.r${i}`).should('exist');
       }
     });
 
     it('should expect 1st row, second cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 0');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 0}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=0] > .slick-cell.l0.r0`).should('contain', 'Task 0');
+      cy.get(`[data-row=0] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3);
       });
 
       for (let i = 2; i <= 14; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 1}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
+        cy.get(`[data-row=1] > .slick-cell:nth(${i})`).contains(/\d+$/); // use regexp to make sure it's a number
       }
     });
 
     it('should expect 3rd row first cell to span (rowspan) across 3 rows', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell.l0.r0.rowspan`).should(($el) =>
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should('contain', 'Task 2');
+      cy.get(`[data-row=2] > .slick-cell.l0.r0.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       for (let i = 2; i <= 5; i++) {
-        cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 2}px;"] > .slick-cell:nth(${i})`).contains(/\d+$/);
+        cy.get(`[data-row=2] > .slick-cell:nth(${i})`).contains(/\d+$/);
       }
     });
 
     it('should expect 4th row to have 2 sections (blue, green) spanning across 3 rows (rowspan) and 2 columns (colspan)', () => {
       // blue rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l2.r2`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l2.r2`).should('exist').contains(/\d+$/);
 
       // green colspan/rowspan section
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l3.r7`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l8.r8`)
-        .should('exist')
-        .contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l9.r9`)
-        .should('exist')
-        .contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l3.r7`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l8.r8`).should('exist').contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l9.r9`).should('exist').contains(/\d+$/);
     });
 
     it('should click on "Toggle blue cell colspan..." and expect colspan to widen from 1 column to 2 columns and from 5 rows to 3 rowspan', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r1.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l1.r1.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 5)
       );
 
       cy.get('[data-test="toggleSpans"]').click();
       cy.get('.slick-cell.l1.r1.rowspan').should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell.l1.r2.rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
     });
 
     it('should expect Task 8 on 2nd column to have rowspan spanning 80 cells', () => {
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
     });
@@ -171,36 +163,36 @@ describe('Example 33 - Column & Row Span', { retries: 0 }, () => {
     it('should scroll to the right and still expect spans without any extra texts', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(400, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(0).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 3}px;"] > .slick-cell:nth(1).rowspan`).should(($el) =>
+      cy.get(`[data-row=3] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=3] > .slick-cell.l1.r2.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should('exist');
+      cy.get(`[data-row=3] > .slick-cell.l3.r7.rowspan`).should(($el) =>
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 3)
       );
 
       // next rows are regular cells
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 4}px;"] > .slick-cell.l4.r4`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=4] > .slick-cell.l4.r4`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 5}px;"] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
+      cy.get(`[data-row=5] > .slick-cell.l3.r3`).should('not.exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 6}px;"] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
+      cy.get(`[data-row=6] > .slick-cell.l4.r4`).should('exist');
     });
 
     it('should scroll back to left and expect Task 8 to have 2 different spans (Revenue Grow: rowspan=80, Policy Index: rowspan=2000,colspan=2)', () => {
       cy.get('.slick-viewport-top.slick-viewport-left').scrollTo(0, 0).wait(10);
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 8');
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1).rowspan`).should(($el) => {
+      cy.get(`[data-row=8] > .slick-cell.l0.r0`).should('contain', 'Task 8');
+      cy.get(`[data-row=8] > .slick-cell.l1.r1.rowspan`).should(($el) => {
         expect(parseInt(`${$el.outerHeight()}`, 10)).to.eq(GRID_ROW_HEIGHT * 80);
       });
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(1)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell:nth(2)`).contains(/\d+$/);
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 8}px;"] > .slick-cell.l3.r4`).should('exist');
+      cy.get(`[data-row=8] > .slick-cell:nth(1)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell:nth(2)`).contains(/\d+$/);
+      cy.get(`[data-row=8] > .slick-cell.l3.r4`).should('exist');
 
-      cy.get(`[style*="top: ${GRID_ROW_HEIGHT * 9}px;"] > .slick-cell.l0.r0`).should('contain', 'Task 9');
+      cy.get(`[data-row=9] > .slick-cell.l0.r0`).should('contain', 'Task 9');
     });
 
     it('should scroll to row 85 and still expect 3 spans in the screen, "Revenue Growth" and "Policy Index" spans', () => {


### PR DESCRIPTION
## Summary

Make RowSpan compatible with `rowTopOffsetRenderType: 'transform'`, which is the default row rendering mode.

Users no longer need to configure:

```ts
rowTopOffsetRenderType: 'top'
```

The grid now uses hybrid positioning internally:

- Regular rows remain transform-positioned.
- RowSpan host rows use compatible top positioning.
- RowSpan host rows are kept above selected/hovered rows so their colors are not clipped.

The legacy `top` mode remains supported for backwards compatibility in v10.

## Tests

- Added core coverage for hybrid RowSpan positioning
- Updated Vanilla, Angular, React, Vue, and Aurelia examples
- Added Cypress coverage for both `top` and `transform` modes
- Full Vitest suite: 5,905 tests across 213 files
- Maintained 100% statement, function, and line coverage
- TypeScript, Prettier, lint, and diff checks passed

## v11 transition

The hybrid positioning is a v10 compatibility implementation that allows RowSpan to work with `transform` while preserving the existing `top` mode.

In v11, transform-based row positioning is planned to become the only supported mode. The `rowTopOffsetRenderType: 'top'` workaround will no longer be necessary, and the `'top'` value may be removed from the API. Keep using `rowTopOffsetRenderType: 'transform'` in v10 and remove the explicit option when upgrading to v11 if it becomes the default or is removed.

## Verification

- Row Detail unit tests: 54/54 passing
- Framework Cypress suites previously validated across Vanilla, React, Angular, Vue, and Aurelia
