### PR TITLE
fix(selection): sync active cell with selected range

### DIFF
--- a/demos/aurelia/test/cypress/e2e/example48.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example48.cy.ts
@@ -229,6 +229,11 @@ describe('Example 48 - Hybrid Selection Model', () => {
 
       cy.get('@clipboardWriteText').should('have.been.calledWith', 'Task 1\t\t\t\t\r\nTask 2\t\t\t\t2\r\nTask 3\t\t\t\t3\r\n');
     });
+
+    it('should expose the active cell as the selected range', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":1,"toCell":1}');
+    });
   });
 
   describe('Grid 2', () => {

--- a/demos/react/test/cypress/e2e/example48.cy.ts
+++ b/demos/react/test/cypress/e2e/example48.cy.ts
@@ -229,6 +229,11 @@ describe('Example 48 - Hybrid Selection Model', () => {
 
       cy.get('@clipboardWriteText').should('have.been.calledWith', 'Task 1\t\t\t\t\r\nTask 2\t\t\t\t2\r\nTask 3\t\t\t\t3\r\n');
     });
+
+    it('should expose the active cell as the selected range', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":1,"toCell":1}');
+    });
   });
 
   describe('Grid 2', () => {

--- a/demos/vue/test/cypress/e2e/example48.cy.ts
+++ b/demos/vue/test/cypress/e2e/example48.cy.ts
@@ -229,6 +229,11 @@ describe('Example 48 - Hybrid Selection Model', () => {
 
       cy.get('@clipboardWriteText').should('have.been.calledWith', 'Task 1\t\t\t\t\r\nTask 2\t\t\t\t2\r\nTask 3\t\t\t\t3\r\n');
     });
+
+    it('should expose the active cell as the selected range', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":1,"toCell":1}');
+    });
   });
 
   describe('Grid 2', () => {

--- a/docs/grid-functionalities/row-selection.md
+++ b/docs/grid-functionalities/row-selection.md
@@ -273,6 +273,8 @@ export class Example1 {
 
 Starting with v9.10.0, you can now use the new Hybrid Selection Model, this new model will allow you to do Cell Selection & Row Selection in the same grid. This wasn't previously doable before that version because SlickGrid only ever allows 1 selection model to be loaded at once and so we had to load either `SlickCellSelectionModel` or `SlickRowSelectionModel` but never both of them at the same time. The new Hybrid Selection Model is merging both of these plugins in a single plugin allowing us to do both type of selections.
 
+When `selectionType: 'cell'`, `selectActiveCell` controls whether the active cell becomes the selected range; `selectActiveRow` does not disable cell selection.
+
 > [!NOTE]
 > You can use `{ enableSelection: true, selectionOptions: { selectionType: 'mixed' }}` (or `enableHybridSelection: true` in v9) grid option to enable the new Hybrid Model, this new model will eventually replace both cell/row selection model in the future since there's no need to keep all these models when only 1 is more than enough
 

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/row-selection.md
@@ -229,6 +229,8 @@ export class Example1 {
 
 Starting with v9.10.0, you can now use the new Hybrid Selection Model, this new model will allow you to do Cell Selection & Row Selection in the same grid. This wasn't previously doable before that version because SlickGrid only ever allows 1 selection model to be loaded at once and so we had to load either `SlickCellSelectionModel` or `SlickRowSelectionModel` but never both of them at the same time. The new Hybrid Selection Model is merging both of these plugins in a single plugin allowing us to do both type of selections.
 
+When `selectionType: 'cell'`, `selectActiveCell` controls whether the active cell becomes the selected range; `selectActiveRow` does not disable cell selection.
+
 > [!NOTE]
 > You can use `{ enableSelection: true, selectionOptions: { selectionType: 'mixed' }}` (or `enableHybridSelection: true` in v9) grid option to enable the new Hybrid Model, this new model will eventually replace both cell/row selection model in the future since there's no need to keep all these models when only 1 is more than enough
 

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example48.cy.ts
@@ -229,6 +229,11 @@ describe('Example 48 - Hybrid Selection Model', () => {
 
       cy.get('@clipboardWriteText').should('have.been.calledWith', 'Task 1\t\t\t\t\r\nTask 2\t\t\t\t2\r\nTask 3\t\t\t\t3\r\n');
     });
+
+    it('should expose the active cell as the selected range', () => {
+      cy.get('#grid48-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":1,"toCell":1}');
+    });
   });
 
   describe('Grid 2', () => {

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/row-selection.md
@@ -241,6 +241,8 @@ export class Example1 {
 
 Starting with v9.10.0, you can now use the new Hybrid Selection Model, this new model will allow you to do Cell Selection & Row Selection in the same grid. This wasn't previously doable before that version because SlickGrid only ever allows 1 selection model to be loaded at once and so we had to load either `SlickCellSelectionModel` or `SlickRowSelectionModel` but never both of them at the same time. The new Hybrid Selection Model is merging both of these plugins in a single plugin allowing us to do both type of selections.
 
+When `selectionType: 'cell'`, `selectActiveCell` controls whether the active cell becomes the selected range; `selectActiveRow` does not disable cell selection.
+
 > [!NOTE]
 > You can use `{ enableSelection: true, selectionOptions: { selectionType: 'mixed' }}` (or `enableHybridSelection: true` in v9) grid option to enable the new Hybrid Model, this new model will eventually replace both cell/row selection model in the future since there's no need to keep all these models when only 1 is more than enough
 

--- a/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/row-selection.md
@@ -322,6 +322,8 @@ export default Example;
 
 Starting with v9.10.0, you can now use the new Hybrid Selection Model, this new model will allow you to do Cell Selection & Row Selection in the same grid. This wasn't previously doable before that version because SlickGrid only ever allows 1 selection model to be loaded at once and so we had to load either `SlickCellSelectionModel` or `SlickRowSelectionModel` but never both of them at the same time. The new Hybrid Selection Model is merging both of these plugins in a single plugin allowing us to do both type of selections.
 
+When `selectionType: 'cell'`, `selectActiveCell` controls whether the active cell becomes the selected range; `selectActiveRow` does not disable cell selection.
+
 > [!NOTE]
 > You can use `{ enableSelection: true, selectionOptions: { selectionType: 'mixed' }}` (or `enableHybridSelection: true` in v9) grid option to enable the new Hybrid Model, this new model will eventually replace both cell/row selection model in the future since there's no need to keep all these models when only 1 is more than enough
 

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/row-selection.md
@@ -392,6 +392,8 @@ function changeRowSelections() {
 
 Starting with v9.10.0, you can now use the new Hybrid Selection Model, this new model will allow you to do Cell Selection & Row Selection in the same grid. This wasn't previously doable before that version because SlickGrid only ever allows 1 selection model to be loaded at once and so we had to load either `SlickCellSelectionModel` or `SlickRowSelectionModel` but never both of them at the same time. The new Hybrid Selection Model is merging both of these plugins in a single plugin allowing us to do both type of selections.
 
+When `selectionType: 'cell'`, `selectActiveCell` controls whether the active cell becomes the selected range; `selectActiveRow` does not disable cell selection.
+
 > [!NOTE]
 > You can use `{ enableSelection: true, selectionOptions: { selectionType: 'mixed' }}` (or `enableHybridSelection: true` in v9) grid option to enable the new Hybrid Model, this new model will eventually replace both cell/row selection model in the future since there's no need to keep all these models when only 1 is more than enough
 

--- a/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickHybridSelectionModel.spec.ts
@@ -1130,7 +1130,12 @@ describe('Cell Selection Model Plugin', () => {
 
   it('should call "setSelectedRanges" with Slick Ranges when triggered by "onActiveCellChanged" and "selectActiveCell" is True', () => {
     vi.spyOn(gridStub, 'getVisibleColumns').mockReturnValueOnce([]);
-    plugin = new SlickHybridSelectionModel({ selectActiveCell: true, cellRangeSelector: undefined as any });
+    plugin = new SlickHybridSelectionModel({
+      selectActiveCell: true,
+      selectActiveRow: false,
+      selectionType: 'cell',
+      cellRangeSelector: undefined as any,
+    });
     plugin.init(gridStub);
     const setSelectRangeSpy = vi.spyOn(plugin, 'setSelectedRanges');
     const mouseEvent = addVanillaEventPropagation(new Event('mouseenter'));

--- a/packages/common/src/extensions/slickHybridSelectionModel.ts
+++ b/packages/common/src/extensions/slickHybridSelectionModel.ts
@@ -313,7 +313,7 @@ export class SlickHybridSelectionModel implements SelectionModel<HybridSelection
     } else {
       if (this._options?.selectActiveCell && isRowDefined && isCellDefined) {
         // if any row selections are visible, leave them untouched unless `selectActiveCell` is enabled
-        if (this._options.selectActiveRow) {
+        if (this._options.selectionType === 'cell' || this._options.selectActiveRow) {
           this.setSelectedRanges([new SlickRange(args.row, args.cell)], undefined, '');
         }
       } else if (!this._options?.selectActiveCell || (!isRowDefined && !isCellDefined)) {

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -276,10 +276,16 @@ describe('Example 37 - Hybrid Selection Model', () => {
 
     it('should select the active cell when cell selection disables active-row selection', () => {
       cy.window()
-        .its('Example37.sgb1.slickGrid', { timeout: 10000 })
-        .should('exist')
-        .then((slickGrid: any) => {
-          const selectionModel = slickGrid.getSelectionModel();
+        .its('main.app.viewModelObj', { timeout: 10000 })
+        .should((viewModelObj: Record<string, any>) => {
+          expect(
+            Object.values(viewModelObj).some((viewModel) => viewModel?.sgb1?.slickGrid),
+            'Grid 1 view model'
+          ).to.be.true;
+        })
+        .then((viewModelObj: Record<string, any>) => {
+          const viewModel = Object.values(viewModelObj).find((candidate) => candidate?.sgb1?.slickGrid);
+          const selectionModel = viewModel.sgb1.slickGrid.getSelectionModel();
           selectionModel.setOptions({ selectActiveCell: true, selectActiveRow: false, selectionType: 'cell' });
           selectionModel.setSelectedRanges([]);
         });

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -273,6 +273,17 @@ describe('Example 37 - Hybrid Selection Model', () => {
 
       cy.get('@clipboardWriteText').should('have.been.calledWith', 'Task 1\t\t\t\t\r\nTask 2\t\t\t\t2\r\nTask 3\t\t\t\t3\r\n');
     });
+
+    it('should select the active cell when cell selection disables active-row selection', () => {
+      cy.window().then((win: any) => {
+        const selectionModel = win.Example37.sgb1.slickGrid.getSelectionModel();
+        selectionModel.setOptions({ selectActiveCell: true, selectActiveRow: false, selectionType: 'cell' });
+        selectionModel.setSelectedRanges([]);
+      });
+
+      cy.get('.grid37-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
+      cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":1,"toCell":1}');
+    });
   });
 
   describe('Grid 2', () => {

--- a/test/cypress/e2e/example37.cy.ts
+++ b/test/cypress/e2e/example37.cy.ts
@@ -275,11 +275,14 @@ describe('Example 37 - Hybrid Selection Model', () => {
     });
 
     it('should select the active cell when cell selection disables active-row selection', () => {
-      cy.window().then((win: any) => {
-        const selectionModel = win.Example37.sgb1.slickGrid.getSelectionModel();
-        selectionModel.setOptions({ selectActiveCell: true, selectActiveRow: false, selectionType: 'cell' });
-        selectionModel.setSelectedRanges([]);
-      });
+      cy.window()
+        .its('Example37.sgb1.slickGrid', { timeout: 10000 })
+        .should('exist')
+        .then((slickGrid: any) => {
+          const selectionModel = slickGrid.getSelectionModel();
+          selectionModel.setOptions({ selectActiveCell: true, selectActiveRow: false, selectionType: 'cell' });
+          selectionModel.setSelectedRanges([]);
+        });
 
       cy.get('.grid37-1 .slick-row[data-row="1"] .slick-cell.l1.r1').click();
       cy.get('#selectionRange1').should('have.text', '{"fromRow":1,"fromCell":1,"toRow":1,"toCell":1}');


### PR DESCRIPTION
## Summary

Fixes #2753

When `selectActiveCell` is enabled and `selectActiveRow` is disabled, changing the active cell did not update the selected range. This could leave the active cell and selection state out of sync.

## Why

Users could click a new cell while APIs such as copy still operated on the previous selected range.

## Changes

- Updated `SlickHybridSelectionModel` to synchronize the active cell in `selectionType: 'cell'` mode.
- Added a core unit regression test.
- Added Vanilla Example 37 Cypress coverage.
- Added equivalent Example 48 Cypress coverage for Angular, Aurelia, React, and Vue.
- Clarified the behavior in the Vanilla, Angular, Aurelia, React, and Vue row-selection documentation.

## Validation

- Vitest: 81 tests passed.
- TypeScript check for `packages/common`.
- Oxlint passed for changed files.
- Prettier checks passed.
- `git diff --check` passed.
- Vanilla Cypress execution was attempted, but Chrome/Electron exited with code 132 before test output.
- Framework Cypress suites were not run because only the Vanilla development server was available.

## Comments

The related SlickGrid fork [issue 345](https://github.com/6pac/SlickGrid/issues/345) was reviewed. It concerns checkbox-based row selection and active-cell focus behavior, but follows a different code path and does not require additional checkbox-selection changes.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex ChatGPT 5.6 Luna
  - **how was it used**: Investigated the issue, implemented the minimal fix, updated tests and documentation, and performed validation.

## Checklist

- [x] The changes are limited to only one scope (shared selection behavior and its related tests/documentation).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.