### PR TITLE
fix: preserve caller-owned columns when disposing grids

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example17.html
+++ b/demos/aurelia/src/examples/slickgrid/example17.html
@@ -45,7 +45,14 @@
         Use default CSV data
       </button>
       &nbsp;/
-      <button class="btn btn-outline-danger btn-sm ms-2" click.trigger="destroyGrid()">Destroy Grid</button>
+      <button
+        class="btn btn-outline-danger btn-sm ms-2"
+        data-test="toggle-grid-btn"
+        disabled.bind="columns.length === 0"
+        click.trigger="toggleGrid()"
+      >
+        ${gridCreated ? 'Destroy Grid' : 'Recreate Grid'}
+      </button>
     </div>
   </div>
 

--- a/demos/aurelia/src/examples/slickgrid/example17.ts
+++ b/demos/aurelia/src/examples/slickgrid/example17.ts
@@ -18,8 +18,8 @@ export class Example17 {
     this.aureliaGrid = aureliaGrid;
   }
 
-  destroyGrid() {
-    this.gridCreated = false;
+  toggleGrid() {
+    this.gridCreated = !this.gridCreated;
   }
 
   handleFileImport(event: any) {

--- a/demos/aurelia/test/cypress/e2e/example17.cy.ts
+++ b/demos/aurelia/test/cypress/e2e/example17.cy.ts
@@ -80,4 +80,16 @@ describe('Example 17 - Dynamically Create Grid from CSV / Excel import', () => {
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(2)`).should('contain', '33');
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(3)`).should('contain', 'Teacher');
   });
+
+  it('should preserve the supplied columns when destroying and recreating the grid', () => {
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Destroy Grid').click();
+    cy.get('#slickGridContainer-grid17').should('not.exist');
+
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Recreate Grid').click();
+    cy.get('#slickGridContainer-grid17')
+      .find('.slick-header-columns')
+      .children()
+      .should('have.length', defaultCsvTitles.length)
+      .each(($column, index) => expect($column.text()).to.eq(defaultCsvTitles[index]));
+  });
 });

