### PR TITLE
fix(common): ignore secondary-button cell range drags

### DIFF
--- a/demos/aurelia/test/cypress/e2e/example48.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example48.cy.ts
@@ -53,6 +53,21 @@ describe('Example 48 - Hybrid Selection Model', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });
 
+    it('should preserve cell selection when dragging with the secondary mouse button', () => {
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').trigger('mousedown', {
+        button: 2,
+        which: 3,
+        force: true,
+      });
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { button: 2, which: 3, force: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+    });
+
     it('should be able to expand the cell selections further to the right', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')

--- a/demos/react/test/cypress/e2e/example48.cy.ts
+++ b/demos/react/test/cypress/e2e/example48.cy.ts
@@ -53,6 +53,21 @@ describe('Example 48 - Hybrid Selection Model', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });
 
+    it('should preserve cell selection when dragging with the secondary mouse button', () => {
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').trigger('mousedown', {
+        button: 2,
+        which: 3,
+        force: true,
+      });
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { button: 2, which: 3, force: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+    });
+
     it('should be able to expand the cell selections further to the right', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')

--- a/demos/vue/test/cypress/e2e/example48.cy.ts
+++ b/demos/vue/test/cypress/e2e/example48.cy.ts
@@ -53,6 +53,21 @@ describe('Example 48 - Hybrid Selection Model', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });
 
+    it('should preserve cell selection when dragging with the secondary mouse button', () => {
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').trigger('mousedown', {
+        button: 2,
+        which: 3,
+        force: true,
+      });
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { button: 2, which: 3, force: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+    });
+
     it('should be able to expand the cell selections further to the right', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
@@ -53,6 +53,21 @@ describe('Example 48 - Hybrid Selection Model', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });
 
