### PR TITLE
fix(events): preserve CustomEvents in React and Vue wrappers

### DIFF
--- a/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
+++ b/frameworks/slickgrid-react/src/components/slickgrid-react.tsx
@@ -66,6 +66,8 @@ interface State {
   showPagination: boolean;
 }
 
+type ReactEventCallback = (event: CustomEvent<any>) => unknown;
+
 export class SlickgridReact<TData = any> extends React.Component<SlickgridReactProps, State> {
   // i18next has to be provided by the external user through our `I18nextProvider`
   static contextType = I18nextContext;
@@ -97,6 +99,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
   protected _collectionObservers: Array<null | { disconnect: () => void }> = [];
   protected _eventHandler!: SlickEventHandler;
   protected _eventPubSubService!: EventPubSubService;
+  protected _reactEventSubscriptions = new Map<string, EventSubscription>();
   protected _hideHeaderRowAfterPageLoad = false;
   protected _i18next: I18Next | null = null;
   protected _isAutosizeColsCalled = false;
@@ -264,7 +267,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
 
     // initialize and assign all Service Dependencies
     this._eventPubSubService = new EventPubSubService();
-    this._eventPubSubService.eventNamingStyle = 'camelCase';
+    this._eventPubSubService.eventNamingStyle = this._options.eventNamingStyle ?? 'camelCase';
 
     this.backendUtilityService = new BackendUtilityService();
     this.gridEventService = new GridEventService();
@@ -375,24 +378,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
     this._mounted = true;
     if (this._elm && this._eventPubSubService instanceof EventPubSubService) {
       this._eventPubSubService.elementSource = this._elm;
-
-      // React doesn't play well with Custom Events & also the render is called after the constructor which brings a second problem
-      // to fix both issues, we need to do the following:
-      // loop through all component props and subscribe to the ones that startsWith "on", we'll assume that it's the custom events
-      // we'll then call the assigned listener(s) when events are dispatching
-      for (const prop in this.props) {
-        if (prop.startsWith('on')) {
-          const eventCallback: any = this.props[prop as keyof SlickgridReactProps];
-          if (typeof eventCallback === 'function') {
-            this.subscriptions.push(
-              this._eventPubSubService.subscribe(prop, (data: unknown) => {
-                const gridEventName = this._eventPubSubService.getEventNameByNamingConvention(prop, '');
-                eventCallback.call(null, new CustomEvent(gridEventName, { detail: data }));
-              })
-            );
-          }
-        }
-      }
+      this.synchronizeReactEventSubscriptions();
     }
 
     // save resource refs to register before the grid options are merged and possibly deep copied
@@ -683,6 +669,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
     }
 
     this._collectionObservers.forEach((obs) => obs?.disconnect());
+    this.disposeReactEventSubscriptions();
     this._eventPubSubService.unsubscribeAll();
 
     // dispose of all Services
