### PR TITLE
fix(utils): allow empty arrays to override defaults

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example48.ts
+++ b/demos/aurelia/src/examples/slickgrid/example48.ts
@@ -106,6 +106,7 @@ export class Example48 {
       gridHeight: 250,
       gridWidth: 800,
       enableCellNavigation: true,
+      preventDragFromKeys: [],
       autoEdit: true,
       editable: true,
       headerRowHeight: 35,

--- a/demos/aurelia/test/cypress/e2e/example48.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example48.cy.ts
@@ -38,17 +38,17 @@ describe('Example 48 - Hybrid Selection Model', () => {
         });
     });
 
-    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+    it('should allow Ctrl-drag from Task 1 to expand the cell selections to include 4 cells', () => {
       cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
       cy.get('@task1').should('contain', 'Task 1');
       cy.get('@task1').click().should('have.class', 'selected');
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 1);
 
-      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
-        .trigger('mousemove', 'bottomRight')
-        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+        .trigger('mousemove', 'bottomRight', { ctrlKey: true, force: true })
+        .trigger('mouseup', 'bottomRight', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });

--- a/demos/react/src/examples/slickgrid/Example48.tsx
+++ b/demos/react/src/examples/slickgrid/Example48.tsx
@@ -81,6 +81,7 @@ const Example48: React.FC = () => {
       gridHeight: 250,
       gridWidth: 800,
       enableCellNavigation: true,
+      preventDragFromKeys: [],
       autoEdit: true,
       editable: true,
       headerRowHeight: 35,

--- a/demos/react/test/cypress/e2e/example48.cy.ts
+++ b/demos/react/test/cypress/e2e/example48.cy.ts
@@ -38,17 +38,17 @@ describe('Example 48 - Hybrid Selection Model', () => {
         });
     });
 
-    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+    it('should allow Ctrl-drag from Task 1 to expand the cell selections to include 4 cells', () => {
       cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
       cy.get('@task1').should('contain', 'Task 1');
       cy.get('@task1').click().should('have.class', 'selected');
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 1);
 
-      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
-        .trigger('mousemove', 'bottomRight')
-        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+        .trigger('mousemove', 'bottomRight', { ctrlKey: true, force: true })
+        .trigger('mouseup', 'bottomRight', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });

--- a/demos/vanilla/src/examples/example37.ts
+++ b/demos/vanilla/src/examples/example37.ts
@@ -143,6 +143,7 @@ export default class Example37 {
       gridHeight: 250,
       gridWidth: 800,
       enableCellNavigation: true,
+      preventDragFromKeys: [],
       autoEdit: true,
       editable: true,
       headerRowHeight: 35,

--- a/demos/vue/src/components/Example48.vue
+++ b/demos/vue/src/components/Example48.vue
@@ -104,6 +104,7 @@ function defineGrids() {
     gridHeight: 250,
     gridWidth: 800,
     enableCellNavigation: true,
+    preventDragFromKeys: [],
     autoEdit: true,
     editable: true,
     headerRowHeight: 35,

--- a/demos/vue/test/cypress/e2e/example48.cy.ts
+++ b/demos/vue/test/cypress/e2e/example48.cy.ts
@@ -38,17 +38,17 @@ describe('Example 48 - Hybrid Selection Model', () => {
         });
     });
 
-    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+    it('should allow Ctrl-drag from Task 1 to expand the cell selections to include 4 cells', () => {
       cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
       cy.get('@task1').should('contain', 'Task 1');
       cy.get('@task1').click().should('have.class', 'selected');
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 1);
 
-      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
-        .trigger('mousemove', 'bottomRight')
-        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+        .trigger('mousemove', 'bottomRight', { ctrlKey: true, force: true })
+        .trigger('mouseup', 'bottomRight', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });

--- a/docs/grid-functionalities/row-selection.md
+++ b/docs/grid-functionalities/row-selection.md
@@ -315,6 +315,12 @@ selectionOptions: {
 
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
+By default, the draggable interaction blocks Ctrl/Cmd drag gestures through `preventDragFromKeys: ['ctrlKey', 'metaKey']`. To allow modifier-key cell-range dragging independently of the selection model, explicitly clear the option:
+
+```ts
+preventDragFromKeys: [],
+```
+
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.
 
 #### ViewModel

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
@@ -272,6 +272,12 @@ With cell selection enabled, click an anchor cell and then Shift-click another c
 
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
+By default, the draggable interaction blocks Ctrl/Cmd drag gestures through `preventDragFromKeys: ['ctrlKey', 'metaKey']`. To allow modifier-key cell-range dragging independently of the selection model, explicitly clear the option:
+
+```ts
+preventDragFromKeys: [],
+```
+
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.
 
 ###### View

--- a/frameworks/angular-slickgrid/src/demos/examples/example48.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example48.component.ts
@@ -114,6 +114,7 @@ export class Example48Component implements OnInit {
       gridHeight: 250,
       gridWidth: 800,
       enableCellNavigation: true,
+      preventDragFromKeys: [],
       autoEdit: true,
       editable: true,
       headerRowHeight: 35,

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
@@ -38,17 +38,17 @@ describe('Example 48 - Hybrid Selection Model', () => {
         });
     });
 
-    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+    it('should allow Ctrl-drag from Task 1 to expand the cell selections to include 4 cells', () => {
       cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
       cy.get('@task1').should('contain', 'Task 1');
       cy.get('@task1').click().should('have.class', 'selected');
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 1);
 
-      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
-        .trigger('mousemove', 'bottomRight')
-        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+        .trigger('mousemove', 'bottomRight', { ctrlKey: true, force: true })
+        .trigger('mouseup', 'bottomRight', { which: 1, ctrlKey: true, force: true });
 
       cy.get('#grid48-1 .slick-cell.selected').should('have.length', 4);
     });

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
@@ -284,6 +284,12 @@ With cell selection enabled, click an anchor cell and then Shift-click another c
 
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
+By default, the draggable interaction blocks Ctrl/Cmd drag gestures through `preventDragFromKeys: ['ctrlKey', 'metaKey']`. To allow modifier-key cell-range dragging independently of the selection model, explicitly clear the option:
+
+```ts
+preventDragFromKeys: [],
+```
+
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.
 
 #### View

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -365,6 +365,12 @@ With cell selection enabled, click an anchor cell and then Shift-click another c
 
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
+By default, the draggable interaction blocks Ctrl/Cmd drag gestures through `preventDragFromKeys: ['ctrlKey', 'metaKey']`. To allow modifier-key cell-range dragging independently of the selection model, explicitly clear the option:
+
+```ts
+preventDragFromKeys: [],
+```
+
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.
 
 #### Component

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
@@ -435,6 +435,12 @@ With cell selection enabled, click an anchor cell and then Shift-click another c
 
 For non-contiguous selection ranges, set `selectionOptions.enableMultiSelection: true`. Ctrl/Cmd-click toggles the clicked cell or row, and Ctrl/Cmd-drag adds another range. In row-selection mode, `multiSelect` continues to control whether multiple rows are allowed.
 
+By default, the draggable interaction blocks Ctrl/Cmd drag gestures through `preventDragFromKeys: ['ctrlKey', 'metaKey']`. To allow modifier-key cell-range dragging independently of the selection model, explicitly clear the option:
+
+```ts
+preventDragFromKeys: [],
+```
+
 When `enableExcelCopyBuffer` is enabled, copying multiple non-contiguous ranges preserves their relative row and column positions in a single rectangular clipboard block; unselected cells inside the bounding rectangle remain blank.
 
 #### Component

--- a/packages/common/src/core/__tests__/slickGrid.spec.ts
+++ b/packages/common/src/core/__tests__/slickGrid.spec.ts
@@ -4203,6 +4203,20 @@ describe('SlickGrid core file', () => {
       expect(onDragInitSpy).toHaveBeenCalled();
     });
 
