### PR TITLE
fix(common): support Shift-click cell range selection

### DIFF
--- a/demos/aurelia/test/cypress/e2e/example48.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example48.cy.ts
@@ -191,6 +191,15 @@ describe('Example 48 - Hybrid Selection Model', () => {
         .then((text) => expect(text.match(/"fromRow"/g)).to.have.length(2));
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');
     });
+
+    it('should select a rectangular cell range when Shift-clicking another cell', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3').click({ shiftKey: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 9);
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":3,"toCell":3}');
+    });
+
     it('should preserve row and column offsets when copying multiple cell ranges', () => {
       cy.get('#grid48-1 .slick-viewport-top.slick-viewport-left').scrollTo('top');
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');

--- a/demos/react/test/cypress/e2e/example48.cy.ts
+++ b/demos/react/test/cypress/e2e/example48.cy.ts
@@ -191,6 +191,15 @@ describe('Example 48 - Hybrid Selection Model', () => {
         .then((text) => expect(text.match(/"fromRow"/g)).to.have.length(2));
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');
     });
+
+    it('should select a rectangular cell range when Shift-clicking another cell', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3').click({ shiftKey: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 9);
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":3,"toCell":3}');
+    });
+
     it('should preserve row and column offsets when copying multiple cell ranges', () => {
       cy.get('#grid48-1 .slick-viewport-top.slick-viewport-left').scrollTo('top');
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');

--- a/demos/vanilla/src/examples/example19.html
+++ b/demos/vanilla/src/examples/example19.html
@@ -28,6 +28,7 @@
     outputs of the selected cells. This also applies if the cells editor is already open due to use of
     <code>copyActiveEditorCell</code>
   </p>
+  <p>Click a cell, then hold Shift and click another cell to select the rectangular range between them.</p>
 </h5>
 <h6 class="title is-6">
   <button class="button is-small" onclick.trigger="undoLastEdit()" data-test="undo-last-edit-btn">

--- a/demos/vanilla/src/examples/example37.html
+++ b/demos/vanilla/src/examples/example37.html
@@ -31,6 +31,7 @@
       <code>rowSelectColumnIds: ['id']</code> as the columns that will trigger row selection.
     </li>
     <li>2. clicking on the any other columns will use <code>CellSelectionModel</code> by default</li>
+    <li>3. with cell selection, hold Shift and click another cell to select the rectangular range between the two cells</li>
   </ul>
 </h5>
 

--- a/demos/vue/test/cypress/e2e/example48.cy.ts
+++ b/demos/vue/test/cypress/e2e/example48.cy.ts
@@ -191,6 +191,15 @@ describe('Example 48 - Hybrid Selection Model', () => {
         .then((text) => expect(text.match(/"fromRow"/g)).to.have.length(2));
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');
     });
+
+    it('should select a rectangular cell range when Shift-clicking another cell', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3').click({ shiftKey: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 9);
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":3,"toCell":3}');
+    });
+
     it('should preserve row and column offsets when copying multiple cell ranges', () => {
       cy.get('#grid48-1 .slick-viewport-top.slick-viewport-left').scrollTo('top');
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
@@ -268,6 +268,8 @@ selectionOptions: {
 }
 ```
 
+With cell selection enabled, click an anchor cell and then Shift-click another cell to select the rectangular range between them. In row-selection mode, Shift-click selects all rows between the anchor and clicked row.
+
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
@@ -191,6 +191,15 @@ describe('Example 48 - Hybrid Selection Model', () => {
         .then((text) => expect(text.match(/"fromRow"/g)).to.have.length(2));
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');
     });
+
+    it('should select a rectangular cell range when Shift-clicking another cell', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#grid48-1 .slick-row[data-row="3"] .slick-cell.l3.r3').click({ shiftKey: true });
+
+      cy.get('#grid48-1 .slick-cell.selected').should('have.length', 9);
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":3,"toCell":3}');
+    });
+
     it('should preserve row and column offsets when copying multiple cell ranges', () => {
       cy.get('#grid48-1 .slick-viewport-top.slick-viewport-left').scrollTo('top');
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
@@ -280,6 +280,8 @@ selectionOptions: {
 }
 ```
 
+With cell selection enabled, click an anchor cell and then Shift-click another cell to select the rectangular range between them. In row-selection mode, Shift-click selects all rows between the anchor and clicked row.
+
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -361,6 +361,8 @@ selectionOptions: {
 }
 ```
 
+With cell selection enabled, click an anchor cell and then Shift-click another cell to select the rectangular range between them. In row-selection mode, Shift-click selects all rows between the anchor and clicked row.
+
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
@@ -431,6 +431,8 @@ selectionOptions: {
 }
 ```
 
+With cell selection enabled, click an anchor cell and then Shift-click another cell to select the rectangular range between them. In row-selection mode, Shift-click selects all rows between the anchor and clicked row.
+
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.

--- a/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
@@ -1001,6 +1001,46 @@ describe('Cell Selection Model Plugin', () => {
     canCellBeSelectedSpy.mockRestore();
   });
 
+  it('should select the range between the active cell and the clicked cell when Shift is clicked', () => {
+    plugin = new SlickHybridSelectionModel({ selectionType: 'cell' });
+    const canCellBeActiveSpy = vi.spyOn(gridStub, 'canCellBeActive').mockReturnValue(true);
+    const canCellBeSelectedSpy = vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);
+    const getCellFromEventSpy = vi.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 2, row: 4 });
+    const getActiveCellSpy = vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 1, row: 2 });
+    const setActiveCellSpy = vi.spyOn(gridStub, 'setActiveCell');
+    plugin.init(gridStub);
+
+    const setSelectedRangesSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const clickEvent = addVanillaEventPropagation(new Event('click'), ['shiftKey']);
+    const stopImmediatePropagationSpy = vi.spyOn(clickEvent, 'stopImmediatePropagation');
+    gridStub.onClick.notify({ cell: 2, row: 4, grid: gridStub }, clickEvent, gridStub);
+
+    expect(setSelectedRangesSpy).toHaveBeenCalledWith([new SlickRange(2, 1, 4, 2)]);
+    expect(setActiveCellSpy).toHaveBeenCalledWith(4, 2, false, false, true);
+    expect(setSelectedRangesSpy.mock.invocationCallOrder[0]).toBeLessThan(setActiveCellSpy.mock.invocationCallOrder[0]);
+    expect(stopImmediatePropagationSpy).toHaveBeenCalled();
+    canCellBeActiveSpy.mockRestore();
+    canCellBeSelectedSpy.mockRestore();
+    getCellFromEventSpy.mockRestore();
+    getActiveCellSpy.mockRestore();
+  });
+
+  it('should ignore a Shift-click on a cell that cannot become active', () => {
+    plugin = new SlickHybridSelectionModel({ selectionType: 'cell' });
+    vi.spyOn(gridStub, 'canCellBeActive').mockReturnValue(false);
+    vi.spyOn(gridStub, 'getCellFromEvent').mockReturnValue({ cell: 2, row: 4 });
+    vi.spyOn(gridStub, 'getActiveCell').mockReturnValue({ cell: 1, row: 2 });
+    plugin.init(gridStub);
+
+    const setSelectedRangesSpy = vi.spyOn(plugin, 'setSelectedRanges');
+    const setActiveCellSpy = vi.spyOn(gridStub, 'setActiveCell');
+    const clickEvent = addVanillaEventPropagation(new Event('click'), ['shiftKey']);
+    gridStub.onClick.notify({ cell: 2, row: 4, grid: gridStub }, clickEvent, gridStub);
+
+    expect(setSelectedRangesSpy).not.toHaveBeenCalled();
+    expect(setActiveCellSpy).not.toHaveBeenCalled();
+  });
+
   it('should add a non-contiguous cell range when Ctrl is clicked with multi-selection enabled', () => {
     plugin = new SlickHybridSelectionModel({ selectionType: 'cell', enableMultiSelection: true });
     const canCellBeSelectedSpy = vi.spyOn(gridStub, 'canCellBeSelected').mockReturnValue(true);

--- a/packages/common/src/extensions/slickHybridSelectionModel.ts
+++ b/packages/common/src/extensions/slickHybridSelectionModel.ts
@@ -200,13 +200,11 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
   }
 
   protected getRowsRange(from: number, to: number): number[] {
-    let i;
     const rows: number[] = [];
-    for (i = from; i <= to; i++) {
-      rows.push(i);
-    }
-    for (i = to; i < from; i++) {
-      rows.push(i);
+    const start = from <= to ? from : to;
+    const end = from <= to ? to : from - 1;
+    for (let row = start; row <= end; row++) {
+      rows.push(row);
     }
     return rows;
   }
@@ -243,26 +241,24 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
 
     if (this._activeSelectionIsRow) {
       this._ranges = ranges;
-
-      // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
-      // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
-      const eventData = new SlickEventData(new CustomEvent('click', { detail: { caller, selectionMode } }), this._ranges);
-      this.onSelectedRangesChanged.notify(this._ranges, eventData);
+      this.notifySelectedRangesChanged(caller, selectionMode);
     } else {
       // if range has not changed, don't fire onSelectedRangesChanged
       const rangeHasChanged = !this.rangesAreEqual(this._ranges, ranges);
 
       this._ranges = this.removeInvalidRanges(ranges);
       if (rangeHasChanged) {
-        // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
-        // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
-        const eventData = new SlickEventData(
-          new CustomEvent('click', { detail: { caller, selectionMode, addDragHandle: true } }),
-          this._ranges
-        );
-        this.onSelectedRangesChanged.notify(this._ranges, eventData);
+        this.notifySelectedRangesChanged(caller, selectionMode, true);
       }
     }
+  }
+
+  protected notifySelectedRangesChanged(caller: string, selectionMode: string, addDragHandle = false): void {
+    // provide extra "caller" argument through SlickEventData event to avoid breaking the previous pubsub event structure
+    // that only accepts an array of selected range `SlickRange[]`, the SlickEventData args will be merged and used later by `onSelectedRowsChanged`
+    const detail = { caller, selectionMode, ...(addDragHandle ? { addDragHandle: true } : {}) };
+    const eventData = new SlickEventData(new CustomEvent('click', { detail }), this._ranges);
+    this.onSelectedRangesChanged.notify(this._ranges, eventData);
   }
 
   currentSelectionModeIsRow(): boolean {
@@ -516,13 +512,14 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
 
       let selection = this.rangesToRows(this._ranges);
       const idx = selection.indexOf(cell.row);
+      let shouldSetActiveCell = false;
 
       if (idx === -1 && (e.ctrlKey || e.metaKey)) {
         selection.push(cell.row);
-        this._grid.setActiveCell(cell.row, cell.cell);
+        shouldSetActiveCell = true;
       } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
         selection = selection.filter((o) => o !== cell.row);
-        this._grid.setActiveCell(cell.row, cell.cell);
+        shouldSetActiveCell = true;
       } else if (selection.length && e.shiftKey) {
         const last = selection.pop() as number;
         const from = Math.min(cell.row, last);
@@ -534,12 +531,24 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
           }
         }
         selection.push(last);