@@ -760,6 +747,8 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
   }
 
   componentDidUpdate(prevProps: SlickgridReactProps) {
+    this.synchronizeReactEventSubscriptions();
+
     // get the grid options (order of precedence is Global Options first, then user option which could overwrite the Global options)
     if (this.props.options !== prevProps.options) {
       this._options = { ...GlobalGridOptions, ...this._options };
@@ -778,6 +767,44 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
       this.datasetHierarchical = this.props.datasetHierarchical;
     }
     this.suggestDateParsingWhenHelpful();
+  }
+
+  /**
+   * React only handles known DOM events on built-in elements, so bridge any function-valued `on*` props to the PubSub host element.
+   * Keep one stable subscription per event name and resolve the latest callback at dispatch time to avoid subscription churn on re-render.
+   */
+  protected synchronizeReactEventSubscriptions(): void {
+    const eventPropNames = new Set([...Object.keys(this.props), ...this._reactEventSubscriptions.keys()]);
+
+    eventPropNames.forEach((propName) => {
+      if (!propName.startsWith('on')) {
+        return;
+      }
+
+      const prop = propName as keyof SlickgridReactProps;
+      const eventCallback = this.props[prop] as ReactEventCallback | undefined;
+      const eventSubscription = this._reactEventSubscriptions.get(propName);
+
+      if (typeof eventCallback === 'function' && !eventSubscription) {
+        this._reactEventSubscriptions.set(
+          propName,
+          this._eventPubSubService.subscribeEvent(propName, (event) => {
+            const currentCallback = this.props[prop] as ReactEventCallback | undefined;
+            if (typeof currentCallback === 'function' && currentCallback.call(null, event) === false) {
+              event.preventDefault();
+            }
+          })
+        );
+      } else if (typeof eventCallback !== 'function' && eventSubscription) {
+        eventSubscription.unsubscribe?.();
+        this._reactEventSubscriptions.delete(propName);
+      }
+    });
+  }
+
+  protected disposeReactEventSubscriptions(): void {
+    this._reactEventSubscriptions.forEach((subscription) => subscription.unsubscribe?.());
+    this._reactEventSubscriptions.clear();
   }
 
   columnsChanged(columns?: Column[]) {

--- a/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
+++ b/frameworks/slickgrid-vue/src/components/SlickgridVue.vue
@@ -55,6 +55,7 @@ import {
   nextTick,
   onBeforeUnmount,
   onMounted,
+  onUpdated,
   ref,
   useAttrs,
   watch,
@@ -73,6 +74,8 @@ interface VueRowDetailView {
   create(columns: Column[], gridOptions: GridOption): any;
   init(grid: SlickGrid, containerService?: ContainerService): void;
 }
+
+type VueEventCallback = (event: CustomEvent<any>) => unknown;
 
 const attrs = useAttrs();
 
@@ -111,6 +114,7 @@ let registeredResources: Array<ExternalResource | ExternalResourceConstructor> =
 let scrollEndCalled = false;
 let showPagination = false;
 let subscriptions: Array<EventSubscription> = [];
+const vueEventSubscriptions = new Map<string, EventSubscription>();
 
 // components / plugins
 let slickEmptyWarning: SlickEmptyWarningComponent | undefined;
@@ -284,6 +288,10 @@ onBeforeUnmount(() => {
   disposing();
 });
 
+onUpdated(() => {
+  synchronizeVueEventSubscriptions();
+});
+
 onMounted(() => {
   if (!columnsModel.value) {
     throw new Error(
@@ -293,25 +301,8 @@ onMounted(() => {
 
   if (elm.value && eventPubSubService instanceof EventPubSubService) {
     eventPubSubService.elementSource = elm.value;
-
-    // Vue doesn't play well with subscribing to native Custom Events & also the render is called after the constructor which brings a second problem
-    // to fix both issues, we need to do the following:
-    // 1. loop through all component props and subscribe to the ones that startsWith "on", we'll assume that it's the custom events
-    // 2. then call the assigned listener(s) when events are dispatched
-    for (const attr in { ...attrs, ...props }) {
-      if (attr.startsWith('onOn')) {
-        const eventCallback = attrs[attr as keyof SlickgridVueProps] || props[attr as keyof SlickgridVueProps];
-        if (typeof eventCallback === 'function') {
-          const singlePrefixEventName = attr.replace(/^onOn/, 'on');
-          subscriptions.push(
-            eventPubSubService.subscribe(singlePrefixEventName, (data: unknown) => {
-              const gridEventName = eventPubSubService.getEventNameByNamingConvention(singlePrefixEventName, '');
-              eventCallback.call(null, new CustomEvent(gridEventName, { detail: data }));
-            })
-          );
-        }
-      }
-    }
+    eventPubSubService.eventNamingStyle = _gridOptions.value.eventNamingStyle ?? 'camelCaseWithExtraOnPrefix';
+    synchronizeVueEventSubscriptions();
   }
 
   initialization();
@@ -629,6 +620,7 @@ function disposing(shouldEmptyDomElementContainer = false) {
   }
 
   collectionObservers.forEach((obs) => obs?.disconnect());
+  disposeVueEventSubscriptions();
   eventPubSubService.unsubscribeAll();
 
   // dispose of all Services
@@ -680,6 +672,45 @@ function disposing(shouldEmptyDomElementContainer = false) {
   if (shouldEmptyDomElementContainer) {
     emptyGridContainerElm();
   }
+}
+
+/**
+ * Bridge function-valued `onOn*` props to the PubSub host element.
+ * Keep one stable subscription per event name and resolve the latest callback at dispatch time to avoid subscription churn on update.
+ */
+function synchronizeVueEventSubscriptions() {
+  const eventPropNames = new Set([...Object.keys(attrs), ...Object.keys(props), ...vueEventSubscriptions.keys()]);
+
+  eventPropNames.forEach((attrName) => {
+    if (!attrName.startsWith('onOn')) {
+      return;
+    }
+
+    const attr = attrName as keyof SlickgridVueProps;
+    const eventCallback = (attrs[attr] || props[attr]) as VueEventCallback | undefined;
+    const eventSubscription = vueEventSubscriptions.get(attrName);
+
+    if (typeof eventCallback === 'function' && !eventSubscription) {
+      const singlePrefixEventName = attrName.replace(/^onOn/, 'on');
+      vueEventSubscriptions.set(
+        attrName,
+        eventPubSubService.subscribeEvent(singlePrefixEventName, (event) => {
+          const currentCallback = (attrs[attr] || props[attr]) as VueEventCallback | undefined;
+          if (typeof currentCallback === 'function' && currentCallback.call(null, event) === false) {
+            event.preventDefault();
+          }
+        })
+      );
+    } else if (typeof eventCallback !== 'function' && eventSubscription) {
+      eventSubscription.unsubscribe?.();
+      vueEventSubscriptions.delete(attrName);
+    }
+  });
+}
+
+function disposeVueEventSubscriptions() {
+  vueEventSubscriptions.forEach((subscription) => subscription.unsubscribe?.());
+  vueEventSubscriptions.clear();
 }
 
 /** Do not rename to `dispose` as it's an Vue hook */

--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -156,6 +156,18 @@ describe('EventPubSub Service', () => {
       expect(service.subscribedEvents.length).toBe(0);
     });
 
+    it('should provide the original CustomEvent and preserve its cancellation', () => {
+      const callback = vi.fn((event: CustomEvent<{ name: string }>) => event.preventDefault());
+      const event = new CustomEvent('onClick', { cancelable: true, detail: { name: 'John' } });
+
+      service.subscribeEvent('onClick', callback);
+      const dispatchResult = divContainer.dispatchEvent(event);
+
+      expect(callback).toHaveBeenCalledWith(event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(dispatchResult).toBe(false);
+    });
+
     it('should call subscribe method and expect "addEventListener" and "getEventNameByNamingConvention" to be called with lowerCase event name', () => {
       const addEventSpy = vi.spyOn(divContainer, 'addEventListener');
       const getEventNameSpy = vi.spyOn(service, 'getEventNameByNamingConvention');

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -169,15 +169,15 @@ export class EventPubSubService implements BasePubSubService {
 
   /**
    * Subscribes to a message channel or message type.
-   * This is similar to the "subscribe" except that the callback receives an event typed as CustomEventInit and the data will be inside its "event.detail"
+   * This is similar to the "subscribe" except that the callback receives the original CustomEvent and the data will be inside its "event.detail"
    * @param {String} event - the event name/message
    * @param {Function} callback - The callback to be invoked when the specified message is published.
    * @return {Subscription} possibly a Subscription
    */
-  subscribeEvent<T = any>(eventName: string, listener: (event: CustomEventInit<T>) => void): Subscription {
+  subscribeEvent<T = any>(eventName: string, listener: (event: CustomEvent<T>) => void): Subscription {
     const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
-    this._elementSource.addEventListener(eventNameByConvention, listener);
-    this._subscribedEvents.push({ name: eventNameByConvention, listener });
+    this._elementSource.addEventListener(eventNameByConvention, listener as EventListener);
+    this._subscribedEvents.push({ name: eventNameByConvention, listener: listener as PubSubEvent<T>['listener'] });
 
     // return a subscription that we can later unsubscribe
     return {


### PR DESCRIPTION
## Summary

Improve SlickGrid event forwarding in Slickgrid-React and Slickgrid-Vue by passing the original `CustomEvent` to consumer callbacks instead of constructing a replacement event.

## Why

Recreating events from `event.detail` loses the original event identity and prevents consumer cancellation from propagating back through `EventPubSubService`.

Event callbacks were also captured only during component mounting, so handlers added, removed, or replaced during later renders were not synchronized.

## Changes

- Forward the original `CustomEvent` through `subscribeEvent()`.
- Correct the `subscribeEvent()` listener type to `CustomEvent<T>`.
- Keep one stable subscription per active event prop.
- Resolve the latest callback at dispatch time to avoid subscription churn.
- Synchronize subscriptions when React or Vue event props are added or removed.
- Preserve cancellation through `preventDefault()` and `return false`.
- Apply the configured event naming style before binding listeners.
- Add unit coverage for original event identity and cancellation.

## Validation

- `pnpm test` — 5,958 tests passed.
- `pnpm lint`
- Prettier check on all affected files.
- EventPubSub build and TypeScript check.
- Slickgrid-React TypeScript check.
- Slickgrid-Vue type-check.
- Git diff whitespace check.

## Comments

Cypress was not run because this focused bridge change was covered by the complete unit suite and both framework type-checks. Running the React and Vue Cypress suites would additionally require starting their respective demo servers.

The implementation retains one DOM listener per active event prop while removing the extra `CustomEvent` allocation and event-name conversion previously performed for every dispatch.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Sol
  - **how was it used**: Analyzed the framework event bridges, implemented the changes, added focused test coverage, and ran validation checks.

## Checklist

- [x] The changes are limited to only one scope (if not please explain why in the comments above).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.