+    it('should allow modifier-key drags when preventDragFromKeys is explicitly empty', () => {
+      grid = new SlickGrid<any, Column>(container, data, columns, {
+        ...defaultOptions,
+        preventDragFromKeys: [],
+      });
+      const onDragInitSpy = vi.spyOn(grid.onDragInit, 'notify');
+      const slickCellElm = container.querySelector('.slick-cell.l1.r1') as HTMLDivElement;
+      const cMouseDownEvent = new MouseEvent('mousedown', { bubbles: true, ctrlKey: true });
+      slickCellElm.dispatchEvent(cMouseDownEvent);
+
+      expect(grid.getOptions().preventDragFromKeys).toEqual([]);
+      expect(onDragInitSpy).toHaveBeenCalled();
+    });
+
     it('should not drag when event has cancelled bubbling (immediatePropagationStopped)', () => {
       grid = new SlickGrid<any, Column>(container, data, columns, defaultOptions);
 

--- a/packages/utils/src/__tests__/nodeExtend.spec.ts
+++ b/packages/utils/src/__tests__/nodeExtend.spec.ts
@@ -593,6 +593,14 @@ describe('extend()', () => {
     test('arrays are merged', () => expect(target).toEqual(expectedTarget));
   });
 
+  describe('deep clone; empty arrays override defaults', () => {
+    const defaults = { arr: [1, 2, 3] };
+    const override = { arr: [] };
+    const target = extend(true, defaults, override);
+
+    test('empty arrays replace the default array', () => expect(target).toEqual({ arr: [] }));
+  });
+
   describe('deep clone === false; objects merged normally', () => {
     const defaults = { a: 1 };
     const override = { a: 2 };

--- a/packages/utils/src/nodeExtend.ts
+++ b/packages/utils/src/nodeExtend.ts
@@ -111,7 +111,8 @@ export function extend<T = any>(...args: any[]): T {
           if (deep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
             if (copyIsArray) {
               copyIsArray = false;
-              clone = src && isArray(src) ? src : [];
+              // An explicitly provided empty array is an override, not an array to merge.
+              clone = src && isArray(src) && copy.length > 0 ? src : [];
             } else {
               clone = src && isPlainObject(src) ? src : {};
             }

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -74,17 +74,17 @@ describe('Example 37 - Hybrid Selection Model', () => {
       });
     });
 
-    it('should click on Task 1 and be able to drag from bottom right corner to expand the cell selections to include 4 cells', () => {
+    it('should allow Ctrl-drag from Task 1 to expand the cell selections to include 4 cells', () => {
       cy.get('.grid37-1 .slick-row[data-row="1"] .slick-cell.l1.r1').as('task1');
       cy.get('@task1').should('contain', 'Task 1');
       cy.get('@task1').click().should('have.class', 'selected');
       cy.get('.grid37-1 .slick-cell.selected').should('have.length', 1);
 
-      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, force: true });
+      cy.get('@task1').find('.slick-drag-replace-handle').trigger('mousedown', { which: 1, ctrlKey: true, force: true });
 
       cy.get('.grid37-1 .slick-row[data-row="2"] .slick-cell.l2.r2')
-        .trigger('mousemove', 'bottomRight')
-        .trigger('mouseup', 'bottomRight', { which: 1, force: true });
+        .trigger('mousemove', 'bottomRight', { ctrlKey: true, force: true })
+        .trigger('mouseup', 'bottomRight', { which: 1, ctrlKey: true, force: true });
 
       cy.get('.grid37-1 .slick-cell.selected').should('have.length', 4);
     });


### PR DESCRIPTION
## Summary

Fixes #2751

Allow explicitly configured empty arrays to replace default arrays during deep option merging.

## Why

`preventDragFromKeys` defaults to `['ctrlKey', 'metaKey']`, but configuring `preventDragFromKeys: []` incorrectly retained those defaults. This prevented Ctrl/Cmd cell-range drag gestures unless consumers mutated the resulting array manually.

## Changes

- Updated the shared deep-merge utility so empty arrays override inherited defaults.
- Added regression tests for empty-array overrides.
- Added Ctrl-drag Cypress coverage to Vanilla Example 37 and framework Example 48:
  - Angular
  - Aurelia
  - React
  - Vue
- Configured the affected examples with `preventDragFromKeys: []`.
- Documented the option in Vanilla and framework row-selection documentation.

## Validation

- Focused Vitest suites: 545 tests passed.
- Vanilla, Aurelia, React, and Vue demo type-checks passed.
- Utility, Common, and Vanilla Bundle builds passed.
- Cypress UI tests passed for the updated examples.
- Prettier and `git diff --check` passed.

## Comments

The change preserves existing non-empty array merge behavior while treating an explicitly supplied empty array as an override.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Luna
  - **how was it used**: Investigated the merge behavior, implemented the fix, added tests, updated demos, and updated documentation.

## Checklist

- [ ] The changes are limited to only one scope (shared utility, demos, tests, and docs are updated together because they cover the same fix).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.