### PR TITLE
fix(common): make SlickDataView filtering CSP-safe by default

### DIFF
--- a/demos/vanilla/src/examples/example03.ts
+++ b/demos/vanilla/src/examples/example03.ts
@@ -346,9 +346,6 @@ export default class Example03 {
       autoResize: {
         container: '.demo-container',
       },
-      dataView: {
-        useCSPSafeFilter: true,
-      },
       enableFormattedDataCache: false, // enable it when you have a large dataset (e.g. we'll enable it when loading over 10K)
       headerMenu: {
         hideFreezeColumnsCommand: false,

--- a/docs/developer-guides/csp-compliance.md
+++ b/docs/developer-guides/csp-compliance.md
@@ -14,8 +14,6 @@ this.gridOptions = {
 
 > **Note** If you're wondering about the `ADD_ATTR: ['level']`, well the "level" is a custom attribute used by SlickGrid Grouping/Draggable Grouping to track the grouping level depth and it must be kept.
 
-> **Note** the DataView is not CSP safe by default, it is opt-in via the `useCSPSafeFilter` option.
-
 ```typescript
 import DOMPurify from 'dompurify';
 import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
@@ -36,22 +34,7 @@ with this code in place, we can use the following CSP meta tag (which is what we
 ```
 
 #### DataView
-Since we use the DataView, you will also need to enable a new `useCSPSafeFilter` flag to be CSP safe as the name suggest. This option is opt-in because it has a slight performance impact when enabling this option (it shouldn't be noticeable unless you use a very large dataset).
-
-```typescript
-import DOMPurify from 'dompurify';
-import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
-
-// DOM Purify is already configured in Slickgrid-Universal with the configuration shown below
-this.gridOptions = {
-  // you could also optionally use the sanitizerOptions instead
-  // sanitizerOptions: { RETURN_TRUSTED_TYPE: true }
-  dataView: {
-    useCSPSafeFilter: true
-  },
-}
-this.sgb = new Slicker.GridBundle(gridContainerElm, this.columns, this.gridOptions, this.dataset);
-```
+DataView filtering is CSP-safe by default and does not use runtime code generation. No DataView option is required. The deprecated `inlineFilters` and `useCSPSafeFilter` options remain accepted for backward compatibility but are ignored.
 
 ### Custom Formatter using native HTML
 We now also allow passing native HTML Element as a Custom Formatter instead of HTML string in order to avoid the use of `innerHTML` and stay CSP safe. We also have a new grid option named `enableHtmlRendering`, which is enabled by default and is allowing the use of `innerHTML` in the library (by Formatters and others), however when disabled it will totally restrict the use of `innerHTML` which will help to stay CSP safe.

--- a/frameworks/angular-slickgrid/docs/developer-guides/csp-compliance.md
+++ b/frameworks/angular-slickgrid/docs/developer-guides/csp-compliance.md
@@ -14,8 +14,6 @@ this.gridOptions = {
 
 > **Note** If you're wondering about the `ADD_ATTR: ['level']`, well the "level" is a custom attribute used by SlickGrid Grouping/Draggable Grouping to track the grouping level depth and it must be kept.
 
-> **Note** the DataView is not CSP safe by default, it is opt-in via the `useCSPSafeFilter` option.
-
 ```typescript
 import DOMPurify from 'dompurify';
 import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
@@ -35,28 +33,7 @@ with this code in place, we can use the following CSP meta tag (which is what we
 ```
 
 #### DataView
-Since we use the DataView, you will also need to enable a new `useCSPSafeFilter` flag to be CSP safe as the name suggest. This option is opt-in because it has a slight performance impact when enabling this option (it shouldn't be noticeable unless you use a very large dataset).
-
-```typescript
-import DOMPurify from 'dompurify';
-import { GridOption } from 'angular-slickgrid';
-
-export class Example1 {
-  gridOptions: GridOption;
-
-  prepareGrid() {
-    // ...
-
-    this.gridOptions = {
-      // you could also optionally use the sanitizerOptions instead
-      // sanitizerOptions: { RETURN_TRUSTED_TYPE: true }
-      dataView: {
-        useCSPSafeFilter: true
-      },
-    }
-  }
-}
-```
+DataView filtering is CSP-safe by default and does not use runtime code generation. No DataView option is required. The deprecated `inlineFilters` and `useCSPSafeFilter` options remain accepted for backward compatibility but are ignored.
 
 ### Custom Formatter using native HTML
 We now also allow passing native HTML Element as a Custom Formatter instead of HTML string in order to avoid the use of `innerHTML` and stay CSP safe. We also have a new grid option named `enableHtmlRendering`, which is enabled by default and is allowing the use of `innerHTML` in the library (by Formatters and others), however when disabled it will totally restrict the use of `innerHTML` which will help to stay CSP safe.

--- a/frameworks/aurelia-slickgrid/docs/developer-guides/csp-compliance.md
+++ b/frameworks/aurelia-slickgrid/docs/developer-guides/csp-compliance.md
@@ -14,8 +14,6 @@ this.gridOptions = {
 
 > **Note** If you're wondering about the `ADD_ATTR: ['level']`, well the "level" is a custom attribute used by SlickGrid Grouping/Draggable Grouping to track the grouping level depth and it must be kept.
 
-> **Note** the DataView is not CSP safe by default, it is opt-in via the `useCSPSafeFilter` option.
-
 ```typescript
 import DOMPurify from 'dompurify';
 import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
@@ -35,28 +33,7 @@ with this code in place, we can use the following CSP meta tag (which is what we
 ```
 
 #### DataView
-Since we use the DataView, you will also need to enable a new `useCSPSafeFilter` flag to be CSP safe as the name suggest. This option is opt-in because it has a slight performance impact when enabling this option (it shouldn't be noticeable unless you use a very large dataset).
-
-```typescript
-import DOMPurify from 'dompurify';
-import { GridOption } from 'aurelia-slickgrid';
-
-export class Example1 {
-  gridOptions: GridOption;
-
-  prepareGrid() {
-    // ...
-
-    this.gridOptions = {
-      // you could also optionally use the sanitizerOptions instead
-      // sanitizerOptions: { RETURN_TRUSTED_TYPE: true }
-      dataView: {
-        useCSPSafeFilter: true
-      },
-    }
-  }
-}
-```
+DataView filtering is CSP-safe by default and does not use runtime code generation. No DataView option is required. The deprecated `inlineFilters` and `useCSPSafeFilter` options remain accepted for backward compatibility but are ignored.
 
 ### Custom Formatter using native HTML
 We now also allow passing native HTML Element as a Custom Formatter instead of HTML string in order to avoid the use of `innerHTML` and stay CSP safe. We also have a new grid option named `enableHtmlRendering`, which is enabled by default and is allowing the use of `innerHTML` in the library (by Formatters and others), however when disabled it will totally restrict the use of `innerHTML` which will help to stay CSP safe.

--- a/frameworks/slickgrid-react/docs/developer-guides/csp-compliance.md
+++ b/frameworks/slickgrid-react/docs/developer-guides/csp-compliance.md
@@ -14,8 +14,6 @@ const gridOptions = {
 
 > **Note** If you're wondering about the `ADD_ATTR: ['level']`, well the "level" is a custom attribute used by SlickGrid Grouping/Draggable Grouping to track the grouping level depth and it must be kept.
 
-> **Note** the DataView is not CSP safe by default, it is opt-in via the `useCSPSafeFilter` option.
-
 ```typescript
 import DOMPurify from 'dompurify';
 import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
@@ -34,37 +32,7 @@ with this code in place, we can use the following CSP meta tag (which is what we
 ```
 
 #### DataView
-Since we use the DataView, you will also need to enable a new `useCSPSafeFilter` flag to be CSP safe as the name suggest. This option is opt-in because it has a slight performance impact when enabling this option (it shouldn't be noticeable unless you use a very large dataset).
-
-```typescript
-import DOMPurify from 'dompurify';
-import { GridOption } from 'slickgrid-react';
-
-const Example: React.FC = () => {
-  const [dataset, setDataset] = useState<any[]>([]);
-  const [columns, setColumns] = useState<Column[]>([]);
-  const [options, setOptions] = useState<GridOption | undefined>(undefined);
-  const reactGridRef = useRef<SlickgridReactInstance | null>(null);
-
-useEffect(() => defineGrid(), []);
-
-  function reactGridReady(reactGrid: SlickgridReactInstance) {
-    reactGridRef.current = reactGrid;
-  }
-
-  function defineGrid() {
-    // ...
-
-    setOptions({
-      // you could also optionally use the sanitizerOptions instead
-      // sanitizerOptions: { RETURN_TRUSTED_TYPE: true }
-      dataView: {
-        useCSPSafeFilter: true
-      },
-    });
-  }
-}
-```
+DataView filtering is CSP-safe by default and does not use runtime code generation. No DataView option is required. The deprecated `inlineFilters` and `useCSPSafeFilter` options remain accepted for backward compatibility but are ignored.
 
 ### Custom Formatter using native HTML
 We now also allow passing native HTML Element as a Custom Formatter instead of HTML string in order to avoid the use of `innerHTML` and stay CSP safe. We also have a new grid option named `enableHtmlRendering`, which is enabled by default and is allowing the use of `innerHTML` in the library (by Formatters and others), however when disabled it will totally restrict the use of `innerHTML` which will help to stay CSP safe.

--- a/frameworks/slickgrid-vue/docs/developer-guides/csp-compliance.md
+++ b/frameworks/slickgrid-vue/docs/developer-guides/csp-compliance.md
@@ -14,8 +14,6 @@ this.gridOptions = {
 
 > **Note** If you're wondering about the `ADD_ATTR: ['level']`, well the "level" is a custom attribute used by SlickGrid Grouping/Draggable Grouping to track the grouping level depth and it must be kept.
 
-> **Note** the DataView is not CSP safe by default, it is opt-in via the `useCSPSafeFilter` option.
-
 ```typescript
 import DOMPurify from 'dompurify';
 import { Slicker, SlickVanillaGridBundle } from '@slickgrid-universal/vanilla-bundle';
@@ -37,35 +35,7 @@ with this code in place, we can use the following CSP meta tag (which is what we
 ```
 
 #### DataView
-Since we use the DataView, you will also need to enable a new `useCSPSafeFilter` flag to be CSP safe as the name suggest. This option is opt-in because it has a slight performance impact when enabling this option (it shouldn't be noticeable unless you use a very large dataset).
-
-```typescript
-<script setup lang="ts">
-import DOMPurify from 'dompurify';
-import { Column, Filters, Formatters, GridOption, SlickgridVue, SortDirection } from 'slickgrid-vue';
-import { onBeforeMount, type Ref } from 'vue';
-
-const gridOptions = ref<GridOption>();
-const columns: Ref<Column[]> = ref([]);
-const dataset = ref<any[]>([]);
-
-onBeforeMount(() => {
-  defineGrid();
-});
-
-function defineGrid() {
-  // ...
-
-  gridOptions.value = {
-    // you could also optionally use the sanitizerOptions instead
-    // sanitizerOptions: { RETURN_TRUSTED_TYPE: true }
-    dataView: {
-      useCSPSafeFilter: true
-    },
-  }
-}
-</script>
-```
+DataView filtering is CSP-safe by default and does not use runtime code generation. No DataView option is required. The deprecated `inlineFilters` and `useCSPSafeFilter` options remain accepted for backward compatibility but are ignored.
 
 ### Custom Formatter using native HTML
 We now also allow passing native HTML Element as a Custom Formatter instead of HTML string in order to avoid the use of `innerHTML` and stay CSP safe. We also have a new grid option named `enableHtmlRendering`, which is enabled by default and is allowing the use of `innerHTML` in the library (by Formatters and others), however when disabled it will totally restrict the use of `innerHTML` which will help to stay CSP safe.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:universal": "tsc --build ./tsconfig.packages.json && pnpm sass:bundle",
     "build:frameworks": "pnpm -r --stream --filter=\"./{demos,frameworks,frameworks-plugins}/**\" run build",
     "build:watch": "tsc --build ./tsconfig.packages.json --watch",
+    "bench:data-view": "vitest bench --config ./test/vitest.benchmark.config.mts --run ./test/benchmarks/slickDataView.bench.ts",
     "angular:watch": "pnpm -r --parallel run angular:dev",
     "aurelia:watch": "pnpm -r --parallel run aurelia:dev",
     "react:watch": "pnpm -r --parallel run react:dev",

--- a/packages/common/src/core/__tests__/slickDataView.spec.ts
+++ b/packages/common/src/core/__tests__/slickDataView.spec.ts
@@ -1734,7 +1734,7 @@ describe('SlickDatView core file', () => {
       expect(refreshSpy).toHaveBeenCalled();
     });
 
-    it('should be able to set a filter with CSP Safe approach and expect items to be filtered', () => {
+    it('should keep the deprecated CSP-safe option backward compatible', () => {
       const items = [
         { id: 1, name: 'Bob', age: 33 },
         { id: 4, name: 'John', age: 20 },
@@ -1753,6 +1753,52 @@ describe('SlickDatView core file', () => {
         { id: 4, name: 'John', age: 20 },
         { id: 3, name: 'Jane', age: 24 },
       ]);
+    });
+
+    it('should always use CSP-safe filtering when deprecated inline filter options are enabled', () => {
+      const minimumId = 2;
+      const items = [
+        { id: 1, name: 'Bob', age: 33 },
+        { id: 4, name: 'John', age: 20 },
+        { id: 3, name: 'Jane', age: 24 },
+      ];
+      const filter = (item: any) => item.id >= minimumId;
+      const functionSpy = vi.spyOn(globalThis, 'Function');
+
+      dv = new SlickDataView({ inlineFilters: true, useCSPSafeFilter: false });
+      dv.setItems(items);
+      dv.setFilter(filter);
+
+      expect(functionSpy).not.toHaveBeenCalled();
+      expect(dv.getFilter()).toBe(filter);
+      expect(dv.getFilteredItems()).toEqual([
+        { id: 4, name: 'John', age: 20 },
+        { id: 3, name: 'Jane', age: 24 },
+      ]);
+
+      functionSpy.mockRestore();
+    });
+
+    it('should cache successful filters when the filter is expanding', () => {
+      const items = [
+        { id: 1, name: 'Bob', age: 33 },
+        { id: 4, name: 'John', age: 20 },
+        { id: 3, name: 'Jane', age: 24 },
+      ];
+      const filter = vi.fn((item: any) => item.id >= 2);
+
+      dv.setItems(items);
+      dv.setRefreshHints({ isFilterExpanding: true });
+      dv.setFilter(filter);
+
+      expect(filter).toHaveBeenCalledTimes(3);
+
+      dv.setRefreshHints({ isFilterExpanding: true });
+      dv.refresh();
+
+      expect(filter).toHaveBeenCalledTimes(4);
+      expect(filter).toHaveBeenLastCalledWith(items[0], undefined);
+      expect(dv.getFilteredItems()).toEqual([items[1], items[2]]);
     });
 
     it('should be able to set a filter and extra filter arguments and expect items to be filtered', () => {
@@ -1782,7 +1828,7 @@ describe('SlickDatView core file', () => {
       ]);
     });
 
-    it('should be able to set a filter as CSP Safe and extra filter arguments and expect items to be filtered', () => {
+    it('should keep deprecated inline and CSP-safe options backward compatible with filter arguments', () => {
       const searchString = 'Ob'; // we'll provide "searchString" as filter args
       const myFilter = (item: any, args: any) => item.name.toLowerCase().includes(args.searchString?.toLowerCase());
       const items = [

--- a/packages/common/src/core/slickDataView.ts
+++ b/packages/common/src/core/slickDataView.ts
@@ -1,13 +1,4 @@
-import {
-  extend,
-  getFunctionDetails,
-  getHtmlStringOutput,
-  isDefined,
-  isHtml,
-  isPrimitiveOrHTML,
-  stripTags,
-  type AnyFunction,
-} from '@slickgrid-universal/utils';
+import { extend, getHtmlStringOutput, isDefined, isHtml, isPrimitiveOrHTML, stripTags } from '@slickgrid-universal/utils';
 import { SlickGroupItemMetadataProvider } from '../extensions/slickGroupItemMetadataProvider.js';
 import { exportWithFormatterWhenDefined } from '../formatters/formatterUtilities.js';
 import type { CssStyleHash, CustomDataView } from '../interfaces/gridOption.interface.js';
@@ -60,8 +51,12 @@ function isLiveDomFormatterResult(
 
 export interface DataViewOption {
   /**
-   * Defaults to false, are we using inline filters?
-   * Note: please use with great care as this will break built-in filters
+   * @deprecated Filters are always CSP-safe and this option is now ignored.
+   * Next major cleanup:
+   * - Remove both `inlineFilters` and `useCSPSafeFilter` from `DataViewOption` and the default options.
+   * - Remove framework and vanilla-bundle code that forwards `inlineFilters`, along with its compatibility tests and documentation.
+   * - Remove the deprecated `FilterCspFn` and `FilterWithCspCachingFn` type aliases.
+   * - Consider renaming the protected `*CSPSafe` methods to neutral names and update their tests and benchmarks.
    */
   inlineFilters: boolean;
 
@@ -72,14 +67,16 @@ export interface DataViewOption {
   groupItemMetadataProvider: SlickGroupItemMetadataProvider | null;
 
   /**
-   * defaults to false, option to use CSP Safe approach,
-   * Note: it is an opt-in option because it is slightly slower (perf impact) when compared to the non-CSP safe approach.
+   * @deprecated Filters are always CSP-safe and this option is now ignored. Remove it in the next major together with
+   * `inlineFilters` by following that option's cleanup checklist.
    */
   useCSPSafeFilter: boolean;
 }
 
 export type FilterFn<T> = (item: T, args: any) => boolean;
+/** @deprecated Filtering is always CSP-safe. Remove this unused alias in the next major. */
 export type FilterCspFn<T> = (item: T[], args: any) => T[];
+/** @deprecated Filtering is always CSP-safe. Remove this unused alias in the next major. */
 export type FilterWithCspCachingFn<T> = (item: T[], args: any, filterCache: any[]) => T[];
 export type DataIdType = number | string;
 export type SlickDataItem = SlickNonDataItem | SlickGroup | SlickGroupTotals | any;
@@ -106,7 +103,6 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected idxById: Map<DataIdType, number> = new Map<DataIdType, number>(); // indexes by id
   protected rowsById: { [id: DataIdType]: number } | undefined = undefined; // rows by id; lazy-calculated
   protected filter: FilterFn<TData> | null = null; // filter function
-  protected filterCSPSafe: FilterFn<TData> | null = null; // filter function
   protected updated: { [id: DataIdType]: boolean } | null = null; // updated item ids
   protected suspend = false; // suspends the recalculation
   protected isBulkSuspend = false; // delays protectedious operations like the
@@ -119,10 +115,6 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected prevRefreshHints: DataViewHints = {};
   protected filterArgs: any;
   protected filteredItems: TData[] = [];
-  protected compiledFilter?: FilterFn<TData> | null;
-  protected compiledFilterCSPSafe?: FilterCspFn<TData> | null;
-  protected compiledFilterWithCaching?: FilterFn<TData> | null;
-  protected compiledFilterWithCachingCSPSafe?: FilterWithCspCachingFn<TData> | null;
   protected filterCache: any[] = [];
   protected _grid?: SlickGrid; // grid object will be defined after using "syncGridSelection()" or "setGrid()" method
   protected _gridOptions?: ReturnType<SlickGrid['getOptions']>; // cached grid options, refreshed via onSetOptions subscription
@@ -238,15 +230,10 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     this.idxById = null as any;
     this.rowsById = null as any;
     this.filter = null as any;
-    this.filterCSPSafe = null as any;
     this.updated = null as any;
     this.sortComparer = null as any;
     this.filterCache = [];
     this.filteredItems = [];
-    this.compiledFilter = null;
-    this.compiledFilterCSPSafe = null;
-    this.compiledFilterWithCaching = null;
-    this.compiledFilterWithCachingCSPSafe = null;
     this.clearFormattedDataCache();
     if (this._grid) {
       this._grid.onSelectedRowsChanged?.unsubscribe();
@@ -444,7 +431,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
   /** Get current Filter used by the DataView */
   getFilter(): FilterFn<TData> | null {
-    return this._options.useCSPSafeFilter ? this.filterCSPSafe : this.filter;
+    return this.filter;
   }
 
   /**
@@ -452,14 +439,7 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
    * @param {Function} fn - filter callback function
    */
   setFilter(filterFn: FilterFn<TData>): void {
-    this.filterCSPSafe = filterFn;
     this.filter = filterFn;
-    if (this._options.inlineFilters) {
-      this.compiledFilterCSPSafe = this.compileFilterCSPSafe;
-      this.compiledFilterWithCachingCSPSafe = this.compileFilterWithCachingCSPSafe;
-      this.compiledFilter = this.compileFilter(this._options.useCSPSafeFilter);
-      this.compiledFilterWithCaching = this.compileFilterWithCaching(this._options.useCSPSafeFilter);
-    }
     this.refresh();
   }
 
@@ -1149,14 +1129,12 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   protected compileAccumulatorLoopCSPSafe(aggregator: Aggregator): (items: any[]) => void {
     if (aggregator.accumulate) {
       return function (items: any[]) {
-        let result;
         if (Array.isArray(items)) {
           for (let i = 0; i < items.length; i++) {
             const item = items[i];
-            result = aggregator.accumulate!.call(aggregator, item);
+            aggregator.accumulate!(item);
           }
         }
-        return result;
       };
     } else {
       return function noAccumulator() {};
@@ -1165,110 +1143,25 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
 
   protected compileFilterCSPSafe(items: TData[], args: any): TData[] {
     /* v8 ignore if */
-    if (typeof this.filterCSPSafe !== 'function') {
+    if (typeof this.filter !== 'function') {
       return [];
     }
     const retval: TData[] = [];
     const il = items.length;
 
     for (let _i = 0; _i < il; _i++) {
-      if (this.filterCSPSafe(items[_i], args)) {
-        retval.push(items[_i]);
+      const item = items[_i];
+      if (this.filter(item, args)) {
+        retval.push(item);
       }
     }
 
     return retval;
-  }
-
-  protected compileFilter(stopRunningIfCSPSafeIsActive = false): FilterFn<TData> | null {
-    if (stopRunningIfCSPSafeIsActive) {
-      return null;
-    }
-    const filterInfo = getFunctionDetails(this.filter as FilterFn<TData>);
-
-    const filterPath1 = '{ continue _coreloop; }$1';
-    const filterPath2 = '{ _retval[_idx++] = $item$; continue _coreloop; }$1';
-    // make some allowances for minification - there's only so far we can go with RegEx
-    const filterBody = filterInfo.body
-      .replace(/return false\s*([;}]|\}|$)/gi, filterPath1)
-      .replace(/return!1([;}]|\}|$)/gi, filterPath1)
-      .replace(/return true\s*([;}]|\}|$)/gi, filterPath2)
-      .replace(/return!0([;}]|\}|$)/gi, filterPath2)
-      .replace(/return ([^;}]+?)\s*([;}]|$)/gi, '{ if ($1) { _retval[_idx++] = $item$; }; continue _coreloop; }$2');
-
-    // This preserves the function template code after JS compression,
-    // so that replace() commands still work as expected.
-    let tpl = [
-      // 'function(_items, _args) { ',
-      'var _retval = [], _idx = 0; ',
-      'var $item$, $args$ = _args; ',
-      '_coreloop: ',
-      'for (var _i = 0, _il = _items.length; _i < _il; _i++) { ',
-      '$item$ = _items[_i]; ',
-      '$filter$; ',
-      '} ',
-      'return _retval; ',
-      // '}'
-    ].join('');
-    tpl = tpl.replace(/\$filter\$/gi, filterBody);
-    tpl = tpl.replace(/\$item\$/gi, filterInfo.params[0]);
-    tpl = tpl.replace(/\$args\$/gi, filterInfo.params[1]);
-    const fn: any = new Function('_items,_args', tpl);
-    const fnName = 'compiledFilter';
-    fn.displayName = fnName;
-    fn.name = this.setFunctionName(fn, fnName);
-    return fn;
-  }
-
-  protected compileFilterWithCaching(stopRunningIfCSPSafeIsActive = false): FilterFn<TData> | null {
-    if (stopRunningIfCSPSafeIsActive) {
-      return null;
-    }
-
-    const filterInfo = getFunctionDetails(this.filter as FilterFn<TData>);
-
-    const filterPath1 = '{ continue _coreloop; }$1';
-    const filterPath2 = '{ _cache[_i] = true;_retval[_idx++] = $item$; continue _coreloop; }$1';
-    // make some allowances for minification - there's only so far we can go with RegEx
-    const filterBody = filterInfo.body
-      .replace(/return false\s*([;}]|\}|$)/gi, filterPath1)
-      .replace(/return!1([;}]|\}|$)/gi, filterPath1)
-      .replace(/return true\s*([;}]|\}|$)/gi, filterPath2)
-      .replace(/return!0([;}]|\}|$)/gi, filterPath2)
-      .replace(/return ([^;}]+?)\s*([;}]|$)/gi, '{ if ((_cache[_i] = $1)) { _retval[_idx++] = $item$; }; continue _coreloop; }$2');
-
-    // This preserves the function template code after JS compression,
-    // so that replace() commands still work as expected.
-    let tpl = [
-      // 'function(_items, _args, _cache) { ',
-      'var _retval = [], _idx = 0; ',
-      'var $item$, $args$ = _args; ',
-      '_coreloop: ',
-      'for (var _i = 0, _il = _items.length; _i < _il; _i++) { ',
-      '$item$ = _items[_i]; ',
-      'if (_cache[_i]) { ',
-      '_retval[_idx++] = $item$; ',
-      'continue _coreloop; ',
-      '} ',
-      '$filter$; ',
-      '} ',
-      'return _retval; ',
-      // '}'
-    ].join('');
-    tpl = tpl.replace(/\$filter\$/gi, filterBody);
-    tpl = tpl.replace(/\$item\$/gi, filterInfo.params[0]);
-    tpl = tpl.replace(/\$args\$/gi, filterInfo.params[1]);
-
-    const fn: any = new Function('_items,_args,_cache', tpl);
-    const fnName = 'compiledFilterWithCaching';
-    fn.displayName = fnName;
-    fn.name = this.setFunctionName(fn, fnName);
-    return fn;
   }
 
   protected compileFilterWithCachingCSPSafe(items: TData[], args: any, filterCache: any[]): TData[] {
     /* v8 ignore if */
-    if (typeof this.filterCSPSafe !== 'function') {
+    if (typeof this.filter !== 'function') {
       return [];
     }
 
@@ -1276,54 +1169,12 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
     const il = items.length;
 
     for (let _i = 0; _i < il; _i++) {
-      if (filterCache[_i] || this.filterCSPSafe(items[_i], args)) {
-        retval.push(items[_i]);
-      }
-    }
-
-    return retval;
-  }
-
-  /**
-   * In ES5 we could set the function name on the fly but in ES6 this is forbidden and we need to set it through differently
-   * We can use Object.defineProperty and set it the property to writable, see MDN for reference
-   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
-   * @param {*} fn
-   * @param {string} fnName
-   */
-  protected setFunctionName(fn: any, fnName: string): void {
-    try {
-      Object.defineProperty(fn, 'name', { writable: true, value: fnName });
-    } /* v8 ignore next */ catch {
-      fn.name = fnName;
-    }
-  }
-
-  protected uncompiledFilter(items: TData[], args: any): any[] {
-    const retval: any[] = [];
-    let idx = 0;
-
-    for (let i = 0, ii = items.length; i < ii; i++) {
-      if (this.filter?.(items[i], args)) {
-        retval[idx++] = items[i];
-      }
-    }
-
-    return retval;
-  }
-
-  protected uncompiledFilterWithCaching(items: TData[], args: any, cache: any): any[] {
-    const retval: any[] = [];
-    let idx = 0;
-    let item: TData;
-
-    for (let i = 0, ii = items.length; i < ii; i++) {
-      item = items[i];
-      if (cache[i]) {
-        retval[idx++] = item;
-      } else if (this.filter?.(item, args)) {
-        retval[idx++] = item;
-        cache[i] = true;
+      const item = items[_i];
+      if (filterCache[_i]) {
+        retval.push(item);
+      } else if (this.filter(item, args)) {
+        filterCache[_i] = true;
+        retval.push(item);
       }
     }
 
@@ -1331,26 +1182,13 @@ export class SlickDataView<TData extends SlickDataItem = any> implements CustomD
   }
 
   protected getFilteredAndPagedItems(items: TData[]): { totalRows: number; rows: TData[] } {
-    if (this._options.useCSPSafeFilter ? this.filterCSPSafe : this.filter) {
-      let batchFilter: AnyFunction;
-      let batchFilterWithCaching: AnyFunction;
-      if (this._options.useCSPSafeFilter) {
-        batchFilter = (this._options.inlineFilters ? this.compiledFilterCSPSafe : this.uncompiledFilter) as AnyFunction;
-        batchFilterWithCaching = (
-          this._options.inlineFilters ? this.compiledFilterWithCachingCSPSafe : this.uncompiledFilterWithCaching
-        ) as AnyFunction;
-      } else {
-        batchFilter = (this._options.inlineFilters ? this.compiledFilter : this.uncompiledFilter) as AnyFunction;
-        batchFilterWithCaching = (
-          this._options.inlineFilters ? this.compiledFilterWithCaching : this.uncompiledFilterWithCaching
-        ) as AnyFunction;
-      }
+    if (this.filter) {
       if (this.refreshHints.isFilterNarrowing) {
-        this.filteredItems = batchFilter.call(this, this.filteredItems, this.filterArgs);
+        this.filteredItems = this.compileFilterCSPSafe(this.filteredItems, this.filterArgs);
       } else if (this.refreshHints.isFilterExpanding) {
-        this.filteredItems = batchFilterWithCaching.call(this, items, this.filterArgs, this.filterCache);
+        this.filteredItems = this.compileFilterWithCachingCSPSafe(items, this.filterArgs, this.filterCache);
       } else if (!this.refreshHints.isFilterUnchanged) {
-        this.filteredItems = batchFilter.call(this, items, this.filterArgs);
+        this.filteredItems = this.compileFilterCSPSafe(items, this.filterArgs);
       }
     } else {
       // special case:  if not filtering and not paging, the resulting

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -1,0 +1,23 @@
+# Performance benchmarks
+
+The SlickDataView benchmark measures the production filter and accumulator loops in isolation from paging, grouping, events, and row-difference calculations.
+
+Run the benchmark on an otherwise idle machine:
+
+```sh
+pnpm bench:data-view
+```
+
+To compare results across revisions, first save a baseline:
+
+```sh
+pnpm bench:data-view --outputJson /tmp/slick-dataview-before.json
+```
+
+Then run the comparison from the changed revision:
+
+```sh
+pnpm bench:data-view --compare /tmp/slick-dataview-before.json
+```
+
+Use the relative results rather than absolute operations per second. Repeat the benchmark at least three times and treat differences smaller than the reported relative margin of error as inconclusive.

--- a/test/benchmarks/slickDataView.bench.ts
+++ b/test/benchmarks/slickDataView.bench.ts
@@ -1,0 +1,108 @@
+import { afterAll, bench, describe, expect } from 'vitest';
+import { SlickDataView } from '../../packages/common/src/core/slickDataView.js';
+import type { Aggregator } from '../../packages/common/src/interfaces/aggregator.interface.js';
+
+interface BenchmarkItem {
+  active: boolean;
+  id: number;
+  name: string;
+  value: number;
+}
+
+interface BenchmarkFilterArgs {
+  minimumId: number;
+  searchTerm: string;
+}
+
+type BenchmarkAccumulatorRunner = (items: BenchmarkItem[]) => void;
+
+class BenchmarkDataView extends SlickDataView<BenchmarkItem> {
+  runFilter(items: BenchmarkItem[], args: BenchmarkFilterArgs): BenchmarkItem[] {
+    return this.compileFilterCSPSafe(items, args);
+  }
+
+  createAccumulatorRunner(aggregator: Aggregator): BenchmarkAccumulatorRunner {
+    return this.compileAccumulatorLoopCSPSafe(aggregator);
+  }
+}
+
+const benchmarkOptions = {
+  time: 1_500,
+  warmupTime: 500,
+};
+const items = Array.from<unknown, BenchmarkItem>({ length: 100_000 }, (_, id) => ({
+  active: id % 2 === 0,
+  id,
+  name: `row-${id}`,
+  value: id % 101,
+}));
+const filterArgs: BenchmarkFilterArgs = {
+  minimumId: 50_000,
+  searchTerm: '99',
+};
+const numericFilter = (item: BenchmarkItem, args: BenchmarkFilterArgs): boolean => {
+  if (!item.active) {
+    return false;
+  }
+  return item.id >= args.minimumId;
+};
+const stringFilter = (item: BenchmarkItem, args: BenchmarkFilterArgs): boolean => item.name.toLowerCase().includes(args.searchTerm);
+
+const numericDataView = new BenchmarkDataView();
+numericDataView.setFilter(numericFilter);
+const stringDataView = new BenchmarkDataView();
+stringDataView.setFilter(stringFilter);
+let observedResult = 0;
+
+describe('SlickDataView filter loop (100,000 items)', () => {
+  bench(
+    'production loop - numeric with early return',
+    () => {
+      observedResult += numericDataView.runFilter(items, filterArgs).length;
+    },
+    benchmarkOptions
+  );
+
+  bench(
+    'production loop - string predicate',
+    () => {
+      observedResult += stringDataView.runFilter(items, filterArgs).length;
+    },
+    benchmarkOptions
+  );
+});
+
+const accumulator: Aggregator & { total: number } = {
+  accumulate(item: BenchmarkItem): void {
+    this.total += item.value;
+  },
+  field: 'value',
+  init(): void {
+    this.total = 0;
+  },
+  storeResult(): void {},
+  total: 0,
+  type: 'sum',
+};
+const accumulatorRunner = numericDataView.createAccumulatorRunner(accumulator);
+
+describe('SlickDataView accumulator loop (100,000 items)', () => {
+  bench(
+    'production loop',
+    () => {
+      accumulator.init();
+      accumulatorRunner.call(accumulator, items);
+      observedResult += accumulator.total;
+    },
+    benchmarkOptions
+  );
+});
+
+afterAll(() => {
+  expect(numericDataView.runFilter(items, filterArgs)).toHaveLength(25_000);
+  expect(stringDataView.runFilter(items, filterArgs)).toHaveLength(3_691);
+  expect(observedResult).toBeGreaterThan(0);
+
+  numericDataView.destroy();
+  stringDataView.destroy();
+});

--- a/test/vitest.benchmark.config.mts
+++ b/test/vitest.benchmark.config.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    benchmark: {
+      include: ['test/benchmarks/**/*.bench.ts'],
+    },
+    environment: 'node',
+    fileParallelism: false,
+    maxWorkers: 1,
+    watch: false,
+  },
+});


### PR DESCRIPTION
## Summary

Make `SlickDataView` filtering and accumulator compilation CSP-safe by default by removing runtime code generation through `new Function()`.

The previous CSP-safe and non-CSP implementations are consolidated into a single callback-based implementation. The existing `inlineFilters` and `useCSPSafeFilter` options remain accepted as deprecated no-ops for backward compatibility.

## Why

The generated filter and accumulator implementations require CSP policies to allow `unsafe-eval`. This prevents applications using a strict Content Security Policy from using every DataView configuration safely.

Maintaining separate CSP and non-CSP implementations also duplicates filtering, caching, accumulator, and dispatch logic.

Benchmarking shows that the unified CSP-safe implementation has equivalent or better performance for the default configuration. However, the explicitly enabled generated `Function` path remains faster for string-heavy predicates. This trade-off is documented in the performance analysis below.

## Changes

- Removed filter compilation through `new Function()`.
- Removed the generated accumulator implementation.
- Consolidated filtering into the existing CSP-safe callback loops.
- Simplified `setFilter()`, `getFilter()`, filtering dispatch, and accumulator setup.
- Corrected the CSP-safe expanding-filter cache so successful matches are stored.
- Deprecated `inlineFilters` and `useCSPSafeFilter`; both remain accepted but are ignored.
- Deprecated the unused `FilterCspFn` and `FilterWithCspCachingFn` aliases.
- Added a next-major cleanup checklist to the deprecated API comments.
- Added unit coverage confirming:
  - filtering never invokes `Function`;
  - deprecated options remain accepted;
  - filtering and filter arguments remain compatible;
  - expanding-filter caching stores successful matches.
- Added an isolated Vitest benchmark for the production filter and accumulator loops.
- Added documentation explaining how to capture and compare benchmark baselines.
- Updated CSP documentation for Angular, Aurelia, React, Vue, and the shared documentation.
- Removed the now-unnecessary CSP option from the vanilla demo.

## Performance analysis

The exact pre-change implementation was loaded alongside the updated implementation in the same Node 24 process.

Each comparison filtered 100,000 items. Execution order was rotated across 12 samples to reduce warm-up, garbage-collection, and benchmark-order bias. The comparison was repeated three times.

The following values are the average median execution time. Lower is better.

| Implementation | Numeric/branch-heavy filter | String-heavy filter |
|---|---:|---:|
| Before: default non-inline loop | 0.943 ms | 4.024 ms |
| Before: generated non-CSP `Function` | 0.831 ms | 3.516 ms |
| Before: CSP-safe callback loop | 0.805 ms | 3.977 ms |
| After: unified CSP-safe loop | 0.788 ms | 4.029 ms |

### Default configuration

Compared with the previous default `inlineFilters: false` path:

- Numeric/branch-heavy filtering improved by approximately **16.5%**.
- String-heavy filtering changed by approximately **0.1%**, which is effectively unchanged.
- The accumulator loop improved by approximately **5–6%**.

This is the relevant comparison for consumers who did not explicitly enable `inlineFilters`.

### Previous CSP-safe path

Compared with the previous CSP-safe callback implementation:

- Numeric filtering improved by approximately **2.1%**.
- String filtering was approximately **1.3% slower**.

These differences are small enough to consider the implementations relatively equivalent.

### Generated inline path

Compared with `inlineFilters: true` using generated `Function` code:

- Numeric filtering improved by approximately **5.1%**.
- String-heavy filtering was approximately **14.6% slower**.

The string predicate is the only tested scenario where generated runtime code showed a consistent advantage. This affects consumers who explicitly enabled `inlineFilters`; the option was disabled by default.

The absolute measured difference was approximately **0.51 ms per 100,000 items**. This is small for an individual filtering pass but could become significant with very large datasets or frequent refreshes.

### CSP-safe optimization investigation

Additional CSP-safe implementations were benchmarked to determine whether the generated string-filter performance could be preserved:

- caching the predicate outside the loop;
- indexed result writes instead of `push()`;
- result-array preallocation;
- a specialized closure created when setting the filter;
- native `Array.filter()`;
- `for...of` iteration.

None consistently matched the generated implementation without regressing another workload.

The generated path benefits from embedding the arbitrary predicate body directly inside the item loop. A generic CSP-safe implementation must retain a callback boundary, which JavaScript engines cannot be relied upon to inline for every predicate.

Caching the predicate occasionally reduced the string-filter regression from approximately 16% to 12%, but the improvement was inconsistent and could reduce numeric-filter performance. Indexed writes did not provide a consistent improvement, while preallocation, `Array.filter()`, and `for...of` were slower.

### Performance conclusion

The performance trade-off is explicit:

- Default users receive equivalent or improved filtering performance.
- Accumulator performance improves.
- Numeric filtering improves across the tested implementations.
- Consumers using the deprecated `inlineFilters: true` option with string-heavy predicates may experience a **12–16% filtering-loop regression**.

This regression is accepted in exchange for unconditional CSP compatibility, removal of runtime code generation, and a simpler single implementation.

## Backward compatibility

The `inlineFilters` and `useCSPSafeFilter` properties remain part of `DataViewOption`, so existing applications continue to compile without configuration changes.

Both properties are deprecated and ignored because filtering is now always CSP-safe. Filtering results and filter-argument behavior remain compatible.

The behavioral difference is limited to the performance characteristics of the previous `inlineFilters: true` generated-code path.

## Next major release

A cleanup checklist was added directly to the deprecated API comments. The next major release can:

- remove `inlineFilters` and `useCSPSafeFilter` from `DataViewOption` and its defaults;
- remove framework and vanilla-bundle code that forwards `inlineFilters`;
- remove the corresponding compatibility tests and deprecated documentation;
- remove the deprecated `FilterCspFn` and `FilterWithCspCachingFn` aliases;
- optionally rename protected `*CSPSafe` methods to neutral names and update their tests and benchmarks.

The unsafe implementations are already removed by this change, so no additional generated filtering or accumulator implementation will need to be removed later.

## Validation

- `pnpm test` — 5,965 tests passed.
- `pnpm lint` — passed.
- `pnpm prettier:check` — passed.
- `pnpm build` — passed.
- `pnpm bench:data-view` — benchmark completed successfully.
- `git diff --check` — passed.
- Scoped coverage reports 100% statements, functions, and lines for the changed production logic.
- Whole-file `SlickDataView` branch coverage remains 90.83% because of unrelated existing branches.

## Comments

The benchmark intentionally isolates filter and accumulator loops from paging, grouping, events, and row-difference calculations. Absolute browser results may differ by JavaScript engine, but the benchmark provides a repeatable comparison of the affected code paths.

The benchmark can be run with:

```sh
pnpm bench:data-view
```

A baseline can be saved and compared across revisions with:

```sh
pnpm bench:data-view --outputJson /tmp/slick-dataview-before.json
pnpm bench:data-view --compare /tmp/slick-dataview-before.json
```

Results should be repeated on an otherwise idle machine. Differences smaller than the reported relative margin of error should be treated as inconclusive.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex GPT-5.6 Sol
  - **how was it used**: Code analysis, implementation assistance, test and benchmark creation, performance comparison, alternative optimization analysis, documentation updates, and change review.

## Checklist

- [x] The changes are limited to one scope. The additional tests, benchmarks, demo change, and documentation support the DataView CSP change.
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.