--- a/demos/react/src/examples/slickgrid/Example17.tsx
+++ b/demos/react/src/examples/slickgrid/Example17.tsx
@@ -11,8 +11,8 @@ const Example17: React.FC = () => {
   const [uploadFileRef, setUploadFileRef] = useState('');
   const [hideSubTitle, setHideSubTitle] = useState(false);
 
-  function destroyGrid() {
-    setGridCreated(false);
+  function toggleGrid() {
+    setGridCreated(!gridCreated);
   }
 
   function handleFileImport(event: any) {
@@ -149,8 +149,13 @@ const Example17: React.FC = () => {
             Use default CSV data
           </button>
           &nbsp;/
-          <button className="btn btn-outline-danger btn-sm ms-2" onClick={() => destroyGrid()}>
-            Destroy Grid
+          <button
+            className="btn btn-outline-danger btn-sm ms-2"
+            data-test="toggle-grid-btn"
+            disabled={columns.length === 0}
+            onClick={() => toggleGrid()}
+          >
+            {gridCreated ? 'Destroy Grid' : 'Recreate Grid'}
           </button>
         </div>
       </div>

--- a/demos/react/test/cypress/e2e/example17.cy.ts
+++ b/demos/react/test/cypress/e2e/example17.cy.ts
@@ -80,4 +80,16 @@ describe('Example 17 - Dynamically Create Grid from CSV / Excel import', () => {
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(2)`).should('contain', '33');
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(3)`).should('contain', 'Teacher');
   });
+
+  it('should preserve the supplied columns when destroying and recreating the grid', () => {
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Destroy Grid').click();
+    cy.get('#slickGridContainer-grid17').should('not.exist');
+
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Recreate Grid').click();
+    cy.get('#slickGridContainer-grid17')
+      .find('.slick-header-columns')
+      .children()
+      .should('have.length', defaultCsvTitles.length)
+      .each(($column, index) => expect($column.text()).to.eq(defaultCsvTitles[index]));
+  });
 });

--- a/demos/vue/src/components/Example17.vue
+++ b/demos/vue/src/components/Example17.vue
@@ -11,8 +11,8 @@ const templateUrl = ref(new URL('./data/users.csv', import.meta.url).href);
 const uploadFileRef = ref('');
 const showSubTitle = ref(true);
 
-function disposeGrid() {
-  gridCreated.value = false;
+function toggleGrid() {
+  gridCreated.value = !gridCreated.value;
 }
 
 function handleFileImport(event: any) {
@@ -134,7 +134,9 @@ function toggleSubTitle() {
         Use default CSV data
       </button>
       &nbsp;/
-      <button class="btn btn-outline-danger btn-sm ms-2" @click="disposeGrid()">Destroy Grid</button>
+      <button class="btn btn-outline-danger btn-sm ms-2" data-test="toggle-grid-btn" :disabled="columns.length === 0" @click="toggleGrid()">
+        {{ gridCreated ? 'Destroy Grid' : 'Recreate Grid' }}
+      </button>
     </div>
   </div>
 

--- a/demos/vue/test/cypress/e2e/example17.cy.ts
+++ b/demos/vue/test/cypress/e2e/example17.cy.ts
@@ -80,4 +80,16 @@ describe('Example 17 - Dynamically Create Grid from CSV / Excel import', () => {
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(2)`).should('contain', '33');
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(3)`).should('contain', 'Teacher');
   });
+
+  it('should preserve the supplied columns when destroying and recreating the grid', () => {
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Destroy Grid').click();
+    cy.get('#slickGridContainer-grid17').should('not.exist');
+
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Recreate Grid').click();
+    cy.get('#slickGridContainer-grid17')
+      .find('.slick-header-columns')
+      .children()
+      .should('have.length', defaultCsvTitles.length)
+      .each(($column, index) => expect($column.text()).to.eq(defaultCsvTitles[index]));
+  });
 });

--- a/frameworks/angular-slickgrid/src/demos/examples/example17.component.html
+++ b/frameworks/angular-slickgrid/src/demos/examples/example17.component.html
@@ -39,7 +39,9 @@
       <button id="uploadBtn" data-test="static-data-btn" class="btn btn-outline-secondary" (click)="handleDefaultCsv()">
         Use default CSV data
       </button>
-      <button class="btn btn-outline-secondary" (click)="destroyGrid()">Destroy Grid</button>
+      <button class="btn btn-outline-secondary" data-test="toggle-grid-btn" [disabled]="columns.length === 0" (click)="toggleGrid()">
+        {{ gridCreated ? 'Destroy Grid' : 'Recreate Grid' }}
+      </button>
     </div>
   </div>
 

--- a/frameworks/angular-slickgrid/src/demos/examples/example17.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example17.component.ts
@@ -43,8 +43,8 @@ export class Example17Component {
     this.uploadFileRef = '';
   }
 
-  destroyGrid() {
-    this.gridCreated = false;
+  toggleGrid() {
+    this.gridCreated = !this.gridCreated;
   }
 
   dynamicallyCreateGrid(csvContent: string) {

--- a/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/frameworks/angular-slickgrid/src/library/components/__tests__/angular-slickgrid.component.spec.ts
@@ -570,6 +570,17 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     expect(pubSubSpy).toHaveBeenNthCalledWith(5, 'onBeforeGridDestroy', expect.any(Object));
   });
 
+  it('should preserve caller-owned columns when destroyed', () => {
+    component.ngAfterViewInit();
+    const suppliedColumns: Column[] = [{ id: 'firstName', field: 'firstName', name: 'First Name' }];
+    component.columns = suppliedColumns;
+
+    component.ngOnDestroy();
+
+    expect(suppliedColumns).toHaveLength(1);
+    expect(suppliedColumns[0]).toMatchObject({ id: 'firstName', field: 'firstName', name: 'First Name' });
+  });
+
   it('should update column definitions when onPluginColumnsChanged event is triggered with updated columns', () => {
     const colsChangeSpy = vi.spyOn(component.columnsChange, 'emit');
     const columnsMock = [

--- a/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
+++ b/frameworks/angular-slickgrid/src/library/components/angular-slickgrid.component.ts
@@ -586,11 +586,6 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
       }
       this.backendServiceApi = undefined;
     }
-    if (this.columns) {
-      for (const prop of Object.keys(this.columns)) {
-        (this.columns as any)[prop] = null;
-      }
-    }
     for (const prop of Object.keys(this.sharedService)) {
       (this.sharedService as any)[prop] = null;
     }

--- a/frameworks/angular-slickgrid/test/cypress/e2e/example17.cy.ts
+++ b/frameworks/angular-slickgrid/test/cypress/e2e/example17.cy.ts
@@ -80,4 +80,16 @@ describe('Example 17 - Dynamically Create Grid from CSV / Excel import', () => {
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(2)`).should('contain', '33');
     cy.get(`[style="transform: translateY(${GRID_ROW_HEIGHT * 0}px);"] > .slick-cell:nth(3)`).should('contain', 'Teacher');
   });
+
+  it('should preserve the supplied columns when destroying and recreating the grid', () => {
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Destroy Grid').click();
+    cy.get('#slickGridContainer-grid17').should('not.exist');
+
+    cy.get('[data-test="toggle-grid-btn"]').should('contain', 'Recreate Grid').click();
+    cy.get('#slickGridContainer-grid17')
+      .find('.slick-header-columns')
+      .children()
+      .should('have.length', defaultCsvTitles.length)
+      .each(($column, index) => expect($column.text()).to.eq(defaultCsvTitles[index]));
+  });
 });

--- a/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/frameworks/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -580,9 +580,6 @@ export class AureliaSlickgridCustomElement {
       }
       this.backendServiceApi = undefined;
     }
-    for (const prop of Object.keys(this.columns)) {
-      (this.columns as any)[prop] = null;
-    }
     for (const prop of Object.keys(this.sharedService)) {
       (this.sharedService as any)[prop] = null;
     }

--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -725,9 +725,6 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
       }
       this.backendServiceApi = undefined;
     }
-    for (const prop of Object.keys(this.props.columns)) {
-      (this.props.columns as any)[prop] = null;
-    }
     for (const prop of Object.keys(this.sharedService)) {
       (this.sharedService as any)[prop] = null;
     }

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -671,12 +671,10 @@ function disposing(shouldEmptyDomElementContainer = false) {
     }
     backendServiceApi = undefined;
   }
-  for (const prop of Object.keys(columnsModel.value)) {
-    (columnsModel.value as any)[prop] = null;
-  }
   for (const prop of Object.keys(sharedService)) {
     (sharedService as any)[prop] = null;
   }
+  _columns.value = [];
 
   // we could optionally also empty the content of the grid container DOM element
   if (shouldEmptyDomElementContainer) {

--- a/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
+++ b/packages/vanilla-bundle/src/components/__tests__/slick-vanilla-grid.spec.ts
@@ -380,6 +380,16 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
     expect(component.isGridInitialized).toBeTruthy();
   });
 
+  it('should preserve caller-owned column definitions when disposed', () => {
+    const suppliedColumns: Column[] = [{ id: 'firstName', field: 'firstName', name: 'First Name' }];
+    component.columnDefinitions = suppliedColumns;
+
+    component.dispose();
+
+    expect(suppliedColumns).toHaveLength(1);
+    expect(suppliedColumns[0]).toMatchObject({ id: 'firstName', field: 'firstName', name: 'First Name' });
+  });
+
   it('should provide the gridService lazily', () => {
     cellDiv = document.createElement('div');
     divContainer.innerHTML = template;

--- a/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
+++ b/packages/vanilla-bundle/src/components/slick-vanilla-grid-bundle.ts
@@ -461,9 +461,6 @@ export class SlickVanillaGridBundle<TData = any> {
       }
       this.backendServiceApi = undefined;
     }
-    for (const prop of Object.keys(this.columnDefinitions)) {
-      (this.columnDefinitions as any)[prop] = null;
-    }
     for (const prop of Object.keys(this.sharedService)) {
       (this.sharedService as any)[prop] = null;
     }


### PR DESCRIPTION
Fixes #2755

## Summary

Prevent SlickGrid wrappers and the vanilla bundle from replacing entries in caller-owned column definition arrays with `null` during grid disposal.

## Why

Column definitions supplied through component props, framework bindings, or public setters belong to the consuming application. Mutating these arrays during teardown prevents consumers from reusing them when mounting the grid again.

The issue was reported for Slickgrid-React, but equivalent cleanup patterns also existed in Angular-Slickgrid, Aurelia-Slickgrid, Slickgrid-Vue, and the vanilla bundle.

## Changes

- Removed teardown logic that nullified supplied column arrays in:
  - Angular-Slickgrid
  - Aurelia-Slickgrid
  - Slickgrid-React
  - Slickgrid-Vue
  - Slick-Vanilla-Grid-Bundle
- Continued releasing internal column references during disposal.
- Explicitly clear Vue's private `_columns` reference without modifying its `v-model`.
- Updated Example 17 in Angular, Aurelia, React, and Vue to destroy and recreate a grid using the same column array.
- Added destroy/recreate Cypress regression coverage for all four framework demos.
- Added direct Angular and vanilla unit tests for preserving dynamically supplied columns.

## Validation

- Angular-Slickgrid unit tests: 118 passed
- Slick-Vanilla-Grid-Bundle unit tests: 116 passed
- Angular framework and demo production builds
- Aurelia framework and demo production builds
- React framework and demo production builds
- Vue framework and demo production builds
- Vanilla bundle build
- Oxlint
- Prettier
- Git diff validation

## Comments

The Cypress E2E specs were not run headlessly in this environment because the browser process exited before loading Cypress while another Cypress UI session was active. The new specs are included for CI and interactive Cypress validation.

No documentation changes are required because this restores expected input ownership without changing the public API.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Luna
  - **how was it used**: Repository inspection, implementation, regression test creation, and validation.

## Checklist

- [x] The changes are limited to only one scope (consistent column ownership during grid disposal).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate (no documentation changes required).