### PR TITLE
fix(row-detail): synchronize framework rendering without microtasks

### DIFF
--- a/demos/aurelia/test/cypress/e2e/example19.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example19.cy.ts
@@ -136,7 +136,9 @@ describe('Example 19 - Row Detail View', () => {
 
     cy.get('@detailContainer0').find('h3').contains('Task 0');
 
-    cy.get('#grid19').find('.slick-row:nth(9)').click();
+    cy.get('#grid19')
+      .contains('.slick-row .slick-cell', /^Task 3$/)
+      .click();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_3 .container_3').as('detailContainer3');
 
@@ -242,21 +244,24 @@ describe('Example 19 - Row Detail View', () => {
       .then((text) => expect(text).to.eq('Task 1'));
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_101').should('not.exist');
+    cy.get('.editor-title').type('{esc}');
+    cy.get('#grid19').contains('.slick-row .slick-cell', /^Task 1$/);
   });
 
   it('should expect the Row Detail to be re-rendered after expanding/collapsing multiple times', () => {
-    cy.get('#grid19').find('.slick-row:nth(1) .slick-cell:nth(0)').as('toggle1');
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
+    const clickTask1Toggle = () => cy.get('#grid19').find('.slick-row[data-row="1"] .slick-cell.l0').click();
+
+    clickTask1Toggle();
+    clickTask1Toggle();
+    clickTask1Toggle();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('@detailContainer').should('not.exist');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
   });

--- a/demos/aurelia/test/cypress/e2e/example45.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example45.cy.ts
@@ -326,7 +326,7 @@ describe('Example 45 - Row Detail with inner Grid', () => {
       it('should go to the bottom end of the grid and open row 987', () => {
         cy.get('#grid45').type('{ctrl}{end}{ctrl}{end}', { release: false });
 
-        cy.get('.slick-row[data-row=1001] .detail-view-toggle').first().click();
+        cy.get('.slick-row[data-row=1001] .slick-cell.detail-view-toggle').click();
 
         cy.get('#innergrid-987 .search-filter.filter-orderId').as('orderIdSearch');
         cy.get('@orderIdSearch').clear();

--- a/demos/aurelia/test/cypress/e2e/example47.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example47.cy.ts
@@ -28,7 +28,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
   it('should open the 1st Row Detail of Duration(0) Group and expect to find some details', () => {
     cy.get('.slick-cell.l0.r0.detail-view-toggle:nth(0)').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -43,7 +43,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="10"] > .slick-cell.l0').click();
     cy.get('[data-row="10"] > .slick-cell.l1').contains(/Task [0-9]*/);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -93,7 +93,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="0"] .slick-group-toggle.collapsed').click();
     cy.get('.slick-cell.l0.r0.detail-view-toggle:nth(0)').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -102,7 +102,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.detail-label input').should('exist');
 
     cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
-    cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
+    cy.get('.dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
   });
@@ -116,7 +116,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
     cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -144,7 +144,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
 
     let assigneeName = '';
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -172,7 +172,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
 
     let assigneeName = '';
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 

--- a/demos/react/test/cypress/e2e/example19.cy.ts
+++ b/demos/react/test/cypress/e2e/example19.cy.ts
@@ -136,7 +136,9 @@ describe('Example 19 - Row Detail View', () => {
 
     cy.get('@detailContainer0').find('h3').contains('Task 0');
 
-    cy.get('#grid19').find('.slick-row:nth(9)').click();
+    cy.get('#grid19')
+      .contains('.slick-row .slick-cell', /^Task 3$/)
+      .click();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_3 .container_3').as('detailContainer3');
 
@@ -242,21 +244,24 @@ describe('Example 19 - Row Detail View', () => {
       .then((text) => expect(text).to.eq('Task 1'));
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_101').should('not.exist');
+    cy.get('.editor-title').type('{esc}');
+    cy.get('#grid19').contains('.slick-row .slick-cell', /^Task 1$/);
   });
 
   it('should expect the Row Detail to be re-rendered after expanding/collapsing multiple times', () => {
-    cy.get('#grid19').find('.slick-row:nth(1) .slick-cell:nth(0)').as('toggle1');
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
+    const clickTask1Toggle = () => cy.get('#grid19').find('.slick-row[data-row="1"] .slick-cell.l0').click();
+
+    clickTask1Toggle();
+    clickTask1Toggle();
+    clickTask1Toggle();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('@detailContainer').should('not.exist');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
   });

--- a/demos/react/test/cypress/e2e/example45.cy.ts
+++ b/demos/react/test/cypress/e2e/example45.cy.ts
@@ -326,7 +326,7 @@ describe('Example 45 - Row Detail with inner Grid', () => {
       it('should go to the bottom end of the grid and open row 987', () => {
         cy.get('#grid45').type('{ctrl}{end}{ctrl}{end}', { release: false });
 
-        cy.get('.slick-row[data-row=1001] .detail-view-toggle').first().click();
+        cy.get('.slick-row[data-row=1001] .slick-cell.detail-view-toggle').click();
 
         cy.get('#innergrid-987 .search-filter.filter-orderId').as('orderIdSearch');
         cy.get('@orderIdSearch').clear();

--- a/demos/react/test/cypress/e2e/example47.cy.ts
+++ b/demos/react/test/cypress/e2e/example47.cy.ts
@@ -28,7 +28,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
   it('should open the 1st Row Detail of Duration(0) Group and expect to find some details', () => {
     cy.get('.slick-cell.l0.r0.detail-view-toggle:nth(0)').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -43,7 +43,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="10"] > .slick-cell.l0').click();
     cy.get('[data-row="10"] > .slick-cell.l1').contains(/Task [0-9]*/);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -93,7 +93,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="0"] .slick-group-toggle.collapsed').click();
     cy.get('.slick-cell.l0.r0.detail-view-toggle:nth(0)').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -102,7 +102,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.detail-label input').should('exist');
 
     cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
-    cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
+    cy.get('.dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
   });
@@ -116,7 +116,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
     cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -144,7 +144,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
 
     let assigneeName = '';
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -172,7 +172,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
 
     let assigneeName = '';
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 

--- a/demos/vue/test/cypress/e2e/example19.cy.ts
+++ b/demos/vue/test/cypress/e2e/example19.cy.ts
@@ -136,7 +136,9 @@ describe('Example 19 - Row Detail View', () => {
 
     cy.get('@detailContainer0').find('h3').contains('Task 0');
 
-    cy.get('#grid19').find('.slick-row:nth(9)').click();
+    cy.get('#grid19')
+      .contains('.slick-row .slick-cell', /^Task 3$/)
+      .click();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_3 .container_3').as('detailContainer3');
 
@@ -242,21 +244,24 @@ describe('Example 19 - Row Detail View', () => {
       .then((text) => expect(text).to.eq('Task 1'));
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_101').should('not.exist');
+    cy.get('.editor-title').type('{esc}');
+    cy.get('#grid19').contains('.slick-row .slick-cell', /^Task 1$/);
   });
 
   it('should expect the Row Detail to be re-rendered after expanding/collapsing multiple times', () => {
-    cy.get('#grid19').find('.slick-row:nth(1) .slick-cell:nth(0)').as('toggle1');
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
+    const clickTask1Toggle = () => cy.get('#grid19').find('.slick-row[data-row="1"] .slick-cell.l0').click();
+
+    clickTask1Toggle();
+    clickTask1Toggle();
+    clickTask1Toggle();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('@detailContainer').should('not.exist');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
   });

--- a/demos/vue/test/cypress/e2e/example45.cy.ts
+++ b/demos/vue/test/cypress/e2e/example45.cy.ts
@@ -326,7 +326,7 @@ describe('Example 45 - Row Detail with inner Grid', () => {
       it('should go to the bottom end of the grid and open row 987', () => {
         cy.get('#grid45').type('{ctrl}{end}{ctrl}{end}', { release: false });
 
-        cy.get('.slick-row[data-row=1001] .detail-view-toggle').first().click();
+        cy.get('.slick-row[data-row=1001] .slick-cell.detail-view-toggle').click();
 
         cy.get('#innergrid-987 .search-filter.filter-orderId').as('orderIdSearch');
         cy.get('@orderIdSearch').clear();

--- a/demos/vue/test/cypress/e2e/example47.cy.ts
+++ b/demos/vue/test/cypress/e2e/example47.cy.ts
@@ -28,7 +28,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
   it('should open the 1st Row Detail of Duration(0) Group and expect to find some details', () => {
     cy.get('.slick-cell.l0.r0.detail-view-toggle:nth(0)').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -43,7 +43,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="10"] > .slick-cell.l0').click();
     cy.get('[data-row="10"] > .slick-cell.l1').contains(/Task [0-9]*/);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -93,7 +93,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="0"] .slick-group-toggle.collapsed').click();
     cy.get('.slick-cell.l0.r0.detail-view-toggle:nth(0)').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -102,7 +102,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('.detail-label input').should('exist');
 
     cy.get('.slick-viewport-top.slick-viewport-left').scrollTo('top');
-    cy.get('.slick-cell + .dynamic-cell-detail').find('[data-test=delete-btn]').click();
+    cy.get('.dynamic-cell-detail').find('[data-test=delete-btn]').click();
     cy.get('.toast.text-bg-danger').contains(/Deleted row with Task [0-9]*/);
     cy.get('.dynamic-cell-detail').should('have.length', 0);
   });
@@ -116,7 +116,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
     cy.get('[data-row="1"] > .slick-cell.l1').contains(/Task [0-9]*/);
     cy.get('[data-row="1"] > .slick-cell.l0').click().wait(40);
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -144,7 +144,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
 
     let assigneeName = '';
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 
@@ -172,7 +172,7 @@ describe('Example 47 - Row Detail View + Grouping', () => {
 
     let assigneeName = '';
 
-    cy.get('.slick-cell + .dynamic-cell-detail')
+    cy.get('.dynamic-cell-detail')
       .find('h3')
       .contains(/Task [0-9]*/);
 

--- a/frameworks-plugins/angular-row-detail-plugin/src/angularRowDetailView.ts
+++ b/frameworks-plugins/angular-row-detail-plugin/src/angularRowDetailView.ts
@@ -52,8 +52,14 @@ export class AngularRowDetailView extends UniversalSlickRowDetailView {
     super(eventPubSubService);
   }
 
-  protected override shouldPreserveOverlay(): boolean {
-    return true;
+  protected override beforeDetailViewRender(item: any): void {
+    this._preloadCompRef?.destroy();
+    this._preloadCompRef = undefined;
+    this.disposeViewByItem(item);
+  }
+
+  protected override renderDetailView(item: any): void {
+    this.renderViewModel(item);
   }
 
   get addonOptions(): RowDetailViewOption {
@@ -154,20 +160,9 @@ export class AngularRowDetailView extends UniversalSlickRowDetailView {
         });
 
         this.eventHandler.subscribe(this.onAsyncEndUpdate, (e, args) => {
-          // destroy preload if exists
-          this._preloadCompRef?.destroy();
-          this.disposeViewByItem(args?.item);
-          this.refreshOverlayPanel(args?.item);
-
-          // triggers after backend called "onAsyncResponse.notify()"
-          // because of the preload destroy above, we need a small delay to make sure the DOM element is ready to render the Row Detail
-          queueMicrotask(() => {
-            this.renderViewModel(args?.item);
-
-            if (this.rowDetailViewOptions && typeof this.rowDetailViewOptions.onAsyncEndUpdate === 'function') {
-              this.rowDetailViewOptions.onAsyncEndUpdate(e, args);
-            }
-          });
+          if (this.rowDetailViewOptions && typeof this.rowDetailViewOptions.onAsyncEndUpdate === 'function') {
+            this.rowDetailViewOptions.onAsyncEndUpdate(e, args);
+          }
         });
 
         this.eventHandler.subscribe(

--- a/frameworks-plugins/aurelia-row-detail-plugin/src/aureliaRowDetailView.ts
+++ b/frameworks-plugins/aurelia-row-detail-plugin/src/aureliaRowDetailView.ts
@@ -40,8 +40,14 @@ export class AureliaRowDetailView extends UniversalSlickRowDetailView {
     super(eventPubSubService);
   }
 
-  protected override shouldPreserveOverlay(): boolean {
-    return true;
+  protected override beforeDetailViewRender(item: any): void {
+    this._preloadController?.dispose();
+    this._preloadController = undefined;
+    this.disposeView(item);
+  }
+
+  protected override renderDetailView(item: any): Promise<void> {
+    return this.renderViewModel(item);
   }
 
   get addonOptions() {
@@ -137,21 +143,10 @@ export class AureliaRowDetailView extends UniversalSlickRowDetailView {
             }
           });
 
-          this._eventHandler.subscribe(this.onAsyncEndUpdate, async (event, args) => {
-            // dispose preload if exists
-            this._preloadController?.dispose();
-            this.disposeView(args?.item);
-            this.refreshOverlayPanel(args?.item);
-
-            // triggers after backend called "onAsyncResponse.notify()"
-            // because of the preload destroy above, we need a small delay to make sure the DOM element is ready to render the Row Detail
-            queueMicrotask(async () => {
-              await this.renderViewModel(args?.item);
-
-              if (typeof this.rowDetailViewOptions?.onAsyncEndUpdate === 'function') {
-                this.rowDetailViewOptions.onAsyncEndUpdate(event, args);
-              }
-            });
+          this._eventHandler.subscribe(this.onAsyncEndUpdate, (event, args) => {
+            if (typeof this.rowDetailViewOptions?.onAsyncEndUpdate === 'function') {
+              this.rowDetailViewOptions.onAsyncEndUpdate(event, args);
+            }
           });
 
           this._eventHandler.subscribe(this.onAfterRowDetailToggle, async (event, args) => {
@@ -206,13 +201,10 @@ export class AureliaRowDetailView extends UniversalSlickRowDetailView {
           // we need to redraw the open detail views if we change column position (column reorder)
           this._eventHandler.subscribe(this._grid.onColumnsReordered, this.redrawAllViewSlots.bind(this, false));
 
-          // Aurelia's view update can complete one render cycle after SlickGrid
-          // has rebuilt rows (notably with autoHeight). Re-evaluate the overlay
-          // viewport after that DOM pass so a detail that returned to view is
-          // given its back-to-viewport callback and its inner grid can mount.
+          // Re-evaluate the overlay after SlickGrid has rebuilt its rows.
           this._eventHandler.subscribe(this._grid.onRendered, () => {
             if (this.isOverlayRenderMode) {
-              queueMicrotask(() => this.recalculateOutOfRangeViews(true, 0));
+              this.recalculateOutOfRangeViews(true, 0);
             }
           });
 

--- a/frameworks-plugins/react-row-detail-plugin/src/reactRowDetailView.ts
+++ b/frameworks-plugins/react-row-detail-plugin/src/reactRowDetailView.ts
@@ -44,8 +44,14 @@ export class ReactRowDetailView extends UniversalSlickRowDetailView {
     super(eventPubSubService);
   }
 
-  protected override shouldPreserveOverlay(): boolean {
-    return true;
+  protected override beforeDetailViewRender(item: any): void {
+    this._preloadRoot?.unmount();
+    this._preloadRoot = undefined;
+    this.disposeViewByItem(item);
+  }
+
+  protected override renderDetailView(item: any): void {
+    this.renderViewModel(item);
   }
 
   get addonOptions() {
@@ -152,25 +158,10 @@ export class ReactRowDetailView extends UniversalSlickRowDetailView {
             }
           });
 
-          this._eventHandler.subscribe(this.onAsyncEndUpdate, async (event, args) => {
-            // dispose preload if exists
-            this._preloadRoot?.unmount();
-            this._preloadRoot = undefined;
-            // An async response can replace an already-rendered detail panel. Unmount the
-            // previous React tree before the overlay panel is recreated, otherwise the next
-            // render would call createRoot() on the same container twice.
-            this.disposeViewByItem(args?.item);
-            this.refreshOverlayPanel(args?.item);
-
-            // triggers after backend called "onAsyncResponse.notify()"
-            // because of the preload destroy above, we need a small delay to make sure the DOM element is ready to render the Row Detail
-            queueMicrotask(() => {
-              this.renderViewModel(args?.item);
-
-              if (typeof this.rowDetailViewOptions?.onAsyncEndUpdate === 'function') {
-                this.rowDetailViewOptions.onAsyncEndUpdate(event, args);
-              }
-            });
+          this._eventHandler.subscribe(this.onAsyncEndUpdate, (event, args) => {
+            if (typeof this.rowDetailViewOptions?.onAsyncEndUpdate === 'function') {
+              this.rowDetailViewOptions.onAsyncEndUpdate(event, args);
+            }
           });
 
           this._eventHandler.subscribe(this.onAfterRowDetailToggle, async (event, args) => {

--- a/frameworks-plugins/vue-row-detail-plugin/src/vueRowDetailView.ts
+++ b/frameworks-plugins/vue-row-detail-plugin/src/vueRowDetailView.ts
@@ -44,8 +44,18 @@ export class VueRowDetailView extends UniversalSlickRowDetailView {
     super(eventPubSubService);
   }
 
-  protected override shouldPreserveOverlay(): boolean {
-    return true;
+  protected override beforeDetailViewRender(item: any): void {
+    if (this._preloadApp) {
+      this._preloadApp.unmount();
+      this._preloadElement?.remove();
+      this._preloadApp = undefined;
+      this._preloadElement = undefined;
+    }
+    this.disposeViewByItem(item);
+  }
+
+  protected override renderDetailView(item: any): void {
+    this.renderViewModel(item);
   }
 
   get addonOptions() {
@@ -152,26 +162,10 @@ export class VueRowDetailView extends UniversalSlickRowDetailView {
             }
           });
 
-          this._eventHandler.subscribe(this.onAsyncEndUpdate, async (event, args) => {
-            // unmount preload if exists AND remove it from DOM
-            if (this._preloadApp) {
-              this._preloadApp.unmount();
-              this._preloadElement?.remove();
-              this._preloadApp = undefined;
-              this._preloadElement = undefined;
+          this._eventHandler.subscribe(this.onAsyncEndUpdate, (event, args) => {
+            if (typeof this.rowDetailViewOptions?.onAsyncEndUpdate === 'function') {
+              this.rowDetailViewOptions.onAsyncEndUpdate(event, args);
             }
-            this.disposeViewByItem(args?.item);
-            this.refreshOverlayPanel(args?.item);
-
-            // triggers after backend called "onAsyncResponse.notify()"
-            // because of the preload destroy above, we need a small delay to make sure the DOM element is ready to render the Row Detail
-            queueMicrotask(async () => {
-              await this.renderViewModel(args?.item);
-
-              if (typeof this.rowDetailViewOptions?.onAsyncEndUpdate === 'function') {
-                this.rowDetailViewOptions.onAsyncEndUpdate(event, args);
-              }
-            });
           });
 
           this._eventHandler.subscribe(this.onAfterRowDetailToggle, async (event, args) => {

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example19.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example19.cy.ts
@@ -136,7 +136,9 @@ describe('Example 19 - Row Detail View', () => {
 
     cy.get('@detailContainer0').find('h3').contains('Task 0');
 
-    cy.get('#grid19').find('.slick-row:nth(9)').click();
+    cy.get('#grid19')
+      .contains('.slick-row .slick-cell', /^Task 3$/)
+      .click();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_3 .container_3').as('detailContainer3');
 
@@ -242,21 +244,24 @@ describe('Example 19 - Row Detail View', () => {
       .then((text) => expect(text).to.eq('Task 1'));
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_101').should('not.exist');
+    cy.get('.editor-title').type('{esc}');
+    cy.get('#grid19').contains('.slick-row .slick-cell', /^Task 1$/);
   });
 
   it('should expect the Row Detail to be re-rendered after expanding/collapsing multiple times', () => {
-    cy.get('#grid19').find('.slick-row:nth(1) .slick-cell:nth(0)').as('toggle1');
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
+    const clickTask1Toggle = () => cy.get('#grid19').find('.slick-row[data-row="1"] .slick-cell.l0').click();
+
+    clickTask1Toggle();
+    clickTask1Toggle();
+    clickTask1Toggle();
 
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('@detailContainer').should('not.exist');
 
-    cy.get('@toggle1').click();
+    clickTask1Toggle();
     cy.get('#grid19').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer');
     cy.get('@detailContainer').find('h3').contains('Task 1');
   });

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example19.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example19.cy.ts
@@ -57,7 +57,7 @@ describe('Example 19 - Row Detail View', () => {
       .find('[data-test=assignee-btn]')
       .click()
       .then(() => {
-        if (assignee === '') {
+        if (!assignee) {
           expect(alertStub.getCall(0)).to.be.calledWith('No one is assigned to this task.');
         } else {
           expect(alertStub.getCall(0)).to.be.calledWith(`Assignee on this task is: ${assignee.toUpperCase()}`);

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example45.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example45.cy.ts
@@ -325,7 +325,7 @@ describe('Example 45 - Row Detail with inner Grid', () => {
       it('should go to the bottom end of the grid and open row 987', () => {
         cy.get('#grid45').type('{ctrl}{end}', { release: false });
 
-        cy.get('.slick-row[data-row=1001] .detail-view-toggle').first().click();
+        cy.get('.slick-row[data-row=1001] .slick-cell.detail-view-toggle').click();
 
         cy.get('#innergrid-987 .search-filter.filter-orderId').as('orderIdSearch');
         cy.get('@orderIdSearch').clear();

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -36,7 +36,7 @@
     "build:incremental": "tsc --incremental --declaration",
     "clean": "remove dist tsconfig.tsbuildinfo",
     "dev": "node build-watch.mjs",
-    "sass:bundle": "remove dist/styles && pnpm run sass:build && pnpm run sass:copy",
+    "sass:bundle": "pnpm run sass:build && pnpm run sass:copy",
     "sass-build-task:scss-compile:default": "sass src/styles/slickgrid-theme-default.scss dist/styles/css/slickgrid-theme-default.css --style=compressed --quiet-deps --no-source-map --load-path=node_modules",
     "sass-build-task:scss-compile:default-lite": "sass src/styles/slickgrid-theme-default.lite.scss dist/styles/css/slickgrid-theme-default.lite.css --style=compressed --quiet-deps --no-source-map --load-path=node_modules",
     "sass-build-task:scss-compile:bootstrap": "sass src/styles/slickgrid-theme-bootstrap.scss dist/styles/css/slickgrid-theme-bootstrap.css --style=compressed --quiet-deps --no-source-map --load-path=node_modules",

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts
@@ -1,5 +1,6 @@
 import {
   createDomElement,
+  OnRowsChangedEventArgs,
   SlickEvent,
   SlickEventData,
   type Column,
@@ -93,6 +94,13 @@ describe('SlickRowDetailView plugin', () => {
     divContainer.className = `slickgrid-container ${GRID_UID}`;
     document.body.appendChild(divContainer);
     vi.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+    vi.mocked(gridStub.getRowCache).mockReturnValue({});
+    vi.mocked(dataviewStub.updateItem).mockImplementation(() => {
+      if ((plugin as any)._pendingAsyncEndUpdates.size > 0) {
+        dataviewStub.onRowsChanged.notify({ rows: [0] } as OnRowsChangedEventArgs);
+        gridStub.onRendered.notify({ startRow: 0, endRow: 0, grid: gridStub });
+      }
+    });
   });
 
   afterEach(() => {
@@ -200,7 +208,7 @@ describe('SlickRowDetailView plugin', () => {
   it('should invalidate all rows and re-render grid when "onRowsChanged" event is triggered', () => {
     const mockItem = { id: 1, firstName: 'John', lastName: 'Doe' };
     const mockProcess = vi.fn();
-    vi.spyOn(gridStub, 'getRowCache').mockReturnValueOnce({
+    vi.spyOn(gridStub, 'getRowCache').mockReturnValue({
       0: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
       1: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
       2: { rowNode: [document.createElement('div')], cellColSpans: [], cellNodesByColumnIdx: [], cellRenderQueue: [] },
@@ -209,7 +217,7 @@ describe('SlickRowDetailView plugin', () => {
     const invalidateRowsSpy = vi.spyOn(gridStub, 'invalidateRows');
     const renderSpy = vi.spyOn(gridStub, 'render');
     vi.spyOn(dataviewStub, 'getItemById').mockReturnValueOnce(mockItem);
-    vi.spyOn(dataviewStub, 'getRowById').mockReturnValueOnce(1).mockReturnValueOnce(1);
+    vi.spyOn(dataviewStub, 'getRowById').mockReturnValue(1);
     vi.spyOn(gridStub, 'getOptions').mockReturnValue({
       ...gridOptionsMock,
       rowDetailView: { process: mockProcess, columnIndexPosition: 0, useRowClick: true, maxRows: 2, panelRows: 2 } as any,
@@ -226,6 +234,10 @@ describe('SlickRowDetailView plugin', () => {
     expect(plugin.eventHandler).toBeTruthy();
     expect(invalidateRowsSpy).toHaveBeenCalledWith([1]); // only row 1 should be invalidated
     expect(renderSpy).toHaveBeenCalled();
+
+    (plugin as any)._renderedIds.add(mockItem.id);
+    dataviewStub.onRowsChanged.notify({ rows: [1] } as OnRowsChangedEventArgs);
+    expect(invalidateRowsSpy).toHaveBeenLastCalledWith([]);
   });
 
   it('should trigger "onAsyncResponse" when calling "expandDetailView()" when template is already cached from loadOnce', () => {
@@ -355,6 +367,24 @@ describe('SlickRowDetailView plugin', () => {
     expect(output).toEqual(parentItemMock);
   });
 
+  it('should never expand a Row Detail padding item', () => {
+    const processMock = vi.fn();
+    const updateItemSpy = vi.spyOn(dataviewStub, 'updateItem');
+    const paddingItem = { id: '1.1', title: 'Task 1', __collapsed: true, __isPadding: true };
+    vi.spyOn(dataviewStub, 'getItemById').mockReturnValue(paddingItem);
+    vi.spyOn(gridStub, 'getOptions').mockReturnValue({
+      ...gridOptionsMock,
+      rowDetailView: { process: processMock, panelRows: 2, useRowClick: true } as any,
+    });
+
+    plugin.init(gridStub);
+    plugin.expandDetailView(paddingItem.id);
+
+    expect((plugin as any).checkExpandableOverride(1, paddingItem, gridStub)).toBe(false);
+    expect(updateItemSpy).not.toHaveBeenCalled();
+    expect(processMock).not.toHaveBeenCalled();
+  });
+
   it('should trigger "onAsyncResponse" but throw an error when there is no item provided', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockReturnValue();
     const updateItemSpy = vi.spyOn(dataviewStub, 'updateItem');
@@ -458,9 +488,10 @@ describe('SlickRowDetailView plugin', () => {
     (plugin as any).renderOverlayPanels();
   });
 
-  it('should defer the async end update notification when overlay rendering is enabled', () => {
+  it('should wait for the actual grid render before notifying the async end update', () => {
     const asyncEndUpdateSpy = vi.spyOn(plugin.onAsyncEndUpdate, 'notify');
     const itemMock = { id: 123, firstName: 'John', lastName: 'Doe' };
+    vi.mocked(dataviewStub.updateItem).mockImplementation(() => undefined);
     vi.spyOn(gridStub, 'getOptions').mockReturnValue({
       ...gridOptionsMock,
       rowDetailView: { renderMode: 'overlay', postTemplate: () => '<span>Post</span>' } as any,
@@ -470,28 +501,74 @@ describe('SlickRowDetailView plugin', () => {
     plugin.onAsyncResponse.notify({ item: itemMock }, new SlickEventData());
 
     expect(asyncEndUpdateSpy).not.toHaveBeenCalled();
-    vi.runAllTimers();
+    gridStub.onRendered.notify({ startRow: 0, endRow: 0, grid: gridStub });
+    expect(asyncEndUpdateSpy).not.toHaveBeenCalled();
+
+    dataviewStub.onRowsChanged.notify({ rows: [0] } as OnRowsChangedEventArgs);
+    gridStub.onRendered.notify({ startRow: 0, endRow: 0, grid: gridStub });
     expect(asyncEndUpdateSpy).toHaveBeenCalledWith({ grid: gridStub, item: itemMock }, expect.anything(), plugin);
   });
 
-  it('should preserve the overlay for Aurelia view model adapters during async response', () => {
+  it('should call framework lifecycle hooks around the grid render', () => {
     const itemMock = { id: 123, firstName: 'John', lastName: 'Doe' };
-    const removeOverlayPanelSpy = vi.spyOn(plugin as any, 'removeOverlayPanel');
-    vi.spyOn(plugin as any, 'shouldPreserveOverlay').mockReturnValue(true);
+    const beforeRenderSpy = vi.spyOn(plugin as any, 'beforeDetailViewRender');
+    const renderDetailViewSpy = vi.spyOn(plugin as any, 'renderDetailView');
+    vi.mocked(dataviewStub.updateItem).mockImplementation(() => undefined);
     vi.spyOn(gridStub, 'getOptions').mockReturnValue({
       ...gridOptionsMock,
-      rowDetailView: {
-        renderMode: 'overlay',
-        viewModel: class DetailViewModel {},
-        preloadViewModel: class PreloadViewModel {},
-        postTemplate: () => '<span>Post</span>',
-      } as any,
+      rowDetailView: { postTemplate: () => '<span>Post</span>' } as any,
     });
 
     plugin.init(gridStub);
     plugin.onAsyncResponse.notify({ item: itemMock }, new SlickEventData());
 
-    expect(removeOverlayPanelSpy).not.toHaveBeenCalled();
+    expect(beforeRenderSpy).toHaveBeenCalledWith(itemMock);
+    expect(beforeRenderSpy.mock.invocationCallOrder[0]).toBeLessThan(vi.mocked(dataviewStub.updateItem).mock.invocationCallOrder[0]);
+    expect(renderDetailViewSpy).not.toHaveBeenCalled();
+
+    dataviewStub.onRowsChanged.notify({ rows: [0] } as OnRowsChangedEventArgs);
+    gridStub.onRendered.notify({ startRow: 0, endRow: 0, grid: gridStub });
+
+    expect(renderDetailViewSpy).toHaveBeenCalledWith(itemMock);
+  });
+
+  it('should finish updateItem before calling the framework render hook when the grid renders synchronously', () => {
+    const itemMock = { id: 123, firstName: 'John', lastName: 'Doe' };
+    const renderDetailViewSpy = vi.spyOn(plugin as any, 'renderDetailView');
+    let updateItemCompleted = false;
+    vi.mocked(dataviewStub.updateItem).mockImplementation(() => {
+      dataviewStub.onRowsChanged.notify({ rows: [0] } as OnRowsChangedEventArgs);
+      gridStub.onRendered.notify({ startRow: 0, endRow: 0, grid: gridStub });
+      expect(renderDetailViewSpy).not.toHaveBeenCalled();
+      updateItemCompleted = true;
+    });
+    renderDetailViewSpy.mockImplementation(() => expect(updateItemCompleted).toBe(true));
+    vi.spyOn(gridStub, 'getOptions').mockReturnValue({
+      ...gridOptionsMock,
+      rowDetailView: { postTemplate: () => '<span>Post</span>' } as any,
+    });
+
+    plugin.init(gridStub);
+    plugin.onAsyncResponse.notify({ item: itemMock }, new SlickEventData());
+
+    expect(renderDetailViewSpy).toHaveBeenCalledWith(itemMock);
+  });
+
+  it('should wait for an async framework render hook before notifying the async end update', async () => {
+    const itemMock = { id: 123, firstName: 'John', lastName: 'Doe' };
+    const asyncEndUpdateSpy = vi.spyOn(plugin.onAsyncEndUpdate, 'notify');
+    vi.spyOn(plugin as any, 'renderDetailView').mockResolvedValue(undefined);
+    vi.spyOn(gridStub, 'getOptions').mockReturnValue({
+      ...gridOptionsMock,
+      rowDetailView: { postTemplate: () => '<span>Post</span>' } as any,
+    });
+
+    plugin.init(gridStub);
+    plugin.onAsyncResponse.notify({ item: itemMock }, new SlickEventData());
+
+    expect(asyncEndUpdateSpy).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(asyncEndUpdateSpy).toHaveBeenCalledWith({ grid: gridStub, item: itemMock }, expect.anything(), plugin);
   });
 
   it('should trigger "onAsyncResponse" with Row Detail from post template with HTML Element when no detailView is provided and expect "updateItem" from DataView to be called with new template & data', () => {

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -70,6 +70,8 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   protected _renderedIds: Set<number | string> = new Set();
   protected _overlayHosts: Map<HTMLElement, HTMLDivElement> = new Map();
   protected _overlayPanels: Map<number | string, HTMLDivElement> = new Map();
+  protected _pendingAsyncEndUpdates: Map<number | string, { eventData: SlickEventData; item: any; isDataViewUpdated: boolean }> = new Map();
+  protected _isUpdatingAsyncResponse = false;
   protected _visibleRenderedCell?: { startRow: number; endRow: number };
   protected _backViewportTimer: any;
   protected _defaults = {
@@ -136,11 +138,6 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     return this._addonOptions?.renderMode === 'overlay';
   }
 
-  /** Framework adapters override this when they own the mounted overlay DOM. */
-  protected shouldPreserveOverlay(): boolean {
-    return false;
-  }
-
   set rowIdsOutOfViewport(rowIds: Array<string | number>) {
     this._rowIdsOutOfViewport = new Set(rowIds);
   }
@@ -192,6 +189,11 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     });
 
     this._eventHandler.subscribe(this.dataView.onRowsChanged, (_e, args) => {
+      // A suspended DataView only emits this event when endUpdate() releases its
+      // accumulated changes. Pending details are safe to finish on the grid render
+      // caused by this notification, not on an unrelated render in the meantime.
+      this._pendingAsyncEndUpdates.forEach((pendingUpdate) => (pendingUpdate.isDataViewUpdated = true));
+
       const cachedRows = Object.keys(this._grid.getRowCache()).map(Number);
       const toInvalidateRows: number[] = [];
       const intersectedRows = args.rows.filter((nb) => cachedRows.includes(nb));
@@ -228,10 +230,12 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
       this._dataViewIdProperty = this.dataView.getIdPropertyName() || 'id';
     });
 
-    this._eventHandler.subscribe(this._grid.onRendered, () => this.isOverlayRenderMode && this.renderOverlayPanels());
-    if (this.isOverlayRenderMode) {
-      queueMicrotask(() => this.renderOverlayPanels());
-    }
+    this._eventHandler.subscribe(this._grid.onRendered, () => {
+      this.isOverlayRenderMode && this.renderOverlayPanels();
+      if (!this._isUpdatingAsyncResponse) {
+        this.flushPendingAsyncEndUpdates();
+      }
+    });
   }
 
   /** Dispose of the Slick Row Detail View */
@@ -241,6 +245,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     this._expandedRowIds.clear();
     this._rowIdsOutOfViewport.clear();
     this._renderedViewportRowIds.clear();
+    this._pendingAsyncEndUpdates.clear();
     clearTimeout(this._backViewportTimer);
   }
 
@@ -350,7 +355,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   /** Expand a row given the dataview item that is to be expanded */
   expandDetailView(itemId: number | string): void {
     const item = this.dataView.getItemById(itemId);
-    if (item) {
+    if (item && !item[`${this._keyPrefix}isPadding`]) {
       if (this._addonOptions?.singleRowExpand) {
         this.collapseAll();
       }
@@ -426,40 +431,27 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
 
     // get item detail argument
     const itemDetail = args.item;
-    const shouldPreserveOverlay = this.shouldPreserveOverlay();
-    if (!shouldPreserveOverlay) {
-      this.removeOverlayPanel(itemDetail[this._dataViewIdProperty]);
-    }
+    const itemId = itemDetail[this._dataViewIdProperty];
+    this.beforeDetailViewRender(itemDetail);
 
     // if we just want to load in a view directly we can use detailView property to do so
     itemDetail[`${this._keyPrefix}detailContent`] = args.detailView ?? this._addonOptions?.postTemplate?.(itemDetail);
     itemDetail[`${this._keyPrefix}detailViewLoaded`] = true;
-    this.dataView.updateItem(itemDetail[this._dataViewIdProperty], itemDetail);
-    // A framework adapter may mount its nested component from onAsyncEndUpdate before
-    // the grid's onRendered event is emitted. Ensure the post-template overlay exists
-    // before notifying adapters so their mount target is connected to the DOM.
-    this.isOverlayRenderMode && !shouldPreserveOverlay && this.renderOverlayPanels();
-
-    // trigger an event once the post template is finished loading
-    this._renderedIds.add(itemDetail[this.dataViewIdProperty]);
-    const notifyAsyncEndUpdate = () =>
-      this.onAsyncEndUpdate.notify(
-        {
-          grid: this._grid,
-          item: itemDetail,
-        },
-        e,
-        this
-      );
-
-    // Overlay panels are mounted from the grid's onRendered event. Defer framework
-    // callbacks by one microtask so custom adapters can safely find the post-template
-    // container before mounting nested components.
-    if (this.isOverlayRenderMode) {
-      queueMicrotask(notifyAsyncEndUpdate);
-    } else {
-      notifyAsyncEndUpdate();
+    // DataView updates can be suspended by beginUpdate()/endUpdate(). Keep the response
+    // pending before updateItem() so onRowsChanged can identify when that update is
+    // released and the following grid render can safely mount the framework view.
+    this._pendingAsyncEndUpdates.set(itemId, {
+      eventData: e,
+      item: itemDetail,
+      isDataViewUpdated: false,
+    });
+    this._isUpdatingAsyncResponse = true;
+    try {
+      this.dataView.updateItem(itemDetail[this._dataViewIdProperty], itemDetail);
+    } finally {
+      this._isUpdatingAsyncResponse = false;
     }
+    this.flushPendingAsyncEndUpdates();
   }
 
   /**
@@ -642,6 +634,43 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   // protected functions
   // ------------------
 
+  /** Framework adapters can synchronously dispose their preload/current view before SlickGrid replaces its template. */
+  protected beforeDetailViewRender(_item: any): void {}
+
+  /** Framework adapters can mount their view after SlickGrid rendered. */
+  protected renderDetailView(_item: any): void | Promise<void> {}
+
+  /** Complete pending async responses only after SlickGrid has finished its actual render cycle. */
+  protected flushPendingAsyncEndUpdates(): void {
+    for (const [itemId, { eventData, item, isDataViewUpdated }] of this._pendingAsyncEndUpdates) {
+      if (!isDataViewUpdated) {
+        continue;
+      }
+      this._pendingAsyncEndUpdates.delete(itemId);
+      this._renderedIds.add(itemId);
+      if (this.isOverlayRenderMode) {
+        this.refreshOverlayPanel(item);
+      }
+
+      const renderResult = this.renderDetailView(item);
+      const notifyAsyncEndUpdate = () =>
+        this.onAsyncEndUpdate.notify(
+          {
+            grid: this._grid,
+            item,
+          },
+          eventData,
+          this
+        );
+
+      if (renderResult instanceof Promise) {
+        void renderResult.then(notifyAsyncEndUpdate);
+      } else {
+        notifyAsyncEndUpdate();
+      }
+    }
+  }
+
   /** Render all expanded panels in sibling overlay layers of their grid canvases. */
   protected renderOverlayPanels(): void {
     if (!this.isOverlayRenderMode || !this._grid) {
@@ -729,7 +758,7 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
     // Keep the outer panel node stable while a framework adapter transitions from
     // its preload component to the real detail component. Replacing the panel
     // itself can detach a React/Vue/Angular tree in the middle of its commit.
-    const innerDetailView = panel.querySelector<HTMLElement>(`.innerDetailView_${itemId}`);
+    const innerDetailView = panel.getElementsByClassName(`innerDetailView_${itemId}`).item(0) as HTMLElement | null;
     if (innerDetailView) {
       this.renderDetailContent(innerDetailView, item);
     }
@@ -830,6 +859,9 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   }
 
   protected checkExpandableOverride(row: number, dataContext: any, grid: SlickGrid): boolean {
+    if (dataContext?.[`${this._keyPrefix}isPadding`]) {
+      return false;
+    }
     if (typeof this._expandableOverride === 'function') {
       return this._expandableOverride(row, dataContext, grid);
     }
@@ -868,46 +900,43 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   ): FormatterResultWithHtml | HTMLElement | '' {
     if (!this.checkExpandableOverride(row, dataContext, grid)) {
       return '';
-    } else {
-      if (dataContext[`${this._keyPrefix}collapsed`] === undefined) {
-        dataContext[`${this._keyPrefix}collapsed`] = true;
-        dataContext[`${this._keyPrefix}sizePadding`] = 0; // the required number of pading rows
-        dataContext[`${this._keyPrefix}height`] = 0; // the actual height in pixels of the detail field
-        dataContext[`${this._keyPrefix}isPadding`] = false;
-        dataContext[`${this._keyPrefix}parent`] = undefined;
-        dataContext[`${this._keyPrefix}offset`] = 0;
+    }
+
+    if (dataContext[`${this._keyPrefix}collapsed`] === undefined) {
+      dataContext[`${this._keyPrefix}collapsed`] = true;
+      dataContext[`${this._keyPrefix}sizePadding`] = 0; // the required number of pading rows
+      dataContext[`${this._keyPrefix}height`] = 0; // the actual height in pixels of the detail field
+      dataContext[`${this._keyPrefix}isPadding`] = false;
+      dataContext[`${this._keyPrefix}parent`] = undefined;
+      dataContext[`${this._keyPrefix}offset`] = 0;
+    }
+
+    if (dataContext[`${this._keyPrefix}collapsed`]) {
+      let collapsedClasses = `sgi ${this._addonOptions.cssClass || ''} expand `;
+      if (this._addonOptions.collapsedClass) {
+        collapsedClasses += this._addonOptions.collapsedClass;
       }
+      return createDomElement('div', { className: classNameToList(collapsedClasses).join(' '), ariaExpanded: 'false' });
+    }
 
-      if (dataContext[`${this._keyPrefix}isPadding`]) {
-        // render nothing
-      } else if (dataContext[`${this._keyPrefix}collapsed`]) {
-        let collapsedClasses = `sgi ${this._addonOptions.cssClass || ''} expand `;
-        if (this._addonOptions.collapsedClass) {
-          collapsedClasses += this._addonOptions.collapsedClass;
-        }
-        return createDomElement('div', { className: classNameToList(collapsedClasses).join(' '), ariaExpanded: 'false' });
-      } else {
-        let expandedClasses = `sgi ${this._addonOptions.cssClass || ''} collapse `;
-        if (this._addonOptions.expandedClass) {
-          expandedClasses += this._addonOptions.expandedClass;
-        }
+    let expandedClasses = `sgi ${this._addonOptions.cssClass || ''} collapse `;
+    if (this._addonOptions.expandedClass) {
+      expandedClasses += this._addonOptions.expandedClass;
+    }
 
-        const result: FormatterResultWithHtml = {
-          html: createDomElement('div', { className: classNameToList(expandedClasses).join(' '), ariaExpanded: 'true' }),
-        };
+    const result: FormatterResultWithHtml = {
+      html: createDomElement('div', { className: classNameToList(expandedClasses).join(' '), ariaExpanded: 'true' }),
+    };
 
-        // @deprecated v11: always mount the detail panel in the overlay layer.
-        if (!this.isOverlayRenderMode) {
-          const detailPanel = this.createDetailViewElement(dataContext, row);
-          if (detailPanel) {
-            result.insertElementAfterTarget = detailPanel;
-          }
-        }
-
-        return result;
+    // @deprecated v11: always mount the detail panel in the overlay layer.
+    if (!this.isOverlayRenderMode) {
+      const detailPanel = this.createDetailViewElement(dataContext, row);
+      if (detailPanel) {
+        result.insertElementAfterTarget = detailPanel;
       }
     }
-    return '';
+
+    return result;
   }
 
   /** When row is getting toggled, we will handle the action of collapsing/expanding */

--- a/test/cypress/e2e/example20.cy.ts
+++ b/test/cypress/e2e/example20.cy.ts
@@ -128,7 +128,9 @@ describe('Example 20 - Row Detail View', () => {
 
     cy.get('.grid20').find('.dynamic-cell-detail .innerDetailView_1').as('detailContainer1');
     cy.get('@detailContainer1').find('h4').contains('Task 1');
-    cy.get('.grid20').find('.slick-row:nth(9) .slick-cell:nth(1)').click();
+    cy.get('.grid20')
+      .contains('.slick-row .slick-cell', /^Task 5$/)
+      .click();
     cy.get('.grid20').find('.dynamic-cell-detail .innerDetailView_5').as('detailContainer5');
     cy.get('@detailContainer5').find('h4').contains('Task 5');
 
@@ -252,10 +254,19 @@ describe('Example 20 - Row Detail View', () => {
   });
 
   it('should expect the Row Detail to be re-rendered after expanding/collapsing multiple times', () => {
-    cy.get('.grid20').find('.slick-row:nth(5) .slick-cell:nth(1)').as('toggle1');
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
-    cy.get('@toggle1').click();
+    const clickTask9Toggle = () =>
+      cy
+        .get('.grid20 .slick-row')
+        .filter(
+          (_index, row) =>
+            row.querySelector('.cell-title')?.textContent?.trim() === 'Task 9' && !!row.querySelector('.detail-view-toggle .sgi')
+        )
+        .find('.detail-view-toggle')
+        .click();
+
+    clickTask9Toggle();
+    clickTask9Toggle();
+    clickTask9Toggle();
 
     cy.get('.grid20').find('.dynamic-cell-detail .innerDetailView_9').as('detailContainer');
     cy.get('@detailContainer').find('h4').contains('Task 9');

--- a/test/cypress/e2e/example20.cy.ts
+++ b/test/cypress/e2e/example20.cy.ts
@@ -130,7 +130,10 @@ describe('Example 20 - Row Detail View', () => {
     cy.get('@detailContainer1').find('h4').contains('Task 1');
     cy.get('.grid20')
       .contains('.slick-row .slick-cell', /^Task 5$/)
-      .click();
+      .closest('.slick-row')
+      .find('.slick-cell.detail-view-toggle')
+      .click()
+      .wait(40);
     cy.get('.grid20').find('.dynamic-cell-detail .innerDetailView_5').as('detailContainer5');
     cy.get('@detailContainer5').find('h4').contains('Task 5');
 
@@ -261,7 +264,7 @@ describe('Example 20 - Row Detail View', () => {
           (_index, row) =>
             row.querySelector('.cell-title')?.textContent?.trim() === 'Task 9' && !!row.querySelector('.detail-view-toggle .sgi')
         )
-        .find('.detail-view-toggle')
+        .find('.slick-cell.detail-view-toggle')
         .click();
 
     clickTask9Toggle();

--- a/test/cypress/e2e/example21.cy.ts
+++ b/test/cypress/e2e/example21.cy.ts
@@ -327,7 +327,7 @@ describe('Example 21 - Row Detail with inner Grid', () => {
       it('should go to the bottom end of the grid and open row 987', () => {
         cy.get('.grid21').type('{ctrl}{end}{ctrl}{end}', { release: false });
 
-        cy.get('.slick-row[data-row=1001] .detail-view-toggle').first().click();
+        cy.get('.slick-row[data-row=1001] .slick-cell.detail-view-toggle').click();
 
         cy.get('.innergrid-987 .search-filter.filter-orderId').as('orderIdSearch');
         cy.get('@orderIdSearch').clear();


### PR DESCRIPTION
## Summary

- replace RowDetail `queueMicrotask` coordination with the DataView
  `onRowsChanged` and SlickGrid `onRendered` lifecycle
- add framework lifecycle hooks to dispose preload views before updating the
  DataView and mount detail views after SlickGrid finishes rendering
- await asynchronous framework render hooks before notifying
  `onAsyncEndUpdate`, while keeping synchronous wrappers synchronous
- preserve overlay panel elements while framework components are replaced
- prevent RowDetail padding rows from being expanded
- safely locate overlay elements when item IDs contain selector characters
- keep compiled Sass files available during watch-mode rebuilds
- stabilize RowDetail Cypress tests across Angular, Aurelia, React, Vue, and
  SlickGrid Universal

## Testing

- Angular Cypress tests
- `pnpm test:coverage --run packages/row-detail-view-plugin/src/slickRowDetailView.spec.ts`
  - 57 tests passed
  - 100% statement, function, and line coverage for `slickRowDetailView.ts`
- `pnpm exec tsc -p packages/row-detail-view-plugin/tsconfig.json --noEmit`
- `pnpm lint`
- Prettier check
- `git diff --check`

## LLM

Implemented with OpenAI Codex using GPT-5.6 Sol.