### PR TITLE
fix(event-pub-sub): align CustomEvent public types

### DIFF
--- a/packages/event-pub-sub/src/eventPubSub.service.spec.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.spec.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { EventPubSubService } from './eventPubSub.service.js';
+import type { BasePubSubService } from './types/basePubSubService.interface.js';
 
 describe('EventPubSub Service', () => {
   let service: EventPubSubService;
@@ -166,6 +167,24 @@ describe('EventPubSub Service', () => {
       expect(callback).toHaveBeenCalledWith(event);
       expect(event.defaultPrevented).toBe(true);
       expect(dispatchResult).toBe(false);
+    });
+
+    it('should expose the original CustomEvent through the base service contract', () => {
+      const baseService: BasePubSubService = service;
+      const callback = vi.fn((event: CustomEvent<{ name: string }>) => {
+        expectTypeOf(event).toEqualTypeOf<CustomEvent<{ name: string }>>();
+        event.preventDefault();
+      });
+      const event = new CustomEvent('onClick', { cancelable: true, detail: { name: 'John' } });
+
+      baseService.subscribeEvent?.('onClick', callback);
+      const dispatchResult = divContainer.dispatchEvent(event);
+
+      expect(callback).toHaveBeenCalledWith(event);
+      expect(dispatchResult).toBe(false);
+
+      baseService.unsubscribe('onClick', callback);
+      expect(service.subscribedEvents.length).toBe(0);
     });
 
     it('should call subscribe method and expect "addEventListener" and "getEventNameByNamingConvention" to be called with lowerCase event name', () => {

--- a/packages/event-pub-sub/src/eventPubSub.service.ts
+++ b/packages/event-pub-sub/src/eventPubSub.service.ts
@@ -3,9 +3,11 @@ import { type BasePubSubService } from './types/basePubSubService.interface.js';
 import { type EventNamingStyle } from './types/eventNamingStyle.type.js';
 import { type EventSubscription, type Subscription } from './types/eventSubscription.interface.js';
 
+export type PubSubEventListener<T = any> = ((event: T | CustomEventInit<T>) => void) | ((event: CustomEvent<T>) => void);
+
 export interface PubSubEvent<T = any> {
   name: string;
-  listener: (event: T | CustomEventInit<T>) => void;
+  listener: PubSubEventListener<T>;
   originalCallback?: (data: T) => void;
 }
 
@@ -154,9 +156,9 @@ export class EventPubSubService implements BasePubSubService {
 
       // the event listener will return the data in the "event.detail", so we need to return its content to the final callback
       // basically we substitute the "data" with "event.detail" so that the user ends up with only the "data" result
-      const wrappedListener = (event: CustomEventInit<T>) => callback.call(null, event.detail as T);
+      const wrappedListener = (event: CustomEvent<T>) => callback.call(null, event.detail);
 
-      this._elementSource.addEventListener(eventNameByConvention, wrappedListener);
+      this._elementSource.addEventListener(eventNameByConvention, wrappedListener as EventListener);
       this._subscribedEvents.push({ name: eventNameByConvention, listener: wrappedListener, originalCallback: callback });
       subscriptions.push(() => this.unsubscribeResolved(eventNameByConvention, wrappedListener as EventListener));
     });
@@ -177,7 +179,7 @@ export class EventPubSubService implements BasePubSubService {
   subscribeEvent<T = any>(eventName: string, listener: (event: CustomEvent<T>) => void): Subscription {
     const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
     this._elementSource.addEventListener(eventNameByConvention, listener as EventListener);
-    this._subscribedEvents.push({ name: eventNameByConvention, listener: listener as PubSubEvent<T>['listener'] });
+    this._subscribedEvents.push({ name: eventNameByConvention, listener });
 
     // return a subscription that we can later unsubscribe
     return {
@@ -192,7 +194,9 @@ export class EventPubSubService implements BasePubSubService {
    * @param {Boolean} [shouldRemoveFromEventList] - should we also remove the event from the subscriptions array?
    * @return possibly a Subscription
    */
-  unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList = true): void {
+  unsubscribe<T = any>(eventName: string, listener: (event: CustomEvent<T>) => void, shouldRemoveFromEventList?: boolean): void;
+  unsubscribe<T = any>(eventName: string, listener: (event: T | CustomEventInit<T>) => void, shouldRemoveFromEventList?: boolean): void;
+  unsubscribe<T = any>(eventName: string, listener: PubSubEventListener<T>, shouldRemoveFromEventList = true): void {
     const eventNameByConvention = this.getEventNameByNamingConvention(eventName, '');
     const subscribedEvents = this._subscribedEvents.filter(
       (pubSubEvent) => pubSubEvent.name === eventNameByConvention && pubSubEvent.originalCallback === listener
@@ -232,7 +236,7 @@ export class EventPubSubService implements BasePubSubService {
   // protected functions
   // --------------------
 
-  protected removeSubscribedEventWhenFound<T>(eventName: string, listener: (event: T | CustomEventInit<T>) => void): void {
+  protected removeSubscribedEventWhenFound<T>(eventName: string, listener: PubSubEvent<T>['listener']): void {
     const eventIdx = this._subscribedEvents.findIndex((evt) => evt.name === eventName && evt.listener === listener);
     if (eventIdx >= 0) {
       this._subscribedEvents.splice(eventIdx, 1);

--- a/packages/event-pub-sub/src/types/basePubSubService.interface.ts
+++ b/packages/event-pub-sub/src/types/basePubSubService.interface.ts
@@ -25,18 +25,19 @@ export interface BasePubSubService {
 
   /**
    * Subscribes to a custom event message channel or message type.
-   * This is similar to the "subscribe" except that the callback receives an event typed as CustomEventInit and the data will be inside its "event.detail"
+   * This is similar to the "subscribe" except that the callback receives the original CustomEvent and the data will be inside its "event.detail"
    * @param event The event channel or event data type.
    * @param callback The callback to be invoked when the specified message is published.
    * @return possibly a Subscription
    */
-  subscribeEvent?<T = any>(_eventName: string | Function, _callback: (event: CustomEventInit<T>) => void): EventSubscription | any;
+  subscribeEvent?<T = any>(_eventName: string | Function, _callback: (event: CustomEvent<T>) => void): EventSubscription | any;
 
   /**
    * Unsubscribes a message name
    * @param event The event name
    * @return possibly a Subscription
    */
+  unsubscribe<T = any>(_eventName: string, _callback: (event: CustomEvent<T>) => void): void;
   unsubscribe(_eventName: string, _callback: (event: CustomEventInit) => void): void;
 
   /** Unsubscribes all subscriptions that currently exists */


### PR DESCRIPTION
## Summary

Align the public EventPubSub type contracts with the original `CustomEvent` behavior introduced in #2762.

## Why

`EventPubSubService.subscribeEvent()` provides the original `CustomEvent<T>`, but `BasePubSubService` still declared the callback argument as `CustomEventInit<T>`.

Consumers using the base interface could not type-check calls such as `event.preventDefault()`. A `CustomEvent<T>` callback also could not be passed cleanly to `unsubscribe()`.

## Changes

- Update `BasePubSubService.subscribeEvent()` to expose `CustomEvent<T>`.
- Add a backward-compatible `unsubscribe()` overload for `CustomEvent<T>` listeners.
- Align internal PubSub listener metadata with both legacy and `CustomEvent` listener types.
- Correct the wrapped DOM listener type to `CustomEvent<T>`.
- Add regression coverage for:
  - The public base-service type contract.
  - Original event identity.
  - Cancellation through `preventDefault()`.
  - Unsubscribing a `CustomEvent<T>` callback.

## Validation

- `pnpm test` — 213 test files and 5,961 tests passed.
- `pnpm lint`
- `pnpm prettier:check`
- EventPubSub TypeScript check.
- Strict TypeScript check of the EventPubSub regression spec.
- Common, Aurelia, React, and Vue TypeScript checks.
- `git diff --check`

## Comments

This is primarily a public TypeScript contract correction follow-up. It does not intentionally change runtime behavior; the original event forwarding and cancellation behavior was implemented in #2762.

The standalone Angular application TypeScript check remains blocked by three pre-existing unresolved Angular row-detail demo imports unrelated to this change.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Luna
  - **how was it used**: Re-audited the event forwarding changes, identified the public type-contract mismatch, implemented the correction and regression coverage, and ran validation checks.

## Checklist

- [x] The changes are limited to only one scope (if not please explain why in the comments above).
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.