### PR TITLE
fix(demos): disable RTL column reordering with SortableJS

### DIFF
--- a/demos/aurelia/src/examples/slickgrid/example57.ts
+++ b/demos/aurelia/src/examples/slickgrid/example57.ts
@@ -53,6 +53,8 @@ export class Example57 {
 
     this.gridOptions = {
       enableFiltering: true,
+      // Disabled in RTL because SortableJS lacks RTL support; patch SortableJS or use https://github.com/HamadHadi/Sortable-rtl to enable it.
+      enableColumnReorder: false,
       gridHeight: 500,
       gridWidth: 700,
       rowHeight: 33,

--- a/demos/react/src/examples/slickgrid/Example57.tsx
+++ b/demos/react/src/examples/slickgrid/Example57.tsx
@@ -53,6 +53,8 @@ const Example57: React.FC = () => {
 
     const opts: GridOption = {
       enableFiltering: true,
+      // Disabled in RTL because SortableJS lacks RTL support; patch SortableJS or use https://github.com/HamadHadi/Sortable-rtl to enable it.
+      enableColumnReorder: false,
       gridHeight: 500,
       gridWidth: 700,
       rowHeight: 33,

--- a/demos/vanilla/src/examples/example46.ts
+++ b/demos/vanilla/src/examples/example46.ts
@@ -63,6 +63,8 @@ export default class Example46 {
 
     this.gridOptions = {
       enableFiltering: true,
+      // Disabled in RTL because SortableJS lacks RTL support; patch SortableJS or use https://github.com/HamadHadi/Sortable-rtl to enable it.
+      enableColumnReorder: false,
       gridHeight: 500,
       gridWidth: 900,
       rowHeight: 33,

--- a/demos/vue/src/components/Example57.vue
+++ b/demos/vue/src/components/Example57.vue
@@ -54,6 +54,8 @@ function defineGrid() {
 
   gridOptions.value = {
     enableFiltering: true,
+    // Disabled in RTL because SortableJS lacks RTL support; patch SortableJS or use https://github.com/HamadHadi/Sortable-rtl to enable it.
+    enableColumnReorder: false,
     gridHeight: 500,
     gridWidth: 700,
     rowHeight: 33,

--- a/frameworks/angular-slickgrid/src/demos/examples/example57.component.ts
+++ b/frameworks/angular-slickgrid/src/demos/examples/example57.component.ts
@@ -58,6 +58,8 @@ export class Example57Component implements OnInit, OnDestroy {
 
     this.gridOptions = {
       enableFiltering: true,
+      // Disabled in RTL because SortableJS lacks RTL support; patch SortableJS or use https://github.com/HamadHadi/Sortable-rtl to enable it.
+      enableColumnReorder: false,
       gridHeight: 500,
       gridWidth: 700,
       rowHeight: 33,


### PR DESCRIPTION
## Summary

Disable column reordering in RTL demo examples because the current SortableJS version does not support RTL ordering reliably.

## Why

This prevents columns from jumping to incorrect positions during RTL drag operations. Users who need RTL reordering can patch SortableJS or use the RTL fork:
https://github.com/HamadHadi/Sortable-rtl

## Changes

- Disabled `enableColumnReorder` in:
  - Vanilla `example46`
  - Angular `example57`
  - React `Example57`
  - Vue `Example57`
  - Aurelia `example57`
- Added explanatory comments to each demo.

## Validation

- Prettier checks passed.
- Vanilla TypeScript check passed.
- `git diff --check` passed.
- No unit tests were changed.

## Comments

This is intentionally limited to RTL demo configurations. Shared SlickGrid behavior is unchanged.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex 5.6 Luna
  - **how was it used**: Reviewed the RTL behavior and updated the affected demo configurations.

## Checklist

- [x] The changes are limited to only one scope.
- [ ] Tests were added or updated where appropriate.
- [ ] Documentation was updated where appropriate.