### PR TITLE
test(common): deflake hidden-grid resizer auto-fix test

### DIFF
--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -944,8 +944,10 @@ describe('Resizer Service', () => {
           }, 15);
         }));
 
-      it('should set "_cResizeCheckRequired" when grid is hidden from UI while auto-fix loop is running', () =>
-        new Promise((done: any) => {
+      it('should set "_cResizeCheckRequired" when grid is hidden from UI while auto-fix loop is running', async () => {
+        vi.useFakeTimers();
+
+        try {
           mockGridOptions.autoFixResizeWhenBrokenStyleDetected = true;
           mockGridOptions.autoFixResizeTimeout = 3;
           service.intervalRetryDelay = 1;
@@ -953,12 +955,15 @@ describe('Resizer Service', () => {
           vi.spyOn(service as any, 'isGridVisibleInUI').mockReturnValue(false);
           service.init(gridStub, divContainer);
 
-          setTimeout(() => {
-            expect((service as any)._cResizeCheckRequired).toBe(true);
-            service.requestStopOfAutoFixResizeGrid(true);
-            done();
-          }, 5);
-        }));
+          await vi.advanceTimersByTimeAsync(service.intervalRetryDelay);
+
+          expect((service as any)._cResizeCheckRequired).toBe(true);
+        } finally {
+          service.requestStopOfAutoFixResizeGrid(true);
+          service.dispose();
+          vi.useRealTimers();
+        }
+      });
 
       it('should try to resize grid when its UI is deemed broken by the 2nd condition check of "getRenderedRange"', () =>
         new Promise((done: any) => {


### PR DESCRIPTION
## Summary

Deflake the resizer service test that verifies `_cResizeCheckRequired` is set when the grid becomes hidden during the auto-fix loop.

## Why

The test relied on a fixed 5 ms timeout while initialization scheduled the auto-fix interval through a promise continuation. Under occasional CI load, the assertion could execute before the interval callback, causing intermittent failures.

## Changes

- Replace the real-time delay with scoped Vitest fake timers.
- Explicitly advance the clock by one auto-fix interval.
- Guarantee timer and service cleanup with a `finally` block.

## Validation

- Full resizer service suite: 47 tests passed.
- Focused test: passed 25 consecutive runs.
- Prettier check passed.
- Oxlint check passed.
- `git diff --check` passed.

## Comments

Test-only change; no production behavior is affected.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Luna
  - **how was it used**: Investigated the timing race, implemented the deterministic timer handling, and ran the validation checks.

## Checklist

- [x] The changes are limited to only one scope (if not please explain why in the comments above).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.