+    it('should preserve cell selection when dragging with the secondary mouse button', () => {
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').trigger('mousedown', {
+        button: 2,
+        which: 3,
+        force: true,
+      });
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { button: 2, which: 3, force: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
+    });
+
     it('should be able to expand the cell selections further to the right', () => {
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -941,6 +941,21 @@ describe('SlickGrid core file', () => {
         expect(secondRowItemCell.classList.contains('selected')).toBeTruthy();
       });
 
+      it('should select rows when the last column is hidden', () => {
+        const columnsWithHiddenLastColumn = [
+          { id: 'firstName', field: 'firstName', name: 'First Name' },
+          { id: 'lastName', field: 'lastName', name: 'Last Name', hidden: true },
+        ] as Column[];
+        const rowSelectionModel = new SlickHybridSelectionModel({ selectionType: 'row' });
+
+        grid = new SlickGrid<any, Column>(container, data, columnsWithHiddenLastColumn, defaultOptions);
+        grid.setSelectionModel(rowSelectionModel);
+        grid.setSelectedRows([1]);
+
+        expect(rowSelectionModel.getSelectedRanges()).toEqual([{ fromCell: 0, fromRow: 1, toCell: 0, toRow: 1 }]);
+        expect(grid.getSelectedRows()).toEqual([1]);
+      });
+
       it('should call SlickHybridSelectionModel.onDragReplaceCells() when selection mode is REP and range is expanding', () => {
         const hybridSelectionModel = new SlickHybridSelectionModel();
         hybridSelectionModel.activeSelectionIsRow = true;

--- a/packages/common/src/core/__tests__/slickInteractions.spec.ts
+++ b/packages/common/src/core/__tests__/slickInteractions.spec.ts
@@ -70,6 +70,32 @@ describe('Draggable class', () => {
     dg.destroy();
   });
 
+  it('should ignore secondary-button mousedown events', () => {
+    const dragInitSpy = vi.fn();
+    const dragStartSpy = vi.fn();
+    const dragSpy = vi.fn();
+    const dragEndSpy = vi.fn();
+    containerElement.className = 'slick-cell';
+
+    dg = Draggable({
+      containerElement,
+      allowDragFrom: 'div.slick-cell',
+      onDrag: dragSpy,
+      onDragInit: dragInitSpy,
+      onDragStart: dragStartSpy,
+      onDragEnd: dragEndSpy,
+    });
+
+    const secondaryButtonEvent = new Event('mousedown');
+    Object.defineProperty(secondaryButtonEvent, 'button', { value: 2 });
+    containerElement.dispatchEvent(secondaryButtonEvent);
+
+    expect(dragInitSpy).not.toHaveBeenCalled();
+    expect(dragStartSpy).not.toHaveBeenCalled();
+    expect(dragSpy).not.toHaveBeenCalled();
+    expect(dragEndSpy).not.toHaveBeenCalled();
+  });
+
   it('should trigger mousedown and expect a dragInit and a dragStart and drag to all happen since it was triggered by an allowed element and we did move afterward', () => {
     const removeBodyListenerSpy = vi.spyOn(document.body, 'removeEventListener');
     const removeWindowListenerSpy = vi.spyOn(window, 'removeEventListener');

--- a/packages/common/src/core/slickInteractions.ts
+++ b/packages/common/src/core/slickInteractions.ts
@@ -94,6 +94,11 @@ export function Draggable(options: DraggableOption): {
   }
 
   function userPressed(event: MouseEvent | TouchEvent | KeyboardEvent): void {
+    // Cell/row dragging is a primary-button action; let secondary clicks open context menus.
+    if (event.type === 'mousedown' && 'button' in event && (event as MouseEvent).button !== 0) {
+      return;
+    }
+
     element = event.target as HTMLElement;
     if (!preventDrag(event)) {
       const targetEvent: MouseEvent | Touch = (event as TouchEvent)?.touches?.[0] ?? event;

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -89,6 +89,21 @@ describe('Example 37 - Hybrid Selection Model', () => {
       cy.get('.grid37-1 .slick-cell.selected').should('have.length', 4);
     });
 
+    it('should preserve cell selection when dragging with the secondary mouse button', () => {
+      cy.get('.grid37-1 .slick-cell.selected').should('have.length', 4);
+
+      cy.get('.grid37-1 .slick-row[data-row="1"] .slick-cell.l1.r1').trigger('mousedown', {
+        button: 2,
+        which: 3,
+        force: true,
+      });
+      cy.get('.grid37-1 .slick-row[data-row="3"] .slick-cell.l3.r3')
+        .trigger('mousemove', 'bottomRight')
+        .trigger('mouseup', 'bottomRight', { button: 2, which: 3, force: true });
+
+      cy.get('.grid37-1 .slick-cell.selected').should('have.length', 4);
+    });
+
     it('should be able to expand the cell selections further to the right', () => {
       cy.get('.grid37-1 .slick-cell.selected').should('have.length', 4);
       cy.get('.grid37-1 .slick-row[data-row="2"] .slick-cell.l2.r2')


### PR DESCRIPTION
## Summary

Fixes #2749

Prevent secondary-button mouse gestures from starting SlickGrid drag operations and replacing an existing cell selection.

## Why

Right-clicking a selected cell while moving the pointer slightly could start a range-selection drag, especially in Windows RDP sessions.

## Changes

- Ignore secondary-button `mousedown` events in the shared draggable interaction.
- Preserve compatibility with existing `CustomEvent('mousedown')` usage.
- Add unit coverage for secondary-button drag prevention.
- Add Cypress regression coverage for vanilla Example 37 and all framework Example 48 demos.
- Preserve regression coverage from #2648 for hidden last columns.

## Validation

- 482 focused unit tests passed.
- Cypress regression tests added and verified.
- Prettier check passed.
- `git diff --check` passed.

## Comments

No documentation update is required because this is an internal behavior fix with no public API changes.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: Codex / GPT-5.6 Luna
  - **how was it used**: Investigated the issue, implemented the minimal fix, and added and validated regression tests.

## Checklist

- [x] The changes are limited to only one scope.
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.
- [ ] Ran a full project build.