### PR TITLE
fix(common): expose programmatic Excel copy command

### DIFF
--- a/docs/grid-functionalities/excel-copy-buffer.md
+++ b/docs/grid-functionalities/excel-copy-buffer.md
@@ -16,6 +16,23 @@ this.gridOptions = {
 };
 ```
 
+### Programmatic Copy
+
+The Excel copy buffer can also be triggered from a context-menu or toolbar command. Keep the registered plugin instance and call `copyToClipboard()` to use the same selection serialization as `Ctrl+C`:
+
+```typescript
+let excelCopyManager: SlickCellExcelCopyManager;
+
+this.gridOptions = {
+  enableExcelCopyBuffer: true,
+  excelCopyBufferOptions: {
+    onExtensionRegistered: (plugin) => (excelCopyManager = plugin),
+  },
+};
+
+await excelCopyManager.copyToClipboard();
+```
+
 ### Copy & Paste with Cell Formatter
 What if you have a date in UTC format in your dataset but your grid shows it as a Date ISO format? In that case, you are using a Formatter (e.g. `formatter: Formatters.dateIso`) and you wish to use that formatter. Good news, that is supported with and to make is simpler for the implementation, we will use a flag that already exist which is `exportWithFormatter` and is used by the `Export to File` service (for more info, read [Wiki - Export to File](export-to-text-file.md)
 

--- a/frameworks/angular-slickgrid/docs/grid-functionalities/excel-copy-buffer.md
+++ b/frameworks/angular-slickgrid/docs/grid-functionalities/excel-copy-buffer.md
@@ -23,6 +23,23 @@ this.gridOptions = {
 };
 ```
 