-        this._grid.setActiveCell(cell.row, cell.cell);
+        shouldSetActiveCell = true;
       }
 
+      if (shouldSetActiveCell) {
+        this._grid.setActiveCell(cell.row, cell.cell);
+      }
       const tempRanges = this.rowsToRanges(selection);
-      this.setSelectedRanges(tempRanges);
-      e.stopImmediatePropagation();
+      this.handleClickSelection(e, tempRanges);
+
+      return true;
+    } else if (e.shiftKey) {
+      const cell = this._grid.getCellFromEvent(e);
+      const activeCell = this._grid.getActiveCell();
+      if (!cell || !activeCell || !this._grid.canCellBeActive(cell.row, cell.cell)) {
+        return false;
+      }
+
+      this.handleCellClickSelection(e, cell, [new SlickRange(activeCell.row, activeCell.cell, cell.row, cell.cell)], true);
 
       return true;
     } else if (this._options.enableMultiSelection && (e.ctrlKey || e.metaKey)) {
@@ -549,12 +558,29 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
       }
 
       const ranges = this.toggleCellSelectionRange(this.getSelectedRanges().slice(), new SlickRange(cell.row, cell.cell));
-      this._grid.setActiveCell(cell.row, cell.cell, false, false, true);
-      this.setSelectedRanges(ranges);
-      e.stopImmediatePropagation();
+      this.handleCellClickSelection(e, cell, ranges);
 
       return true;
     }
