### PR TITLE
chore(tests): fix Vitest warning about vmThread

### DIFF
--- a/packages/excel-export/src/excelExport.service.spec.ts
+++ b/packages/excel-export/src/excelExport.service.spec.ts
@@ -27,12 +27,11 @@ vi.mock('excel-builder-vanilla', async (importOriginal) => ({
   ...((await importOriginal()) as any),
   downloadExcelFile: vi.fn().mockResolvedValue(true),
   createExcelFileStream: vi.fn(() => {
-    return new ReadableStream({
-      async pull(controller) {
-        controller.enqueue('streaming content');
-        controller.close();
+    return {
+      async *[Symbol.asyncIterator]() {
+        yield new Uint8Array([115, 116, 114, 101, 97, 109, 105, 110, 103, 32, 99, 111, 110, 116, 101, 110, 116]);
       },
-    });
+    };
   }),
 }));
 

--- a/test/vitest.config.mts
+++ b/test/vitest.config.mts
@@ -28,6 +28,9 @@ export default defineConfig({
     },
     exclude: [...configDefaults.exclude, 'frameworks/*'],
     environment: 'jsdom',
+    // Reuse the jsdom VM between files while retaining per-file isolation.
+    // This avoids creating a new jsdom environment for every test file.
+    pool: 'vmThreads',
     onUnhandledError: (error) => {
       // Ignore specific error patterns
       // not really sure why JSDOM throws these errors but it doesn't impact the tests


### PR DESCRIPTION
<!-- PR title should be using conventional commit with a length below 73 chars. See https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- if this PR fixes an issue, please add it on a separate line for proper linking and following this structure "fixes #123" (replace 123 with the correct issue number) -->

## Summary

Fixed a Vitest warning about `vmThread` or `isolate`

## Why

I saw this recent warning after running Vitest:

> Environment  jsdom was created 215 times · 207.86s total, 64% of tracked time
             create it once per worker with pool: 'vmThreads' (keeps per-file isolation) or isolate: false (shares it across files)
             learn more: https://vitest.dev/guide/improving-performance#test-environments

## Changes

Vitest config and 1 Export Service spec file change

## Validation

Run all unit tests and make sure warning is gone

## Comments

This is a new warning coming from Vitest 5, switching to `vmThread` also cuts the testing time by more than half which is great

## AI / LLM assistance

- AI / LLM assistance used:
  - [ ] No
  - [x] Yes
- If **Yes**:
  - **which tool/model**: Codex ChatGPT 5.6 Luna
  - **how was it used**: prompt about the Vitest warning

## Checklist

- [x] The changes are limited to only one scope (if not please explain why in the comments above).
- [ ] Tests were added or updated where appropriate.
- [ ] Documentation was updated where appropriate.