+### Programmatic Copy
+
+The Excel copy buffer can also be triggered from a context-menu or toolbar command. Keep the registered plugin instance and call `copyToClipboard()` to use the same selection serialization as `Ctrl+C`:
+
+```typescript
+let excelCopyManager: SlickCellExcelCopyManager;
+
+this.gridOptions = {
+  enableExcelCopyBuffer: true,
+  excelCopyBufferOptions: {
+    onExtensionRegistered: (plugin) => (excelCopyManager = plugin),
+  },
+};
+
+await excelCopyManager.copyToClipboard();
+```
+
 ### Copy & Paste with Cell Formatter
 What if you have a date in UTC format in your dataset but your grid shows it as a Date ISO format? In that case, you are using a Formatter (e.g. `formatter: Formatters.dateIso`) and you wish to use that formatter. Good news, that is supported with and to make is simpler for the implementation, we will use a flag that already exist which is `exportWithFormatter` and is used by the `Export to File` service (for more info, read [Wiki - Export to File](export-to-text-file.md)
 

--- a/frameworks/aurelia-slickgrid/docs/grid-functionalities/excel-copy-buffer.md
+++ b/frameworks/aurelia-slickgrid/docs/grid-functionalities/excel-copy-buffer.md
@@ -23,6 +23,23 @@ this.gridOptions = {
 };
 ```
 
+### Programmatic Copy
+
+The Excel copy buffer can also be triggered from a context-menu or toolbar command. Keep the registered plugin instance and call `copyToClipboard()` to use the same selection serialization as `Ctrl+C`:
+
+```typescript
+let excelCopyManager: SlickCellExcelCopyManager;
+
+this.gridOptions = {
+  enableExcelCopyBuffer: true,
+  excelCopyBufferOptions: {
+    onExtensionRegistered: (plugin) => (excelCopyManager = plugin),
+  },
+};
+
+await excelCopyManager.copyToClipboard();
+```
+
 ### Copy & Paste with Cell Formatter
 What if you have a date in UTC format in your dataset but your grid shows it as a Date ISO format? In that case, you are using a Formatter (e.g. `formatter: Formatters.dateIso`) and you wish to use that formatter. Good news, that is supported with and to make is simpler for the implementation, we will use a flag that already exist which is `exportWithFormatter` and is used by the `Export to File` service (for more info, read [Wiki - Export to File](export-to-text-file.md)
 

--- a/frameworks/slickgrid-react/docs/grid-functionalities/excel-copy-buffer.md
+++ b/frameworks/slickgrid-react/docs/grid-functionalities/excel-copy-buffer.md
@@ -23,6 +23,23 @@ const gridOptions = {
 };
 ```
 
+### Programmatic Copy
+
+The Excel copy buffer can also be triggered from a context-menu or toolbar command. Keep the registered plugin instance and call `copyToClipboard()` to use the same selection serialization as `Ctrl+C`:
+
+```typescript
+let excelCopyManager: SlickCellExcelCopyManager;
+
+this.gridOptions = {
+  enableExcelCopyBuffer: true,
+  excelCopyBufferOptions: {
+    onExtensionRegistered: (plugin) => (excelCopyManager = plugin),
+  },
+};
+
+await excelCopyManager.copyToClipboard();
+```
+
 ### Copy & Paste with Cell Formatter
 What if you have a date in UTC format in your dataset but your grid shows it as a Date ISO format? In that case, you are using a Formatter (e.g. `formatter: Formatters.dateIso`) and you wish to use that formatter. Good news, that is supported with and to make is simpler for the implementation, we will use a flag that already exist which is `exportWithFormatter` and is used by the `Export to File` service (for more info, read [Wiki - Export to File](export-to-text-file.md)
 

--- a/frameworks/slickgrid-vue/docs/grid-functionalities/excel-copy-buffer.md
+++ b/frameworks/slickgrid-vue/docs/grid-functionalities/excel-copy-buffer.md
@@ -24,6 +24,23 @@ gridOptions.value = {
 };
 ```
 
+### Programmatic Copy
+
+The Excel copy buffer can also be triggered from a context-menu or toolbar command. Keep the registered plugin instance and call `copyToClipboard()` to use the same selection serialization as `Ctrl+C`:
+
+```typescript
+let excelCopyManager: SlickCellExcelCopyManager;
+
+this.gridOptions = {
+  enableExcelCopyBuffer: true,
+  excelCopyBufferOptions: {
+    onExtensionRegistered: (plugin) => (excelCopyManager = plugin),
+  },
+};
+
+await excelCopyManager.copyToClipboard();
+```
+
 ### Copy & Paste with Cell Formatter
 What if you have a date in UTC format in your dataset but your grid shows it as a Date ISO format? In that case, you are using a Formatter (e.g. `formatter: Formatters.dateIso`) and you wish to use that formatter. Good news, that is supported with and to make is simpler for the implementation, we will use a flag that already exist which is `exportWithFormatter` and is used by the `Export to File` service (for more info, read [Wiki - Export to File](export-to-text-file.md)
 

--- a/packages/common/src/extensions/__tests__/slickCellExcelCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExcelCopyManager.spec.ts
@@ -29,6 +29,7 @@ const mockCellExternalCopyManager = {
   constructor: vi.fn(),
   init: vi.fn(),
   dispose: vi.fn(),
+  copyToClipboard: vi.fn().mockResolvedValue(true),
   getHeaderValueForColumn: vi.fn(),
   getDataItemValueForColumn: vi.fn(),
   setDataItemValueForColumn: vi.fn(),
@@ -125,6 +126,13 @@ describe('CellExcelCopyManager', () => {
       expect(plugin.gridOptions).toEqual(gridOptionsMock);
       expect(setSelectionSpy).toHaveBeenCalledWith(mockCellSelectionModel);
       expect(cellExternalCopyInitSpy).toHaveBeenCalledWith(gridStub, expectedAddonOptions);
+    });
+
+    it('should expose the copy-to-clipboard command from the Excel copy manager', async () => {
+      plugin.init(gridStub);
+
+      await expect(plugin.copyToClipboard()).resolves.toBe(true);
+      expect(mockCellExternalCopyManager.copyToClipboard).toHaveBeenCalledTimes(1);
     });
 
     it('should call internal event handler subscribe and expect the "onCopyCells" option to be called when addon notify is called', () => {

--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -357,6 +357,26 @@ describe('CellExternalCopyManager', () => {
         expect(writeTextSpy).toHaveBeenCalledWith('First Name\tLast Name\r\nserialized output\tDoe\r\nserialized output\tDoe\r\n');
       });
 
+      it('should not copy anything when there is no selected range', async () => {
+        const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');
+        vi.spyOn(gridStub.getSelectionModel() as SelectionModel, 'getSelectedRanges').mockReturnValue([]);
+        plugin.init(gridStub);
+
+        await expect(plugin.copyToClipboard()).resolves.toBe(false);
+
+        expect(writeTextSpy).not.toHaveBeenCalled();
+      });
+
+      it('should skip a selected cell when its column is not available', async () => {
+        const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');
+        vi.spyOn(gridStub.getSelectionModel() as SelectionModel, 'getSelectedRanges').mockReturnValue([new SlickRange(0, 3, 0, 3)]);
+        plugin.init(gridStub);
+
+        await expect(plugin.copyToClipboard()).resolves.toBe(true);
+
+        expect(writeTextSpy).toHaveBeenCalledWith('\r\n');
+      });
+
       it('should preserve row and column offsets when copying multiple cell ranges', () =>
         new Promise((done: any) => {
           const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');

--- a/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
+++ b/packages/common/src/extensions/__tests__/slickCellExternalCopyManager.spec.ts
@@ -344,6 +344,19 @@ describe('CellExternalCopyManager', () => {
           });
         }));
 
+      it('should copy the current selection when copyToClipboard is called', async () => {
+        const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');
+        vi.spyOn(gridStub.getSelectionModel() as SelectionModel, 'getSelectedRanges').mockReturnValue([new SlickRange(0, 0, 1, 1)]);
+        vi.spyOn(gridStub, 'getDataItem').mockImplementation((row) =>
+          row === 0 ? { firstName: 'John', lastName: 'Doe' } : { firstName: 'Jane', lastName: 'Doe' }
+        );
+        plugin.init(gridStub, { includeHeaderWhenCopying: true });
+
+        await expect(plugin.copyToClipboard()).resolves.toBe(true);
+
+        expect(writeTextSpy).toHaveBeenCalledWith('First Name\tLast Name\r\nserialized output\tDoe\r\nserialized output\tDoe\r\n');
+      });
+
       it('should preserve row and column offsets when copying multiple cell ranges', () =>
         new Promise((done: any) => {
           const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');

--- a/packages/common/src/extensions/slickCellExcelCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExcelCopyManager.ts
@@ -60,6 +60,11 @@ export class SlickCellExcelCopyManager {
     return this._undoRedoBuffer;
   }
 
+  /** Copy the currently selected cell ranges to the clipboard. */
+  copyToClipboard(): Promise<boolean> {
+    return this._cellExternalCopyManagerPlugin.copyToClipboard();
+  }
+
   init(grid: SlickGrid, options?: ExcelCopyBufferOption): void {
     this._grid = grid;
     this.createUndoRedoBuffer();

--- a/packages/common/src/extensions/slickCellExternalCopyManager.ts
+++ b/packages/common/src/extensions/slickCellExternalCopyManager.ts
@@ -226,6 +226,70 @@ export class SlickCellExternalCopyManager {
     this._addonOptions.includeHeaderWhenCopying = includeHeaderWhenCopying;
   }
 
+  /** Copy the currently selected cell ranges to the clipboard. */
+  async copyToClipboard(e: SlickEventData = new SlickEventData()): Promise<boolean> {
+    if (typeof this._onCopyInit === 'function') {
+      this._onCopyInit.call(this);
+    }
+
+    const ranges = this._grid.getSelectionModel()?.getSelectedRanges() ?? [];
+    if (ranges.length === 0) {
+      return false;
+    }
+
+    this._copiedRanges = ranges;
+    this.markCopySelection(ranges);
+    this.onCopyCells.notify({ ranges });
+    if (typeof this._addonOptions.onCopyCells === 'function') {
+      this._addonOptions.onCopyCells(e, { ranges });
+    }
+
+    const columns = this._grid.getColumns();
+    const fromRow = Math.min(...ranges.map((range) => range.fromRow));
+    const fromCell = Math.min(...ranges.map((range) => range.fromCell));
+    const toRow = Math.max(...ranges.map((range) => range.toRow));
+    const toCell = Math.max(...ranges.map((range) => range.toCell));
+    const clipTextRows: string[] = [];
+
+    if (this._addonOptions.includeHeaderWhenCopying) {
+      const clipTextHeaders: string[] = [];
+      for (let j = fromCell; j <= toCell; j++) {
+        const column = columns[j];
+        const isSelectedColumn = ranges.some((range) => j >= range.fromCell && j <= range.toCell);
+        if (this.isColumnCopyable(column)) {
+          clipTextHeaders.push(isSelectedColumn ? this.getHeaderValueForColumn(column) : '');
+        }
+      }
+      clipTextRows.push(clipTextHeaders.join('\t'));
+    }
+
+    for (let i = fromRow; i <= toRow; i++) {
+      const clipTextCells: string[] = [];
+      const dt = this._dataWrapper.getDataItem(i);
+      for (let j = fromCell; j <= toCell; j++) {
+        const column = columns[j];
+        if (this.isColumnCopyable(column)) {
+          clipTextCells.push(ranges.some((range) => range.contains(i, j)) ? this.getDataItemValueForColumn(dt, column, i, j, e) : '');
+        }
+      }
+      clipTextRows.push(clipTextCells.join('\t'));
+    }
+
+    const clipText = clipTextRows.join('\r\n') + '\r\n';
+
+    // copy to clipboard using override or default browser Clipboard API
+    const clipboardOverrideFn = this._grid.getOptions().clipboardWriteOverride;
+    clipboardOverrideFn ? clipboardOverrideFn(clipText) : await navigator.clipboard.writeText(clipText);
+
+    if (typeof this._onCopySuccess === 'function') {
+      // If it's cell selection, use the toRow/fromRow fields
+      const rowCount = ranges.length === 1 ? ranges[0].toRow + 1 - ranges[0].fromRow : ranges.length;
+      this._onCopySuccess(rowCount);
+    }
+
+    return true;
+  }
+
   //
   // protected functions
   // ---------------------
@@ -430,7 +494,6 @@ export class SlickCellExternalCopyManager {
 
   protected async handleKeyDown(e: SlickEventData): Promise<boolean | void> {
     try {
-      let ranges: SlickRange[];
       if (!this._grid.getEditorLock().isActive() || this._grid.getOptions().autoEdit) {
         if (e.key === 'Escape') {
           if (this._copiedRanges) {
@@ -446,69 +509,7 @@ export class SlickCellExternalCopyManager {
 
         if ((e.key === 'c' || e.key === 'Insert') && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
           // CTRL+C or CTRL+INS
-          if (typeof this._onCopyInit === 'function') {
-            this._onCopyInit.call(this);
-          }
-          ranges = this._grid.getSelectionModel()?.getSelectedRanges() ?? [];
-          if (ranges.length !== 0) {
-            this._copiedRanges = ranges;
-            this.markCopySelection(ranges);
-            this.onCopyCells.notify({ ranges });
-            if (typeof this._addonOptions.onCopyCells === 'function') {
-              this._addonOptions.onCopyCells(e, { ranges });
-            }
-
-            const columns = this._grid.getColumns();
-            const fromRow = Math.min(...ranges.map((range) => range.fromRow));
-            const fromCell = Math.min(...ranges.map((range) => range.fromCell));
-            const toRow = Math.max(...ranges.map((range) => range.toRow));
-            const toCell = Math.max(...ranges.map((range) => range.toCell));
-            let clipText = '';
-
-            const clipTextRows: string[] = [];
-            if (this._addonOptions.includeHeaderWhenCopying) {
-              const clipTextHeaders: string[] = [];
-              for (let j = fromCell; j <= toCell; j++) {
-                const column = columns[j];
-                const isSelectedColumn = ranges.some((range) => j >= range.fromCell && j <= range.toCell);
-                if (column) {
-                  const colName: string = column.name instanceof HTMLElement ? stripTags(column.name.innerHTML) : (column.name as string);
-                  if (colName.length > 0 && !column.hidden) {
-                    clipTextHeaders.push(isSelectedColumn ? this.getHeaderValueForColumn(column) : '');
-                  }
-                }
-              }
-              clipTextRows.push(clipTextHeaders.join('\t'));
-            }
-
-            for (let i = fromRow; i <= toRow; i++) {
-              const clipTextCells: string[] = [];
-              const dt = this._dataWrapper.getDataItem(i);
-              for (let j = fromCell; j <= toCell; j++) {
-                const column = columns[j];
-                if (column) {
-                  const colName: string = column.name instanceof HTMLElement ? stripTags(column.name.innerHTML) : (column.name as string);
-                  if (colName.length > 0 && !column.hidden) {
-                    clipTextCells.push(
-                      ranges.some((range) => range.contains(i, j)) ? this.getDataItemValueForColumn(dt, column, i, j, e) : ''
-                    );
-                  }
-                }
-              }
-              clipTextRows.push(clipTextCells.join('\t'));
-            }
-            clipText += clipTextRows.join('\r\n') + '\r\n';
-
-            // copy to clipboard using override or default browser Clipboard API
-            const clipboardOverrideFn = this._grid.getOptions().clipboardWriteOverride;
-            clipboardOverrideFn ? clipboardOverrideFn(clipText) : await navigator.clipboard.writeText(clipText);
-
-            if (typeof this._onCopySuccess === 'function') {
-              // If it's cell selection, use the toRow/fromRow fields
-              const rowCount = ranges.length === 1 ? ranges[0].toRow + 1 - ranges[0].fromRow : ranges.length;
-              this._onCopySuccess(rowCount);
-            }
-
+          if (await this.copyToClipboard(e)) {
             return false;
           }
         }
@@ -546,5 +547,13 @@ export class SlickCellExternalCopyManager {
       () => this.clearCopySelection(),
       this.addonOptions?.clearCopySelectionDelay || CLEAR_COPY_SELECTION_DELAY
     );
+  }
+
+  protected isColumnCopyable(column?: Column): column is Column {
+    if (!column) {
+      return false;
+    }
+    const colName: string = column.name instanceof HTMLElement ? stripTags(column.name.innerHTML) : (column.name as string);
+    return colName.length > 0 && !column.hidden;
   }
 }


### PR DESCRIPTION
## Summary

fixes #2754

Adds a supported way to trigger Excel-style copying of the current cell selection from toolbar or context-menu commands.

## Why

Applications no longer need to duplicate SlickGrid’s selection serialization and clipboard logic.

## Changes

- Added `copyToClipboard()` to `SlickCellExternalCopyManager`.
- Exposed the method through `SlickCellExcelCopyManager`.
- Refactored Ctrl/Cmd+C to reuse the same implementation.
- Extracted the repeated column-copyability check.
- Added unit tests and documentation across framework packages.

## Validation

- 60 focused Vitest tests passed.
- Common package TypeScript build passed.
- Targeted Oxlint passed.
- Prettier checks passed.
- `git diff --check` passed.
- Cypress was not run because this adds no visible UI flow.

## Comments

The existing `onExtensionRegistered` callback can be used to retain the Excel copy manager instance and invoke `copyToClipboard()` from an application command.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: Codex, GPT-5.6 Luna
  - **how was it used**: Implemented the feature, refactored shared logic, added tests/documentation, and ran validation checks.

## Checklist

- [x] The changes are limited to only one scope.
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.