+  }
+
+  protected handleCellClickSelection(
+    e: SlickEventData,
+    cell: { row: number; cell: number },
+    ranges: SlickRange[],
+    setActiveCellAfterSelection = false
+  ): void {
+    const setActiveCell = () => this._grid.setActiveCell(cell.row, cell.cell, false, false, true);
+    if (!setActiveCellAfterSelection) {
+      setActiveCell();
+    }
+    this.handleClickSelection(e, ranges, setActiveCellAfterSelection ? setActiveCell : undefined);
+  }
+
+  protected handleClickSelection(e: SlickEventData, ranges: SlickRange[], afterSelection?: () => void): void {
+    this.setSelectedRanges(ranges);
+    afterSelection?.();
+    e.stopImmediatePropagation();
   }
 
   protected toggleCellSelectionRange(ranges: SlickRange[], range: SlickRange): SlickRange[] {

--- a/test/cypress/e2e/example19.cy.ts
+++ b/test/cypress/e2e/example19.cy.ts
@@ -77,6 +77,14 @@ describe('Example 19 - ExcelCopyBuffer with Cell Selection', () => {
   });
 
   describe('with Pagination of size 20', () => {
+    it('should select a rectangular cell range when Shift-clicking another cell', () => {
+      cy.getCell(10, 4, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).click();
+      cy.getCell(12, 6, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).click({ shiftKey: true });
+
+      cy.get('.grid19 .slick-cell.selected').should('have.length', 9);
+      cy.get('#selectionRange').should('have.text', '{"fromRow":10,"fromCell":4,"toRow":12,"toCell":6}');
+    });
+
     it('should click on cell B14 then Ctrl+Shift+End with selection B14-CV19', () => {
       cy.getCell(14, 3, '', { parentSelector: '.grid19', rowHeight: GRID_ROW_HEIGHT }).as('cell_B14').click();
 

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -235,6 +235,15 @@ describe('Example 37 - Hybrid Selection Model', () => {
         .then((text) => expect(text.match(/"fromRow"/g)).to.have.length(2));
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');
     });
+
+    it('should select a rectangular cell range when Shift-clicking another cell', () => {
+      cy.get('.grid37-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('.grid37-1 .slick-row[data-row="3"] .slick-cell.l3.r3').click({ shiftKey: true });
+
+      cy.get('.grid37-1 .slick-cell.selected').should('have.length', 9);
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":3,"toCell":3}');
+    });
+
     it('should preserve row and column offsets when copying multiple cell ranges', () => {
       cy.get('.grid37-1 .slick-viewport-top.slick-viewport-left').scrollTo('top');
       cy.get('[data-test="enable-multi-selection"]').should('be.checked');


### PR DESCRIPTION
## Summary

Fixes #2750

Adds spreadsheet-style Shift-click range selection for cell selection. Holding Shift and clicking another cell now selects the rectangular range between the active cell and clicked cell.

## Why

Users expect spreadsheet-style range selection when working with tabular data. Previously, Shift-click did not create a cell range.

## Changes

- Added Shift-click range selection to `SlickHybridSelectionModel`.
- Refactored repeated selection finalization and range-change notification logic (DRY).
- Added regression coverage for cell and hybrid selection modes:
  - Vanilla example 19.
  - Vanilla example 37.
  - Framework example 48 equivalents for Angular, Aurelia, React, and Vue.
- Updated Vanilla demo guidance.
- Updated row-selection documentation across all framework packages.

## Validation

- Focused selection-model suite: 80 tests passed.
- Full common-package suite: 4,364 tests passed.
- Prettier passed.
- Oxlint passed.
- `git diff --check` passed.
- Cypress coverage was added; browser execution should be verified in CI/local demo environments.

## Comments

The selection logic remains in the shared common package, so the behavior applies consistently across all framework wrappers.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex, GPT-5.6 Luna
  - **how was it used**: Implemented the selection behavior, refactored duplicated logic, added tests, updated documentation, and assisted with validation.

## Checklist

- [x] The changes are limited to only one scope (shared selection behavior and related tests/docs).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.
- [ ] Ran a full project build (required when code logic changed)
