### PR TITLE
fix(common): skip content resize when DataView has no items

### DIFF
--- a/packages/common/src/services/__tests__/resizer.service.spec.ts
+++ b/packages/common/src/services/__tests__/resizer.service.spec.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { SlickEvent, type SlickDataView, type SlickGrid } from '../../core/index.js';
@@ -678,6 +680,20 @@ describe('Resizer Service', () => {
 
         expect(reRenderSpy).toHaveBeenCalledWith(false);
         expect(mockColDefs[1].width).toBe(56); // longest word "Destinee" (length 8 * charWidth(7) * ratio(0.88)) + cellPadding(6) = 55.28 ceil to => 56
+      });
+
+      it('should leave the column unchanged when the DataView has no accessible items', () => {
+        const reRenderSpy = vi.spyOn(gridStub, 'reRenderColumns');
+        const initialWidth = 120;
+        mockColDefs[1].width = initialWidth;
+        vi.spyOn(mockDataView, 'getItems').mockReturnValue([]);
+
+        mockGridOptions.enableColumnResizeOnDoubleClick = true;
+        service.init(gridStub, divContainer);
+        gridStub.onColumnsResizeDblClick.notify({ triggeredByColumn: 'firstName', grid: gridStub });
+
+        expect(reRenderSpy).not.toHaveBeenCalled();
+        expect(mockColDefs[1].width).toBe(initialWidth);
       });
 
       it('should call handleSingleColumnResizeByContent when "onHeaderMenuColumnResizeByContent" gets triggered but expect a resized column width when left section width becomes greater than full viewport width', () => {

--- a/packages/common/src/services/resizer.service.ts
+++ b/packages/common/src/services/resizer.service.ts
@@ -668,6 +668,15 @@ export class ResizerService {
   }
 
   protected handleSingleColumnResizeByContent(columnId: string): void {
+    // A custom DataView might not expose all rows through getItems() (for example, a windowed
+    // DataView can intentionally return an empty array). In that case we cannot calculate a
+    // content width, so leave the current column width unchanged and let the consumer provide
+    // its own resize handler if it can fetch the rows asynchronously.
+    const dataItems = this.dataView?.getItems?.();
+    if (!Array.isArray(dataItems) || dataItems.length === 0) {
+      return;
+    }
+
     const columns = this._grid.getColumns();
     const columnDefIdx = columns.findIndex((col) => col.id === columnId);
 


### PR DESCRIPTION
## Summary

Prevent double-click column auto-resize from changing the column width when a custom DataView does not expose any items.

## Why

Windowed or custom DataViews may return an empty array from `getItems()`. Resizing in that situation incorrectly recalculates the column width from its minimum width.

## Changes

- Skip single-column resize-by-content when `getItems()` is unavailable or empty.
- Preserve the current column width.
- Add regression coverage for empty custom DataViews.

## Validation

- `pnpm exec vitest run packages/common/src/services/__tests__/resizer.service.spec.ts --config test/vitest.config.mts`
- `pnpm exec prettier --check packages/common/src/services/resizer.service.ts packages/common/src/services/__tests__/resizer.service.spec.ts`

## Comments

Custom or windowed DataViews can provide their own asynchronous resize handler when they need to fetch rows before measuring content.

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: OpenAI Codex, GPT-5
  - **how was it used**: Reviewed the implementation, proposed the defensive guard, added tests, and verified formatting and unit tests.

## Checklist

- [x] The changes are limited to only one scope.
- [x] Tests were added or updated where appropriate.
- [x] Documentation was updated where appropriate.