### PR TITLE
fix(security): harden dynamic object maps against prototype pollution

### DIFF
--- a/packages/common/src/aggregators/__tests__/sumAggregator.spec.ts
+++ b/packages/common/src/aggregators/__tests__/sumAggregator.spec.ts
@@ -60,6 +60,21 @@ describe('sumAggregator', () => {
       const total = 58 + 14 + 87;
       expect(groupTotals.sum[fieldName]).toBe(total);
     });
+
+    it('should safely store a field name that matches an Object prototype property', () => {
+      delete (Object.prototype as any).polluted;
+      const fieldName = '__proto__';
+      const groupTotals: GroupTotals = {};
+      const item = JSON.parse('{"__proto__":5}');
+      aggregator = new SumAggregator(fieldName);
+      aggregator.init();
+      aggregator.accumulate(item);
+      aggregator.storeResult(groupTotals);
+
+      expect(Object.prototype.hasOwnProperty.call(groupTotals.sum, fieldName)).toBe(true);
+      expect(groupTotals.sum[fieldName]).toBe(5);
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
   });
 
   describe('Tree Aggregator', () => {

--- a/packages/common/src/aggregators/avgAggregator.ts
+++ b/packages/common/src/aggregators/avgAggregator.ts
@@ -22,12 +22,12 @@ export class AvgAggregator extends BaseAggregatorClass implements Aggregator {
     this._isTreeAggregator = isTreeAggregator;
     if (isTreeAggregator) {
       if (!item.__treeTotals) {
-        item.__treeTotals = {};
+        item.__treeTotals = Object.create(null);
       }
       if (item.__treeTotals[this._type] === undefined) {
-        item.__treeTotals[this._type] = {};
-        item.__treeTotals.sum = {};
-        item.__treeTotals.count = {};
+        item.__treeTotals[this._type] = Object.create(null);
+        item.__treeTotals.sum = Object.create(null);
+        item.__treeTotals.count = Object.create(null);
       }
       item.__treeTotals[this._type][this._field] = 0;
       item.__treeTotals['count'][this._field] = 0;
@@ -48,7 +48,7 @@ export class AvgAggregator extends BaseAggregatorClass implements Aggregator {
     } else {
       if (isTreeParent) {
         if (!item.__treeTotals) {
-          item.__treeTotals = {};
+          item.__treeTotals = Object.create(null);
         }
         this.addGroupTotalPropertiesWhenNotExist(item.__treeTotals);
         this._sum = parseFloat(item.__treeTotals['sum'][this._field] ?? 0);
@@ -81,13 +81,13 @@ export class AvgAggregator extends BaseAggregatorClass implements Aggregator {
 
   protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     if (this._isTreeAggregator && groupTotals['sum'] === undefined) {
-      groupTotals['sum'] = {};
+      groupTotals['sum'] = Object.create(null);
     }
     if (this._isTreeAggregator && groupTotals['count'] === undefined) {
-      groupTotals['count'] = {};
+      groupTotals['count'] = Object.create(null);
     }
   }
 }

--- a/packages/common/src/aggregators/cloneAggregator.ts
+++ b/packages/common/src/aggregators/cloneAggregator.ts
@@ -27,7 +27,7 @@ export class CloneAggregator extends BaseAggregatorClass implements Aggregator {
 
   storeResult(groupTotals: GroupTotals): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     groupTotals[this._type][this._field] = this._data;
   }

--- a/packages/common/src/aggregators/countAggregator.ts
+++ b/packages/common/src/aggregators/countAggregator.ts
@@ -19,10 +19,10 @@ export class CountAggregator extends BaseAggregatorClass implements Aggregator {
     // when dealing with Tree Data structure, we also need to keep sum & itemCount refs
     if (isTreeAggregator) {
       if (!item.__treeTotals) {
-        item.__treeTotals = {};
+        item.__treeTotals = Object.create(null);
       }
       if (item.__treeTotals[this._type] === undefined) {
-        item.__treeTotals[this._type] = {};
+        item.__treeTotals[this._type] = Object.create(null);
       }
       item.__treeTotals[this._type][this._field] = 0;
     }
@@ -35,10 +35,10 @@ export class CountAggregator extends BaseAggregatorClass implements Aggregator {
     if (this._isTreeAggregator) {
       if (isTreeParent) {
         if (!item.__treeTotals) {
-          item.__treeTotals = {};
+          item.__treeTotals = Object.create(null);
         }
         if (item.__treeTotals[this._type] === undefined) {
-          item.__treeTotals[this._type] = {};
+          item.__treeTotals[this._type] = Object.create(null);
         }
         this._count = item.__treeTotals[this._type][this._field] ?? 0;
       } else if (isNumber(val)) {
@@ -49,7 +49,7 @@ export class CountAggregator extends BaseAggregatorClass implements Aggregator {
 
   storeResult(groupTotals: GroupTotals<number | number[]>): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     let itemCount = this._count;
 

--- a/packages/common/src/aggregators/distinctAggregator.ts
+++ b/packages/common/src/aggregators/distinctAggregator.ts
@@ -27,7 +27,7 @@ export class DistinctAggregator extends BaseAggregatorClass implements Aggregato
 
   storeResult(groupTotals: GroupTotals<any[]>): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     groupTotals[this._type][this._field] = this._distinctValues;
   }

--- a/packages/common/src/aggregators/maxAggregator.ts
+++ b/packages/common/src/aggregators/maxAggregator.ts
@@ -19,10 +19,10 @@ export class MaxAggregator extends BaseAggregatorClass implements Aggregator {
     this._isTreeAggregator = isTreeAggregator;
     if (isTreeAggregator) {
       if (!item.__treeTotals) {
-        item.__treeTotals = {};
+        item.__treeTotals = Object.create(null);
       }
       if (item.__treeTotals[this._type] === undefined) {
-        item.__treeTotals[this._type] = {};
+        item.__treeTotals[this._type] = Object.create(null);
       }
       item.__treeTotals[this._type][this._field] = null;
     }
@@ -38,7 +38,7 @@ export class MaxAggregator extends BaseAggregatorClass implements Aggregator {
     } else {
       if (isTreeParent) {
         if (!item.__treeTotals) {
-          item.__treeTotals = {};
+          item.__treeTotals = Object.create(null);
         }
         this.addGroupTotalPropertiesWhenNotExist(item.__treeTotals);
         const parentMax =
@@ -68,7 +68,7 @@ export class MaxAggregator extends BaseAggregatorClass implements Aggregator {
 
   protected addGroupTotalPropertiesWhenNotExist(groupTotals: GroupTotals): void {
     if (groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
   }
 

--- a/packages/common/src/aggregators/minAggregator.ts
+++ b/packages/common/src/aggregators/minAggregator.ts
@@ -19,10 +19,10 @@ export class MinAggregator extends BaseAggregatorClass implements Aggregator {
     this._isTreeAggregator = isTreeAggregator;
     if (isTreeAggregator) {
       if (!item.__treeTotals) {
-        item.__treeTotals = {};
+        item.__treeTotals = Object.create(null);
       }
       if (item.__treeTotals[this._type] === undefined) {
-        item.__treeTotals[this._type] = {};
+        item.__treeTotals[this._type] = Object.create(null);
       }
       item.__treeTotals[this._type][this._field] = null;
     }
@@ -38,7 +38,7 @@ export class MinAggregator extends BaseAggregatorClass implements Aggregator {
     } else {
       if (isTreeParent) {
         if (!item.__treeTotals) {
-          item.__treeTotals = {};
+          item.__treeTotals = Object.create(null);
         }
         this.addGroupTotalPropertiesWhenNotExist(item.__treeTotals);
         const parentMin =
@@ -68,7 +68,7 @@ export class MinAggregator extends BaseAggregatorClass implements Aggregator {
 
   protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
   }
 

--- a/packages/common/src/aggregators/sumAggregator.ts
+++ b/packages/common/src/aggregators/sumAggregator.ts
@@ -21,11 +21,11 @@ export class SumAggregator extends BaseAggregatorClass implements Aggregator {
     // when dealing with Tree Data structure, we also need to keep sum & itemCount refs
     if (isTreeAggregator) {
       if (!item.__treeTotals) {
-        item.__treeTotals = {};
+        item.__treeTotals = Object.create(null);
       }
       if (item.__treeTotals[this._type] === undefined) {
-        item.__treeTotals[this._type] = {};
-        item.__treeTotals.count = {};
+        item.__treeTotals[this._type] = Object.create(null);
+        item.__treeTotals.count = Object.create(null);
       }
       item.__treeTotals['count'][this._field] = 0;
       item.__treeTotals[this._type][this._field] = 0;
@@ -44,7 +44,7 @@ export class SumAggregator extends BaseAggregatorClass implements Aggregator {
     } else {
       if (isTreeParent) {
         if (!item.__treeTotals) {
-          item.__treeTotals = {};
+          item.__treeTotals = Object.create(null);
         }
         this.addGroupTotalPropertiesWhenNotExist(item.__treeTotals);
         this._sum = parseFloat(item.__treeTotals[this._type][this._field] ?? 0);
@@ -58,7 +58,7 @@ export class SumAggregator extends BaseAggregatorClass implements Aggregator {
 
   storeResult(groupTotals: GroupTotals): void {
     if (!groupTotals || groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     this.addGroupTotalPropertiesWhenNotExist(groupTotals);
     let sum = this._sum;
@@ -75,10 +75,10 @@ export class SumAggregator extends BaseAggregatorClass implements Aggregator {
 
   protected addGroupTotalPropertiesWhenNotExist(groupTotals: any): void {
     if (groupTotals[this._type] === undefined) {
-      groupTotals[this._type] = {};
+      groupTotals[this._type] = Object.create(null);
     }
     if (this._isTreeAggregator && groupTotals['count'] === undefined) {
-      groupTotals['count'] = {};
+      groupTotals['count'] = Object.create(null);
     }
   }
 }

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -7235,6 +7235,20 @@ describe('SlickGrid core file', () => {
       );
     });
 
+    it('should support CSS style keys that match Object prototype properties', () => {
+      grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });
+      const hash = { 0: { age: 'highlight' } };
+
+      grid.addCellCssStyles('__proto__', hash);
+      grid.addCellCssStyles('constructor', hash);
+      grid.addCellCssStyles('toString', hash);
+
+      expect(grid.getCellCssStyles('__proto__')).toBe(hash);
+      expect(grid.getCellCssStyles('constructor')).toBe(hash);
+      expect(grid.getCellCssStyles('toString')).toBe(hash);
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
+
     it('should exit early when trying to remove CSS Style key that does not exist in hash', () => {
       const hashCopy = { ...hash };
       grid = new SlickGrid<any, Column>(container, items, columns, { ...defaultOptions, enableCellNavigation: true });

--- a/packages/common/src/core/slickDataview.ts
+++ b/packages/common/src/core/slickDataview.ts
@@ -613,9 +613,9 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
     // Also update the rows? no need since the `refresh()`, further down, blows away the `rows[]` cache and recalculates it via `recalc()`!
     if (!this.updated) {
-      this.updated = {};
+      this.updated = Object.create(null);
     }
-    this.updated[id] = true;
+    this.updated![id] = true;
   }
 
   /**
@@ -1002,7 +1002,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     let group: SlickGroup;
     let val: any;
     const groups: SlickGroup[] = [];
-    const groupsByVal: any = {};
+    const groupsByVal: Record<string, SlickGroup> = Object.create(null);
     let r;
     const level = parentGroup ? parentGroup.level + 1 : 0;
     const gi = this.groupingInfos[level];

--- a/packages/common/src/core/slickGrid.ts
+++ b/packages/common/src/core/slickGrid.ts
@@ -460,8 +460,8 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
   protected selectedRanges: SlickRange[] = [];
 
   protected plugins: SlickPlugin[] = [];
-  protected cellCssClasses: CssStyleHash = {};
-  protected cellCssClassesByCell: CssStyleHash = {};
+  protected cellCssClasses: CssStyleHash = Object.create(null);
+  protected cellCssClassesByCell: CssStyleHash = Object.create(null);
 
   protected columnsById: Record<string, number> = Object.create(null);
   protected visibleColumnsById: Record<string, number> = Object.create(null);
@@ -3536,13 +3536,13 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
     this.selectionRightCell = -1;
     this.dragReplaceEl.removeEl();
     this.selectedRows = [];
-    const hash: CssStyleHash = {};
+    const hash: CssStyleHash = Object.create(null);
     for (let i = 0; i < ranges.length; i++) {
       for (let j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
         if (!hash[j]) {
           // prevent duplicates
           this.selectedRows.push(j);
-          hash[j] = {};
+          hash[j] = Object.create(null);
         }
         for (let k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
           if (this.canCellBeSelected(j, k)) {
@@ -6164,11 +6164,11 @@ export class SlickGrid<TData = any, C extends Column<TData> = Column<TData>, O e
 
   /** Merges the keyed CSS overlays once on update, rather than for every rendered cell. */
   protected updateCellCssClassesByCell(): void {
-    this.cellCssClassesByCell = {};
+    this.cellCssClassesByCell = Object.create(null);
 
     Object.values(this.cellCssClasses).forEach((hash) => {
       Object.entries(hash).forEach(([row, cellClasses]) => {
-        const mergedRowClasses = (this.cellCssClassesByCell[row] ??= {});
+        const mergedRowClasses = (this.cellCssClassesByCell[row] ??= Object.create(null));
         Object.entries(cellClasses).forEach(([columnId, cssClasses]) => {
           if (cssClasses) {
             mergedRowClasses[columnId] = mergedRowClasses[columnId] ? `${mergedRowClasses[columnId]} ${cssClasses}` : cssClasses;

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -532,10 +532,10 @@ export class SlickCellExternalCopyManager {
     this.clearCopySelection();
 
     const columns = this._grid.getColumns();
-    const hash: CssStyleHash = {};
+    const hash: CssStyleHash = Object.create(null);
     for (const range of ranges) {
       for (let j = range.fromRow; j <= range.toRow; j++) {
-        hash[j] = {};
+        hash[j] = Object.create(null);
         for (let k = range.fromCell; k <= range.toCell && k < columns.length; k++) {
           hash[j][columns[k].id] = this._copiedCellStyle;
         }

--- a/packages/common/src/extensions/slickRowBasedEdit.ts
+++ b/packages/common/src/extensions/slickRowBasedEdit.ts
@@ -59,7 +59,7 @@ export class SlickRowBasedEdit {
 
   private _existingEditCommandHandler: ((item: any, column: Column<any>, command: EditCommand) => void) | undefined;
   protected _currentLang = 'en';
-  private _translations: { [locale: string]: ButtonTranslation } = {};
+  private _translations: { [locale: string]: ButtonTranslation } = Object.create(null);
 
   /** Constructor of the SlickGrid 3rd party plugin, it can optionally receive options */
   constructor(

--- a/packages/common/src/services/__tests__/filter.service.spec.ts
+++ b/packages/common/src/services/__tests__/filter.service.spec.ts
@@ -154,6 +154,13 @@ describe('FilterService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('should expose column filters as a plain-object snapshot for compatibility', () => {
+    const columnFilters = service.getColumnFilters();
+
+    expect(typeof columnFilters.hasOwnProperty).toBe('function');
+    expect(columnFilters).toEqual({});
+  });
+
   it('should dispose of the event handler', () => {
     const spy = vi.spyOn(slickgridEventHandler, 'unsubscribeAll');
     service.dispose();

--- a/packages/common/src/services/extension.service.ts
+++ b/packages/common/src/services/extension.service.ts
@@ -34,8 +34,8 @@ import type { TranslaterService } from './translater.service.js';
 import type { TreeDataService } from './treeData.service.js';
 
 export class ExtensionService {
-  protected _extensionCreatedList: ExtensionList<any> = {} as ExtensionList<any>;
-  protected _extensionList: ExtensionList<any> = {} as ExtensionList<any>;
+  protected _extensionCreatedList: ExtensionList<any> = Object.create(null);
+  protected _extensionList: ExtensionList<any> = Object.create(null);
 
   protected _cellMenuPlugin?: SlickCellMenu;
   protected _cellExcelCopyManagerPlugin?: SlickCellExcelCopyManager;
@@ -78,7 +78,7 @@ export class ExtensionService {
 
       // dispose each extension
       extensionNames.forEach((extensionName) => {
-        if (this._extensionList.hasOwnProperty(extensionName)) {
+        if (Object.prototype.hasOwnProperty.call(this._extensionList, extensionName)) {
           const extension = this._extensionList[
             extensionName as keyof Record<ExtensionName | ExtensionNameTypeString, ExtensionModel<any>>
           ] as ExtensionModel<any>;
@@ -104,7 +104,7 @@ export class ExtensionService {
     this._rowMoveManagerPlugin = null as any;
     this._selectionModel = null as any;
     this._extensionCreatedList = null as any;
-    this._extensionList = {} as ExtensionList<any>;
+    this._extensionList = Object.create(null);
   }
 
   /**
@@ -136,7 +136,7 @@ export class ExtensionService {
   getCreatedExtensionByName<P extends SlickControlList | SlickPluginList = any>(
     name: ExtensionName | ExtensionNameTypeString
   ): ExtensionModel<P> | undefined {
-    if (this._extensionCreatedList?.hasOwnProperty(name)) {
+    if (Object.prototype.hasOwnProperty.call(this._extensionCreatedList, name)) {
       return this._extensionCreatedList[name];
     }
     return undefined;

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -721,7 +721,9 @@ export class FilterService {
   }
 
   getColumnFilters(): ColumnFilters {
-    return this._columnFilters;
+    // Keep the internal dictionary prototype-free while preserving the historical
+    // plain-object shape for consumers of this public getter.
+    return { ...this._columnFilters };
   }
 
   getPreviousFilters(): CurrentFilter[] {

--- a/packages/common/src/services/filter.service.ts
+++ b/packages/common/src/services/filter.service.ts
@@ -42,7 +42,7 @@ export class FilterService {
   protected _isFilterFirstRender = true;
   protected _firstColumnIdRendered: string | number = '';
   protected _filtersMetadata: Array<Filter> = [];
-  protected _columnFilters: ColumnFilters = {};
+  protected _columnFilters: ColumnFilters = Object.create(null);
   protected _grid!: SlickGrid;
   protected _isTreePresetExecuted = false;
   protected _previousFilters: CurrentFilter[] = [];
@@ -600,7 +600,7 @@ export class FilterService {
     const isNotExcludingChildAndValidateOnlyTreeColumn =
       !excludeChildrenWhenFilteringTree && this._gridOptions.treeDataOptions?.autoApproveParentItemWhenTreeColumnIsValid === true;
 
-    const treeObj = {};
+    const treeObj = Object.create(null) as Record<string | number, any>;
     const filteredChildrenAndParents = new Set<number | string>(); // use Set instead of simple array to avoid duplicates
 
     // a Map of unique itemId/value pair where the value is a boolean which tells us if the parent matches the filter criteria or not
@@ -1032,7 +1032,7 @@ export class FilterService {
   async updateSingleFilter(filter: CurrentFilter, emitChangedEvent = true, triggerBackendQuery = true): Promise<boolean> {
     const columnDef = this._grid.getColumns().find((col) => col.id === filter.columnId);
     if (columnDef && filter.columnId) {
-      this._columnFilters = {};
+      this._columnFilters = Object.create(null);
       const emptySearchTermReturnAllValues = columnDef.filter?.emptySearchTermReturnAllValues ?? true;
 
       if (
@@ -1258,7 +1258,7 @@ export class FilterService {
       const eventKey = (event as KeyboardEvent)?.key;
       if (
         this._onSearchChange &&
-        (args.forceOnSearchChangeEvent || eventKey === 'Enter' || !dequal(oldColumnFilters, this._columnFilters))
+        (args.forceOnSearchChangeEvent || eventKey === 'Enter' || !dequal(oldColumnFilters, { ...this._columnFilters }))
       ) {
         const eventArgs = {
           clearFilterTriggered: args.clearFilterTriggered,

--- a/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
@@ -167,6 +167,20 @@ describe('Composite Editor Factory', () => {
     expect(document.activeElement).not.toBeUndefined();
   });
 
+  it('should keep composite form values prototype-free while preserving hasOwnProperty compatibility', () => {
+    const output = new factory(textEditorArgs);
+    const formValues = output.getEditors()[0].args.compositeEditorOptions?.formValues as Record<string, any>;
+
+    expect(Object.getPrototypeOf(formValues)).toBeNull();
+    expect(typeof formValues.hasOwnProperty).toBe('function');
+    expect(formValues.hasOwnProperty('missingField')).toBe(false);
+
+    formValues.__proto__ = { polluted: true };
+    expect(Object.getPrototypeOf(formValues)).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(formValues, '__proto__')).toBe(true);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
   it('should be able to call the cancelChanges & commitChanges function to test the noop function after initialization', () => {
     const output = new factory(textEditorArgs);
     const cancelOutput = output.getEditors()[0].args.cancelChanges();

--- a/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.spec.ts
@@ -168,10 +168,15 @@ describe('Composite Editor Factory', () => {
   });
 
   it('should keep composite form values prototype-free while preserving hasOwnProperty compatibility', () => {
-    const output = new factory(textEditorArgs);
+    const factoryWithInitialValues = new (SlickCompositeEditor as any)(columnsMock, containers, {
+      ...compositeOptions,
+      formValues: { existingField: 'initial value' },
+    });
+    const output = new factoryWithInitialValues(textEditorArgs);
     const formValues = output.getEditors()[0].args.compositeEditorOptions?.formValues as Record<string, any>;
 
     expect(Object.getPrototypeOf(formValues)).toBeNull();
+    expect(formValues.existingField).toBe('initial value');
     expect(typeof formValues.hasOwnProperty).toBe('function');
     expect(formValues.hasOwnProperty('missingField')).toBe(false);
 

--- a/packages/composite-editor-component/src/compositeEditor.factory.ts
+++ b/packages/composite-editor-component/src/compositeEditor.factory.ts
@@ -21,6 +21,26 @@ export interface CompositeEditor extends Editor {
 }
 
 /**
+ * Create a prototype-free dynamic map while retaining the historical
+ * `map.hasOwnProperty(key)` compatibility used by some composite-editor consumers.
+ */
+function createSafeDynamicMap<T extends Record<string, any>>(initialValues?: T): T {
+  const target = Object.create(null) as Record<string, any>;
+  Object.keys(initialValues ?? {}).forEach((key) => {
+    target[key] = initialValues![key];
+  });
+
+  return new Proxy(target, {
+    get(map, property, receiver) {
+      if (property === 'hasOwnProperty' && !Object.prototype.hasOwnProperty.call(map, property)) {
+        return Object.prototype.hasOwnProperty.bind(map);
+      }
+      return Reflect.get(map, property, receiver);
+    },
+  }) as T;
+}
+
+/**
  * A composite SlickGrid editor factory.
  * Generates an editor that is composed of multiple editors for given columns.
  * Individual editors are provided given containers instead of the original cell.
@@ -64,10 +84,11 @@ export function SlickCompositeEditor(
     hide: null,
     position: null,
     destroy: null,
-    formValues: {},
+    formValues: createSafeDynamicMap(),
     editors: Object.create(null),
   } as unknown as CompositeEditorOption;
   options = { ...defaultOptions, ...options };
+  options.formValues = createSafeDynamicMap(options.formValues);
   let _timer: any;
 
   /* no operation (empty) function */
@@ -110,7 +131,7 @@ export function SlickCompositeEditor(
             cancelChanges: noop,
             compositeEditorOptions: options,
             isCompositeEditor: true,
-            formValues: {},
+            formValues: createSafeDynamicMap(),
           } as CompositeEditorArguments);
           options.editors[column.id] = currentEditor; // add every Editor instance refs
           editors.push(currentEditor as Editor & { args: EditorArguments });

--- a/packages/graphql/src/services/graphql.service.ts
+++ b/packages/graphql/src/services/graphql.service.ts
@@ -132,14 +132,14 @@ export class GraphqlService implements BackendService {
     }
 
     // add dataset filters, could be Pagination and SortingFilters and/or FieldFilters
-    let datasetFilters: GraphqlDatasetFilter = {};
+    let datasetFilters: GraphqlDatasetFilter = Object.create(null);
 
     // only add pagination if it's enabled in the grid options
     if (this._gridOptions.enablePagination !== false || this.options.infiniteScroll) {
-      datasetFilters = {};
+      datasetFilters = Object.create(null);
 
       if (this.options.useCursor && this.options.paginationOptions) {
-        datasetFilters = { ...this.options.paginationOptions };
+        datasetFilters = Object.assign(Object.create(null), this.options.paginationOptions);
       } else {
         const paginationOptions = this.options?.paginationOptions;
         datasetFilters.first =

--- a/packages/odata/src/services/__tests__/odataQueryBuilder.service.spec.ts
+++ b/packages/odata/src/services/__tests__/odataQueryBuilder.service.spec.ts
@@ -224,6 +224,15 @@ describe('OdataService', () => {
         LastName: { search: ['Doe'], value: 'Doe' },
       });
     });
+
+    it('should safely store filter names that match Object prototype properties', () => {
+      service.saveColumnFilter('__proto__', 'John', ['John']);
+      service.saveColumnFilter('constructor', 'Doe', ['Doe']);
+
+      expect(service.columnFilters['__proto__']).toEqual({ search: ['John'], value: 'John' });
+      expect(service.columnFilters.constructor).toEqual({ search: ['Doe'], value: 'Doe' });
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
   });
 
   describe('removeColumnFilter method', () => {

--- a/packages/odata/src/services/grid-odata.service.ts
+++ b/packages/odata/src/services/grid-odata.service.ts
@@ -316,7 +316,7 @@ export class GridOdataService implements BackendService {
 
     // loop through all columns to inspect filters
     for (const columnId in columnFilters) {
-      if (columnFilters.hasOwnProperty(columnId)) {
+      if (Object.prototype.hasOwnProperty.call(columnFilters, columnId)) {
         const columnFilter = (columnFilters as any)[columnId];
 
         // if user defined some "presets", then we need to find the filters from the column definitions instead

--- a/packages/odata/src/services/odataQueryBuilder.service.ts
+++ b/packages/odata/src/services/odataQueryBuilder.service.ts
@@ -24,7 +24,7 @@ export class OdataQueryBuilderService {
       orderBy: '',
     };
     this._defaultSortBy = '';
-    this._columnFilters = {};
+    this._columnFilters = Object.create(null);
   }
 
   /*

--- a/packages/row-detail-view-plugin/src/slickRowDetailView.ts
+++ b/packages/row-detail-view-plugin/src/slickRowDetailView.ts
@@ -871,20 +871,23 @@ export class SlickRowDetailView implements ExternalResource, UniversalRowDetailV
   /** Get the Row Detail padding (which are the rows dedicated to the detail panel) */
   protected getPaddingItem(parent: any, offset: any): any {
     const item: any = {};
+    const setItemProperty = (property: string, value: any) => {
+      Object.defineProperty(item, property, { configurable: true, enumerable: true, writable: true, value });
+    };
 
     // to make it work with Grouping,
     // copy the parent's columns field values so that padding rows can follow the parent's group and be filtered/sorted with it
     this._grid.getColumns().forEach(({ field }) => {
-      item[field] = parent[field];
+      setItemProperty(field, parent[field]);
     });
 
-    item[this._dataViewIdProperty] = `${parent[this._dataViewIdProperty]}.${offset}`;
+    setItemProperty(this._dataViewIdProperty, `${parent[this._dataViewIdProperty]}.${offset}`);
 
     // additional hidden padding metadata fields
-    item[`${this._keyPrefix}collapsed`] = true;
-    item[`${this._keyPrefix}isPadding`] = true;
-    item[`${this._keyPrefix}parent`] = parent;
-    item[`${this._keyPrefix}offset`] = offset;
+    setItemProperty(`${this._keyPrefix}collapsed`, true);
+    setItemProperty(`${this._keyPrefix}isPadding`, true);
+    setItemProperty(`${this._keyPrefix}parent`, parent);
+    setItemProperty(`${this._keyPrefix}offset`, offset);
 
     return item;
   }

--- a/packages/utils/src/__tests__/utils.spec.ts
+++ b/packages/utils/src/__tests__/utils.spec.ts
@@ -510,6 +510,16 @@ describe('Service/Utilies', () => {
       expect(arr2[0].address.zip).toBe(888888);
       expect(arr2[1].address.zip).toBe(999999);
     });
+
+    it('should not allow copied prototype keys to modify Object.prototype', () => {
+      delete (Object.prototype as any).polluted;
+      const input = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+
+      const output = deepCopy(input);
+
+      expect(output.__proto__.polluted).toBe('yes');
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
   });
 
   describe('deepMerge() method', () => {
@@ -853,6 +863,17 @@ describe('Service/Utilies', () => {
           ],
         },
       });
+    });
+
+    it('should not allow a __proto__ path to modify Object.prototype', () => {
+      delete (Object.prototype as any).polluted;
+      const output: any = {};
+
+      setDeepValue(output, '__proto__.polluted', 'yes');
+
+      expect(Object.prototype.hasOwnProperty.call(output, '__proto__')).toBe(true);
+      expect(output.__proto__.polluted).toBe('yes');
+      expect((Object.prototype as any).polluted).toBeUndefined();
     });
   });
 

--- a/packages/utils/src/__tests__/utils.spec.ts
+++ b/packages/utils/src/__tests__/utils.spec.ts
@@ -875,6 +875,17 @@ describe('Service/Utilies', () => {
       expect(output.__proto__.polluted).toBe('yes');
       expect((Object.prototype as any).polluted).toBeUndefined();
     });
+
+    it('should safely set a leaf __proto__ property without modifying Object.prototype', () => {
+      delete (Object.prototype as any).polluted;
+      const output: any = {};
+
+      setDeepValue(output, '__proto__', { polluted: 'yes' });
+
+      expect(Object.prototype.hasOwnProperty.call(output, '__proto__')).toBe(true);
+      expect(output.__proto__).toEqual({ polluted: 'yes' });
+      expect((Object.prototype as any).polluted).toBeUndefined();
+    });
   });
 
   describe('titleCase() method', () => {

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -63,7 +63,12 @@ export function deepCopy(objectOrArray: any | any[]): any | any[] {
     // Recursively copy it's value and add to the clone
     Object.keys(objectOrArray).forEach((key) => {
       if (Object.prototype.hasOwnProperty.call(objectOrArray, key)) {
-        (clone as any)[key] = deepCopy(objectOrArray[key]);
+        const value = deepCopy(objectOrArray[key]);
+        if (key === '__proto__') {
+          Object.defineProperty(clone, key, { configurable: true, enumerable: true, writable: true, value });
+        } else {
+          (clone as any)[key] = value;
+        }
       }
     });
     return clone;
@@ -144,7 +149,7 @@ export function deepMerge(target: any, ...sources: any[]): any {
 export function emptyObject(obj: any): any {
   if (isObject(obj)) {
     Object.keys(obj).forEach((key) => {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         delete obj[key];
       }
     });
@@ -307,17 +312,28 @@ export function setDeepValue<T = unknown>(obj: T, path: string | string[], value
   if (path.length > 1) {
     const e = path.shift() as keyof T;
     if (obj && e !== undefined) {
-      setDeepValue(
-        (obj[e] =
-          isDefined(obj[e]) && (Array.isArray(obj[e]) || Object.prototype.toString.call(obj[e]) === '[object Object]')
-            ? obj[e]
-            : ({} as any)),
-        path,
-        value
-      );
+      const key = String(e);
+      const hasOwnProperty = Object.prototype.hasOwnProperty.call(obj, e);
+      const currentValue = hasOwnProperty ? obj[e] : undefined;
+      const nextValue =
+        isDefined(currentValue) && (Array.isArray(currentValue) || Object.prototype.toString.call(currentValue) === '[object Object]')
+          ? currentValue
+          : ({} as any);
+
+      if (key === '__proto__') {
+        Object.defineProperty(obj, e, { configurable: true, enumerable: true, writable: true, value: nextValue });
+      } else {
+        obj[e] = nextValue;
+      }
+      setDeepValue(nextValue, path, value);
     }
   } else if (obj && path[0]) {
-    obj[path[0] as keyof T] = value;
+    const key = String(path[0]);
+    if (key === '__proto__') {
+      Object.defineProperty(obj, path[0] as keyof T, { configurable: true, enumerable: true, writable: true, value });
+    } else {
+      obj[path[0] as keyof T] = value;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up security hardening for prototype-pollution risks identified during PR #2742.

This also extends the protection introduced in PR #2630 beyond `deepMerge()` to other dynamic object-handling paths.

## Changes

- Harden dynamic maps used by filtering, grouping, CSS styles, extensions, OData, GraphQL, and aggregators.
- Protect `deepCopy()` and nested property assignment from `__proto__` pollution.
- Safely assign dynamic row-detail properties.
- Add regression tests for `__proto__`, `constructor`, and `toString` keys.
- Leave demos and ordinary configuration objects unchanged.

## Validation

- TypeScript builds passed.
- Focused Vitest suites passed.
- Prettier and `git diff --check` passed.

Related: #2630, #2742

## LLM

Implemented and reviewed with OpenAI GPT-5.6 Luna.